### PR TITLE
Refactor registry lifecycle, fix xDS snapshots, and make SPIRE optional

### DIFF
--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -50,13 +50,15 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 	}
 
 	// Subscribe to SVID for this pod via the SPIRE Delegated Identity API
-	spiffeID := proxy.SpiffeIDFromPod(cniPod, s.trustDomain)
-	if cniPod.GetPid() != nil {
-		if err = s.spireBridge.SubscribePod(ctx, spiffeID, int32(cniPod.GetPid().GetValue())); err != nil {
-			log.Error(err, "failed to subscribe to SVID", "spiffeID", spiffeID)
+	if s.spireBridge != nil {
+		spiffeID := proxy.SpiffeIDFromPod(cniPod, s.trustDomain)
+		if cniPod.GetPid() != nil {
+			if err = s.spireBridge.SubscribePod(ctx, spiffeID, int32(cniPod.GetPid().GetValue())); err != nil {
+				log.Error(err, "failed to subscribe to SVID", "spiffeID", spiffeID)
+			}
+		} else {
+			log.V(1).Info("skipping SVID subscription: PID not available", "spiffeID", spiffeID)
 		}
-	} else {
-		log.V(1).Info("skipping SVID subscription: PID not available", "spiffeID", spiffeID)
 	}
 
 	return &cniv1.AddPodResponse{
@@ -102,9 +104,11 @@ func (s *CNIServer) RemovePod(ctx context.Context, req *cniv1.RemovePodRequest) 
 	}
 
 	// Unsubscribe from SVID for this pod
-	spiffeID := proxy.SpiffeIDFromPod(storedPod, s.trustDomain)
-	if unsubErr := s.spireBridge.UnsubscribePod(ctx, spiffeID); unsubErr != nil {
-		log.Error(unsubErr, "failed to unsubscribe from SVID", "spiffeID", spiffeID)
+	if s.spireBridge != nil {
+		spiffeID := proxy.SpiffeIDFromPod(storedPod, s.trustDomain)
+		if unsubErr := s.spireBridge.UnsubscribePod(ctx, spiffeID); unsubErr != nil {
+			log.Error(unsubErr, "failed to unsubscribe from SVID", "spiffeID", spiffeID)
+		}
 	}
 
 	// Remove listener from xDS first

--- a/agent/internal/cni/server/pod_test.go
+++ b/agent/internal/cni/server/pod_test.go
@@ -32,7 +32,8 @@ type testRegistry struct {
 
 var _ registry.Registry = (*testRegistry)(nil)
 
-func (r *testRegistry) Start(_ context.Context) error { return nil }
+func (r *testRegistry) Initialize(_ context.Context) error { return nil }
+func (r *testRegistry) Close() error                        { return nil }
 
 func (r *testRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, _ *registryv1.ServiceEndpoint) error {
 	return r.registerEndpointErr

--- a/agent/internal/xds/cache/cache_test.go
+++ b/agent/internal/xds/cache/cache_test.go
@@ -18,7 +18,8 @@ type mockRegistry struct {
 
 var _ registry.Registry = (*mockRegistry)(nil)
 
-func (m *mockRegistry) Start(_ context.Context) error { return nil }
+func (m *mockRegistry) Initialize(_ context.Context) error { return nil }
+func (m *mockRegistry) Close() error                        { return nil }
 
 func (m *mockRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, _ *registryv1.ServiceEndpoint) error {
 	return nil

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -205,17 +205,17 @@ func (c *SnapshotCache) generateClusterSnapshot(ctx context.Context) error {
 	clusters, endpoints, vhosts := c.clustersEndpointsAndVhosts()
 	c.log.V(1).Info("setting snapshot", "version", v, "clusters", len(clusters), "endpoints", len(endpoints), "vhosts", len(vhosts))
 
-	snapshot, err := cachev3.NewSnapshot(v, map[resourcev3.Type][]types.Resource{
+	resources := map[resourcev3.Type][]types.Resource{
 		resourcev3.ClusterType:  clusters,
 		resourcev3.EndpointType: endpoints,
-		resourcev3.RouteType:    {proxy.BuildOutboundRouteConfiguration(vhosts)},
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create snapshot: %w", err)
+	}
+	if len(vhosts) > 0 {
+		resources[resourcev3.RouteType] = []types.Resource{proxy.BuildOutboundRouteConfiguration(vhosts)}
 	}
 
-	if err := snapshot.Consistent(); err != nil {
-		return fmt.Errorf("snapshot inconsistency: %w", err)
+	snapshot, err := cachev3.NewSnapshot(v, resources)
+	if err != nil {
+		return fmt.Errorf("failed to create snapshot: %w", err)
 	}
 
 	if err := c.SnapshotCache.SetSnapshot(ctx, c.nodeName, snapshot); err != nil {

--- a/agent/internal/xds/cache/cluster_test.go
+++ b/agent/internal/xds/cache/cluster_test.go
@@ -153,18 +153,12 @@ func TestSnapshotCache_RemoveCluster_NonExisting(t *testing.T) {
 }
 
 // TestSnapshotCache_RemoveCluster_ExistingCluster verifies that removing a cluster that
-// exists removes it from the map and calls generateClusterSnapshot. Because the cluster
-// snapshot always includes a RouteConfiguration resource that go-control-plane's
-// Consistent() check expects to be referenced by a listener, the snapshot generation
-// reports a "snapshot inconsistency" error. The map mutation (deletion) still happens
-// before the error is returned.
+// exists removes it from the map and generates a valid cluster snapshot.
 func TestSnapshotCache_RemoveCluster_ExistingCluster(t *testing.T) {
 	tests := []struct {
-		name             string
-		setupFunc        func(c *SnapshotCache)
-		clusterName      string
-		wantClusterGone  bool
-		wantErrSubstring string
+		name        string
+		setupFunc   func(c *SnapshotCache)
+		clusterName string
 	}{
 		{
 			name: "remove existing cluster deletes it from the map",
@@ -173,9 +167,7 @@ func TestSnapshotCache_RemoveCluster_ExistingCluster(t *testing.T) {
 					"target": {},
 				}
 			},
-			clusterName:      "target",
-			wantClusterGone:  true,
-			wantErrSubstring: "snapshot inconsistency",
+			clusterName: "target",
 		},
 		{
 			name: "remove one of several clusters leaves others intact",
@@ -185,9 +177,7 @@ func TestSnapshotCache_RemoveCluster_ExistingCluster(t *testing.T) {
 					"remove": {},
 				}
 			},
-			clusterName:      "remove",
-			wantClusterGone:  true,
-			wantErrSubstring: "snapshot inconsistency",
+			clusterName: "remove",
 		},
 	}
 
@@ -198,15 +188,10 @@ func TestSnapshotCache_RemoveCluster_ExistingCluster(t *testing.T) {
 
 			err := c.RemoveCluster(context.Background(), tt.clusterName)
 
-			// The cluster is removed from the map before snapshot generation is attempted.
 			_, stillExists := c.clusters[tt.clusterName]
-			assert.False(t, stillExists, "cluster %q should be removed from map before snapshot error", tt.clusterName)
+			assert.False(t, stillExists, "cluster %q should be removed from map", tt.clusterName)
 
-			// Snapshot generation fails because go-control-plane's Consistent() check
-			// requires that every named RouteConfiguration be referenced by a Listener,
-			// but the cluster snapshot includes a RouteConfiguration with no matching listener.
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErrSubstring)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -324,9 +309,8 @@ func TestSnapshotCache_RemoveEndpoint_RemovesIP(t *testing.T) {
 			c := newTestCache("node-1")
 			tt.setupFunc(c)
 
-			// RemoveEndpoint triggers generateClusterSnapshot which returns a
-			// snapshot inconsistency error (same as RemoveCluster tests).
-			_ = c.RemoveEndpoint(context.Background(), tt.clusterName, tt.ip)
+			err := c.RemoveEndpoint(context.Background(), tt.clusterName, tt.ip)
+			require.NoError(t, err)
 
 			entry, ok := c.clusters[tt.clusterName]
 			require.True(t, ok, "cluster should still exist after endpoint removal")
@@ -458,11 +442,7 @@ func TestLoadClustersFromRegistry_RegistryError(t *testing.T) {
 }
 
 // TestLoadClustersFromRegistry_MapPopulation verifies that the in-memory cluster map
-// is correctly populated with all expected keys before the snapshot generation step.
-// Note: the snapshot generation itself produces a "snapshot inconsistency" error because
-// go-control-plane requires named RouteConfigurations to be referenced by Listeners,
-// but the cluster snapshot includes a RouteConfiguration with no corresponding Listeners.
-// This test focuses on the map mutation behavior that occurs before that error.
+// is correctly populated with all expected keys after loading from the registry.
 func TestLoadClustersFromRegistry_MapPopulation(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -562,8 +542,8 @@ func TestLoadClustersFromRegistry_MapPopulation(t *testing.T) {
 				},
 			}
 
-			// Map mutation happens before snapshot generation; ignore the snapshot error.
-			_ = c.LoadClustersFromRegistry(context.Background(), tt.clusterName, tt.cacheNodeName, reg)
+			err := c.LoadClustersFromRegistry(context.Background(), tt.clusterName, tt.cacheNodeName, reg)
+			require.NoError(t, err)
 
 			for _, key := range tt.wantClusterKeys {
 				_, ok := c.clusters[key]
@@ -579,16 +559,15 @@ func TestLoadClustersFromRegistry_MapPopulation(t *testing.T) {
 }
 
 // TestLoadClustersFromRegistry_IncreasesVersion verifies that loading clusters increments
-// the snapshot version counter even when snapshot generation fails the consistency check.
+// the snapshot version counter.
 func TestLoadClustersFromRegistry_IncreasesVersion(t *testing.T) {
 	c := newTestCache("node-1")
 	versionBefore := c.version.Load()
 
 	reg := &mockRegistry{}
-	// Ignore the snapshot inconsistency error; verify version incremented.
-	_ = c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg)
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
 
-	assert.Greater(t, c.version.Load(), versionBefore, "version counter should increase even when snapshot consistency check fails")
+	assert.Greater(t, c.version.Load(), versionBefore, "version counter should increase after loading clusters")
 }
 
 // TestLoadClustersFromRegistry_EndpointsReachable verifies that after loading, Endpoints()
@@ -603,8 +582,7 @@ func TestLoadClustersFromRegistry_EndpointsReachable(t *testing.T) {
 		},
 	}
 
-	// Ignore the snapshot inconsistency error; verify the in-memory state.
-	_ = c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg)
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
 
 	eps := c.Endpoints("my-svc")
 	require.NotNil(t, eps)
@@ -623,8 +601,7 @@ func TestLoadClustersFromRegistry_VirtualHostsPopulated(t *testing.T) {
 		},
 	}
 
-	// Ignore the snapshot inconsistency error; verify the in-memory state.
-	_ = c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg)
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
 
 	vhosts := c.VirtualHosts()
 	assert.NotEmpty(t, vhosts)

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -118,10 +118,6 @@ func (c *SnapshotCache) generateListenerSnapshot(ctx context.Context) error {
 		return fmt.Errorf("failed to create snapshot: %w", err)
 	}
 
-	if err := snapshot.Consistent(); err != nil {
-		return fmt.Errorf("snapshot inconsistency: %w", err)
-	}
-
 	if err := c.SetSnapshot(ctx, c.nodeName, snapshot); err != nil {
 		return fmt.Errorf("failed to set snapshot: %w", err)
 	}

--- a/agent/internal/xds/cache/listener_test.go
+++ b/agent/internal/xds/cache/listener_test.go
@@ -35,21 +35,13 @@ func initListeners(c *SnapshotCache) {
 }
 
 // seedListeners pre-populates the cache by calling LoadListenersFromStorage with
-// the given pods. The snapshot generation step is expected to report a consistency
-// error (the outbound listener's RDS reference to the "out_http" RouteConfiguration
-// is not included in a listener-only snapshot), so this helper ignores that
-// specific error and only fails if the map was not populated.
-// This mirrors how cluster_test.go calls LoadClustersFromRegistry.
+// the given pods.
 func seedListeners(c *SnapshotCache, pods ...*cniv1.CNIPod) {
 	initListeners(c)
 	store := storage.NewMockStorage[*cniv1.CNIPod]()
 	store.GetAllFunc = func(_ context.Context) ([]*cniv1.CNIPod, error) {
 		return pods, nil
 	}
-	// Snapshot generation consistently fails the go-control-plane consistency
-	// check because the outbound listener references the "out_http"
-	// RouteConfiguration via RDS, but that RouteConfiguration is not included
-	// in a listener-only snapshot. Ignore this expected error.
 	_ = c.LoadListenersFromStorage(context.Background(), store, "example.org")
 }
 
@@ -158,28 +150,18 @@ func TestSnapshotCache_RemovePod_NonExisting(t *testing.T) {
 }
 
 // TestSnapshotCache_RemovePod_ExistingPod verifies that removing a pod that
-// exists deletes it from the map before snapshot generation. Because the
-// remaining outbound listener still references the "out_http" RouteConfiguration
-// via RDS (not present in a listener-only snapshot), the snapshot consistency
-// check fails. The map mutation happens before that error, so we verify map
-// state and expect the snapshot error.
-//
-// When the last pod is removed the listener list is empty, which produces a
-// valid (empty) snapshot — no error is expected in that case.
+// exists deletes it from the map and generates a valid listener snapshot.
 func TestSnapshotCache_RemovePod_ExistingPod(t *testing.T) {
 	tests := []struct {
-		name             string
-		initialPods      []*cniv1.CNIPod
-		removeNetns      string
-		wantMapLen       int
-		wantGone         string
-		wantRemaining    []string
-		wantErrSubstring string // non-empty when snapshot generation is expected to fail
+		name          string
+		initialPods   []*cniv1.CNIPod
+		removeNetns   string
+		wantMapLen    int
+		wantGone      string
+		wantRemaining []string
 	}{
 		{
-			// After removing the only pod the listener list is empty, so the
-			// snapshot is valid and no error should be returned.
-			name: "remove the only pod results in empty listener map and no error",
+			name: "remove the only pod results in empty listener map",
 			initialPods: []*cniv1.CNIPod{
 				makeCNIPod("pod-a", "default", "/proc/100/ns/net"),
 			},
@@ -188,19 +170,15 @@ func TestSnapshotCache_RemovePod_ExistingPod(t *testing.T) {
 			wantGone:    "/proc/100/ns/net",
 		},
 		{
-			// Removing one of two pods leaves a listener that references the
-			// "out_http" route config via RDS. The listener-only snapshot fails
-			// the consistency check, but the map deletion still completes first.
-			name: "remove one of two pods: map is updated, snapshot consistency fails",
+			name: "remove one of two pods leaves the other intact",
 			initialPods: []*cniv1.CNIPod{
 				makeCNIPod("pod-a", "default", "/proc/100/ns/net"),
 				makeCNIPod("pod-b", "default", "/proc/200/ns/net"),
 			},
-			removeNetns:      "/proc/100/ns/net",
-			wantMapLen:       1,
-			wantGone:         "/proc/100/ns/net",
-			wantRemaining:    []string{"/proc/200/ns/net"},
-			wantErrSubstring: "snapshot inconsistency",
+			removeNetns:   "/proc/100/ns/net",
+			wantMapLen:    1,
+			wantGone:      "/proc/100/ns/net",
+			wantRemaining: []string{"/proc/200/ns/net"},
 		},
 	}
 
@@ -210,8 +188,8 @@ func TestSnapshotCache_RemovePod_ExistingPod(t *testing.T) {
 			seedListeners(c, tt.initialPods...)
 
 			err := c.RemovePod(context.Background(), tt.removeNetns)
+			require.NoError(t, err)
 
-			// Verify the map is updated regardless of the snapshot error.
 			assert.Len(t, c.listeners, tt.wantMapLen)
 			_, stillExists := c.listeners[tt.wantGone]
 			assert.False(t, stillExists, "removed netns %q should be absent from map", tt.wantGone)
@@ -219,13 +197,6 @@ func TestSnapshotCache_RemovePod_ExistingPod(t *testing.T) {
 			for _, key := range tt.wantRemaining {
 				_, ok := c.listeners[key]
 				assert.True(t, ok, "netns %q should still be present in map", key)
-			}
-
-			if tt.wantErrSubstring != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErrSubstring)
-			} else {
-				require.NoError(t, err)
 			}
 		})
 	}
@@ -313,9 +284,8 @@ func TestLoadListenersFromStorage_ValidPodsMapPopulation(t *testing.T) {
 				return tt.pods, nil
 			})
 
-			// Snapshot generation fails the consistency check (see function
-			// doc), so we ignore the error and only verify map state.
-			_ = c.LoadListenersFromStorage(context.Background(), store, "example.org")
+			err := c.LoadListenersFromStorage(context.Background(), store, "example.org")
+			require.NoError(t, err)
 
 			assert.Len(t, c.listeners, tt.wantEntries)
 			// Each entry contributes both an inbound and outbound resource.
@@ -325,11 +295,9 @@ func TestLoadListenersFromStorage_ValidPodsMapPopulation(t *testing.T) {
 }
 
 // TestLoadListenersFromStorage_ValidPodsSnapshotInconsistency verifies that
-// LoadListenersFromStorage returns a "snapshot inconsistency" error when valid
-// pods are loaded. This is expected because the outbound listener references the
-// "out_http" RouteConfiguration via RDS, which is not present in a listener-only
-// snapshot.
-func TestLoadListenersFromStorage_ValidPodsSnapshotInconsistency(t *testing.T) {
+// TestLoadListenersFromStorage_ValidPodsSucceeds verifies that loading valid pods
+// produces a successful snapshot.
+func TestLoadListenersFromStorage_ValidPodsSucceeds(t *testing.T) {
 	c := newTestCache("node-1")
 	initListeners(c)
 	store := storage.NewMockStorageWithGetAll[*cniv1.CNIPod](func(_ context.Context) ([]*cniv1.CNIPod, error) {
@@ -338,9 +306,7 @@ func TestLoadListenersFromStorage_ValidPodsSnapshotInconsistency(t *testing.T) {
 
 	err := c.LoadListenersFromStorage(context.Background(), store, "example.org")
 
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "snapshot inconsistency")
-	// Despite the snapshot error, the map was populated.
+	require.NoError(t, err)
 	assert.Len(t, c.listeners, 1)
 }
 
@@ -355,8 +321,7 @@ func TestLoadListenersFromStorage_ValidPods_NetnsKeyed(t *testing.T) {
 		return []*cniv1.CNIPod{pod}, nil
 	})
 
-	// Ignore snapshot inconsistency error; focus on map state.
-	_ = c.LoadListenersFromStorage(context.Background(), store, "example.org")
+	require.NoError(t, c.LoadListenersFromStorage(context.Background(), store, "example.org"))
 
 	entry, ok := c.listeners["/proc/42/ns/net"]
 	require.True(t, ok, "listener entry must be keyed by network namespace")

--- a/agent/internal/xds/server/server_integration_test.go
+++ b/agent/internal/xds/server/server_integration_test.go
@@ -302,7 +302,7 @@ func TestIntegration_GracefulShutdown(t *testing.T) {
 }
 
 // TestIntegration_PreListenFailsPreventsServerStart verifies that when
-// PreListen returns an error (e.g., from snapshot inconsistency), Start
+// PreListen returns an error (e.g., from a storage failure), Start
 // propagates the error and the server does not accept connections.
 func TestIntegration_PreListenFailsPreventsServerStart(t *testing.T) {
 	if testing.Short() {
@@ -320,17 +320,13 @@ func TestIntegration_PreListenFailsPreventsServerStart(t *testing.T) {
 	log := logr.Discard()
 	agentCache := cache.NewSnapshotCache(nodeName, log)
 
-	// Empty storage and empty registry leads to a snapshot inconsistency error
-	// in PreListen because the cluster snapshot includes a route config that is
-	// not referenced by any listener.
+	// Storage returns an error, which causes PreListen to fail before
+	// the server starts accepting connections.
+	storageErr := fmt.Errorf("storage unavailable")
 	store := storage.NewMockStorageWithGetAll(func(_ context.Context) ([]*cniv1.CNIPod, error) {
-		return []*cniv1.CNIPod{}, nil
+		return nil, storageErr
 	})
-	reg := &mockRegistry{
-		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
-			return map[string][]*registryv1.ServiceEndpoint{}, nil
-		},
-	}
+	reg := &mockRegistry{}
 
 	sockPath := integrationSocketPath(t)
 	cfg := xds.NewServerConfig(
@@ -353,6 +349,5 @@ func TestIntegration_PreListenFailsPreventsServerStart(t *testing.T) {
 	// Start should return an error because PreListen fails.
 	err := srv.Start(ctx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "snapshot inconsistency",
-		"expected PreListen snapshot inconsistency error to propagate through Start")
+	assert.ErrorIs(t, err, storageErr)
 }

--- a/agent/internal/xds/server/server_test.go
+++ b/agent/internal/xds/server/server_test.go
@@ -22,7 +22,8 @@ type mockRegistry struct {
 
 var _ registry.Registry = (*mockRegistry)(nil)
 
-func (m *mockRegistry) Start(_ context.Context) error { return nil }
+func (m *mockRegistry) Initialize(_ context.Context) error { return nil }
+func (m *mockRegistry) Close() error                        { return nil }
 
 func (m *mockRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, _ *registryv1.ServiceEndpoint) error {
 	return nil
@@ -153,18 +154,13 @@ func TestAgentXdsServer_PreListen(t *testing.T) {
 			wantErr: errRegistry,
 		},
 		{
-			// When both the storage and registry calls succeed, generateClusterSnapshot
-			// is called by LoadClustersFromRegistry. Because there are no listeners to
-			// reference the route configuration, the snapshot consistency check fails.
-			// PreListen surfaces this error.
-			name: "both succeed propagates snapshot inconsistency error",
+			name: "both succeed with empty data produces valid snapshot",
 			storageGetAll: func(_ context.Context) ([]*cniv1.CNIPod, error) {
 				return []*cniv1.CNIPod{}, nil
 			},
 			registryListAll: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 				return map[string][]*registryv1.ServiceEndpoint{}, nil
 			},
-			wantErrContains: "snapshot inconsistency",
 		},
 	}
 

--- a/agent/pkg/cmd/config.go
+++ b/agent/pkg/cmd/config.go
@@ -29,6 +29,8 @@ type AgentConfig struct {
 	// CloudMapNamespace is the AWS Cloud Map HTTP namespace for service discovery
 	CloudMapNamespace string
 
+	// SpireEnabled controls whether the SPIRE bridge is started
+	SpireEnabled bool
 	// SpireTrustDomain is the SPIFFE trust domain for the cluster
 	SpireTrustDomain string
 	// SpireAdminSocketPath is the path to the SPIRE agent admin socket
@@ -48,6 +50,7 @@ func NewAgentConfig() *AgentConfig {
 		RegistryBackend:        "kubernetes",
 		EtcdEndpoints:          []string{"localhost:2379"},
 		CloudMapNamespace:      constants.DefaultCloudMapNamespace,
+		SpireEnabled:           true,
 		SpireTrustDomain:       constants.DefaultSpireTrustDomain,
 		SpireAdminSocketPath:   constants.DefaultSpireAdminSocketPath,
 	}

--- a/agent/pkg/cmd/root.go
+++ b/agent/pkg/cmd/root.go
@@ -57,7 +57,8 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", "kubernetes", "Registry backend (kubernetes, dynamodb, etcd, cloudmap)")
 	rootCmd.Flags().StringSliceVar(&cfg.EtcdEndpoints, "etcd-endpoints", []string{"localhost:2379"}, "etcd endpoints")
 	rootCmd.Flags().StringVar(&cfg.CloudMapNamespace, "cloudmap-namespace", constants.DefaultCloudMapNamespace, "AWS Cloud Map HTTP namespace")
-	rootCmd.Flags().StringVar(&cfg.SpireTrustDomain, "spire-trust-domain", "ROOTCA", "SPIFFE trust domain for the cluster")
+	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", true, "Enable SPIRE integration for mTLS via SDS")
+	rootCmd.Flags().StringVar(&cfg.SpireTrustDomain, "spire-trust-domain", constants.DefaultSpireTrustDomain, "SPIFFE trust domain for the cluster")
 	rootCmd.Flags().StringVar(&cfg.SpireAdminSocketPath, "spire-admin-socket", constants.DefaultSpireAdminSocketPath, "Path to SPIRE agent admin socket")
 
 	_ = rootCmd.MarkPersistentFlagRequired("cluster-name")
@@ -89,13 +90,19 @@ func runAgent(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	defer reg.Close()
 
 	snapshotCache := cache.NewSnapshotCache(cfg.NodeName, l)
 
-	// Create and start the SPIRE bridge for SDS
-	spireBridge := spire.NewBridge(cfg.SpireAdminSocketPath, snapshotCache, l)
-	if err = m.Add(spireBridge); err != nil {
-		return fmt.Errorf("failed to add SPIRE bridge: %w", err)
+	// Optionally create and start the SPIRE bridge for SDS
+	var spireBridge *spire.Bridge
+	if cfg.SpireEnabled {
+		spireBridge = spire.NewBridge(cfg.SpireAdminSocketPath, snapshotCache, l)
+		if err = m.Add(spireBridge); err != nil {
+			return fmt.Errorf("failed to add SPIRE bridge: %w", err)
+		}
+	} else {
+		l.Info("SPIRE integration disabled")
 	}
 
 	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache); err != nil {
@@ -196,8 +203,8 @@ func setupRegistry(ctx context.Context, m ctrl.Manager) (registry.Registry, erro
 		return nil, fmt.Errorf("unknown registry backend: %s", cfg.RegistryBackend)
 	}
 
-	if err := m.Add(reg); err != nil {
-		return nil, err
+	if err := reg.Initialize(ctx); err != nil {
+		return nil, fmt.Errorf("failed to initialize registry: %w", err)
 	}
 
 	return reg, nil

--- a/registry/etcd.go
+++ b/registry/etcd.go
@@ -8,7 +8,12 @@ import (
 // EtcdConfig is the configuration for the etcd registry backend.
 type EtcdConfig = etcd.Config
 
+// EtcdRegistry is a Registry implementation backed by etcd.
+type EtcdRegistry = etcd.EtcdRegistry
+
 // NewEtcdRegistry creates a new Registry implementation backed by etcd.
-func NewEtcdRegistry(log logr.Logger, cfg EtcdConfig) Registry {
+// Call Initialize on the returned registry to establish the client connection
+// before adding it to the controller manager.
+func NewEtcdRegistry(log logr.Logger, cfg EtcdConfig) *EtcdRegistry {
 	return etcd.NewEtcdRegistry(log, cfg)
 }

--- a/registry/internal/cloudmap/cloudmap.go
+++ b/registry/internal/cloudmap/cloudmap.go
@@ -56,9 +56,9 @@ func NewCloudMapRegistry(log logr.Logger, awsCfg aws.Config, clusterName string,
 	return r
 }
 
-// Start initializes the Cloud Map registry by resolving the HTTP namespace.
-func (r *CloudMapRegistry) Start(ctx context.Context) error {
-	r.log.V(1).Info("starting registry and resolving namespace", "namespace", r.namespace)
+// Initialize resolves the Cloud Map HTTP namespace.
+func (r *CloudMapRegistry) Initialize(ctx context.Context) error {
+	r.log.V(1).Info("initializing registry and resolving namespace", "namespace", r.namespace)
 
 	nsID, err := r.resolveNamespaceID(ctx)
 	if err != nil {
@@ -66,7 +66,12 @@ func (r *CloudMapRegistry) Start(ctx context.Context) error {
 	}
 	r.namespaceID = nsID
 
-	r.log.Info("Cloud Map registry started", "namespace", r.namespace, "namespaceID", r.namespaceID)
+	r.log.Info("Cloud Map registry initialized", "namespace", r.namespace, "namespaceID", r.namespaceID)
+	return nil
+}
+
+// Close is a no-op for the Cloud Map registry as it uses stateless HTTP clients.
+func (r *CloudMapRegistry) Close() error {
 	return nil
 }
 

--- a/registry/internal/cloudmap/cloudmap_test.go
+++ b/registry/internal/cloudmap/cloudmap_test.go
@@ -41,14 +41,14 @@ func setupRegistry(t *testing.T, fake *fakeClient, clusterName string) *CloudMap
 		WithNamespaceTTL(0),
 	)
 
-	require.NoError(t, reg.Start(context.Background()))
+	require.NoError(t, reg.Initialize(context.Background()))
 	return reg
 }
 
-// --- Test: Start ---
+// --- Test: Initialize ---
 
-func TestCloudMapRegistry_Start(t *testing.T) {
-	t.Run("successful start with existing namespace", func(t *testing.T) {
+func TestCloudMapRegistry_Initialize(t *testing.T) {
+	t.Run("successful initialize with existing namespace", func(t *testing.T) {
 		fake := newTestFake()
 		reg := NewCloudMapRegistry(
 			logr.Discard(),
@@ -58,7 +58,7 @@ func TestCloudMapRegistry_Start(t *testing.T) {
 			WithNamespace(testNamespace),
 		)
 
-		err := reg.Start(context.Background())
+		err := reg.Initialize(context.Background())
 		assert.NoError(t, err)
 	})
 
@@ -72,7 +72,7 @@ func TestCloudMapRegistry_Start(t *testing.T) {
 			WithNamespace("nonexistent-namespace"),
 		)
 
-		err := reg.Start(context.Background())
+		err := reg.Initialize(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})

--- a/registry/internal/ddb/dynamodb.go
+++ b/registry/internal/ddb/dynamodb.go
@@ -54,8 +54,8 @@ func NewDynamoDBRegistry(log logr.Logger, awsCfg aws.Config, opts ...Option) *Dy
 	return r
 }
 
-// Start initializes the DynamoDB registry by verifying that the service table exists.
-func (r *DynamoDBRegistry) Start(ctx context.Context) error {
+// Initialize initializes the DynamoDB registry by verifying that the service table exists.
+func (r *DynamoDBRegistry) Initialize(ctx context.Context) error {
 	r.log.V(1).Info("starting registry and checking for table existence", "table", r.tableName)
 
 	_, err := r.client.DescribeTable(ctx, &dynamodb.DescribeTableInput{
@@ -72,6 +72,11 @@ func (r *DynamoDBRegistry) Start(ctx context.Context) error {
 
 	r.log.V(1).Info("registry table exists", "table", r.tableName)
 	r.log.Info("DynamoDB registry started", "table", r.tableName)
+	return nil
+}
+
+// Close is a no-op for DynamoDB since the HTTP client does not require explicit cleanup.
+func (r *DynamoDBRegistry) Close() error {
 	return nil
 }
 

--- a/registry/internal/ddb/dynamodb_test.go
+++ b/registry/internal/ddb/dynamodb_test.go
@@ -84,30 +84,30 @@ func setupRegistry(ctx context.Context, t *testing.T) *ddb.DynamoDBRegistry {
 	createTable(ctx, t, table)
 
 	registry := ddb.NewDynamoDBRegistry(logr.Discard(), testAWSCfg, ddb.WithTableName(table))
-	require.NoError(t, registry.Start(ctx))
+	require.NoError(t, registry.Initialize(ctx))
 
 	return registry
 }
 
-func TestDynamoDBRegistry_Start(t *testing.T) {
+func TestDynamoDBRegistry_Initialize(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
 
 	ctx := context.Background()
 
-	t.Run("successful start with existing table", func(t *testing.T) {
+	t.Run("successful initialization with existing table", func(t *testing.T) {
 		table := tableName(t)
 		createTable(ctx, t, table)
 
 		registry := ddb.NewDynamoDBRegistry(logr.Discard(), testAWSCfg, ddb.WithTableName(table))
-		err := registry.Start(ctx)
+		err := registry.Initialize(ctx)
 		assert.NoError(t, err)
 	})
 
 	t.Run("fails when table does not exist", func(t *testing.T) {
 		registry := ddb.NewDynamoDBRegistry(logr.Discard(), testAWSCfg, ddb.WithTableName("nonexistent"))
-		err := registry.Start(ctx)
+		err := registry.Initialize(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "does not exist")
 	})

--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -45,7 +45,7 @@ type EtcdRegistry struct {
 }
 
 // NewEtcdRegistry creates a new etcd-backed Registry.
-// The client connection is not established until Start is called.
+// Call Initialize before using the registry to establish the etcd client connection.
 func NewEtcdRegistry(log logr.Logger, cfg Config) *EtcdRegistry {
 	keyPrefix := cfg.KeyPrefix
 	if keyPrefix == "" {
@@ -65,10 +65,10 @@ func NewEtcdRegistry(log logr.Logger, cfg Config) *EtcdRegistry {
 	}
 }
 
-// Start initializes the etcd registry by establishing a connection to etcd
-// and verifying connectivity.
-func (r *EtcdRegistry) Start(ctx context.Context) error {
-	r.log.V(1).Info("starting registry and connecting to etcd", "endpoints", r.config.Endpoints)
+// Initialize creates the etcd client connection and verifies connectivity.
+// It must be called before any registry operations.
+func (r *EtcdRegistry) Initialize(ctx context.Context) error {
+	r.log.V(1).Info("initializing etcd client", "endpoints", r.config.Endpoints)
 
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints:   r.config.Endpoints,
@@ -86,12 +86,13 @@ func (r *EtcdRegistry) Start(ctx context.Context) error {
 
 	_, err = r.client.Status(statusCtx, r.config.Endpoints[0])
 	if err != nil {
+		_ = client.Close()
+		r.client = nil
 		r.log.Error(err, "failed to verify etcd connectivity")
 		return fmt.Errorf("failed to verify etcd connectivity: %w", err)
 	}
 
-	r.log.V(1).Info("etcd connectivity verified")
-	r.log.Info("etcd registry started", "endpoints", r.config.Endpoints)
+	r.log.Info("etcd registry initialized", "endpoints", r.config.Endpoints)
 	return nil
 }
 

--- a/registry/internal/etcd/etcd_test.go
+++ b/registry/internal/etcd/etcd_test.go
@@ -23,14 +23,14 @@ func TestMain(m *testing.M) {
 
 	container, err := tcetcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.21")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to start etcd container: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "failed to start etcd container: %v\n", err)
 		os.Exit(1)
 	}
 
 	testEndpoint, err = container.ClientEndpoint(ctx)
 	if err != nil {
 		_ = container.Terminate(ctx)
-		fmt.Fprintf(os.Stderr, "failed to get endpoint: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "failed to get endpoint: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -39,9 +39,9 @@ func TestMain(m *testing.M) {
 		Endpoints:   []string{testEndpoint},
 		DialTimeout: 30 * time.Second,
 	})
-	if err := ready.Start(ctx); err != nil {
+	if err := ready.Initialize(ctx); err != nil {
 		_ = container.Terminate(ctx)
-		fmt.Fprintf(os.Stderr, "etcd not ready: %v\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "etcd not ready: %v\n", err)
 		os.Exit(1)
 	}
 	_ = ready.Close()
@@ -57,7 +57,7 @@ func keyPrefix(t *testing.T) string {
 	return "/" + strings.ReplaceAll(t.Name(), "/", "_")
 }
 
-// setupRegistry returns a started EtcdRegistry with a per-test key prefix.
+// setupRegistry returns an initialized EtcdRegistry with a per-test key prefix.
 func setupRegistry(ctx context.Context, t *testing.T) *etcd.EtcdRegistry {
 	t.Helper()
 
@@ -66,13 +66,13 @@ func setupRegistry(ctx context.Context, t *testing.T) *etcd.EtcdRegistry {
 		DialTimeout: 5 * time.Second,
 		KeyPrefix:   keyPrefix(t),
 	})
-	require.NoError(t, registry.Start(ctx))
+	require.NoError(t, registry.Initialize(ctx))
 	t.Cleanup(func() { _ = registry.Close() })
 
 	return registry
 }
 
-func TestEtcdRegistry_Start(t *testing.T) {
+func TestEtcdRegistry_Initialize(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
@@ -86,7 +86,7 @@ func TestEtcdRegistry_Start(t *testing.T) {
 			KeyPrefix:   keyPrefix(t),
 		})
 
-		err := registry.Start(ctx)
+		err := registry.Initialize(ctx)
 		assert.NoError(t, err)
 		_ = registry.Close()
 	})
@@ -97,7 +97,7 @@ func TestEtcdRegistry_Start(t *testing.T) {
 			DialTimeout: 1 * time.Second,
 		})
 
-		err := registry.Start(ctx)
+		err := registry.Initialize(ctx)
 		assert.Error(t, err)
 	})
 }
@@ -363,7 +363,7 @@ func TestEtcdRegistry_CustomKeyPrefix(t *testing.T) {
 		DialTimeout: 5 * time.Second,
 		KeyPrefix:   "/custom/prefix",
 	})
-	require.NoError(t, registry.Start(ctx))
+	require.NoError(t, registry.Initialize(ctx))
 	t.Cleanup(func() { _ = registry.Close() })
 
 	ep := &registryv1.ServiceEndpoint{
@@ -394,7 +394,7 @@ func TestEtcdRegistry_Close(t *testing.T) {
 		DialTimeout: 5 * time.Second,
 		KeyPrefix:   keyPrefix(t),
 	})
-	require.NoError(t, registry.Start(ctx))
+	require.NoError(t, registry.Initialize(ctx))
 
 	err := registry.Close()
 	assert.NoError(t, err)

--- a/registry/internal/k8s/kubernetes.go
+++ b/registry/internal/k8s/kubernetes.go
@@ -43,10 +43,15 @@ func NewKubernetesRegistry(log logr.Logger, reader client.Reader, cfg Config) *K
 	}
 }
 
-// Start is a no-op for the Kubernetes registry.
+// Initialize is a no-op for the Kubernetes registry.
 // The API server connection is managed by the controller-runtime manager.
-func (r *KubernetesRegistry) Start(_ context.Context) error {
-	r.log.Info("kubernetes registry started", "cluster", r.clusterName)
+func (r *KubernetesRegistry) Initialize(_ context.Context) error {
+	r.log.Info("kubernetes registry initialized", "cluster", r.clusterName)
+	return nil
+}
+
+// Close is a no-op for the Kubernetes registry.
+func (r *KubernetesRegistry) Close() error {
 	return nil
 }
 

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -67,11 +67,11 @@ func topologyNode(name, region, zone string) *corev1.Node {
 	}
 }
 
-// ─── Start ───────────────────────────────────────────────────────────────────
+// ─── Initialize ──────────────────────────────────────────────────────────────
 
-func TestStart(t *testing.T) {
+func TestInitialize(t *testing.T) {
 	r := newTestRegistry("test-cluster")
-	err := r.Start(context.Background())
+	err := r.Initialize(context.Background())
 	require.NoError(t, err)
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -12,8 +12,10 @@ import (
 // Registry manages service endpoint registration, deregistration, and discovery.
 // It maintains a list of service endpoints and supports querying by service name and protocol.
 type Registry interface {
-	// Start initializes the registry. This should be called before using other methods.
-	Start(ctx context.Context) error
+	// Initialize initializes the registry. This should be called before using other methods.
+	Initialize(ctx context.Context) error
+	// Close releases any resources held by the registry.
+	Close() error
 	// RegisterEndpoint registers a single endpoint for a service with a specific protocol.
 	RegisterEndpoint(ctx context.Context, serviceName string, protocol registryv1.Service_Protocol, endpoint *registryv1.ServiceEndpoint) error
 	// UnregisterEndpoint unregisters an endpoint for a service by its IP address.


### PR DESCRIPTION
## Summary
- Rename `Registry.Start` to `Initialize` and add `Close` to the interface for explicit lifecycle management outside the controller manager
- Fix etcd client leak when connectivity check fails during initialization
- Add `--spire-enabled` flag (default `true`) to allow running without SPIRE; nil-guard spireBridge calls in CNI server pod handlers
- Remove `Consistent()` checks from partial listener/cluster snapshots that were incorrectly failing due to cross-resource references
- Skip empty `RouteConfiguration` when no virtual hosts exist
- Update all registry backends (DynamoDB, etcd, CloudMap, Kubernetes) to implement the new `Initialize`/`Close` interface

## Test plan
- [x] All unit tests pass (`bazel test //agent/... //registry/...`)
- [x] CI passes (unit tests, integration tests)
- [ ] Verify agent starts correctly with `--spire-enabled=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)