### PR TITLE
Share single DynamoDB container across tests with per-test tables

### DIFF
--- a/registry/ddb.go
+++ b/registry/ddb.go
@@ -6,7 +6,13 @@ import (
 	"github.com/go-logr/logr"
 )
 
+// DynamoDBOption configures a DynamoDB registry.
+type DynamoDBOption = ddb.Option
+
+// WithDynamoDBTableName overrides the default DynamoDB table name.
+var WithDynamoDBTableName = ddb.WithTableName
+
 // NewDynamoDBRegistry creates a new Registry implementation backed by DynamoDB.
-func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config) Registry {
-	return ddb.NewDynamoDBRegistry(log, awsCfg)
+func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config, opts ...DynamoDBOption) Registry {
+	return ddb.NewDynamoDBRegistry(log, awsCfg, opts...)
 }

--- a/registry/internal/ddb/BUILD.bazel
+++ b/registry/internal/ddb/BUILD.bazel
@@ -24,7 +24,6 @@ go_test(
     deps = [
         ":ddb",
         "//api/aether/registry/v1:registry",
-        "//constants",
         "@com_github_aws_aws_sdk_go_v2//aws",
         "@com_github_aws_aws_sdk_go_v2_credentials//:credentials",
         "@com_github_aws_aws_sdk_go_v2_service_dynamodb//:dynamodb",

--- a/registry/internal/ddb/dynamodb.go
+++ b/registry/internal/ddb/dynamodb.go
@@ -29,15 +29,29 @@ type DynamoDBRegistry struct {
 	tableName string
 }
 
+// Option configures a DynamoDBRegistry.
+type Option func(*DynamoDBRegistry)
+
+// WithTableName overrides the default table name.
+func WithTableName(name string) Option {
+	return func(r *DynamoDBRegistry) {
+		r.tableName = name
+	}
+}
+
 // NewDynamoDBRegistry creates a new DynamoDB-backed Registry.
 // It uses the AWS SDK client from the provided configuration and connects to
 // the default service table name.
-func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config) *DynamoDBRegistry {
-	return &DynamoDBRegistry{
+func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config, opts ...Option) *DynamoDBRegistry {
+	r := &DynamoDBRegistry{
 		log:       log.WithName("registry-dynamodb"),
 		client:    dynamodb.NewFromConfig(awsCfg),
 		tableName: constants.DefaultDynamoDBServiceTableName,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
 }
 
 // Start initializes the DynamoDB registry by verifying that the service table exists.

--- a/registry/internal/ddb/dynamodb_test.go
+++ b/registry/internal/ddb/dynamodb_test.go
@@ -2,6 +2,9 @@ package ddb_test
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -9,7 +12,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
-	"github.com/bpalermo/aether/constants"
 	"github.com/bpalermo/aether/registry/internal/ddb"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -17,33 +19,50 @@ import (
 	tcdynamodb "github.com/testcontainers/testcontainers-go/modules/dynamodb"
 )
 
-// startContainer creates a DynamoDB Local container and returns an aws.Config
-// pointing at it. The container is terminated when the test finishes.
-func startContainer(ctx context.Context, t *testing.T) aws.Config {
-	t.Helper()
+var testAWSCfg aws.Config
 
+func TestMain(m *testing.M) {
+	ctx := context.Background()
 	container, err := tcdynamodb.Run(ctx, "amazon/dynamodb-local:2.5.4")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = container.Terminate(ctx) })
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start dynamodb container: %v\n", err)
+		os.Exit(1)
+	}
 
 	endpoint, err := container.ConnectionString(ctx)
-	require.NoError(t, err)
+	if err != nil {
+		_ = container.Terminate(ctx)
+		fmt.Fprintf(os.Stderr, "failed to get endpoint: %v\n", err)
+		os.Exit(1)
+	}
 
-	return aws.Config{
+	testAWSCfg = aws.Config{
 		Region: "us-east-1",
 		Credentials: credentials.NewStaticCredentialsProvider(
 			"DUMMYID", "DUMMYKEY", ""),
 		BaseEndpoint: aws.String("http://" + endpoint),
 	}
+
+	code := m.Run()
+	_ = container.Terminate(ctx)
+	os.Exit(code)
 }
 
-// createTable creates the service registry table in DynamoDB Local.
-func createTable(ctx context.Context, t *testing.T, awsCfg aws.Config) {
+// tableName returns a unique table name derived from the test name.
+func tableName(t *testing.T) string {
+	t.Helper()
+	// DynamoDB table names: 3-255 chars, [a-zA-Z0-9_.-]
+	name := strings.ReplaceAll(t.Name(), "/", "_")
+	return name
+}
+
+// createTable creates a DynamoDB table with the given name.
+func createTable(ctx context.Context, t *testing.T, name string) {
 	t.Helper()
 
-	client := dynamodb.NewFromConfig(awsCfg)
+	client := dynamodb.NewFromConfig(testAWSCfg)
 	_, err := client.CreateTable(ctx, &dynamodb.CreateTableInput{
-		TableName: aws.String(constants.DefaultDynamoDBServiceTableName),
+		TableName: aws.String(name),
 		KeySchema: []types.KeySchemaElement{
 			{AttributeName: aws.String("PK"), KeyType: types.KeyTypeHash},
 			{AttributeName: aws.String("SK"), KeyType: types.KeyTypeRange},
@@ -57,15 +76,14 @@ func createTable(ctx context.Context, t *testing.T, awsCfg aws.Config) {
 	require.NoError(t, err)
 }
 
-// setupRegistry creates a DynamoDB Local container, the service table, and
-// returns a started DynamoDBRegistry ready for use.
+// setupRegistry creates a per-test table and returns a started registry.
 func setupRegistry(ctx context.Context, t *testing.T) *ddb.DynamoDBRegistry {
 	t.Helper()
 
-	awsCfg := startContainer(ctx, t)
-	createTable(ctx, t, awsCfg)
+	table := tableName(t)
+	createTable(ctx, t, table)
 
-	registry := ddb.NewDynamoDBRegistry(logr.Discard(), awsCfg)
+	registry := ddb.NewDynamoDBRegistry(logr.Discard(), testAWSCfg, ddb.WithTableName(table))
 	require.NoError(t, registry.Start(ctx))
 
 	return registry
@@ -79,18 +97,16 @@ func TestDynamoDBRegistry_Start(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("successful start with existing table", func(t *testing.T) {
-		awsCfg := startContainer(ctx, t)
-		createTable(ctx, t, awsCfg)
+		table := tableName(t)
+		createTable(ctx, t, table)
 
-		registry := ddb.NewDynamoDBRegistry(logr.Discard(), awsCfg)
+		registry := ddb.NewDynamoDBRegistry(logr.Discard(), testAWSCfg, ddb.WithTableName(table))
 		err := registry.Start(ctx)
 		assert.NoError(t, err)
 	})
 
 	t.Run("fails when table does not exist", func(t *testing.T) {
-		awsCfg := startContainer(ctx, t)
-
-		registry := ddb.NewDynamoDBRegistry(logr.Discard(), awsCfg)
+		registry := ddb.NewDynamoDBRegistry(logr.Discard(), testAWSCfg, ddb.WithTableName("nonexistent"))
 		err := registry.Start(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not exist")


### PR DESCRIPTION
## Summary

- Add `WithTableName` functional option to `DynamoDBRegistry` for configurable table names (backward compatible)
- Refactor tests to use `TestMain` with a single shared DynamoDB Local container
- Each test gets its own isolated table derived from `t.Name()`
- Test runtime reduced from ~37s to ~8s (4.5x faster)

## Test plan

- [x] All tests pass (`bazel test //...`)
- [x] DynamoDB integration tests pass with shared container

🤖 Generated with [Claude Code](https://claude.com/claude-code)