### PR TITLE
fix: Handle ignored errors across the codebase

### DIFF
--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -72,7 +72,9 @@ func (b *Bridge) Start(ctx context.Context) error {
 	}
 	b.client = client
 	defer func() {
-		_ = client.Close()
+		if closeErr := client.Close(); closeErr != nil {
+			b.log.V(1).Info("failed to close SPIRE client", "error", closeErr)
+		}
 	}()
 
 	b.log.Info("connected to SPIRE agent", "socket", b.socketPath)

--- a/agent/pkg/cmd/BUILD.bazel
+++ b/agent/pkg/cmd/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//agent/pkg/constants",
         "//agent/pkg/storage",
         "//api/aether/cni/v1:cni",
+        "//common/must",
         "//log",
         "//registry",
         "@com_github_go_logr_logr//:logr",

--- a/agent/pkg/cmd/root.go
+++ b/agent/pkg/cmd/root.go
@@ -95,12 +95,10 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.SpireTrustDomain, "spire-trust-domain", constants.DefaultSpireTrustDomain, "SPIFFE trust domain for the cluster, used for service identity")
 	rootCmd.Flags().StringVar(&cfg.SpireAdminSocketPath, "spire-admin-socket", constants.DefaultSpireAdminSocketPath, "Path to SPIRE agent admin socket for X.509 certificate delegation")
 
-	// Mark required flags
-	_ = rootCmd.MarkPersistentFlagRequired("cluster-name")
-	_ = rootCmd.MarkPersistentFlagRequired("node-name")
-	_ = rootCmd.MarkPersistentFlagRequired("proxy-id")
-	_ = rootCmd.MarkPersistentFlagRequired("proxy-region")
-	_ = rootCmd.MarkPersistentFlagRequired("proxy-zone")
+	// These calls only fail if the flag name is not registered, which would be a programming error.
+	must(rootCmd.MarkFlagRequired("cluster-name"))
+	must(rootCmd.MarkFlagRequired("node-name"))
+	must(rootCmd.MarkFlagRequired("proxy-id"))
 }
 
 // runAgent initializes and runs the Aether agent. It sets up the controller-runtime Manager,
@@ -262,4 +260,11 @@ func setupRegistry(ctx context.Context, m ctrl.Manager) (registry.Registry, erro
 	}
 
 	return reg, nil
+}
+
+// must panics if err is non-nil. Use only for programming errors that should never occur at runtime.
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
 }

--- a/agent/pkg/cmd/root.go
+++ b/agent/pkg/cmd/root.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	"github.com/bpalermo/aether/agent/internal/awsconfig"
+	"github.com/bpalermo/aether/common/must"
 	cniServer "github.com/bpalermo/aether/agent/internal/cni/server"
 	"github.com/bpalermo/aether/agent/internal/spire"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
@@ -96,9 +97,9 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.SpireAdminSocketPath, "spire-admin-socket", constants.DefaultSpireAdminSocketPath, "Path to SPIRE agent admin socket for X.509 certificate delegation")
 
 	// These calls only fail if the flag name is not registered, which would be a programming error.
-	must(rootCmd.MarkFlagRequired("cluster-name"))
-	must(rootCmd.MarkFlagRequired("node-name"))
-	must(rootCmd.MarkFlagRequired("proxy-id"))
+	must.NoError(rootCmd.MarkFlagRequired("cluster-name"))
+	must.NoError(rootCmd.MarkFlagRequired("node-name"))
+	must.NoError(rootCmd.MarkFlagRequired("proxy-id"))
 }
 
 // runAgent initializes and runs the Aether agent. It sets up the controller-runtime Manager,
@@ -263,8 +264,3 @@ func setupRegistry(ctx context.Context, m ctrl.Manager) (registry.Registry, erro
 }
 
 // must panics if err is non-nil. Use only for programming errors that should never occur at runtime.
-func must(err error) {
-	if err != nil {
-		panic(err)
-	}
-}

--- a/cni/internal/cri/cri.go
+++ b/cni/internal/cri/cri.go
@@ -28,7 +28,10 @@ func GetContainerPID(ctx context.Context, criSocket, containerID string) (uint32
 		return 0, fmt.Errorf("failed to create CRI client: %w", err)
 	}
 	defer func(conn *grpc.ClientConn) {
-		_ = conn.Close()
+		// Best-effort close; nothing actionable if it fails on a read-only connection.
+		if closeErr := conn.Close(); closeErr != nil {
+			_ = closeErr // intentionally ignored: transient gRPC connection close error
+		}
 	}(conn)
 
 	client := runtimeapi.NewRuntimeServiceClient(conn)

--- a/cni/internal/util/watcher.go
+++ b/cni/internal/util/watcher.go
@@ -30,7 +30,9 @@ func (w *Watcher) Wait(ctx context.Context) error {
 }
 
 func (w *Watcher) Close() {
-	_ = w.watcher.Close()
+	if err := w.watcher.Close(); err != nil {
+		utilLog.V(1).Info("failed to close file watcher", "error", err)
+	}
 }
 
 // CreateFileWatcher creates a file watcher that watches for any changes to the directory

--- a/common/file/file.go
+++ b/common/file/file.go
@@ -30,22 +30,30 @@ func WriteFileAtomic(filePath string, data []byte) error {
 	}
 	tempPath := tempFile.Name()
 
+	log := ctrl.Log.WithName("file")
+
 	// Clean up temp file on error
 	defer func() {
 		if err != nil {
-			_ = os.Remove(tempPath)
+			if rmErr := os.Remove(tempPath); rmErr != nil {
+				log.V(1).Info("failed to remove temp file during cleanup", "path", tempPath, "error", rmErr)
+			}
 		}
 	}()
 
 	// Write data to the temp file
 	if _, err = tempFile.Write(data); err != nil {
-		_ = tempFile.Close()
+		if closeErr := tempFile.Close(); closeErr != nil {
+			log.V(1).Info("failed to close temp file during cleanup", "path", tempPath, "error", closeErr)
+		}
 		return fmt.Errorf("failed to write to temp file: %w", err)
 	}
 
 	// Ensure data is flushed to the disk
 	if err = tempFile.Sync(); err != nil {
-		_ = tempFile.Close()
+		if closeErr := tempFile.Close(); closeErr != nil {
+			log.V(1).Info("failed to close temp file during cleanup", "path", tempPath, "error", closeErr)
+		}
 		return fmt.Errorf("failed to sync temp file: %w", err)
 	}
 

--- a/common/must/BUILD.bazel
+++ b/common/must/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "must",
+    srcs = ["must.go"],
+    importpath = "github.com/bpalermo/aether/common/must",
+    visibility = ["//visibility:public"],
+)

--- a/common/must/must.go
+++ b/common/must/must.go
@@ -1,0 +1,12 @@
+// Package must provides panic-on-error helpers for programming errors
+// that should never occur at runtime, such as invalid flag registrations
+// or failed type assertions on known types.
+package must
+
+// NoError panics if err is not nil. Use this only for programming errors
+// that indicate a bug rather than a runtime failure.
+func NoError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -86,7 +86,9 @@ func (r *EtcdRegistry) Initialize(ctx context.Context) error {
 
 	_, err = r.client.Status(statusCtx, r.config.Endpoints[0])
 	if err != nil {
-		_ = client.Close()
+		if closeErr := client.Close(); closeErr != nil {
+			r.log.V(1).Info("failed to close etcd client during cleanup", "error", closeErr)
+		}
 		r.client = nil
 		r.log.Error(err, "failed to verify etcd connectivity")
 		return fmt.Errorf("failed to verify etcd connectivity: %w", err)

--- a/xds/server.go
+++ b/xds/server.go
@@ -85,7 +85,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 	if s.cfg.Network == "unix" {
 		if err := os.Chmod(s.cfg.Address, os.ModePerm); err != nil {
-			_ = listener.Close()
+			if closeErr := listener.Close(); closeErr != nil {
+				s.Log.V(1).Error(closeErr, "failed to close listener during cleanup")
+			}
 			return fmt.Errorf("failed to set socket file permissions: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- Fix 13 instances of ignored errors (`_ = err`) across 7 files
- Cleanup/defer paths now log errors at appropriate levels
- Removed 2 dead `MarkPersistentFlagRequired` calls for never-registered flags (`proxy-region`, `proxy-zone`)
- Fixed `MarkPersistentFlagRequired` → `MarkFlagRequired` for local flags
- Added `must()` helper for flag registration errors (programming errors that should panic)

## Files Changed
- `xds/server.go` — Log listener close error on chmod failure
- `common/file/file.go` — Log temp file cleanup errors at debug level
- `registry/internal/etcd/etcd.go` — Log client close error
- `agent/internal/spire/bridge.go` — Log client close error
- `cni/internal/cri/cri.go` — Document intentional ignore with comment
- `cni/internal/util/watcher.go` — Log watcher close error
- `agent/pkg/cmd/root.go` — Fix flag required calls, remove dead code

## Test plan
- [x] `bazel test --config=llm //...` passes (17/17 non-integration tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)