### PR TITLE
feat: Bazel-built Helm charts published to GHCR

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   IMAGE_REGISTRY: index.docker.io/palermo
@@ -25,15 +26,28 @@ jobs:
           bazelisk-cache: true
           disk-cache: ${{ github.workflow }}
           repository-cache: true
-      - name: Log in to the Container registry
+      - name: Log in to Docker Hub (images)
         uses: docker/login-action@v4
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Log in to GHCR (charts)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         run: |
           bazel build --stamp //...
-      - name: Push
+      - name: Push images
         run: |
           bazel run --stamp //agent/cmd/agent:image_push
           bazel run --stamp //registrar/cmd/registrar:image_push
+      - name: Push charts
+        env:
+          HELM_REGISTRY_USERNAME: ${{ github.actor }}
+          HELM_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bazel run --stamp //charts/agent:agent.push_registry
+          bazel run --stamp //charts/registrar:registrar.push_registry

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,7 @@ bazel_dep(name = "protovalidate", version = "1.2.0")
 bazel_dep(name = "aspect_rules_lint", version = "2.5.2")
 bazel_dep(name = "rules_buf", version = "0.5.4")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
+bazel_dep(name = "rules_helm", version = "0.29.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.26.2")
@@ -120,6 +121,14 @@ use_repo(
 buf = use_extension("@rules_buf//buf:extensions.bzl", "buf")
 buf.toolchains(version = "v1.67.0")
 use_repo(buf, "rules_buf_toolchains")
+
+# Hermetic Helm toolchain (downloads helm) plus a @helm//:helm host alias for
+# `bazel run @helm//:helm -- ...`.
+helm = use_extension("@rules_helm//helm:extensions.bzl", "helm")
+helm.host_tools()
+use_repo(helm, "helm", "helm_toolchains")
+
+register_toolchains("@helm_toolchains//:all")
 
 pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -275,6 +275,8 @@
     "https://bcr.bazel.build/modules/rules_go/0.59.0/MODULE.bazel": "b7e43e7414a3139a7547d1b4909b29085fbe5182b6c58cbe1ed4c6272815aeae",
     "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
     "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
+    "https://bcr.bazel.build/modules/rules_helm/0.29.0/MODULE.bazel": "af43671722ffbc886a584b3d215547e461cb47e50f7f9e6146fcc01360cccee6",
+    "https://bcr.bazel.build/modules/rules_helm/0.29.0/source.json": "293aa36ab357df834504ece744b86679cc9fe4f167b95b0df7f300b560aba1ac",
     "https://bcr.bazel.build/modules/rules_img/0.3.11/MODULE.bazel": "85b9d7e2c5d83a321766dbc382c613c2399db680174bdfa32966f477989ee361",
     "https://bcr.bazel.build/modules/rules_img/0.3.11/source.json": "fbde1bc544519df0fe254fa5c1be3b6189d44f548af3ee131935215ea6e8d078",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
@@ -1481,7 +1483,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "4G0VNUtiR3SdDMbxzZU37YskEBfp+LhljUnbHropXAY=",
+        "bzlTransitiveDigest": "k0OHvQkCnvhuR3JuYVFVOVxNYBTaWuTjOZNeS8ohgpg=",
         "usagesDigest": "dQ7SQZ7uSSL3vVKSMBKRxKJUm9OVrZZA+S1/QQfT570=",
         "recordedInputs": [
           "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
@@ -2029,6 +2031,168 @@
         "windows_arm64": [
           "go1.25.0.windows-arm64.zip",
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
+        ]
+      },
+      "1.25.4": {
+        "aix_ppc64": [
+          "go1.25.4.aix-ppc64.tar.gz",
+          "013b5da7d3bb174ded9fd6f57e098170d778d900b26b7b4a6acaefafc3df55d8"
+        ],
+        "darwin_amd64": [
+          "go1.25.4.darwin-amd64.tar.gz",
+          "33ba03ff9973f5bd26d516eea35328832a9525ecc4d169b15937ffe2ce66a7d8"
+        ],
+        "darwin_arm64": [
+          "go1.25.4.darwin-arm64.tar.gz",
+          "c1b04e74251fe1dfbc5382e73d0c6d96f49642d8aebb7ee10a7ecd4cae36ebd2"
+        ],
+        "dragonfly_amd64": [
+          "go1.25.4.dragonfly-amd64.tar.gz",
+          "046556da7cfa021a09d1c9e3f948a21da225863f58a19aac5b32bd18a6fa2f77"
+        ],
+        "freebsd_386": [
+          "go1.25.4.freebsd-386.tar.gz",
+          "2e2073fd74c2421bda91bd3900a6ffc1db4c97380ac8deb193731204f5b97b23"
+        ],
+        "freebsd_amd64": [
+          "go1.25.4.freebsd-amd64.tar.gz",
+          "6256dad7368f8b4d7ddbeb80ed98b3368a553df7b17dad18894f0637840f6d50"
+        ],
+        "freebsd_arm": [
+          "go1.25.4.freebsd-arm.tar.gz",
+          "48c0aa810585b50e8d1e475b9466fb403eec3b5bdf06a8be6d634b7dde686bfa"
+        ],
+        "freebsd_arm64": [
+          "go1.25.4.freebsd-arm64.tar.gz",
+          "d74cfa54a4a97737d238f35866d257638607417dfc60b647429e898ea7c9a7a4"
+        ],
+        "freebsd_riscv64": [
+          "go1.25.4.freebsd-riscv64.tar.gz",
+          "c1bb0d2ae78415e6e78d71b0aede0e3bee3f220a220e6d0390c3219ba5604ca1"
+        ],
+        "illumos_amd64": [
+          "go1.25.4.illumos-amd64.tar.gz",
+          "3dcb72f967e924543c49bf20ac6d4057ff8c5b8f4120d7e021ba37a7e62aef77"
+        ],
+        "linux_386": [
+          "go1.25.4.linux-386.tar.gz",
+          "0cf5f721ab7c5e7a170dedb2b51d9b1fedfe6ef1b2c626bf7a47fb9a613c5d96"
+        ],
+        "linux_amd64": [
+          "go1.25.4.linux-amd64.tar.gz",
+          "9fa5ffeda4170de60f67f3aa0f824e426421ba724c21e133c1e35d6159ca1bec"
+        ],
+        "linux_arm64": [
+          "go1.25.4.linux-arm64.tar.gz",
+          "a68e86d4b72c2c2fecf7dfed667680b6c2a071221bbdb6913cf83ce3f80d9ff0"
+        ],
+        "linux_armv6l": [
+          "go1.25.4.linux-armv6l.tar.gz",
+          "ff86a6406310d840edb170f539a51a7efac0ac2b2f84527b1b2bf5935fc4ab6d"
+        ],
+        "linux_loong64": [
+          "go1.25.4.linux-loong64.tar.gz",
+          "54b967c86b756609b3ee18ec8136ce9ee901270892b0fce01d0c78bec6a0c9b5"
+        ],
+        "linux_mips": [
+          "go1.25.4.linux-mips.tar.gz",
+          "a59d20ae357e70a08e10359779b2927608f885f1b2593a76da0e3a9b60f8ae47"
+        ],
+        "linux_mips64": [
+          "go1.25.4.linux-mips64.tar.gz",
+          "8deca53dc406a556949c82c6aed4293330f9f36773732654a1439cbd744f3beb"
+        ],
+        "linux_mips64le": [
+          "go1.25.4.linux-mips64le.tar.gz",
+          "7e6e914678e537de5e12158231e0dbf4e9fa8a427b4ba295128f76a88b4cfed9"
+        ],
+        "linux_mipsle": [
+          "go1.25.4.linux-mipsle.tar.gz",
+          "e1858f934609ef1c8ee54d2788b46e867204b75c6fddd77274bf8424af2cb45a"
+        ],
+        "linux_ppc64": [
+          "go1.25.4.linux-ppc64.tar.gz",
+          "3c5c07ffa4bb0ee415178346f55a0fd33559880801ced56fb1da5ef0eca86ab8"
+        ],
+        "linux_ppc64le": [
+          "go1.25.4.linux-ppc64le.tar.gz",
+          "38c8ac8463537c99fbc1ef368f243b626144446c09db71b1d20634a4237c966d"
+        ],
+        "linux_riscv64": [
+          "go1.25.4.linux-riscv64.tar.gz",
+          "0a00a0eba831b5fe511e852909b99b83992ea09e81fdfbd9f805e5a4b646f803"
+        ],
+        "linux_s390x": [
+          "go1.25.4.linux-s390x.tar.gz",
+          "2482e7b3b924348b120b6d7d7c13035905c009c2a3ecc0c8dc56bf0fd3184a58"
+        ],
+        "netbsd_386": [
+          "go1.25.4.netbsd-386.tar.gz",
+          "7e2327a093b4a648180db8094316df90d21b1b42123fda66b01fa274d1d047db"
+        ],
+        "netbsd_amd64": [
+          "go1.25.4.netbsd-amd64.tar.gz",
+          "22d7f0a46aed0d1cd00f7e1789e5bb0b831b5bf20c094fc2e2cb635e93ba427f"
+        ],
+        "netbsd_arm": [
+          "go1.25.4.netbsd-arm.tar.gz",
+          "6aea4c3ebbc4d662c8b08edc716c0fc31c93174979dd70f26b5eb8e42c687462"
+        ],
+        "netbsd_arm64": [
+          "go1.25.4.netbsd-arm64.tar.gz",
+          "25a07e88368be0b392e2c0e38a1b332f9322482d1cac802d7470888c0cb1bae2"
+        ],
+        "openbsd_386": [
+          "go1.25.4.openbsd-386.tar.gz",
+          "fed31e86ba4fda76391427d48a33fcf5f020bf24d6537b0fc3a06640146f6a18"
+        ],
+        "openbsd_amd64": [
+          "go1.25.4.openbsd-amd64.tar.gz",
+          "7a63182f1e5fbeaca5de73f71f3f8e7fbe6bf3c20260ab24543a543cd1b026f3"
+        ],
+        "openbsd_arm": [
+          "go1.25.4.openbsd-arm.tar.gz",
+          "a4845622453997f761bcabad337afe0febc421b8c04b58414bf8b352d2acbdae"
+        ],
+        "openbsd_arm64": [
+          "go1.25.4.openbsd-arm64.tar.gz",
+          "4665a3c19c3f8120ed4fbaebad690969683b6a8e646017f341786016faabc0b9"
+        ],
+        "openbsd_ppc64": [
+          "go1.25.4.openbsd-ppc64.tar.gz",
+          "e8c022a4cbf8ad29b06498cca9ee278878f9beb2353f7fc1a2622cb07ef76dd5"
+        ],
+        "openbsd_riscv64": [
+          "go1.25.4.openbsd-riscv64.tar.gz",
+          "544831b3306861f824a608ffa539c39a066cd93d9628b8a53dc9f06966395684"
+        ],
+        "plan9_386": [
+          "go1.25.4.plan9-386.tar.gz",
+          "617e2ca6061178363abecef20e859337c91a8409201e6845e4f4ec3c1a094079"
+        ],
+        "plan9_amd64": [
+          "go1.25.4.plan9-amd64.tar.gz",
+          "8721a367802a170e62d991643f46645909a3b7a9567ae94b51d406a8b10cac6a"
+        ],
+        "plan9_arm": [
+          "go1.25.4.plan9-arm.tar.gz",
+          "a290aefedc0868717ecfeda1cfa6e4e2a075a2dee039efc0ec6b8d1f63f26b82"
+        ],
+        "solaris_amd64": [
+          "go1.25.4.solaris-amd64.tar.gz",
+          "a5640bdf4cd807b90d9b2695f60fd36db6978ea965f892c905ee1f579bf68ce1"
+        ],
+        "windows_386": [
+          "go1.25.4.windows-386.zip",
+          "f21fe4990449799a571971fd5efdc38b911667c628c949cbdfb77326cf877606"
+        ],
+        "windows_amd64": [
+          "go1.25.4.windows-amd64.zip",
+          "6dad204d42719795f22067553b2b042c0e710b32c5a00f6c67892865167fdfd0"
+        ],
+        "windows_arm64": [
+          "go1.25.4.windows-arm64.zip",
+          "138aa10a6808b4cff8657478be14772a05335bc8d7e51955e7a6d9ac335af3e4"
         ]
       },
       "1.26.2": {

--- a/bazel/img/go_multi_arch_image.bzl
+++ b/bazel/img/go_multi_arch_image.bzl
@@ -98,6 +98,9 @@ def go_multi_arch_image(name, binary, repository, registry = "docker.io", base =
     image_push(
         name = "image_push",
         image = ":image_index",
+        # Public so the Helm charts under //charts can reference the push targets
+        # for image substitution and chart-with-images publishing.
+        visibility = ["//visibility:public"],
         registry = registry,
         repository = repository,
         tag_list = [

--- a/charts/README.md
+++ b/charts/README.md
@@ -1,0 +1,97 @@
+# Helm charts
+
+Bazel-built Helm charts for Aether, using
+[`rules_helm`](https://registry.bazel.build/modules/rules_helm).
+
+| Chart | Path | Deploys |
+| --- | --- | --- |
+| `aether-agent` | [`charts/agent`](./agent) | Agent DaemonSet (xDS + CNI install) and, optionally, the per-node Envoy proxy DaemonSet. Owns the `aether-system` namespace and RBAC. |
+| `aether-registrar` | [`charts/registrar`](./registrar) | Registrar Deployment, Service and RBAC. |
+
+The container image references in each `values.yaml` are written as
+`{@//path/to:image_push}` placeholders. At package time `rules_helm` substitutes
+them with the digest-pinned reference produced by the corresponding in-repo
+image, so packaged charts are always pinned to a concrete image digest.
+
+## Versioning & stamping
+
+| Field | Value | Notes |
+| --- | --- | --- |
+| Chart `version` | `0.1.0+{GIT_COMMIT}` | SemVer; commit becomes build metadata. |
+| Chart `appVersion` | `{STABLE_GIT_VERSION}` | `git describe` value — matches the binaries' embedded `Version`. |
+| Image refs | `repo@sha256:…` | Pinned to the exact built digest (strongest form). |
+
+The `{...}` placeholders in `Chart.yaml` are filled from the workspace status
+(`bazel/workspace_status.sh`) **only on `--stamp` builds**:
+
+```bash
+bazel build --stamp //charts/agent //charts/registrar   # embed git version
+bazel run   --stamp //charts/agent:agent.push           # publish a stamped chart
+```
+
+Without `--stamp` the braces are stripped (e.g. `0.1.0+GIT_COMMIT`) so the chart
+still lints/templates — but release builds should pass `--stamp`. Image digests
+are stamped independently of this flag (they always reflect the built image), and
+the published image tags themselves already embed the git commit.
+
+## Build & test
+
+```bash
+# Package a chart (.tgz under bazel-bin/charts/<name>/)
+bazel build //charts/agent //charts/registrar
+
+# Lint + `helm template` smoke tests
+bazel test //charts/...
+```
+
+## Install
+
+```bash
+bazel run //charts/agent:agent.install
+bazel run //charts/registrar:registrar.install
+# Counterparts: .upgrade, .uninstall
+```
+
+## Multiple instances & labels
+
+Resource names are release-prefixed (`<release>-aether-agent`, …) and
+cluster-scoped resources (ClusterRole/ClusterRoleBinding) additionally include
+the namespace, so several releases coexist without collisions. Customize naming
+with `nameOverride` / `fullnameOverride`, and target a namespace with
+`helm install <release> -n <ns> [--create-namespace]` (or `namespace.create=true`).
+
+> The **agent** is effectively singleton-per-node by design: it owns host paths
+> (`/run/aether`, `/opt/cni/bin`, `/etc/cni/net.d`, …) and the CNI plugin, so only
+> one agent release should target a given set of nodes. The **registrar** is an
+> ordinary Deployment and runs fine as multiple instances.
+
+All objects carry the [recommended `app.kubernetes.io/*` labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
+(`name`, `instance`, `version`, `component`, `part-of: aether`, `managed-by`) plus
+`helm.sh/chart`. Workload selectors use the immutable subset (`name` + `instance`
++ `component`).
+
+## Publish to GitHub Container Registry (OCI)
+
+Charts publish as OCI artifacts to `oci://ghcr.io/bpalermo`. (Container images
+themselves still publish to Docker Hub under `docker.io/palermo` — only the Helm
+charts live on GHCR.)
+
+```bash
+export HELM_REGISTRY_USERNAME=<github-user>
+export HELM_REGISTRY_PASSWORD=<github-pat>   # PAT with write:packages, or HELM_REGISTRY_PASSWORD_FILE
+
+# Push the chart together with the images it references:
+bazel run //charts/agent:agent.push
+bazel run //charts/registrar:registrar.push
+
+# Push only the chart (skip images):
+bazel run //charts/agent:agent.push_registry
+bazel run //charts/registrar:registrar.push_registry
+```
+
+The push target performs `helm registry login` automatically when the
+`HELM_REGISTRY_USERNAME` / `HELM_REGISTRY_PASSWORD` environment variables are set.
+In CI, authenticate to GHCR with the built-in `GITHUB_TOKEN` (`username: ${{ github.actor }}`,
+`password: ${{ secrets.GITHUB_TOKEN }}`) and grant the job `packages: write`.
+Adjust the `registry_url` / `login_url` in each chart's `BUILD.bazel` to target a
+different namespace or registry.

--- a/charts/agent/BUILD.bazel
+++ b/charts/agent/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@rules_helm//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
+
+# aether-agent Helm chart.
+#
+# `images` wires the in-repo image_push targets into the chart so that:
+#   * the `{@//...:image_push}` placeholders in values.yaml are substituted with
+#     digest-pinned references at package time, and
+#   * `:agent.push` publishes those images alongside the chart.
+#
+# Publish targets (GitHub Container Registry, OCI):
+#   bazel run //charts/agent:agent.push           # chart + images
+#   bazel run //charts/agent:agent.push_registry  # chart only
+# Authenticate first via HELM_REGISTRY_USERNAME / HELM_REGISTRY_PASSWORD.
+helm_chart(
+    name = "agent",
+    chart = "Chart.yaml",
+    images = [
+        "//agent/cmd/agent:image_push",
+        "//cni/cmd/cni-install:image_push",
+    ],
+    login_url = "ghcr.io",
+    registry_url = "oci://ghcr.io/bpalermo",
+    values = "values.yaml",
+    visibility = ["//visibility:public"],
+)
+
+helm_lint_test(
+    name = "agent_lint_test",
+    chart = ":agent",
+)
+
+helm_template_test(
+    name = "agent_template_test",
+    chart = ":agent",
+)

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: aether-agent
+description: |
+  Aether service mesh node agent. Deploys the agent DaemonSet (which manages
+  the Envoy xDS control plane and installs the CNI plugin) and, optionally, the
+  per-node Envoy proxy DaemonSet.
+type: application
+# Stamped at package time when built with `--stamp`:
+#   version    -> 0.1.0+<git-commit> (SemVer build metadata)
+#   appVersion -> the `git describe` version, matching the binary's embedded Version
+# Without `--stamp` the braces are stripped, yielding literal placeholder text.
+version: "0.1.0+{GIT_COMMIT}"
+appVersion: "{STABLE_GIT_VERSION}"
+keywords:
+  - aether
+  - service-mesh
+  - envoy
+  - cni
+sources:
+  - https://github.com/bpalermo/aether

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -1,0 +1,121 @@
+{{/*
+Chart name, optionally overridden via nameOverride.
+*/}}
+{{- define "aether-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified, release-prefixed name. Used for namespaced resource names so
+multiple releases can coexist. Honours fullnameOverride / nameOverride.
+*/}}
+{{- define "aether-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Proxy fullname.
+*/}}
+{{- define "aether-agent.proxy.fullname" -}}
+{{- printf "%s-proxy" (include "aether-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Namespace the chart deploys into. Defaults to the release namespace.
+*/}}
+{{- define "aether-agent.namespace" -}}
+{{- default .Release.Namespace .Values.namespace.name -}}
+{{- end -}}
+
+{{/*
+Name for cluster-scoped resources (ClusterRole/ClusterRoleBinding). Includes the
+namespace so two releases of the same name in different namespaces don't collide.
+*/}}
+{{- define "aether-agent.clusterScopedName" -}}
+{{- printf "%s-%s" (include "aether-agent.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+ServiceAccount names.
+*/}}
+{{- define "aether-agent.serviceAccountName" -}}
+{{- include "aether-agent.fullname" . -}}
+{{- end -}}
+
+{{- define "aether-agent.proxy.serviceAccountName" -}}
+{{- include "aether-agent.proxy.fullname" . -}}
+{{- end -}}
+
+{{/*
+Proxy config ConfigMap name.
+*/}}
+{{- define "aether-agent.proxy.configMapName" -}}
+{{- printf "%s-config" (include "aether-agent.proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+AWS credentials Secret name. Defaults to a release-derived name.
+*/}}
+{{- define "aether-agent.awsSecretName" -}}
+{{- default (printf "%s-aws-credentials" (include "aether-agent.fullname" .)) .Values.awsCredentials.secretName -}}
+{{- end -}}
+
+{{/*
+Chart label value (name-version).
+*/}}
+{{- define "aether-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Agent selector labels (immutable subset).
+*/}}
+{{- define "aether-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aether-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: agent
+{{- end -}}
+
+{{/*
+Agent common labels.
+*/}}
+{{- define "aether-agent.labels" -}}
+helm.sh/chart: {{ include "aether-agent.chart" . }}
+{{ include "aether-agent.selectorLabels" . }}
+app.kubernetes.io/part-of: aether
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Proxy selector labels (immutable subset).
+*/}}
+{{- define "aether-agent.proxy.selectorLabels" -}}
+app.kubernetes.io/name: aether-proxy
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: proxy
+{{- end -}}
+
+{{/*
+Proxy common labels.
+*/}}
+{{- define "aether-agent.proxy.labels" -}}
+helm.sh/chart: {{ include "aether-agent.chart" . }}
+{{ include "aether-agent.proxy.selectorLabels" . }}
+app.kubernetes.io/part-of: aether
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aether-agent.proxy.configMapName" . }}
+  namespace: {{ include "aether-agent.namespace" . }}
+  labels:
+    {{- include "aether-agent.proxy.labels" . | nindent 4 }}
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 9901
+
+    dynamic_resources:
+      ads_config:
+        api_type: DELTA_GRPC
+        grpc_services:
+          - envoy_grpc:
+              cluster_name: agent_xds
+      cds_config:
+        ads: {}
+      lds_config:
+        ads: {}
+
+    static_resources:
+      clusters:
+      - name: agent_xds
+        type: STATIC
+        load_assignment:
+          cluster_name: local_xds
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      pipe:
+                        path: /run/aether/xds.sock
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options:
+                connection_keepalive:
+                  interval: 15s
+                  timeout: 5s
+                initial_stream_window_size: 1048576    # 1 MiB
+                initial_connection_window_size: 1048576 # 1 MiB
+                max_concurrent_streams: 10
+{{- end }}

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -1,0 +1,159 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "aether-agent.fullname" . }}
+  namespace: {{ include "aether-agent.namespace" . }}
+  labels:
+    {{- include "aether-agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "aether-agent.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "aether-agent.labels" . | nindent 8 }}
+    spec:
+      hostNetwork: true
+      serviceAccountName: {{ include "aether-agent.serviceAccountName" . }}
+      priorityClassName: system-node-critical
+      initContainers:
+        - name: cni-install
+          image: {{ .Values.cniInstall.image.ref | quote }}
+          imagePullPolicy: {{ .Values.cniInstall.image.pullPolicy }}
+          args:
+            - "--debug={{ .Values.debug }}"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+          volumeMounts:
+            - name: cni-bin-dir
+              mountPath: /host/opt/cni/bin
+            - name: cni-conf-dir
+              mountPath: /host/etc/cni/net.d
+          resources:
+            {{- toYaml .Values.cniInstall.resources | nindent 12 }}
+      containers:
+        - name: agent
+          image: {{ .Values.agent.image.ref | quote }}
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          args:
+            - "--debug={{ .Values.debug }}"
+            - "--proxy-id=$(NODE_NAME)"
+            - "--cluster-name={{ .Values.clusterName }}"
+            - "--node-name=$(NODE_NAME)"
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aether-agent.awsSecretName" . }}
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "aether-agent.awsSecretName" . }}
+                  key: AWS_SECRET_ACCESS_KEY
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsUser: 0
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: run-dir
+              mountPath: /run/aether
+              mountPropagation: HostToContainer
+            - name: cni-netns-dir
+              mountPath: /host/var/run/netns
+              mountPropagation: HostToContainer
+            - name: cni-registry-dir
+              mountPath: /host/var/lib/aether/registry
+              mountPropagation: HostToContainer
+            - name: containerd-sock
+              mountPath: /run/containerd/containerd.sock
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+          resources:
+            {{- toYaml .Values.agent.resources | nindent 12 }}
+      volumes:
+        - name: run-dir
+          hostPath:
+            path: /run/aether
+            type: DirectoryOrCreate
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+            type: DirectoryOrCreate
+        - name: cni-conf-dir
+          hostPath:
+            path: /etc/cni/net.d
+            type: DirectoryOrCreate
+        - name: cni-netns-dir
+          hostPath:
+            path: /var/run/netns
+            type: DirectoryOrCreate
+            # DirectoryOrCreate instead of Directory for the following reason - CNI may not bind mount this until a non-hostnetwork pod is scheduled on the node,
+            # and we don't want to block CNI agent pod creation on waiting for the first non-hostnetwork pod.
+            # Once the CNI does mount this, it will get populated and we're good.
+        - name: cni-registry-dir
+          hostPath:
+            path: /var/lib/aether/registry
+            type: DirectoryOrCreate
+            # DirectoryOrCreate instead of Directory for the following reason - CNI may not bind mount this until a non-hostnetwork pod is scheduled on the node,
+            # and we don't want to block CNI agent pod creation on waiting for the first non-hostnetwork pod.
+            # Once the CNI does mount this, it will get populated and we're good.
+        - name: containerd-sock
+          hostPath:
+            path: /run/containerd/containerd.sock
+            type: Socket
+        - name: tmp
+          emptyDir: {}

--- a/charts/agent/templates/namespace.yaml
+++ b/charts/agent/templates/namespace.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "aether-agent.namespace" . }}
+  labels:
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
+    {{- include "aether-agent.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.proxy.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "aether-agent.proxy.fullname" . }}
+  namespace: {{ include "aether-agent.namespace" . }}
+  labels:
+    {{- include "aether-agent.proxy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "aether-agent.proxy.selectorLabels" . | nindent 6 }}
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        {{- include "aether-agent.proxy.labels" . | nindent 8 }}
+    spec:
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: {{ include "aether-agent.proxy.serviceAccountName" . }}
+      priorityClassName: system-node-critical
+      containers:
+        - name: proxy
+          image: "{{ .Values.proxy.image.repository }}@{{ .Values.proxy.image.digest }}"
+          command:
+            - "/usr/local/bin/envoy"
+            - "-c"
+            - "/etc/envoy/envoy.yaml"
+            - "-l"
+            - {{ .Values.proxy.logLevel | quote }}
+            - "--service-cluster"
+            - "aether-proxy"
+            - "--service-node"
+            - "$(NODE_NAME)"
+            - "--service-zone"
+            - "$(ZONE)"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: REGION
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.annotations['topology.kubernetes.io/region']
+            - name: ZONE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+            - name: ENVOY_UID
+              value: "0"
+            - name: ENVOY_GID
+              value: "0"
+          securityContext:
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+              add:
+                - NET_ADMIN
+          volumeMounts:
+            - name: proxy-config
+              mountPath: /etc/envoy
+              readOnly: true
+            - name: run-dir
+              mountPath: /run/aether
+              mountPropagation: HostToContainer
+            - name: netns-dir
+              mountPath: /var/run/netns
+              mountPropagation: HostToContainer
+            - name: workload-socket
+              mountPath: /run/secrets/workload-spiffe-uds
+              readOnly: true
+      volumes:
+        - name: proxy-config
+          configMap:
+            name: {{ include "aether-agent.proxy.configMapName" . }}
+            items:
+              - key: envoy.yaml
+                path: envoy.yaml
+        - name: netns-dir
+          hostPath:
+            path: /var/run/netns
+            type: DirectoryOrCreate
+        - name: run-dir
+          hostPath:
+            path: /run/aether
+            type: DirectoryOrCreate
+        - name: workload-socket
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true
+{{- end }}

--- a/charts/agent/templates/rbac.yaml
+++ b/charts/agent/templates/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "aether-agent.clusterScopedName" . }}
+  labels:
+    {{- include "aether-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "aether-agent.clusterScopedName" . }}
+  labels:
+    {{- include "aether-agent.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aether-agent.clusterScopedName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aether-agent.serviceAccountName" . }}
+    namespace: {{ include "aether-agent.namespace" . }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.awsCredentials.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "aether-agent.awsSecretName" . }}
+  namespace: {{ include "aether-agent.namespace" . }}
+  labels:
+    {{- include "aether-agent.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: {{ required "awsCredentials.accessKeyId is required when awsCredentials.create is true" .Values.awsCredentials.accessKeyId | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ required "awsCredentials.secretAccessKey is required when awsCredentials.create is true" .Values.awsCredentials.secretAccessKey | quote }}
+{{- end }}

--- a/charts/agent/templates/serviceaccount.yaml
+++ b/charts/agent/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aether-agent.serviceAccountName" . }}
+  namespace: {{ include "aether-agent.namespace" . }}
+  labels:
+    {{- include "aether-agent.labels" . | nindent 4 }}
+{{- if .Values.proxy.enabled }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aether-agent.proxy.serviceAccountName" . }}
+  namespace: {{ include "aether-agent.namespace" . }}
+  labels:
+    {{- include "aether-agent.proxy.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1,0 +1,73 @@
+# Default values for the aether-agent chart.
+
+# Override the chart name / fully-qualified resource name. Resource names are
+# release-prefixed so multiple releases can coexist; use these to customize that.
+nameOverride: ""
+fullnameOverride: ""
+
+# Namespace the agent resources are deployed into. Defaults to the release
+# namespace when `name` is empty. When `create` is true the chart renders the
+# namespace (with privileged pod-security labels, required by the agent's
+# hostNetwork + NET_ADMIN privileges).
+#
+# NOTE: the agent DaemonSet is effectively singleton-per-node — it owns host
+# paths (/run/aether, /opt/cni/bin, /etc/cni/net.d, ...) and the CNI plugin, so
+# only one agent release should target a given set of nodes regardless of the
+# release-aware templating below.
+namespace:
+  create: true
+  name: ""
+
+# Cluster name passed to the agent (`--cluster-name`).
+clusterName: talos-main
+
+# Enable verbose logging on the agent and cni-install containers (`--debug`).
+debug: true
+
+agent:
+  image:
+    # Substituted at package time with the digest-pinned reference produced by
+    # the in-repo `//agent/cmd/agent:image_push` target, e.g.
+    # docker.io/palermo/aether-agent@sha256:...
+    ref: "{@//agent/cmd/agent:image_push}"
+    pullPolicy: Always
+  resources:
+    requests:
+      cpu: 200m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 64Mi
+
+cniInstall:
+  image:
+    ref: "{@//cni/cmd/cni-install:image_push}"
+    pullPolicy: Always
+  resources:
+    requests:
+      cpu: 100m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 32Mi
+
+# Per-node Envoy proxy DaemonSet. Disable to deploy only the agent.
+proxy:
+  enabled: true
+  image:
+    # Envoy is an upstream image; pin it explicitly (not built by this repo).
+    repository: docker.io/envoyproxy/envoy
+    # envoyproxy/envoy:distroless-v1.37.0
+    digest: sha256:92fdb97b9fdb47da82fbe3651b83bd1419e544966d264632af4864004652685f
+  logLevel: info
+
+# AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
+# The chart never bakes credentials into the image. By default it references an
+# existing secret; set `create: true` and supply the keys to have the chart
+# render the Secret instead.
+awsCredentials:
+  create: false
+  # Defaults to "<release>-aether-agent-aws-credentials" when empty.
+  secretName: ""
+  accessKeyId: ""
+  secretAccessKey: ""

--- a/charts/registrar/BUILD.bazel
+++ b/charts/registrar/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_helm//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
+
+# aether-registrar Helm chart.
+#
+# Publish targets (GitHub Container Registry, OCI):
+#   bazel run //charts/registrar:registrar.push           # chart + image
+#   bazel run //charts/registrar:registrar.push_registry  # chart only
+# Authenticate first via HELM_REGISTRY_USERNAME / HELM_REGISTRY_PASSWORD.
+helm_chart(
+    name = "registrar",
+    chart = "Chart.yaml",
+    images = [
+        "//registrar/cmd/registrar:image_push",
+    ],
+    login_url = "ghcr.io",
+    registry_url = "oci://ghcr.io/bpalermo",
+    values = "values.yaml",
+    visibility = ["//visibility:public"],
+)
+
+helm_lint_test(
+    name = "registrar_lint_test",
+    chart = ":registrar",
+)
+
+helm_template_test(
+    name = "registrar_template_test",
+    chart = ":registrar",
+)

--- a/charts/registrar/Chart.yaml
+++ b/charts/registrar/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: aether-registrar
+description: |
+  Aether service mesh registrar. Deploys the in-cluster Registrar Deployment that
+  proxies registry operations, caches an endpoint snapshot, and streams changes to
+  node agents over gRPC.
+type: application
+# Stamped at package time when built with `--stamp`:
+#   version    -> 0.1.0+<git-commit> (SemVer build metadata)
+#   appVersion -> the `git describe` version, matching the binary's embedded Version
+# Without `--stamp` the braces are stripped, yielding literal placeholder text.
+version: "0.1.0+{GIT_COMMIT}"
+appVersion: "{STABLE_GIT_VERSION}"
+keywords:
+  - aether
+  - service-mesh
+  - registrar
+sources:
+  - https://github.com/bpalermo/aether

--- a/charts/registrar/templates/_helpers.tpl
+++ b/charts/registrar/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Chart name, optionally overridden via nameOverride.
+*/}}
+{{- define "aether-registrar.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified, release-prefixed name. Used for namespaced resource names so
+multiple releases can coexist. Honours fullnameOverride / nameOverride.
+*/}}
+{{- define "aether-registrar.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Namespace the chart deploys into. Defaults to the release namespace.
+*/}}
+{{- define "aether-registrar.namespace" -}}
+{{- default .Release.Namespace .Values.namespace.name -}}
+{{- end -}}
+
+{{/*
+Name for cluster-scoped resources (ClusterRole/ClusterRoleBinding). Includes the
+namespace so two releases of the same name in different namespaces don't collide.
+*/}}
+{{- define "aether-registrar.clusterScopedName" -}}
+{{- printf "%s-%s" (include "aether-registrar.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "aether-registrar.serviceAccountName" -}}
+{{- include "aether-registrar.fullname" . -}}
+{{- end -}}
+
+{{/*
+Chart label value (name-version).
+*/}}
+{{- define "aether-registrar.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels (immutable subset).
+*/}}
+{{- define "aether-registrar.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "aether-registrar.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: registrar
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "aether-registrar.labels" -}}
+helm.sh/chart: {{ include "aether-registrar.chart" . }}
+{{ include "aether-registrar.selectorLabels" . }}
+app.kubernetes.io/part-of: aether
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/registrar/templates/deployment.yaml
+++ b/charts/registrar/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "aether-registrar.fullname" . }}
+  namespace: {{ include "aether-registrar.namespace" . }}
+  labels:
+    {{- include "aether-registrar.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "aether-registrar.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "aether-registrar.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "aether-registrar.serviceAccountName" . }}
+      containers:
+        - name: registrar
+          image: {{ .Values.image.ref | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--debug={{ .Values.debug }}"
+            - "--cluster-name={{ .Values.clusterName }}"
+            - "--registry-backend={{ .Values.registryBackend }}"
+            - "--grpc-address=:{{ .Values.service.targetPort }}"
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.service.targetPort }}
+              protocol: TCP
+            - name: metrics
+              containerPort: 8081
+              protocol: TCP
+            - name: health
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          env:
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.cpu
+                  divisor: "1"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          {{- if .Values.spire.enabled }}
+          volumeMounts:
+            - name: workload-socket
+              mountPath: /run/secrets/workload-spiffe-uds
+              readOnly: true
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- if .Values.spire.enabled }}
+      volumes:
+        - name: workload-socket
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true
+      {{- end }}

--- a/charts/registrar/templates/namespace.yaml
+++ b/charts/registrar/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "aether-registrar.namespace" . }}
+  labels:
+    {{- include "aether-registrar.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/registrar/templates/rbac.yaml
+++ b/charts/registrar/templates/rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "aether-registrar.clusterScopedName" . }}
+  labels:
+    {{- include "aether-registrar.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "get", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list", "get", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "aether-registrar.clusterScopedName" . }}
+  labels:
+    {{- include "aether-registrar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aether-registrar.clusterScopedName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aether-registrar.serviceAccountName" . }}
+    namespace: {{ include "aether-registrar.namespace" . }}

--- a/charts/registrar/templates/service.yaml
+++ b/charts/registrar/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aether-registrar.fullname" . }}
+  namespace: {{ include "aether-registrar.namespace" . }}
+  labels:
+    {{- include "aether-registrar.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "aether-registrar.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc
+      port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP

--- a/charts/registrar/templates/serviceaccount.yaml
+++ b/charts/registrar/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aether-registrar.serviceAccountName" . }}
+  namespace: {{ include "aether-registrar.namespace" . }}
+  labels:
+    {{- include "aether-registrar.labels" . | nindent 4 }}

--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -1,0 +1,46 @@
+# Default values for the aether-registrar chart.
+
+# Override the chart name / fully-qualified resource name. Resource names are
+# release-prefixed so multiple releases can coexist; use these to customize that.
+nameOverride: ""
+fullnameOverride: ""
+
+# Namespace the registrar resources are deployed into. Defaults to the release
+# namespace when `name` is empty. The agent chart owns the namespace by default,
+# so creation is off here; enable it for a standalone registrar install.
+namespace:
+  create: false
+  name: ""
+
+# Cluster name passed to the registrar (`--cluster-name`).
+clusterName: talos-main
+
+# Registry backend (`--registry-backend`): kubernetes, dynamodb, etcd, cloudmap.
+registryBackend: kubernetes
+
+# Enable verbose logging (`--debug`).
+debug: true
+
+replicaCount: 1
+
+image:
+  # Substituted at package time with the digest-pinned reference produced by
+  # the in-repo `//registrar/cmd/registrar:image_push` target.
+  ref: "{@//registrar/cmd/registrar:image_push}"
+  pullPolicy: Always
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 64Mi
+
+service:
+  port: 443
+  targetPort: 8443
+
+# Mount the SPIFFE workload API socket (CSI driver) into the registrar.
+spire:
+  enabled: true


### PR DESCRIPTION
## Summary
Adds Bazel-built Helm charts for Aether (`aether-agent`, `aether-registrar`) using `rules_helm`, published as OCI artifacts.

Docker Hub namespaces are username-bound; to give the charts a clean home without an org, they publish to **GitHub Container Registry** (`oci://ghcr.io/bpalermo`). Container **images** are unchanged — they still publish to Docker Hub (`docker.io/palermo`). Only the Helm charts live on GHCR.

## Changes
- **`MODULE.bazel`** — add `rules_helm` 0.29.0 + hermetic helm toolchain.
- **`charts/`** — `agent` and `registrar` charts with templates, `values.yaml`, and lint + `helm template` smoke tests. Image refs use `{@//...:image_push}` placeholders, substituted with digest-pinned references at package time.
- **`bazel/img/go_multi_arch_image.bzl`** — make `image_push` public so charts can reference image targets for substitution.
- **`.github/workflows/publish.yaml`** — add GHCR login (`GITHUB_TOKEN`) + `packages: write`; push charts via `*.push_registry` (chart-only, images push separately to Docker Hub).

## Notes
- Local pushes need a GitHub PAT with `write:packages` in `HELM_REGISTRY_PASSWORD`.
- First push creates the chart packages **private** by default — flip to public in GitHub package settings if desired.

## Test plan
- `bazel test //charts/...` — lint + template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)