### PR TITLE
Add --config=llm to .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,4 +10,12 @@ run --workspace_status_command=./bazel/workspace_status.sh
 test --test_env=HOME
 test --test_env=DOCKER_HOST
 test --test_env=TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE
+
+# LLM-friendly output (usage: --config=llm)
+common:llm --color=no
+common:llm --curses=no
+build:llm --verbose_failures
+build:llm --show_result=10
+test:llm --test_output=errors
+test:llm --test_summary=detailed
     


### PR DESCRIPTION
## Summary
- Adds a `--config=llm` Bazel config profile that produces clean, text-only output optimized for LLM consumption
- Strips ANSI colors and curses progress bar, enables verbose failures, and tunes test output for plain-text parsing

## Flags

| Flag | Purpose |
|---|---|
| `--color=no` | Strip ANSI escape codes |
| `--curses=no` | Disable progress bar / cursor rewriting |
| `--verbose_failures` | Print full command line on failure |
| `--show_result=10` | List up to 10 built targets with output paths |
| `--test_output=errors` | Only print stdout/stderr for failing tests |
| `--test_summary=detailed` | Show per-test-case pass/fail |

## Test plan
- [x] `bazel build --config=llm //agent/cmd/agent/...` — clean output, no ANSI codes
- [x] `bazel test --config=llm //agent/internal/xds/config:config_test` — clean output, detailed test summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)