### PR TITLE
Add comprehensive Go documentation

### DIFF
--- a/agent/internal/awsconfig/aws.go
+++ b/agent/internal/awsconfig/aws.go
@@ -1,3 +1,4 @@
+// Package awsconfig provides AWS SDK configuration utilities.
 package awsconfig
 
 import (
@@ -7,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 )
 
+// LoadConfig loads the default AWS configuration using EC2 metadata when available.
+// It falls back to us-east-1 if EC2 metadata is not available.
 func LoadConfig(ctx context.Context) (aws.Config, error) {
 	return config.LoadDefaultConfig(ctx,
 		config.WithRegion("us-east-1"), // Fallback region

--- a/agent/internal/cni/server/config.go
+++ b/agent/internal/cni/server/config.go
@@ -1,11 +1,18 @@
+// Package server implements a gRPC server for the CNI plugin interface.
+// It handles pod registration and deregistration, queries node metadata,
+// stores pod data locally, and registers endpoints in the service registry.
 package server
 
 import "github.com/bpalermo/aether/agent/pkg/constants"
 
+// CNIServerConfig holds configuration for the CNIServer.
 type CNIServerConfig struct {
+	// SocketPath is the Unix domain socket path where the CNI gRPC server listens.
 	SocketPath string
 }
 
+// NewCNIServerConfig creates a new CNIServerConfig with default values.
+// The default socket path is the standard CNI socket path.
 func NewCNIServerConfig() *CNIServerConfig {
 	return &CNIServerConfig{
 		SocketPath: constants.DefaultCNISocketPath,

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// AddPod handles CNI ADD requests for a pod.
+// It enriches the pod data with Kubernetes annotations and labels, validates that the pod
+// should be managed (not in system namespaces or lacking the aether service label),
+// stores the pod locally, and registers its endpoints in the service registry.
 func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv1.AddPodResponse, error) {
 	cniPod := req.GetPod()
 	log := s.log.WithValues("pod", cniPod.GetName(), "namespace", cniPod.GetNamespace())
@@ -51,6 +55,10 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 	}, nil
 }
 
+// RemovePod handles CNI DEL requests for a pod.
+// It retrieves the pod from local storage, validates that it should be managed,
+// unregisters its endpoints from the service registry, and removes the pod from local storage.
+// If the pod is not found locally, it assumes the pod was either already removed or ignored.
 func (s *CNIServer) RemovePod(ctx context.Context, req *cniv1.RemovePodRequest) (*cniv1.RemovePodResponse, error) {
 	containerId := req.GetContainerId()
 	podName := req.GetName()
@@ -96,10 +104,10 @@ func (s *CNIServer) RemovePod(ctx context.Context, req *cniv1.RemovePodRequest) 
 	}, nil
 }
 
-// enhanceCNIPod enhances a CNIPod with additional data retrieved from the API server
-// we collect all annotations and labels, regardless. We leave to the registry implementation the decision of which to keep.
-// This will allow us to change registry implementation without having to change the CNI implementation, as the local stored file
-// will always contain all the relevant information.
+// enhanceCNIPod enriches a CNIPod with annotations and labels retrieved from the Kubernetes API server.
+// All annotations and labels are collected and stored; the registry implementation decides which to use.
+// This allows changing the registry implementation without modifying the CNI plugin,
+// since the local stored file contains all relevant information.
 func (s *CNIServer) enhanceCNIPod(ctx context.Context, cniPod *cniv1.CNIPod) error {
 	var k8sPod corev1.Pod
 	if err := s.k8sClient.Get(ctx, client.ObjectKey{
@@ -115,6 +123,8 @@ func (s *CNIServer) enhanceCNIPod(ctx context.Context, cniPod *cniv1.CNIPod) err
 	return nil
 }
 
+// validateAndCheckIgnorable validates a CNIPod and determines if it should be ignored.
+// It returns an error if the pod is nil, or a boolean indicating if the pod is ignorable.
 func validateAndCheckIgnorable(cniPod *cniv1.CNIPod) (bool, error) {
 	if cniPod == nil {
 		return false, status.Error(codes.InvalidArgument, "pod is required")
@@ -122,6 +132,9 @@ func validateAndCheckIgnorable(cniPod *cniv1.CNIPod) (bool, error) {
 	return isIgnorablePod(cniPod), nil
 }
 
+// isIgnorablePod determines if a pod should be ignored by the service mesh.
+// Pods in kube-system or aether-system namespaces, pods without the aether service label,
+// or pods without IP addresses are considered ignorable.
 func isIgnorablePod(cniPod *cniv1.CNIPod) bool {
 	if cniPod.GetNamespace() == "kube-system" || cniPod.GetNamespace() == "aether-system" {
 		return true

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -18,6 +18,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// CNIServer is a gRPC server that implements the CNI plugin interface.
+// It handles pod registration and deregistration requests, stores pod data locally,
+// and registers service endpoints in the registry. The server also queries Kubernetes
+// node metadata (region and zone) for topology-aware routing.
+//
+// CNIServer embeds xds.Server and implements the ServerCallback interface to query
+// node metadata before accepting client connections.
 type CNIServer struct {
 	cniv1.UnimplementedCNIServiceServer
 	xds.Server
@@ -38,7 +45,9 @@ type CNIServer struct {
 
 var _ xds.ServerCallback = (*CNIServer)(nil)
 
-// NewCNIServer creates a new CNI gRPC server
+// NewCNIServer creates a new CNI gRPC server.
+// The server listens on a Unix domain socket and registers the CNI service with
+// protovalidate middleware for request validation.
 func NewCNIServer(clusterName string, nodeName string, proxyID string, localStorage storage.Storage[*cniv1.CNIPod], registry registry.Registry, log logr.Logger, k8sClient client.Client, cfg *CNIServerConfig) (*CNIServer, error) {
 	validator, _ := protovalidate.New()
 
@@ -64,6 +73,8 @@ func NewCNIServer(clusterName string, nodeName string, proxyID string, localStor
 	return cniSrv, nil
 }
 
+// PreListen queries Kubernetes node metadata before the server starts accepting connections.
+// It retrieves the region and zone labels from the node object.
 func (s *CNIServer) PreListen(ctx context.Context) error {
 	s.log.V(2).Info("querying node metadata")
 	region, zone, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
@@ -78,6 +89,9 @@ func (s *CNIServer) PreListen(ctx context.Context) error {
 	return nil
 }
 
+// queryNodeMetadata retrieves the region and zone labels from a Kubernetes node.
+// It returns the topology.kubernetes.io/region and topology.kubernetes.io/zone labels,
+// or empty strings if the labels are not present.
 func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (string, string, error) {
 	node := &corev1.Node{}
 	if err := client.Get(ctx, types.NamespacedName{Name: proxyID}, node); err != nil {

--- a/agent/internal/xds/config/common.go
+++ b/agent/internal/xds/config/common.go
@@ -1,3 +1,6 @@
+// Package config provides Envoy configuration helpers for xDS resources.
+// It contains utility functions for building common Envoy configuration patterns
+// such as ADS config sources, protocol options, and SPIRE cluster configurations.
 package config
 
 import (
@@ -6,12 +9,16 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+// XDSConfigSourceADS creates a ConfigSource that uses ADS (Aggregated Discovery Service)
+// for dynamic configuration updates.
 func XDSConfigSourceADS() *corev3.ConfigSource {
 	return &corev3.ConfigSource{
 		ConfigSourceSpecifier: &corev3.ConfigSource_Ads{},
 	}
 }
 
+// TypedConfig wraps a protobuf message as a Google Any type.
+// This is used to package Envoy extension configurations for transport in xDS messages.
 func TypedConfig(config proto.Message) *anypb.Any {
 	c, _ := anypb.New(config)
 	return c

--- a/agent/internal/xds/config/constants.go
+++ b/agent/internal/xds/config/constants.go
@@ -1,5 +1,7 @@
 package config
 
 const (
+	// UpstreamHTTPProtocolOptionsKey is the Envoy extension key for HTTP protocol options
+	// applied to upstream (outbound) connections.
 	UpstreamHTTPProtocolOptionsKey = "envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
 )

--- a/agent/internal/xds/config/http.go
+++ b/agent/internal/xds/config/http.go
@@ -5,6 +5,8 @@ import (
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 )
 
+// Http1ProtocolOptions creates HTTP/1.1 protocol options for upstream clusters.
+// This is used to configure Envoy to communicate with services that only support HTTP/1.1.
 func Http1ProtocolOptions() *httpv3.HttpProtocolOptions {
 	return &httpv3.HttpProtocolOptions{
 		UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{
@@ -17,6 +19,8 @@ func Http1ProtocolOptions() *httpv3.HttpProtocolOptions {
 	}
 }
 
+// Http2ProtocolOptions creates HTTP/2 protocol options for upstream clusters.
+// This is used to configure Envoy to communicate with services that support HTTP/2.
 func Http2ProtocolOptions() *httpv3.HttpProtocolOptions {
 	return &httpv3.HttpProtocolOptions{
 		UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{

--- a/agent/internal/xds/config/spire.go
+++ b/agent/internal/xds/config/spire.go
@@ -11,10 +11,17 @@ import (
 )
 
 const (
+	// SpireAgentClusterName is the Envoy cluster name for the local SPIRE agent
+	// used to retrieve SVIDs for mTLS.
 	SpireAgentClusterName = "spire_sds"
-	spireAgentSocketFile  = "/run/secrets/workload-spiffe-uds/socket"
+	// spireAgentSocketFile is the path to the SPIRE agent's Unix domain socket
+	// for secret discovery service requests.
+	spireAgentSocketFile = "/run/secrets/workload-spiffe-uds/socket"
 )
 
+// NewLocalSpireCluster creates an Envoy cluster that connects to the local SPIRE agent
+// via Unix domain socket for retrieving SVIDs. The cluster uses EDS for dynamic endpoint
+// discovery and HTTP/2 for protocol communication.
 func NewLocalSpireCluster() *clusterv3.Cluster {
 	return &clusterv3.Cluster{
 		Name:           SpireAgentClusterName,
@@ -31,6 +38,8 @@ func NewLocalSpireCluster() *clusterv3.Cluster {
 	}
 }
 
+// NewLocalSpireClusterLoadAssignment creates an endpoint assignment for the SPIRE agent cluster,
+// pointing to the Unix domain socket where the SPIRE agent listens.
 func NewLocalSpireClusterLoadAssignment() *endpointv3.ClusterLoadAssignment {
 	return &endpointv3.ClusterLoadAssignment{
 		ClusterName: SpireAgentClusterName,

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -4,7 +4,6 @@ go_library(
     name = "proxy",
     srcs = [
         "cluster.go",
-        "doc.go",
         "endpoint.go",
         "filterchain.go",
         "httpfilter.go",

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "proxy",
     srcs = [
         "cluster.go",
+        "doc.go",
         "endpoint.go",
         "filterchain.go",
         "httpfilter.go",

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -1,3 +1,7 @@
+// Package proxy provides functions to generate Envoy resource types
+// (listeners, clusters, endpoints, routes, filter chains) from pod and
+// service registry data. It encapsulates the details of building Envoy
+// configurations for transparent traffic interception and service discovery.
 package proxy
 
 import (

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -14,9 +14,13 @@ import (
 )
 
 const (
+	// defaultLocalClusterUpstreamBindConfigAddress is the default bind address for local cluster upstreams
 	defaultLocalClusterUpstreamBindConfigAddress = "127.0.0.1"
 )
 
+// NewClusterForService creates an Envoy cluster for a service.
+// The cluster uses EDS for dynamic endpoint discovery via ADS.
+// Upstream connections use HTTP/2 protocol.
 func NewClusterForService(serviceName string) *clusterv3.Cluster {
 	protocolOptions := config.Http2ProtocolOptions()
 
@@ -34,6 +38,9 @@ func NewClusterForService(serviceName string) *clusterv3.Cluster {
 	}
 }
 
+// NewLocalClusterForService creates an Envoy cluster for a local service endpoint.
+// The cluster binds to 127.0.0.1 and uses the target pod's network namespace.
+// It includes health checks and uses HTTP/2 for upstream connections.
 func NewLocalClusterForService(serviceName string, endpoint *registryv1.ServiceEndpoint) *clusterv3.Cluster {
 	protocolOptions := config.Http2ProtocolOptions()
 

--- a/agent/internal/xds/proxy/doc.go
+++ b/agent/internal/xds/proxy/doc.go
@@ -1,5 +1,0 @@
-// Package proxy provides functions to generate Envoy resource types
-// (listeners, clusters, endpoints, routes, filter chains) from pod and
-// service registry data. It encapsulates the details of building Envoy
-// configurations for transparent traffic interception and service discovery.
-package proxy

--- a/agent/internal/xds/proxy/doc.go
+++ b/agent/internal/xds/proxy/doc.go
@@ -1,0 +1,5 @@
+// Package proxy provides functions to generate Envoy resource types
+// (listeners, clusters, endpoints, routes, filter chains) from pod and
+// service registry data. It encapsulates the details of building Envoy
+// configurations for transparent traffic interception and service discovery.
+package proxy

--- a/agent/internal/xds/proxy/endpoint.go
+++ b/agent/internal/xds/proxy/endpoint.go
@@ -8,16 +8,24 @@ import (
 )
 
 const (
+	// envoyFilterMetadataSubsetNamespace is the Envoy metadata namespace for load balancing subsets
 	envoyFilterMetadataSubsetNamespace = "envoy.lb"
 
-	subsetClusterKey      = "cluster"
-	subsetIPKey           = "ip"
+	// subsetClusterKey is the metadata key for the cluster name
+	subsetClusterKey = "cluster"
+	// subsetIPKey is the metadata key for the endpoint IP address
+	subsetIPKey = "ip"
+	// subsetPodNamespaceKey is the metadata key for the pod namespace
 	subsetPodNamespaceKey = "namespace"
-	subsetPodNameKey      = "pod"
+	// subsetPodNameKey is the metadata key for the pod name
+	subsetPodNameKey = "pod"
 
+	// defaultLocalEndpointBindAddress is the default bind address for local endpoints (localhost)
 	defaultLocalEndpointBindAddress = "127.0.0.1"
 )
 
+// NewClusterLoadAssignment creates an empty cluster load assignment for a service.
+// Endpoints should be added to the Endpoints field.
 func NewClusterLoadAssignment(serviceName string) *endpointv3.ClusterLoadAssignment {
 	return &endpointv3.ClusterLoadAssignment{
 		ClusterName: serviceName,
@@ -25,6 +33,8 @@ func NewClusterLoadAssignment(serviceName string) *endpointv3.ClusterLoadAssignm
 	}
 }
 
+// LocalLocalityLbEndpointFromRegistryEndpoint creates a locality lb endpoint for a local service endpoint.
+// It binds to 127.0.0.1 (localhost) for local-only access within the pod's network namespace.
 func LocalLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEndpoint) *endpointv3.LocalityLbEndpoints {
 	return &endpointv3.LocalityLbEndpoints{
 		LbEndpoints: []*endpointv3.LbEndpoint{
@@ -53,6 +63,10 @@ func LocalLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEnd
 	}
 }
 
+// LocalityLbEndpointFromRegistryEndpoint creates a locality lb endpoint from a service endpoint in the registry.
+// It includes the endpoint's IP address and port, along with metadata for load balancing subsets.
+// Metadata includes cluster name, IP, pod name, and pod namespace for topology-aware routing.
+// If the endpoint includes locality information (region/zone), it is included in the endpoint.
 func LocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEndpoint) *endpointv3.LocalityLbEndpoints {
 	var locality *core.Locality
 	if endpoint.GetLocality() != nil && endpoint.GetLocality().GetRegion() != "" && endpoint.GetLocality().GetZone() != "" {

--- a/agent/internal/xds/proxy/filterchain.go
+++ b/agent/internal/xds/proxy/filterchain.go
@@ -10,9 +10,12 @@ import (
 )
 
 const (
+	// spiffeDefaultBundleName is the SPIRE default bundle name used for root CA trust
 	spiffeDefaultBundleName = "ROOTCA"
 )
 
+// buildDefaultInboundHTTPFilterChain creates a filter chain for inbound HTTP traffic.
+// It includes TLS configuration, client certificate forwarding, and an HTTP connection manager.
 func buildDefaultInboundHTTPFilterChain(name string, tlsCertificateSecretName string) *listenerv3.FilterChain {
 	routeConfig := buildInboundRouteConfiguration()
 
@@ -32,6 +35,9 @@ func buildDefaultInboundHTTPFilterChain(name string, tlsCertificateSecretName st
 	}
 }
 
+// buildDefaultOutboundHTTPFilterChain creates a filter chain for outbound HTTP traffic.
+// It uses RDS (Route Discovery Service) to dynamically fetch routes and includes
+// network namespace filter state.
 func buildDefaultOutboundHTTPFilterChain(name string) *listenerv3.FilterChain {
 	hcm := buildHTTPConnectionManager(name, nil)
 

--- a/agent/internal/xds/proxy/httpfilter.go
+++ b/agent/internal/xds/proxy/httpfilter.go
@@ -8,13 +8,16 @@ import (
 )
 
 const (
+	// httpRouterFilterName is the Envoy HTTP router filter name
 	httpRouterFilterName = "envoy.filters.http.router"
 )
 
+// routerHttpFilter creates a router HTTP filter for forwarding matched requests to clusters.
 func routerHttpFilter() *http_connection_managerv3.HttpFilter {
 	return httpFilter(httpRouterFilterName, &routerv3.Router{})
 }
 
+// httpFilter creates an HTTP filter with the given name and configuration.
 func httpFilter(name string, msg proto.Message) *http_connection_managerv3.HttpFilter {
 	return &http_connection_managerv3.HttpFilter{
 		Name: name,

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -9,12 +9,20 @@ import (
 )
 
 const (
-	defaultInboundAddress   = "0.0.0.0"
-	defaultHTTPInboundPort  = 18080
-	defaultOutboundAddress  = "127.0.0.1"
+	// defaultInboundAddress is the address for inbound listeners (all interfaces)
+	defaultInboundAddress = "0.0.0.0"
+	// defaultHTTPInboundPort is the port for inbound HTTP listeners
+	defaultHTTPInboundPort = 18080
+	// defaultOutboundAddress is the address for outbound listeners (localhost only)
+	defaultOutboundAddress = "127.0.0.1"
+	// defaultHTTPOutboundPort is the port for outbound HTTP listeners
 	defaultHTTPOutboundPort = 18081
 )
 
+// GenerateListenersFromRegistryPod generates inbound and outbound HTTP listeners for a pod.
+// Inbound listeners accept traffic from any interface on the pod's network namespace.
+// Outbound listeners route traffic destined for other services.
+// Both listeners use HTTP protocol and include appropriate filter chains.
 func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, err error) {
 	inbound, err = generateInboundHTTPListener(cniPod)
 	if err != nil {

--- a/agent/internal/xds/proxy/listenerfilter.go
+++ b/agent/internal/xds/proxy/listenerfilter.go
@@ -8,9 +8,12 @@ import (
 )
 
 const (
+	// listenerFilterTLSInspectorName is the Envoy TLS inspector listener filter name
 	listenerFilterTLSInspectorName = "envoy.filters.listener.tls_inspector"
 )
 
+// buildInboundListenerFilters creates listener filters for inbound connections.
+// It includes a TLS inspector to detect TLS protocol on incoming connections.
 func buildInboundListenerFilters() []*listenerv3.ListenerFilter {
 	var filters []*listenerv3.ListenerFilter
 
@@ -19,11 +22,13 @@ func buildInboundListenerFilters() []*listenerv3.ListenerFilter {
 	return filters
 }
 
+// tlsInspector creates a TLS inspector listener filter.
 func tlsInspector() *listenerv3.ListenerFilter {
 	filter := &tls_inspectorv3.TlsInspector{}
 	return listenerFilter(listenerFilterTLSInspectorName, filter)
 }
 
+// listenerFilter creates a listener filter with the given name and configuration.
 func listenerFilter(name string, msg proto.Message) *listenerv3.ListenerFilter {
 	return &listenerv3.ListenerFilter{
 		Name: name,

--- a/agent/internal/xds/proxy/networkfilter.go
+++ b/agent/internal/xds/proxy/networkfilter.go
@@ -12,13 +12,17 @@ import (
 )
 
 const (
+	// networkNamespaceFilterStateKey is the filter state key for the network namespace
 	networkNamespaceFilterStateKey = "aether.network.network_namespace"
 )
 
+// buildNetworkNamespaceFilterState creates a filter that captures the network namespace
+// from Envoy's filter state and makes it available to upstream filters.
 func buildNetworkNamespaceFilterState() *listenerv3.Filter {
 	return buildSetFilterState(networkNamespaceFilterStateKey, "%FILTER_STATE(envoy.network.network_namespace:PLAIN)%")
 }
 
+// buildSetFilterState creates a set_filter_state network filter that stores a value in filter state.
 func buildSetFilterState(objectKey string, inlineStringFormatString string) *listenerv3.Filter {
 	filter := &set_filter_state_v3.Config{
 		OnNewConnection: []*setFilterStatev3.FilterStateValue{
@@ -45,6 +49,9 @@ func buildSetFilterState(objectKey string, inlineStringFormatString string) *lis
 	return networkFilter("envoy.filters.network.set_filter_state", filter)
 }
 
+// buildHTTPConnectionManager creates an HTTP connection manager for processing HTTP traffic.
+// It includes a router HTTP filter and uses the provided route configuration.
+// If routeConfig is nil, routes will be retrieved via RDS.
 func buildHTTPConnectionManager(name string, routeConfig *routev3.RouteConfiguration) *http_connection_managerv3.HttpConnectionManager {
 	return &http_connection_managerv3.HttpConnectionManager{
 		StatPrefix: name,
@@ -58,10 +65,12 @@ func buildHTTPConnectionManager(name string, routeConfig *routev3.RouteConfigura
 	}
 }
 
+// buildHTTPConnectionManagerFilter creates a network filter wrapping an HTTP connection manager.
 func buildHTTPConnectionManagerFilter(config *http_connection_managerv3.HttpConnectionManager) *listenerv3.Filter {
 	return networkFilter("envoy.http_connection_manager", config)
 }
 
+// networkFilter creates a network filter with the given name and configuration.
 func networkFilter(name string, msg proto.Message) *listenerv3.Filter {
 	return &listenerv3.Filter{
 		Name: name,

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -8,9 +8,12 @@ import (
 )
 
 const (
+	// OutboundHTTPRouteName is the name of the outbound HTTP route configuration
 	OutboundHTTPRouteName = "out_http"
 )
 
+// buildInboundRouteConfiguration creates a route configuration for inbound traffic.
+// It includes a catch-all virtual host that returns 404 for all requests.
 func buildInboundRouteConfiguration() *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name: "in_http",
@@ -42,6 +45,9 @@ func buildInboundRouteConfiguration() *routev3.RouteConfiguration {
 	}
 }
 
+// BuildOutboundRouteConfiguration creates a route configuration for outbound traffic.
+// It includes the provided virtual hosts along with a catch-all virtual host that returns 404.
+// Each virtual host matches requests by cluster name and FQDN.
 func BuildOutboundRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
 	result := make([]*routev3.VirtualHost, len(vhosts)+1)
 	result = append(vhosts, vhosts...)
@@ -75,6 +81,8 @@ func BuildOutboundRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.Rou
 	}
 }
 
+// BuildOutboundClusterVirtualHost creates a virtual host that routes traffic to a specific cluster.
+// The virtual host matches both the cluster name and its FQDN (cluster.aether.internal).
 func BuildOutboundClusterVirtualHost(clusterName string) *routev3.VirtualHost {
 	fqdn := fmt.Sprintf("%s.%s", clusterName, "aether.internal")
 	return &routev3.VirtualHost{

--- a/agent/internal/xds/proxy/transportsocket.go
+++ b/agent/internal/xds/proxy/transportsocket.go
@@ -9,9 +9,12 @@ import (
 )
 
 const (
+	// tlsTransportSocketName is the Envoy TLS transport socket name
 	tlsTransportSocketName = "envoy.transport_sockets.tls"
 )
 
+// DownstreamTransportSocket creates a TLS transport socket for downstream (inbound) connections.
+// It requires mutual TLS and retrieves certificates and validation context from SPIRE via SDS.
 func DownstreamTransportSocket(tlsCertificateSecretName string, validationContextName string) *corev3.TransportSocket {
 	downstreamTlsContext := &transport_sockets_v3.DownstreamTlsContext{
 		RequireClientCertificate: wrapperspb.Bool(true),
@@ -66,6 +69,8 @@ func DownstreamTransportSocket(tlsCertificateSecretName string, validationContex
 	return transportSocket(downstreamTlsContext)
 }
 
+// UpstreamTransportSocket creates a TLS transport socket for upstream (outbound) connections.
+// It requires mutual TLS and retrieves validation context from SPIRE via SDS.
 func UpstreamTransportSocket(validationContextName string) *corev3.TransportSocket {
 	upstreamTlsContext := &transport_sockets_v3.DownstreamTlsContext{
 		RequireClientCertificate: wrapperspb.Bool(true),
@@ -98,6 +103,7 @@ func UpstreamTransportSocket(validationContextName string) *corev3.TransportSock
 	return transportSocket(upstreamTlsContext)
 }
 
+// transportSocket creates a TLS transport socket from the given TLS context message.
 func transportSocket(msg proto.Message) *corev3.TransportSocket {
 	return &corev3.TransportSocket{
 		Name: tlsTransportSocketName,

--- a/agent/internal/xds/proxy/vhost.go
+++ b/agent/internal/xds/proxy/vhost.go
@@ -4,6 +4,8 @@ import (
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 )
 
+// NewServiceVirtualHost creates a virtual host that routes all traffic to a service.
+// It matches requests by service name and routes all paths to the corresponding cluster.
 func NewServiceVirtualHost(svcName string) *routev3.VirtualHost {
 	return &routev3.VirtualHost{
 		Name:    svcName,

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -1,3 +1,6 @@
+// Package server implements the agent-specific Envoy xDS server.
+// It builds xDS snapshots from local pod storage and the service registry,
+// generating Envoy listeners, clusters, endpoints, and routes.
 package server
 
 import (
@@ -24,6 +27,12 @@ import (
 	"go.uber.org/atomic"
 )
 
+// AgentXdsServer is an xDS server that generates Envoy configuration from local pod storage
+// and a service registry. It embeds xds.XdsServer and implements the ServerCallback interface
+// to generate an initial snapshot before starting to accept connections.
+//
+// The server maintains versioned snapshots of Envoy resources (listeners, clusters, endpoints, routes)
+// and serves them to local Envoy proxy instances via the xDS protocol.
 type AgentXdsServer struct {
 	xds.XdsServer
 
@@ -40,6 +49,10 @@ type AgentXdsServer struct {
 	version *atomic.Uint64
 }
 
+// NewXdsServer creates a new AgentXdsServer.
+// It initializes an xDS server with a snapshot cache and registers itself as a callback
+// to generate the initial Envoy snapshot before listening for client connections.
+// The server listens on a Unix domain socket at the default xDS socket path.
 func NewXdsServer(ctx context.Context, clusterName string, nodeName string, registry registry.Registry, storage storage.Storage[*cniv1.CNIPod], log logr.Logger) (*AgentXdsServer, error) {
 	cfg := xds.NewServerConfig(
 		xds.WithUDS(constants.DefaultXdsSocketPath),
@@ -63,6 +76,9 @@ func NewXdsServer(ctx context.Context, clusterName string, nodeName string, regi
 	return aXdsServer, nil
 }
 
+// PreListen generates the initial Envoy snapshot from local pod storage and the service registry.
+// It creates listeners, clusters, endpoints, and routes, then sets the snapshot in the cache
+// before the server starts accepting xDS client connections.
 func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 	s.log.V(1).Info("generating initial snapshot")
 
@@ -104,12 +120,18 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 	return nil
 }
 
+// generateSnapshotVersion generates a unique version string for snapshots.
+// The version combines the current Unix millisecond timestamp with an incrementing counter
+// to ensure uniqueness even for snapshots generated in the same millisecond.
 func (s *AgentXdsServer) generateSnapshotVersion() string {
 	timestamp := time.Now().UnixMilli()
 	version := s.version.Add(1)
 	return fmt.Sprintf("%d.%d", timestamp, version)
 }
 
+// generateListeners generates Envoy listener resources from local pod data.
+// It creates inbound and outbound listeners for each pod in the local storage.
+// If any listener generation fails, the errors are collected and returned.
 func generateListeners(ctx context.Context, storage storage.Storage[*cniv1.CNIPod], log logr.Logger) ([]types.Resource, error) {
 	log.V(2).Info("generating listeners")
 
@@ -143,6 +165,10 @@ func generateListeners(ctx context.Context, storage storage.Storage[*cniv1.CNIPo
 	return listeners, nil
 }
 
+// generateClustersAndEndpoints generates Envoy cluster and endpoint resources from the registry.
+// It creates clusters and cluster load assignments for each service endpoint found in the registry.
+// For endpoints on the local node, it also creates local-only clusters and endpoints to support
+// topology-aware routing. Additionally, it creates a special local SPIRE cluster for mTLS.
 func generateClustersAndEndpoints(ctx context.Context, clusterName string, nodeName string, registry registry.Registry, log logr.Logger) ([]types.Resource, []types.Resource, error) {
 	log.V(2).Info("generating endpoints")
 
@@ -189,6 +215,9 @@ func generateClustersAndEndpoints(ctx context.Context, clusterName string, nodeN
 	return clusters, clas, nil
 }
 
+// generateRoutes generates Envoy route resources from cluster information.
+// It creates virtual hosts for outbound traffic, one per cluster, and returns
+// a single outbound route configuration containing all virtual hosts.
 func generateRoutes(clusters []types.Resource, log logr.Logger) ([]types.Resource, error) {
 	var errs []error
 
@@ -214,6 +243,8 @@ func generateRoutes(clusters []types.Resource, log logr.Logger) ([]types.Resourc
 	return []types.Resource{outRoute}, nil
 }
 
+// isLocal determines if a service endpoint is on the local node.
+// It returns true if the endpoint's cluster name and node name match the provided values.
 func isLocal(clusterName string, nodeName string, endpoint *registryv1.ServiceEndpoint) bool {
 	return clusterName == endpoint.GetClusterName() && nodeName == endpoint.GetKubernetesMetadata().GetNodeName()
 }

--- a/agent/pkg/cmd/config.go
+++ b/agent/pkg/cmd/config.go
@@ -1,3 +1,4 @@
+// Package cmd provides command-line interface configuration for the Aether agent.
 package cmd
 
 import (
@@ -5,20 +6,26 @@ import (
 	"github.com/bpalermo/aether/agent/pkg/constants"
 )
 
+// AgentConfig holds configuration for the Aether agent.
 type AgentConfig struct {
-	// Debug
+	// Debug enables debug logging
 	Debug bool
-	// XDS nodeID
+	// ProxyServiceNodeID is the xDS node ID for identifying the Envoy proxy instance
 	ProxyServiceNodeID string
 
-	NodeName    string
+	// NodeName is the Kubernetes node name where the agent runs
+	NodeName string
+	// ClusterName is the Kubernetes cluster name
 	ClusterName string
 
+	// MountedLocalStorageDir is the directory where pod data is stored locally
 	MountedLocalStorageDir string
 
+	// CNIServerConfig holds CNI server configuration
 	CNIServerConfig *cniServer.CNIServerConfig
 }
 
+// NewAgentConfig creates a new AgentConfig with default values.
 func NewAgentConfig() *AgentConfig {
 	return &AgentConfig{
 		Debug:                  false,

--- a/agent/pkg/constants/constants.go
+++ b/agent/pkg/constants/constants.go
@@ -1,12 +1,17 @@
+// Package constants defines agent-specific constants for socket paths and directory defaults.
 package constants
 
 import "github.com/bpalermo/aether/constants"
 
 const (
+	// DefaultProxyID is the default xDS node ID for the Envoy proxy
 	DefaultProxyID = "proxy"
 
+	// DefaultHostCNIRegistryDir is the default directory for storing CNI registry data on the host
 	DefaultHostCNIRegistryDir = "/host" + constants.CNIDefaultRegistryPath
 
+	// DefaultXdsSocketPath is the default Unix domain socket path for the xDS server
 	DefaultXdsSocketPath = "/run/aether/xds.sock"
+	// DefaultCNISocketPath is the default Unix domain socket path for the CNI server
 	DefaultCNISocketPath = "/run/aether/cni.sock"
 )

--- a/agent/pkg/storage/local.go
+++ b/agent/pkg/storage/local.go
@@ -15,6 +15,9 @@ import (
 
 var unmarshalOpts = protojson.UnmarshalOptions{DiscardUnknown: true}
 
+// CachedLocalStorage is a storage implementation that persists resources to the local filesystem
+// and maintains an in-memory cache for fast access. Each resource is stored as a JSON file.
+// The implementation is safe for concurrent access using RWMutex.
 type CachedLocalStorage[T proto.Message] struct {
 	basePath    string
 	cache       map[types.ContainerID]T
@@ -26,8 +29,9 @@ type CachedLocalStorage[T proto.Message] struct {
 	initErr     error
 }
 
-// NewCachedLocalStorage creates a new cached file storage
-// Resources are stored as individual files in the specified basePath and in memory
+// NewCachedLocalStorage creates a new CachedLocalStorage instance.
+// Resources are stored as individual JSON files in the specified basePath and cached in memory.
+// The newFunc parameter is a factory function that creates new instances of type T for unmarshaling.
 func NewCachedLocalStorage[T proto.Message](basePath string, newFunc func() T) *CachedLocalStorage[T] {
 	return &CachedLocalStorage[T]{
 		basePath: basePath,
@@ -37,8 +41,9 @@ func NewCachedLocalStorage[T proto.Message](basePath string, newFunc func() T) *
 	}
 }
 
-// Initialize loads all resources from the disk into the cache.
-// Safe to call multiple times - only the first call performs initialization.
+// Initialize loads all resources from disk into the in-memory cache.
+// It is safe to call multiple times; only the first call performs initialization.
+// Subsequent calls return the result of the first initialization.
 func (f *CachedLocalStorage[T]) Initialize(ctx context.Context) error {
 	f.initOnce.Do(func() {
 		_, f.initErr = f.loadAll(ctx)
@@ -52,7 +57,8 @@ func (f *CachedLocalStorage[T]) Initialize(ctx context.Context) error {
 	return f.initErr
 }
 
-// WaitUntilReady blocks until the cache is populated or context is canceled.
+// WaitUntilReady blocks until the cache is populated from disk or the context is canceled.
+// It should be called before using other methods to ensure all resources are loaded.
 func (f *CachedLocalStorage[T]) WaitUntilReady(ctx context.Context) error {
 	select {
 	case <-f.initDone:
@@ -62,6 +68,8 @@ func (f *CachedLocalStorage[T]) WaitUntilReady(ctx context.Context) error {
 	}
 }
 
+// AddResource stores a resource atomically to disk and updates the in-memory cache.
+// The resource is serialized as JSON and written atomically to ensure consistency.
 func (f *CachedLocalStorage[T]) AddResource(_ context.Context, key types.ContainerID, resource T) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -90,6 +98,8 @@ func (f *CachedLocalStorage[T]) AddResource(_ context.Context, key types.Contain
 	return nil
 }
 
+// RemoveResource deletes a resource from disk and the in-memory cache.
+// It does not return an error if the resource file does not exist.
 func (f *CachedLocalStorage[T]) RemoveResource(_ context.Context, key types.ContainerID) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -108,6 +118,8 @@ func (f *CachedLocalStorage[T]) RemoveResource(_ context.Context, key types.Cont
 	return nil
 }
 
+// GetResource retrieves a resource by key, checking the in-memory cache first.
+// If not in cache, it loads the resource from disk and caches it for future access.
 func (f *CachedLocalStorage[T]) GetResource(_ context.Context, key types.ContainerID) (T, error) {
 	f.mu.RLock()
 
@@ -151,7 +163,8 @@ func (f *CachedLocalStorage[T]) GetResource(_ context.Context, key types.Contain
 	return resource, nil
 }
 
-// GetAll returns all resources from the cache as a slice
+// GetAll returns all cached resources as a slice.
+// Resources must be initialized before calling this method.
 func (f *CachedLocalStorage[T]) GetAll(_ context.Context) ([]T, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
@@ -165,7 +178,8 @@ func (f *CachedLocalStorage[T]) GetAll(_ context.Context) ([]T, error) {
 	return result, nil
 }
 
-// loadAll loads all resources from the disk into the memory cache
+// loadAll loads all resources from disk into the in-memory cache.
+// It reads all JSON files from the base directory and unmarshals them.
 func (f *CachedLocalStorage[T]) loadAll(_ context.Context) ([]T, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/agent/pkg/storage/storage.go
+++ b/agent/pkg/storage/storage.go
@@ -1,3 +1,6 @@
+// Package storage provides interfaces and implementations for persisting and retrieving
+// pod data. It supports both local file-based storage with in-memory caching and
+// file watching via fsnotify.
 package storage
 
 import (
@@ -7,12 +10,24 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Storage defines an interface for storing and retrieving protobuf messages.
+// Implementations manage the lifecycle of resources and maintain consistency
+// between persistent storage and in-memory caches.
 type Storage[T proto.Message] interface {
+	// Initialize prepares the storage for use, including creating directories
+	// and loading initial data if necessary.
 	Initialize(ctx context.Context) error
+	// WaitUntilReady waits until the storage is ready to serve requests.
+	// This may involve waiting for file watching mechanisms to be initialized.
 	WaitUntilReady(ctx context.Context) error
+	// AddResource stores a new resource with the given key.
 	AddResource(ctx context.Context, key types.ContainerID, resource T) error
+	// RemoveResource deletes a resource by key.
 	RemoveResource(ctx context.Context, key types.ContainerID) error
+	// GetResource retrieves a single resource by key.
 	GetResource(ctx context.Context, key types.ContainerID) (T, error)
+	// GetAll returns all stored resources from the in-memory cache.
 	GetAll(_ context.Context) ([]T, error)
+	// loadAll loads all resources from persistent storage. This is an internal method.
 	loadAll(ctx context.Context) ([]T, error)
 }

--- a/agent/pkg/types/container.go
+++ b/agent/pkg/types/container.go
@@ -1,7 +1,10 @@
+// Package types provides type definitions used throughout the Aether agent.
 package types
 
+// ContainerID represents a unique container identifier as a string.
 type ContainerID string
 
+// String returns the string representation of the ContainerID.
 func (c ContainerID) String() string {
 	return string(c)
 }

--- a/common/file/file.go
+++ b/common/file/file.go
@@ -1,3 +1,7 @@
+// Package file provides atomic file write utilities and platform-specific optimizations.
+// Atomic writes ensure that files are either fully written or not modified, preventing corruption
+// from partial writes or concurrent access. Large files are marked as not needed to optimize
+// page cache behavior on Linux systems.
 package file
 
 import (
@@ -12,6 +16,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
+// WriteFileAtomic writes data to a file atomically using a temporary file and rename.
+// It ensures that the file is either fully written with the new data or left unchanged.
+// Data is flushed to disk before the rename operation to ensure durability.
 func WriteFileAtomic(filePath string, data []byte) error {
 	dir := filepath.Dir(filePath)
 	base := filepath.Base(filePath)
@@ -54,6 +61,8 @@ func WriteFileAtomic(filePath string, data []byte) error {
 	return nil
 }
 
+// Exists checks if a file or directory exists at the given path.
+// It returns false only if the file does not exist; other errors (such as permission denied) return true.
 func Exists(name string) bool {
 	// We must explicitly check if the error is due to the file not existing (as opposed to a
 	// permissions error).
@@ -61,11 +70,14 @@ func Exists(name string) bool {
 	return !errors.Is(err, fs.ErrNotExist)
 }
 
-// AtomicWrite writes atomically by writing to a temporary file in the same directory then renaming
+// AtomicWrite writes data atomically to a file with the specified permissions.
+// It uses a temporary file in the same directory and atomically renames it to the target path.
 func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	return AtomicWriteReader(path, bytes.NewReader(data), mode)
 }
 
+// AtomicWriteReader writes data from a reader atomically to a file with the specified permissions.
+// It uses a temporary file and atomically renames it, marking large files as not needed for cache optimization.
 func AtomicWriteReader(path string, data io.Reader, mode os.FileMode) error {
 	tmpFile, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".tmp.")
 	if err != nil {
@@ -102,6 +114,9 @@ func AtomicWriteReader(path string, data io.Reader, mode os.FileMode) error {
 	return os.Rename(tmpFile.Name(), path)
 }
 
+// tryMarkLargeFileAsNotNeeded attempts to mark a file as not needed in the page cache.
+// This is a performance optimization for large files to free up memory.
+// It only applies to files larger than a threshold and silently ignores errors.
 func tryMarkLargeFileAsNotNeeded(size int64, in *os.File) {
 	// Somewhat arbitrary value to doesn't bother with this on small files
 	const largeFileThreshold = 16 * 1024

--- a/constants/annotations.go
+++ b/constants/annotations.go
@@ -1,17 +1,23 @@
+// Package constants defines shared constants used throughout the Aether codebase.
+// It includes Kubernetes labels, annotations, and configuration constants for the service mesh.
 package constants
 
 const (
-	// Aether
+	// Aether annotations
 	annotationAetherPrefix         = "aether.io/"
 	annotationAetherEndpointPrefix = "endpoint." + annotationAetherPrefix
 
-	AnnotationEndpointPort   = annotationAetherEndpointPrefix + "port"
+	// AnnotationEndpointPort is the pod annotation key for specifying the service port
+	AnnotationEndpointPort = annotationAetherEndpointPrefix + "port"
+	// AnnotationEndpointWeight is the pod annotation key for specifying endpoint weight in load balancing
 	AnnotationEndpointWeight = annotationAetherEndpointPrefix + "weight"
 
+	// AnnotationAetherEndpointMetadataPrefix is the prefix for endpoint metadata annotations
 	AnnotationAetherEndpointMetadataPrefix = "metadata." + annotationAetherEndpointPrefix
 
-	// KubernetesNodes
-
+	// Kubernetes topology annotations
+	// AnnotationKubernetesNodeTopologyRegion is the Kubernetes node label for the region
 	AnnotationKubernetesNodeTopologyRegion = "topology.kubernetes.io/region"
-	AnnotationKubernetesNodeTopologyZone   = "topology.kubernetes.io/zone"
+	// AnnotationKubernetesNodeTopologyZone is the Kubernetes node label for the zone
+	AnnotationKubernetesNodeTopologyZone = "topology.kubernetes.io/zone"
 )

--- a/constants/cni.go
+++ b/constants/cni.go
@@ -1,5 +1,6 @@
 package constants
 
 const (
+	// CNIDefaultRegistryPath is the default directory where CNI plugin data is stored
 	CNIDefaultRegistryPath = "/var/lib/aether/registry"
 )

--- a/constants/endpoint.go
+++ b/constants/endpoint.go
@@ -1,6 +1,8 @@
 package constants
 
 const (
-	DefaultEndpointPort   uint16 = 8080
+	// DefaultEndpointPort is the default port used for service endpoints if not specified
+	DefaultEndpointPort uint16 = 8080
+	// DefaultEndpointWeight is the default weight used for load balancing if not specified
 	DefaultEndpointWeight uint32 = 1024
 )

--- a/constants/labels.go
+++ b/constants/labels.go
@@ -3,5 +3,7 @@ package constants
 const (
 	aetherLabelPrefix = "aether.io"
 
+	// LabelAetherService is the Kubernetes label used to mark pods as managed by Aether
+	// and to specify which service they belong to. The value should be the service name.
 	LabelAetherService = aetherLabelPrefix + "/service"
 )

--- a/constants/registry.go
+++ b/constants/registry.go
@@ -1,6 +1,6 @@
 package constants
 
 const (
-	// DefaultDynamoDBServiceTableName the default service table name
+	// DefaultDynamoDBServiceTableName is the default DynamoDB table name for storing service information
 	DefaultDynamoDBServiceTableName = "AetherService"
 )

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -9,6 +9,10 @@ import (
 	"github.com/bpalermo/aether/constants"
 )
 
+// NewServiceEndpointFromCNIPod creates a ServiceEndpoint from a CNIPod.
+// It extracts the service name from the pod's labels and the port and weight from annotations.
+// The service protocol is always HTTP. Container and Kubernetes metadata are included
+// along with node locality information.
 func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
 	protocol := registryv1.Service_HTTP
 
@@ -51,6 +55,7 @@ func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegio
 	return serviceName, protocol, endpoint, nil
 }
 
+// ExtractCNIPodInformation extracts the service name and IP addresses from a CNIPod.
 func ExtractCNIPodInformation(pod *cniv1.CNIPod) (string, []string, error) {
 	serviceName, err := getServiceNameFromLabels(pod.GetLabels())
 	if err != nil {
@@ -60,6 +65,7 @@ func ExtractCNIPodInformation(pod *cniv1.CNIPod) (string, []string, error) {
 	return serviceName, pod.GetIps(), nil
 }
 
+// getServiceNameFromLabels extracts the service name from a pod's labels.
 func getServiceNameFromLabels(labels map[string]string) (string, error) {
 	serviceName, ok := labels[constants.LabelAetherService]
 	if !ok {
@@ -68,6 +74,8 @@ func getServiceNameFromLabels(labels map[string]string) (string, error) {
 	return serviceName, nil
 }
 
+// getPortFromAnnotations extracts the endpoint port from pod annotations.
+// If the port annotation is not present, it returns the default endpoint port.
 func getPortFromAnnotations(annotations map[string]string) (uint16, error) {
 	s, ok := annotations[constants.AnnotationEndpointPort]
 	if !ok {
@@ -81,6 +89,8 @@ func getPortFromAnnotations(annotations map[string]string) (uint16, error) {
 	return uint16(port), nil
 }
 
+// getWeightFromAnnotations extracts the endpoint weight from pod annotations.
+// If the weight annotation is not present, it returns the default endpoint weight.
 func getWeightFromAnnotations(annotations map[string]string) (uint32, error) {
 	s, ok := annotations[constants.AnnotationEndpointWeight]
 	if !ok {
@@ -95,6 +105,8 @@ func getWeightFromAnnotations(annotations map[string]string) (uint32, error) {
 	return uint32(weight), nil
 }
 
+// getEndpointMetadataFromAnnotations extracts endpoint metadata from pod annotations.
+// All annotations with the aether endpoint metadata prefix are included in the result.
 func getEndpointMetadataFromAnnotations(annotations map[string]string) map[string]string {
 	metadata := map[string]string{}
 	prefix := constants.AnnotationAetherEndpointMetadataPrefix

--- a/registry/ddb.go
+++ b/registry/ddb.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// NewDynamoDBRegistry creates a new Registry implementation backed by DynamoDB.
 func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config) Registry {
 	return ddb.NewDynamoDBRegistry(log, awsCfg)
 }

--- a/registry/internal/ddb/dynamodb.go
+++ b/registry/internal/ddb/dynamodb.go
@@ -1,3 +1,6 @@
+// Package ddb implements the Registry interface using AWS DynamoDB as the backend.
+// Service endpoints are organized by service name and protocol, with endpoints stored
+// in a map keyed by IP address.
 package ddb
 
 import (
@@ -15,6 +18,9 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// DynamoDBRegistry is a Registry implementation backed by AWS DynamoDB.
+// It stores service endpoints in a DynamoDB table with partition key (service name)
+// and sort key (protocol), and endpoints are organized in a map attribute.
 type DynamoDBRegistry struct {
 	log logr.Logger
 
@@ -23,6 +29,9 @@ type DynamoDBRegistry struct {
 	tableName string
 }
 
+// NewDynamoDBRegistry creates a new DynamoDB-backed Registry.
+// It uses the AWS SDK client from the provided configuration and connects to
+// the default service table name.
 func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config) *DynamoDBRegistry {
 	return &DynamoDBRegistry{
 		log:       log.WithName("registry-dynamodb"),
@@ -31,6 +40,7 @@ func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config) *DynamoDBRegistry {
 	}
 }
 
+// Start initializes the DynamoDB registry by verifying that the service table exists.
 func (r *DynamoDBRegistry) Start(ctx context.Context) error {
 	r.log.V(1).Info("starting registry and checking for table existence", "table", r.tableName)
 
@@ -51,8 +61,9 @@ func (r *DynamoDBRegistry) Start(ctx context.Context) error {
 	return nil
 }
 
-// RegisterEndpoint registers the given endpoint to its service.
-// It stores the endpoint in a map attribute keyed by the endpoint IP.
+// RegisterEndpoint registers an endpoint to a service and protocol in DynamoDB.
+// It stores the endpoint in the endpoints map attribute keyed by the endpoint IP address.
+// If the endpoints map doesn't exist, it is created first.
 func (r *DynamoDBRegistry) RegisterEndpoint(ctx context.Context, serviceName string, protocol registryv1.Service_Protocol, endpoint *registryv1.ServiceEndpoint) error {
 	ip := endpoint.GetIp()
 	r.log.V(1).Info(
@@ -116,11 +127,13 @@ func (r *DynamoDBRegistry) RegisterEndpoint(ctx context.Context, serviceName str
 	return nil
 }
 
+// UnregisterEndpoint removes a single endpoint from the registry for all protocols.
 func (r *DynamoDBRegistry) UnregisterEndpoint(ctx context.Context, serviceName string, ip string) error {
 	return r.UnregisterEndpoints(ctx, serviceName, []string{ip})
 }
 
-// UnregisterEndpoints removes endpoints from the registry for all protocols
+// UnregisterEndpoints removes multiple endpoints from the registry for all protocols.
+// It queries all protocol items for the service and removes the specified IPs from each.
 func (r *DynamoDBRegistry) UnregisterEndpoints(ctx context.Context, serviceName string, ips []string) error {
 	r.log.V(1).Info("unregistering endpoints",
 		"service", serviceName,
@@ -179,7 +192,7 @@ func (r *DynamoDBRegistry) UnregisterEndpoints(ctx context.Context, serviceName 
 	return nil
 }
 
-// ListEndpoints returns the endpoints registered for the given service and its protocol.
+// ListEndpoints retrieves all endpoints for a specific service and protocol from DynamoDB.
 func (r *DynamoDBRegistry) ListEndpoints(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
 	r.log.V(1).Info("listing endpoints", "service", service, "protocol", protocol)
 
@@ -212,7 +225,9 @@ func (r *DynamoDBRegistry) ListEndpoints(ctx context.Context, service string, pr
 	return endpoints, nil
 }
 
-// ListAllEndpoints returns all endpoints registered for the given protocol.
+// ListAllEndpoints retrieves all endpoints for the given protocol across all services from DynamoDB.
+// Endpoints are organized by service name in the returned map.
+// It uses pagination to handle large result sets.
 func (r *DynamoDBRegistry) ListAllEndpoints(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 	r.log.V(1).Info("listing all endpoints for protocol", "protocol", protocol)
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,3 +1,6 @@
+// Package registry provides interfaces for service endpoint registration and discovery.
+// It manages the lifecycle of service endpoints and allows querying available services
+// and their endpoints. Implementations can use different backends (e.g., DynamoDB).
 package registry
 
 import (
@@ -6,11 +9,20 @@ import (
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 )
 
+// Registry manages service endpoint registration, deregistration, and discovery.
+// It maintains a list of service endpoints and supports querying by service name and protocol.
 type Registry interface {
+	// Start initializes the registry. This should be called before using other methods.
 	Start(ctx context.Context) error
+	// RegisterEndpoint registers a single endpoint for a service with a specific protocol.
 	RegisterEndpoint(ctx context.Context, serviceName string, protocol registryv1.Service_Protocol, endpoint *registryv1.ServiceEndpoint) error
+	// UnregisterEndpoint unregisters an endpoint for a service by its IP address.
 	UnregisterEndpoint(ctx context.Context, serviceName string, ip string) error
+	// UnregisterEndpoints unregisters multiple endpoints for a service by their IP addresses.
 	UnregisterEndpoints(ctx context.Context, serviceName string, ips []string) error
+	// ListEndpoints returns all endpoints for a service with a specific protocol.
 	ListEndpoints(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error)
+	// ListAllEndpoints returns all endpoints for all services of a specific protocol,
+	// organized in a map keyed by service name.
 	ListAllEndpoints(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error)
 }

--- a/xds/callbacks.go
+++ b/xds/callbacks.go
@@ -2,6 +2,11 @@ package xds
 
 import "context"
 
+// ServerCallback provides lifecycle hooks for the Server.
+// Implementations can perform setup tasks before the server starts accepting connections.
 type ServerCallback interface {
+	// PreListen is called before the server starts listening on the configured address.
+	// It is called after the context is created but before net.Listen is invoked.
+	// Implementations should return an error if setup fails; the server will not start.
 	PreListen(ctx context.Context) error
 }

--- a/xds/config.go
+++ b/xds/config.go
@@ -10,16 +10,27 @@ const (
 	defaultServerShutdownTimeout = time.Second * 30
 )
 
+// ServerConfig holds configuration for a Server.
+//
+// Network and Address specify the network type and address for the server to bind to.
+// For Unix domain sockets, use WithUDS. For TCP, the Address should be ":port" format.
+// ShutdownTimeout specifies how long to wait for graceful shutdown before forcefully
+// stopping the server.
 type ServerConfig struct {
-	Network         string
-	Address         string
+	// Network is the network type: "tcp" or "unix"
+	Network string
+	// Address is the address to bind to (e.g., ":50051" for TCP or "/tmp/server.sock" for Unix domain socket)
+	Address string
+	// ShutdownTimeout is the maximum time to wait for graceful shutdown
 	ShutdownTimeout time.Duration
 
 	grpcServerOptions []grpc.ServerOption
 }
 
+// ServerConfigOpt is a functional option for configuring ServerConfig.
 type ServerConfigOpt func(*ServerConfig)
 
+// WithUDS configures the server to use a Unix domain socket at the given address.
 func WithUDS(address string) ServerConfigOpt {
 	return func(c *ServerConfig) {
 		c.Network = "unix"
@@ -27,6 +38,9 @@ func WithUDS(address string) ServerConfigOpt {
 	}
 }
 
+// NewServerConfig creates a new ServerConfig with default values.
+// The default network is TCP on port 50051 with a 30-second shutdown timeout.
+// Options can be provided to override defaults.
 func NewServerConfig(opts ...ServerConfigOpt) *ServerConfig {
 	cfg := &ServerConfig{
 		Network:           "tcp",

--- a/xds/readiness.go
+++ b/xds/readiness.go
@@ -2,11 +2,17 @@ package xds
 
 import "net/http"
 
+// HealthzCheck is a liveness probe handler for health check endpoints.
+// It always returns nil and can be used by external health check systems to verify
+// that the server process is running.
 func (s *Server) HealthzCheck(req *http.Request) error {
 	s.Log.V(2).Info("liveness check called")
 	return nil
 }
 
+// ReadyzCheck is a readiness probe handler for health check endpoints.
+// It always returns nil and can be used by external readiness check systems to verify
+// that the server is ready to accept client requests.
 func (s *Server) ReadyzCheck(req *http.Request) error {
 	s.Log.V(2).Info("readiness check called")
 	return nil

--- a/xds/server.go
+++ b/xds/server.go
@@ -12,6 +12,10 @@ import (
 	"google.golang.org/grpc"
 )
 
+// Server is a gRPC server that manages lifecycle and provides health checks.
+// It supports both TCP and Unix domain socket transports and implements graceful shutdown.
+//
+// Server is safe for concurrent use.
 type Server struct {
 	Log logr.Logger
 
@@ -25,9 +29,11 @@ type Server struct {
 	callback ServerCallback
 }
 
-// ServerOption is a functional option for configuring the Server
+// ServerOption is a functional option for configuring a Server.
 type ServerOption func(*Server)
 
+// NewServer creates a new Server with the given configuration and logger.
+// The server is not started until Start is called.
 func NewServer(cfg *ServerConfig, log logr.Logger, opts ...ServerOption) Server {
 	s := Server{
 		Log:       log.WithName("xds"),
@@ -44,16 +50,23 @@ func NewServer(cfg *ServerConfig, log logr.Logger, opts ...ServerOption) Server 
 	return s
 }
 
+// WithGRPCServer sets a pre-configured gRPC server to be used by the Server.
+// If not provided, a new gRPC server will be created with default settings.
 func WithGRPCServer(srv *grpc.Server) ServerOption {
 	return func(s *Server) {
 		s.gSrv = srv
 	}
 }
 
+// AddCallback registers a ServerCallback to be invoked before the server starts listening.
 func (s *Server) AddCallback(callback ServerCallback) {
 	s.callback = callback
 }
 
+// Start starts the gRPC server and blocks until the context is cancelled or the server errors.
+// It invokes the PreListen callback before starting to listen if a callback is registered.
+// For Unix domain sockets, it sets appropriate permissions on the socket file.
+// The server will attempt graceful shutdown when the context is cancelled.
 func (s *Server) Start(ctx context.Context) error {
 	s.Log.V(1).Info("starting server", "network", s.cfg.Network, "address", s.cfg.Address)
 
@@ -100,6 +113,10 @@ func (s *Server) Start(ctx context.Context) error {
 	}
 }
 
+// shutdown performs graceful shutdown of the gRPC server.
+// It first sets readiness to false, then waits for the server to gracefully stop.
+// If graceful stop takes longer than the configured ShutdownTimeout, the server
+// is forcefully stopped.
 func (s *Server) shutdown() error {
 	s.readiness.Store(false)
 

--- a/xds/xds.go
+++ b/xds/xds.go
@@ -16,6 +16,13 @@ import (
 	"google.golang.org/grpc/keepalive"
 )
 
+// XdsServer is a gRPC server that implements Envoy's xDS discovery services.
+// It embeds Server and registers discovery service handlers for LDS, CDS, EDS, RDS,
+// and ADS with Envoy's go-control-plane server. The server uses a snapshot cache
+// to manage versioned Envoy configurations.
+//
+// XdsServer is configured with appropriate keepalive parameters for long-lived client
+// connections and supports up to 1000 concurrent gRPC streams.
 type XdsServer struct {
 	Server
 
@@ -24,6 +31,10 @@ type XdsServer struct {
 	cache cachev3.SnapshotCache
 }
 
+// NewXdsServer creates a new XdsServer with Envoy discovery services registered.
+// It configures the gRPC server with keepalive parameters suitable for long-lived
+// client connections, registers all Envoy discovery services (LDS, CDS, EDS, RDS, ADS),
+// and returns an XdsServer ready to be started.
 func NewXdsServer(ctx context.Context, cfg *ServerConfig, cache cachev3.SnapshotCache, callbacks serverv3.Callbacks, log logr.Logger) XdsServer {
 	keepAliveTime := 30 * time.Second
 	grpcServer := grpc.NewServer(


### PR DESCRIPTION
## Summary
- Add package-level doc comments to all packages across the codebase
- Document all exported functions, types, interfaces, methods, and constants
- Follow Go doc conventions (first-sentence summaries, proper grammar)

## Packages covered
- `xds/` — Base gRPC server infrastructure and Envoy xDS server
- `agent/internal/xds/` — Agent-specific xDS logic (server, proxy, config)
- `agent/internal/cni/server/` — CNI gRPC server
- `registry/` — Service registry interface and DynamoDB implementation
- `agent/pkg/storage/` — Local file-based storage
- `constants/` — Shared Kubernetes labels, annotations, and constants
- `common/file/` — Atomic file write utilities
- `agent/pkg/cmd/`, `agent/pkg/types/`, `agent/pkg/constants/`, `agent/internal/awsconfig/`

## Test plan
- [x] Documentation-only changes — no functional code modified
- [ ] Verify `make build-agent` succeeds
- [ ] Verify `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)