### PR TITLE
Add Kubernetes-native registry backend

### DIFF
--- a/agent/pkg/cmd/config.go
+++ b/agent/pkg/cmd/config.go
@@ -21,7 +21,7 @@ type AgentConfig struct {
 	// MountedLocalStorageDir is the directory where pod data is stored locally
 	MountedLocalStorageDir string
 
-	// RegistryBackend selects the registry backend ("dynamodb" or "etcd")
+	// RegistryBackend selects the registry backend ("kubernetes", "dynamodb", or "etcd")
 	RegistryBackend string
 	// EtcdEndpoints is the list of etcd endpoints when using the etcd backend
 	EtcdEndpoints []string
@@ -42,7 +42,7 @@ func NewAgentConfig() *AgentConfig {
 		ProxyServiceNodeID:     constants.DefaultProxyID,
 		CNIServerConfig:        cniServer.NewCNIServerConfig(),
 		MountedLocalStorageDir: constants.DefaultHostCNIRegistryDir,
-		RegistryBackend:        "dynamodb",
+		RegistryBackend:        "kubernetes",
 		EtcdEndpoints:          []string{"localhost:2379"},
 		SpireTrustDomain:       constants.DefaultSpireTrustDomain,
 		SpireAdminSocketPath:   constants.DefaultSpireAdminSocketPath,

--- a/agent/pkg/cmd/root.go
+++ b/agent/pkg/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", constants.DefaultProxyID, "The xDS proxy ID (service-node)")
 	rootCmd.Flags().StringVar(&cfg.ProxyServiceNodeID, "proxy-id", constants.DefaultProxyID, "The xDS proxy ID (service-node)")
 	rootCmd.Flags().StringVar(&cfg.MountedLocalStorageDir, "mounted-registry-dir", constants.DefaultHostCNIRegistryDir, "Directory where CNI registry entries are located")
-	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", "dynamodb", "Registry backend (dynamodb, etcd)")
+	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", "kubernetes", "Registry backend (kubernetes, dynamodb, etcd)")
 	rootCmd.Flags().StringSliceVar(&cfg.EtcdEndpoints, "etcd-endpoints", []string{"localhost:2379"}, "etcd endpoints")
 	rootCmd.Flags().StringVar(&cfg.SpireTrustDomain, "spire-trust-domain", "ROOTCA", "SPIFFE trust domain for the cluster")
 	rootCmd.Flags().StringVar(&cfg.SpireAdminSocketPath, "spire-admin-socket", constants.DefaultSpireAdminSocketPath, "Path to SPIRE agent admin socket")
@@ -84,7 +84,7 @@ func runAgent(ctx context.Context) error {
 		return err
 	}
 
-	ddbRegistry, err := setupRegistry(ctx, m)
+	reg, err := setupRegistry(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -97,11 +97,11 @@ func runAgent(ctx context.Context) error {
 		return fmt.Errorf("failed to add SPIRE bridge: %w", err)
 	}
 
-	if err = setXDSServer(ctx, m, ddbRegistry, localStorage, snapshotCache); err != nil {
+	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache); err != nil {
 		return err
 	}
 
-	if err = setupCNIServer(m, localStorage, ddbRegistry, snapshotCache, spireBridge); err != nil {
+	if err = setupCNIServer(m, localStorage, reg, snapshotCache, spireBridge); err != nil {
 		return err
 	}
 
@@ -169,6 +169,10 @@ func setupRegistry(ctx context.Context, m ctrl.Manager) (registry.Registry, erro
 	var reg registry.Registry
 
 	switch cfg.RegistryBackend {
+	case "kubernetes":
+		reg = registry.NewKubernetesRegistry(l, m.GetAPIReader(), registry.KubernetesConfig{
+			ClusterName: cfg.ClusterName,
+		})
 	case "dynamodb":
 		awsCfg, err := awsconfig.LoadConfig(ctx)
 		if err != nil {

--- a/registry/BUILD.bazel
+++ b/registry/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "cni.go",
         "ddb.go",
         "etcd.go",
+        "k8s.go",
         "registry.go",
     ],
     importpath = "github.com/bpalermo/aether/registry",
@@ -16,7 +17,9 @@ go_library(
         "//constants",
         "//registry/internal/ddb",
         "//registry/internal/etcd",
+        "//registry/internal/k8s",
         "@com_github_aws_aws_sdk_go_v2//aws",
         "@com_github_go_logr_logr//:logr",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
     ],
 )

--- a/registry/internal/k8s/BUILD.bazel
+++ b/registry/internal/k8s/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "k8s",
+    srcs = ["kubernetes.go"],
+    importpath = "github.com/bpalermo/aether/registry/internal/k8s",
+    visibility = ["//registry:__subpackages__"],
+    deps = [
+        "//api/aether/registry/v1:registry",
+        "//constants",
+        "@com_github_go_logr_logr//:logr",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
+)
+
+go_test(
+    name = "k8s_test",
+    srcs = ["kubernetes_test.go"],
+    embed = [":k8s"],
+    deps = [
+        "//api/aether/registry/v1:registry",
+        "//constants",
+        "@com_github_go_logr_logr//:logr",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
+    ],
+)

--- a/registry/internal/k8s/kubernetes.go
+++ b/registry/internal/k8s/kubernetes.go
@@ -1,0 +1,264 @@
+// Package k8s implements the Registry interface using the Kubernetes API server as the backend.
+// It discovers service endpoints by listing pods with the aether.io/managed=true label
+// and derives service names from each pod's ServiceAccount. Node topology labels provide
+// region and zone locality information.
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/constants"
+)
+
+// Config holds the configuration for the Kubernetes registry backend.
+type Config struct {
+	// ClusterName is the name of the cluster, used to populate ServiceEndpoint.ClusterName.
+	ClusterName string
+}
+
+// KubernetesRegistry is a Registry implementation backed by the Kubernetes API server.
+// It reads pods labeled with aether.io/managed=true and converts them to ServiceEndpoints.
+// Write operations (Register/Unregister) are no-ops since the API server is the source of truth.
+type KubernetesRegistry struct {
+	log         logr.Logger
+	clusterName string
+	reader      client.Reader
+}
+
+// NewKubernetesRegistry creates a new Kubernetes API server backed Registry.
+// The reader should be a direct API reader (e.g., manager.GetAPIReader()) to avoid
+// cache synchronization issues during startup.
+func NewKubernetesRegistry(log logr.Logger, reader client.Reader, cfg Config) *KubernetesRegistry {
+	return &KubernetesRegistry{
+		log:         log.WithName("registry-kubernetes"),
+		clusterName: cfg.ClusterName,
+		reader:      reader,
+	}
+}
+
+// Start is a no-op for the Kubernetes registry.
+// The API server connection is managed by the controller-runtime manager.
+func (r *KubernetesRegistry) Start(_ context.Context) error {
+	r.log.Info("kubernetes registry started", "cluster", r.clusterName)
+	return nil
+}
+
+// RegisterEndpoint is a no-op. The Kubernetes API server is the source of truth for pod endpoints.
+func (r *KubernetesRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, _ *registryv1.ServiceEndpoint) error {
+	return nil
+}
+
+// UnregisterEndpoint is a no-op. The Kubernetes API server is the source of truth for pod endpoints.
+func (r *KubernetesRegistry) UnregisterEndpoint(_ context.Context, _ string, _ string) error {
+	return nil
+}
+
+// UnregisterEndpoints is a no-op. The Kubernetes API server is the source of truth for pod endpoints.
+func (r *KubernetesRegistry) UnregisterEndpoints(_ context.Context, _ string, _ []string) error {
+	return nil
+}
+
+// ListEndpoints returns all endpoints for a service by listing managed pods whose ServiceAccount
+// matches the given service name. Node topology labels are used for locality information.
+func (r *KubernetesRegistry) ListEndpoints(ctx context.Context, service string, _ registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
+	r.log.V(1).Info("listing endpoints", "service", service)
+
+	pods, err := r.listManagedPods(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeLocalities, err := r.buildNodeLocalities(ctx, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	var endpoints []*registryv1.ServiceEndpoint
+	for i := range pods {
+		pod := &pods[i]
+		if pod.Spec.ServiceAccountName != service {
+			continue
+		}
+		ep, err := r.podToEndpoint(pod, nodeLocalities)
+		if err != nil {
+			r.log.Error(err, "failed to convert pod to endpoint", "pod", pod.Name, "namespace", pod.Namespace)
+			continue
+		}
+		endpoints = append(endpoints, ep)
+	}
+
+	r.log.V(1).Info("listed endpoints", "service", service, "count", len(endpoints))
+	return endpoints, nil
+}
+
+// ListAllEndpoints returns all endpoints for all services, grouped by service name (ServiceAccount).
+// It lists all managed pods, resolves node localities, and converts each pod to a ServiceEndpoint.
+func (r *KubernetesRegistry) ListAllEndpoints(ctx context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	r.log.V(1).Info("listing all endpoints")
+
+	pods, err := r.listManagedPods(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	nodeLocalities, err := r.buildNodeLocalities(ctx, pods)
+	if err != nil {
+		return nil, err
+	}
+
+	endpointsByService := make(map[string][]*registryv1.ServiceEndpoint)
+	for i := range pods {
+		pod := &pods[i]
+		serviceName := pod.Spec.ServiceAccountName
+		if serviceName == "" {
+			r.log.V(1).Info("skipping pod without service account", "pod", pod.Name, "namespace", pod.Namespace)
+			continue
+		}
+
+		ep, err := r.podToEndpoint(pod, nodeLocalities)
+		if err != nil {
+			r.log.Error(err, "failed to convert pod to endpoint", "pod", pod.Name, "namespace", pod.Namespace)
+			continue
+		}
+		endpointsByService[serviceName] = append(endpointsByService[serviceName], ep)
+	}
+
+	r.log.V(1).Info("listed all endpoints", "services", len(endpointsByService))
+	return endpointsByService, nil
+}
+
+// locality holds the region and zone for a node.
+type locality struct {
+	region string
+	zone   string
+}
+
+// listManagedPods lists all running pods with the aether.io/managed=true label that have a PodIP.
+func (r *KubernetesRegistry) listManagedPods(ctx context.Context) ([]corev1.Pod, error) {
+	var podList corev1.PodList
+	err := r.reader.List(ctx, &podList,
+		client.MatchingLabels{constants.LabelAetherManaged: "true"},
+	)
+	if err != nil {
+		r.log.Error(err, "failed to list managed pods")
+		return nil, fmt.Errorf("failed to list managed pods: %w", err)
+	}
+
+	// Filter to running pods with an IP
+	var pods []corev1.Pod
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != "" {
+			pods = append(pods, *pod)
+		}
+	}
+
+	return pods, nil
+}
+
+// buildNodeLocalities fetches topology labels for all unique nodes referenced by the given pods.
+// Results are cached by node name to avoid redundant API calls.
+func (r *KubernetesRegistry) buildNodeLocalities(ctx context.Context, pods []corev1.Pod) (map[string]locality, error) {
+	// Collect unique node names
+	nodeNames := make(map[string]struct{})
+	for i := range pods {
+		if nodeName := pods[i].Spec.NodeName; nodeName != "" {
+			nodeNames[nodeName] = struct{}{}
+		}
+	}
+
+	localities := make(map[string]locality, len(nodeNames))
+	for nodeName := range nodeNames {
+		var node corev1.Node
+		if err := r.reader.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
+			r.log.Error(err, "failed to get node for locality", "node", nodeName)
+			return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		}
+		localities[nodeName] = locality{
+			region: node.Labels[constants.AnnotationKubernetesNodeTopologyRegion],
+			zone:   node.Labels[constants.AnnotationKubernetesNodeTopologyZone],
+		}
+	}
+
+	return localities, nil
+}
+
+// podToEndpoint converts a Kubernetes Pod to a ServiceEndpoint.
+func (r *KubernetesRegistry) podToEndpoint(pod *corev1.Pod, nodeLocalities map[string]locality) (*registryv1.ServiceEndpoint, error) {
+	port, err := getPortFromAnnotations(pod.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+
+	weight, err := getWeightFromAnnotations(pod.Annotations)
+	if err != nil {
+		return nil, fmt.Errorf("pod %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+
+	ep := &registryv1.ServiceEndpoint{
+		Ip:          pod.Status.PodIP,
+		ClusterName: r.clusterName,
+		Port:        uint32(port),
+		Weight:      weight,
+		Metadata:    getEndpointMetadataFromAnnotations(pod.Annotations),
+		KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+			Namespace: pod.Namespace,
+			PodName:   pod.Name,
+			NodeName:  pod.Spec.NodeName,
+		},
+	}
+
+	if loc, ok := nodeLocalities[pod.Spec.NodeName]; ok {
+		ep.Locality = &registryv1.ServiceEndpoint_Locality{
+			Region: loc.region,
+			Zone:   loc.zone,
+		}
+	}
+
+	return ep, nil
+}
+
+// getPortFromAnnotations extracts the endpoint port from pod annotations.
+func getPortFromAnnotations(annotations map[string]string) (uint16, error) {
+	s, ok := annotations[constants.AnnotationEndpointPort]
+	if !ok {
+		return constants.DefaultEndpointPort, nil
+	}
+	port, err := strconv.ParseUint(s, 10, 16)
+	if err != nil {
+		return 0, fmt.Errorf("invalid port annotation: %w", err)
+	}
+	return uint16(port), nil
+}
+
+// getWeightFromAnnotations extracts the endpoint weight from pod annotations.
+func getWeightFromAnnotations(annotations map[string]string) (uint32, error) {
+	s, ok := annotations[constants.AnnotationEndpointWeight]
+	if !ok {
+		return constants.DefaultEndpointWeight, nil
+	}
+	weight, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid weight annotation: %w", err)
+	}
+	return uint32(weight), nil
+}
+
+// getEndpointMetadataFromAnnotations extracts endpoint metadata from pod annotations.
+func getEndpointMetadataFromAnnotations(annotations map[string]string) map[string]string {
+	metadata := map[string]string{}
+	prefix := constants.AnnotationAetherEndpointMetadataPrefix
+	for key, value := range annotations {
+		if len(key) > len(prefix) && key[:len(prefix)] == prefix {
+			metadata[key[len(prefix):]] = value
+		}
+	}
+	return metadata
+}

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -1,0 +1,1006 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/constants"
+)
+
+// newTestRegistry constructs a KubernetesRegistry wired to a fake client built
+// from the supplied Kubernetes objects.
+func newTestRegistry(clusterName string, objects ...any) *KubernetesRegistry {
+	b := fake.NewClientBuilder()
+	for _, o := range objects {
+		switch v := o.(type) {
+		case *corev1.Pod:
+			b = b.WithObjects(v)
+		case *corev1.Node:
+			b = b.WithObjects(v)
+		}
+	}
+	reader := b.Build()
+	return NewKubernetesRegistry(logr.Discard(), reader, Config{ClusterName: clusterName})
+}
+
+// managedPod returns a running pod with a PodIP and the aether managed label.
+// The caller can override fields via the returned pointer before passing to newTestRegistry.
+func managedPod(name, namespace, serviceAccount, podIP, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				constants.LabelAetherManaged: "true",
+			},
+			Annotations: map[string]string{},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: serviceAccount,
+			NodeName:           nodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: podIP,
+		},
+	}
+}
+
+// topologyNode returns a Node with region and zone topology labels.
+func topologyNode(name, region, zone string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				constants.AnnotationKubernetesNodeTopologyRegion: region,
+				constants.AnnotationKubernetesNodeTopologyZone:   zone,
+			},
+		},
+	}
+}
+
+// ─── Start ───────────────────────────────────────────────────────────────────
+
+func TestStart(t *testing.T) {
+	r := newTestRegistry("test-cluster")
+	err := r.Start(context.Background())
+	require.NoError(t, err)
+}
+
+// ─── RegisterEndpoint ────────────────────────────────────────────────────────
+
+func TestRegisterEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		service  string
+		protocol registryv1.Service_Protocol
+		endpoint *registryv1.ServiceEndpoint
+		wantErr  bool
+	}{
+		{
+			name:     "no-op returns nil",
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			endpoint: &registryv1.ServiceEndpoint{
+				Ip:          "10.0.0.1",
+				ClusterName: "test-cluster",
+				Port:        8080,
+				Weight:      1024,
+			},
+			wantErr: false,
+		},
+		{
+			name:     "nil endpoint returns nil",
+			service:  "my-service",
+			protocol: registryv1.Service_PROTOCOL_UNSPECIFIED,
+			endpoint: nil,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry("test-cluster")
+			err := r.RegisterEndpoint(context.Background(), tt.service, tt.protocol, tt.endpoint)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// ─── UnregisterEndpoint ──────────────────────────────────────────────────────
+
+func TestUnregisterEndpoint(t *testing.T) {
+	tests := []struct {
+		name      string
+		service   string
+		ipAddress string
+		wantErr   bool
+	}{
+		{
+			name:      "no-op returns nil",
+			service:   "my-service",
+			ipAddress: "10.0.0.1",
+			wantErr:   false,
+		},
+		{
+			name:      "empty service and address returns nil",
+			service:   "",
+			ipAddress: "",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry("test-cluster")
+			err := r.UnregisterEndpoint(context.Background(), tt.service, tt.ipAddress)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// ─── UnregisterEndpoints ─────────────────────────────────────────────────────
+
+func TestUnregisterEndpoints(t *testing.T) {
+	tests := []struct {
+		name        string
+		service     string
+		ipAddresses []string
+		wantErr     bool
+	}{
+		{
+			name:        "no-op returns nil for multiple addresses",
+			service:     "my-service",
+			ipAddresses: []string{"10.0.0.1", "10.0.0.2"},
+			wantErr:     false,
+		},
+		{
+			name:        "no-op returns nil for empty slice",
+			service:     "my-service",
+			ipAddresses: []string{},
+			wantErr:     false,
+		},
+		{
+			name:        "no-op returns nil for nil slice",
+			service:     "my-service",
+			ipAddresses: nil,
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry("test-cluster")
+			err := r.UnregisterEndpoints(context.Background(), tt.service, tt.ipAddresses)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+// ─── ListEndpoints ───────────────────────────────────────────────────────────
+
+func TestListEndpoints(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		objects     []any
+		service     string
+		protocol    registryv1.Service_Protocol
+		expected    []*registryv1.ServiceEndpoint
+		wantErr     bool
+	}{
+		{
+			name:        "no pods returns empty slice",
+			clusterName: "test-cluster",
+			objects:     nil,
+			service:     "my-service",
+			protocol:    registryv1.Service_HTTP,
+			expected:    nil,
+			wantErr:     false,
+		},
+		{
+			name:        "running pod with matching service account is returned",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1"),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "test-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "us-east-1",
+						Zone:   "us-east-1a",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "pod with different service account is filtered out",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "other-service", "10.0.0.1", "node-1"),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:        "pod not in Running phase is excluded",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Status.Phase = corev1.PodPending
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:        "pod without PodIP is excluded",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "my-service", "", "node-1"),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:        "pod without aether managed label is excluded",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					delete(p.Labels, constants.LabelAetherManaged)
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:        "pod with explicit port annotation uses that port",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationEndpointPort] = "9090"
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "test-cluster",
+					Port:        9090,
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "us-east-1",
+						Zone:   "us-east-1a",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "pod with explicit weight annotation uses that weight",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationEndpointWeight] = "512"
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "test-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      512,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "us-east-1",
+						Zone:   "us-east-1a",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "pod with metadata annotations includes metadata in endpoint",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationAetherEndpointMetadataPrefix+"version"] = "v2"
+					p.Annotations[constants.AnnotationAetherEndpointMetadataPrefix+"env"] = "production"
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "test-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata: map[string]string{
+						"version": "v2",
+						"env":     "production",
+					},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "us-east-1",
+						Zone:   "us-east-1a",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "pod with invalid port annotation is skipped without error",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationEndpointPort] = "not-a-port"
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			// The pod is skipped (error logged, not propagated), so no endpoints are returned.
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:        "pod with invalid weight annotation is skipped without error",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationEndpointWeight] = "not-a-weight"
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:        "missing node returns error",
+			clusterName: "test-cluster",
+			objects: []any{
+				// Pod references node-1 but the node is not in the fake client.
+				managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:        "pod on node with no topology labels has nil locality",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1"),
+				// Node with no topology labels.
+				&corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "node-1",
+						Labels: map[string]string{},
+					},
+				},
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "test-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "",
+						Zone:   "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "multiple pods with matching service account are all returned",
+			clusterName: "prod-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1"),
+				managedPod("pod-b", "default", "my-service", "10.0.0.2", "node-1"),
+				managedPod("pod-c", "default", "other-service", "10.0.0.3", "node-1"),
+				topologyNode("node-1", "eu-west-1", "eu-west-1b"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "prod-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "eu-west-1",
+						Zone:   "eu-west-1b",
+					},
+				},
+				{
+					Ip:          "10.0.0.2",
+					ClusterName: "prod-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-b",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "eu-west-1",
+						Zone:   "eu-west-1b",
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry(tt.clusterName, tt.objects...)
+			got, err := r.ListEndpoints(context.Background(), tt.service, tt.protocol)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// ─── ListAllEndpoints ────────────────────────────────────────────────────────
+
+func TestListAllEndpoints(t *testing.T) {
+	tests := []struct {
+		name        string
+		clusterName string
+		objects     []any
+		protocol    registryv1.Service_Protocol
+		expected    map[string][]*registryv1.ServiceEndpoint
+		wantErr     bool
+	}{
+		{
+			name:        "no pods returns empty map",
+			clusterName: "test-cluster",
+			objects:     nil,
+			protocol:    registryv1.Service_HTTP,
+			expected:    map[string][]*registryv1.ServiceEndpoint{},
+			wantErr:     false,
+		},
+		{
+			name:        "single pod returns map with one service",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1"),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{
+				"svc-a": {
+					{
+						Ip:          "10.0.0.1",
+						ClusterName: "test-cluster",
+						Port:        uint32(constants.DefaultEndpointPort),
+						Weight:      constants.DefaultEndpointWeight,
+						Metadata:    map[string]string{},
+						KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+							Namespace: "default",
+							PodName:   "pod-a",
+							NodeName:  "node-1",
+						},
+						Locality: &registryv1.ServiceEndpoint_Locality{
+							Region: "us-east-1",
+							Zone:   "us-east-1a",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "pods with multiple service accounts are grouped correctly",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1"),
+				managedPod("pod-b", "default", "svc-b", "10.0.0.2", "node-1"),
+				managedPod("pod-c", "default", "svc-a", "10.0.0.3", "node-1"),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{
+				"svc-a": {
+					{
+						Ip:          "10.0.0.1",
+						ClusterName: "test-cluster",
+						Port:        uint32(constants.DefaultEndpointPort),
+						Weight:      constants.DefaultEndpointWeight,
+						Metadata:    map[string]string{},
+						KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+							Namespace: "default",
+							PodName:   "pod-a",
+							NodeName:  "node-1",
+						},
+						Locality: &registryv1.ServiceEndpoint_Locality{
+							Region: "us-east-1",
+							Zone:   "us-east-1a",
+						},
+					},
+					{
+						Ip:          "10.0.0.3",
+						ClusterName: "test-cluster",
+						Port:        uint32(constants.DefaultEndpointPort),
+						Weight:      constants.DefaultEndpointWeight,
+						Metadata:    map[string]string{},
+						KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+							Namespace: "default",
+							PodName:   "pod-c",
+							NodeName:  "node-1",
+						},
+						Locality: &registryv1.ServiceEndpoint_Locality{
+							Region: "us-east-1",
+							Zone:   "us-east-1a",
+						},
+					},
+				},
+				"svc-b": {
+					{
+						Ip:          "10.0.0.2",
+						ClusterName: "test-cluster",
+						Port:        uint32(constants.DefaultEndpointPort),
+						Weight:      constants.DefaultEndpointWeight,
+						Metadata:    map[string]string{},
+						KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+							Namespace: "default",
+							PodName:   "pod-b",
+							NodeName:  "node-1",
+						},
+						Locality: &registryv1.ServiceEndpoint_Locality{
+							Region: "us-east-1",
+							Zone:   "us-east-1a",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:        "pod without service account is skipped",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "", "10.0.0.1", "node-1")
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{},
+			wantErr:  false,
+		},
+		{
+			name:        "pod not in Running phase is excluded",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1")
+					p.Status.Phase = corev1.PodFailed
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{},
+			wantErr:  false,
+		},
+		{
+			name:        "pod without PodIP is excluded",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "svc-a", "", "node-1"),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{},
+			wantErr:  false,
+		},
+		{
+			name:        "pod with invalid port annotation is skipped",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationEndpointPort] = "99999999"
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{},
+			wantErr:  false,
+		},
+		{
+			name:        "missing node returns error",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-missing"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: nil,
+			wantErr:  true,
+		},
+		{
+			name:        "pods on different nodes resolve correct localities",
+			clusterName: "test-cluster",
+			objects: []any{
+				managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-west"),
+				managedPod("pod-b", "default", "svc-a", "10.0.0.2", "node-east"),
+				topologyNode("node-west", "us-west-2", "us-west-2a"),
+				topologyNode("node-east", "us-east-1", "us-east-1b"),
+			},
+			protocol: registryv1.Service_HTTP,
+			expected: map[string][]*registryv1.ServiceEndpoint{
+				"svc-a": {
+					{
+						Ip:          "10.0.0.1",
+						ClusterName: "test-cluster",
+						Port:        uint32(constants.DefaultEndpointPort),
+						Weight:      constants.DefaultEndpointWeight,
+						Metadata:    map[string]string{},
+						KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+							Namespace: "default",
+							PodName:   "pod-a",
+							NodeName:  "node-west",
+						},
+						Locality: &registryv1.ServiceEndpoint_Locality{
+							Region: "us-west-2",
+							Zone:   "us-west-2a",
+						},
+					},
+					{
+						Ip:          "10.0.0.2",
+						ClusterName: "test-cluster",
+						Port:        uint32(constants.DefaultEndpointPort),
+						Weight:      constants.DefaultEndpointWeight,
+						Metadata:    map[string]string{},
+						KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+							Namespace: "default",
+							PodName:   "pod-b",
+							NodeName:  "node-east",
+						},
+						Locality: &registryv1.ServiceEndpoint_Locality{
+							Region: "us-east-1",
+							Zone:   "us-east-1b",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newTestRegistry(tt.clusterName, tt.objects...)
+			got, err := r.ListAllEndpoints(context.Background(), tt.protocol)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// ─── Annotation parsing helpers (unit-level) ─────────────────────────────────
+
+func TestGetPortFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    uint16
+		wantErr     bool
+	}{
+		{
+			name:        "no annotation returns default port",
+			annotations: map[string]string{},
+			expected:    constants.DefaultEndpointPort,
+			wantErr:     false,
+		},
+		{
+			name:        "nil annotations returns default port",
+			annotations: nil,
+			expected:    constants.DefaultEndpointPort,
+			wantErr:     false,
+		},
+		{
+			name:        "valid port annotation is parsed",
+			annotations: map[string]string{constants.AnnotationEndpointPort: "9090"},
+			expected:    9090,
+			wantErr:     false,
+		},
+		{
+			name:        "minimum port value 1 is valid",
+			annotations: map[string]string{constants.AnnotationEndpointPort: "1"},
+			expected:    1,
+			wantErr:     false,
+		},
+		{
+			name:        "maximum port value 65535 is valid",
+			annotations: map[string]string{constants.AnnotationEndpointPort: "65535"},
+			expected:    65535,
+			wantErr:     false,
+		},
+		{
+			name:        "port value exceeding uint16 max returns error",
+			annotations: map[string]string{constants.AnnotationEndpointPort: "65536"},
+			expected:    0,
+			wantErr:     true,
+		},
+		{
+			name:        "non-numeric port annotation returns error",
+			annotations: map[string]string{constants.AnnotationEndpointPort: "not-a-port"},
+			expected:    0,
+			wantErr:     true,
+		},
+		{
+			name:        "negative port annotation returns error",
+			annotations: map[string]string{constants.AnnotationEndpointPort: "-1"},
+			expected:    0,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getPortFromAnnotations(tt.annotations)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetWeightFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    uint32
+		wantErr     bool
+	}{
+		{
+			name:        "no annotation returns default weight",
+			annotations: map[string]string{},
+			expected:    constants.DefaultEndpointWeight,
+			wantErr:     false,
+		},
+		{
+			name:        "nil annotations returns default weight",
+			annotations: nil,
+			expected:    constants.DefaultEndpointWeight,
+			wantErr:     false,
+		},
+		{
+			name:        "valid weight annotation is parsed",
+			annotations: map[string]string{constants.AnnotationEndpointWeight: "512"},
+			expected:    512,
+			wantErr:     false,
+		},
+		{
+			name:        "weight of zero is valid",
+			annotations: map[string]string{constants.AnnotationEndpointWeight: "0"},
+			expected:    0,
+			wantErr:     false,
+		},
+		{
+			name:        "maximum uint32 weight is valid",
+			annotations: map[string]string{constants.AnnotationEndpointWeight: "4294967295"},
+			expected:    4294967295,
+			wantErr:     false,
+		},
+		{
+			name:        "weight exceeding uint32 max returns error",
+			annotations: map[string]string{constants.AnnotationEndpointWeight: "4294967296"},
+			expected:    0,
+			wantErr:     true,
+		},
+		{
+			name:        "non-numeric weight annotation returns error",
+			annotations: map[string]string{constants.AnnotationEndpointWeight: "heavy"},
+			expected:    0,
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getWeightFromAnnotations(tt.annotations)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestGetEndpointMetadataFromAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[string]string
+	}{
+		{
+			name:        "nil annotations returns empty map",
+			annotations: nil,
+			expected:    map[string]string{},
+		},
+		{
+			name:        "empty annotations returns empty map",
+			annotations: map[string]string{},
+			expected:    map[string]string{},
+		},
+		{
+			name: "non-metadata annotations are ignored",
+			annotations: map[string]string{
+				"some.other.annotation/key": "value",
+				constants.AnnotationEndpointPort: "8080",
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "single metadata annotation is extracted with key suffix",
+			annotations: map[string]string{
+				constants.AnnotationAetherEndpointMetadataPrefix + "version": "v2",
+			},
+			expected: map[string]string{
+				"version": "v2",
+			},
+		},
+		{
+			name: "multiple metadata annotations are all extracted",
+			annotations: map[string]string{
+				constants.AnnotationAetherEndpointMetadataPrefix + "version": "v2",
+				constants.AnnotationAetherEndpointMetadataPrefix + "env":     "production",
+				constants.AnnotationAetherEndpointMetadataPrefix + "tier":    "backend",
+			},
+			expected: map[string]string{
+				"version": "v2",
+				"env":     "production",
+				"tier":    "backend",
+			},
+		},
+		{
+			name: "annotation key equal to prefix alone is not extracted",
+			annotations: map[string]string{
+				constants.AnnotationAetherEndpointMetadataPrefix: "value",
+			},
+			expected: map[string]string{},
+		},
+		{
+			name: "metadata annotations mixed with non-metadata annotations extracts only metadata",
+			annotations: map[string]string{
+				constants.AnnotationAetherEndpointMetadataPrefix + "canary": "true",
+				constants.AnnotationEndpointPort:   "9090",
+				constants.AnnotationEndpointWeight: "256",
+			},
+			expected: map[string]string{
+				"canary": "true",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getEndpointMetadataFromAnnotations(tt.annotations)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/registry/k8s.go
+++ b/registry/k8s.go
@@ -1,0 +1,20 @@
+package registry
+
+import (
+	"github.com/bpalermo/aether/registry/internal/k8s"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// KubernetesConfig is the configuration for the Kubernetes registry backend.
+type KubernetesConfig = k8s.Config
+
+// KubernetesRegistry is a Registry implementation backed by the Kubernetes API server.
+type KubernetesRegistry = k8s.KubernetesRegistry
+
+// NewKubernetesRegistry creates a new Registry implementation backed by the Kubernetes API server.
+// It discovers service endpoints by listing pods with the aether.io/managed=true label.
+// The reader should be a direct API reader (e.g., manager.GetAPIReader()) to avoid cache timing issues.
+func NewKubernetesRegistry(log logr.Logger, reader client.Reader, cfg KubernetesConfig) *KubernetesRegistry {
+	return k8s.NewKubernetesRegistry(log, reader, cfg)
+}


### PR DESCRIPTION
## Summary

- Adds a new `kubernetes` registry backend that discovers service endpoints by listing pods directly from the Kubernetes API server, with no external dependencies (no DynamoDB, no etcd)
- Pods with the `aether.io/managed=true` label are listed, service names are derived from `ServiceAccountName` (consistent with existing backends), and node topology labels provide region/zone locality
- Write operations (`RegisterEndpoint`, `UnregisterEndpoint`) are no-ops since the API server is the source of truth — CNI server code is unchanged
- Sets `kubernetes` as the default `--registry-backend`, replacing `dynamodb`

## Test plan

- [x] Unit tests for all registry interface methods (52 test cases)
- [x] Tests cover pod filtering (phase, PodIP, labels), annotation parsing (port, weight, metadata), node locality resolution, multi-service grouping, and error cases
- [ ] Verify agent starts with `--registry-backend=kubernetes` in a kind cluster
- [ ] Verify existing `dynamodb` and `etcd` backends still work when explicitly selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)