### PR TITLE
deps: drop orphaned github.com/docker/docker (clears 5 Dependabot alerts)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/dave/jennifer v1.7.1 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/docker/docker v28.5.1+incompatible // indirect
 	github.com/docker/go-connections v0.6.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,6 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v28.5.1+incompatible h1:Bm8DchhSD2J6PsFzxC35TZo4TLGR2PdW/E69rU45NhM=
-github.com/docker/docker v28.5.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pMmjSD94=
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=


### PR DESCRIPTION
## Summary
Closes all 5 open Dependabot alerts for `github.com/docker/docker` by removing the dependency — an orphaned `// indirect` entry that nothing imports anymore.

> Originally intended to be stacked on #60, but that PR merged into `main` while this was in progress, so this now targets `main` directly.

## Investigation
- All 5 alerts target `github.com/docker/docker` (Docker daemon-side CVEs: `docker cp` races, `PUT /containers/{id}/archive`, AuthZ plugin bypass).
- It was an **indirect, test-only** transitive. `go mod why -m github.com/docker/docker` → *"main module does not need module github.com/docker/docker"*.
- `testcontainers-go v0.42.0` (our version, already latest) migrated to the split `github.com/moby/moby/api` + `github.com/moby/moby/client` modules and no longer pulls `docker/docker`.
- There is **no fixed release on the `github.com/docker/docker` module path** — it tops out at `v28.5.2+incompatible`; the v29 fixes moved to the new `github.com/moby/moby/v2` path (beta only). A version bump is therefore impossible; dropping the unused dep is the correct fix.

## Changes
- Remove the `github.com/docker/docker` require from `go.mod` and its `go.sum` entries.
- Re-synced with `bazel mod tidy` + `gazelle`. (`go mod tidy` can't run here — the Bazel-generated `api/aether/*/v1` proto packages aren't on disk, which is why the project forbids raw `go mod tidy`.)
- `docker/docker` was not exposed via `MODULE.bazel` `use_repo`, so no Bazel repo changes were needed.

## Alerts cleared
`GHSA-rg2x-37c3-w2rh`, `GHSA-vp62-88p7-qqf5`, `GHSA-x86f-5xw2-fm2r`, `GHSA-x744-4wpc-v9h2`, `GHSA-pxq6-2prw-chj9`

## Test plan
- `bazel build //...` — clean.
- `bazel test //...` — all pass (incl. `//charts/...`).
- `grep docker/docker go.mod go.sum MODULE.bazel` → 0 matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)