### PR TITLE
fix(charts): rename to agent/registrar; dash-separated version tag

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -5,8 +5,13 @@ Bazel-built Helm charts for Aether, using
 
 | Chart | Path | Deploys |
 | --- | --- | --- |
-| `aether-agent` | [`charts/agent`](./agent) | Agent DaemonSet (xDS + CNI install) and, optionally, the per-node Envoy proxy DaemonSet. Owns the `aether-system` namespace and RBAC. |
-| `aether-registrar` | [`charts/registrar`](./registrar) | Registrar Deployment, Service and RBAC. |
+| `agent` | [`charts/agent`](./agent) | Agent DaemonSet (xDS + CNI install) and, optionally, the per-node Envoy proxy DaemonSet. Owns the `aether-system` namespace and RBAC. |
+| `registrar` | [`charts/registrar`](./registrar) | Registrar Deployment, Service and RBAC. |
+
+The chart `name` (`agent` / `registrar`) is the trailing path segment of the
+published OCI artifact (`ghcr.io/bpalermo/aether/charts/<name>`). Resource names
+are derived from the **release** name, so install with `helm install aether …`
+to get `aether-agent`, `aether-registrar`, etc.
 
 The container image references in each `values.yaml` are written as
 `{@//path/to:image_push}` placeholders. At package time `rules_helm` substitutes
@@ -17,7 +22,7 @@ image, so packaged charts are always pinned to a concrete image digest.
 
 | Field | Value | Notes |
 | --- | --- | --- |
-| Chart `version` | `0.1.0+{GIT_COMMIT}` | SemVer; commit becomes build metadata. |
+| Chart `version` | `0.1.0-{GIT_COMMIT}` | SemVer pre-release; commit becomes the OCI tag (dash-separated — `+build` metadata would be rewritten to `_` by helm). |
 | Chart `appVersion` | `{STABLE_GIT_VERSION}` | `git describe` value — matches the binaries' embedded `Version`. |
 | Image refs | `repo@sha256:…` | Pinned to the exact built digest (strongest form). |
 
@@ -29,7 +34,7 @@ bazel build --stamp //charts/agent //charts/registrar   # embed git version
 bazel run   --stamp //charts/agent:agent.push           # publish a stamped chart
 ```
 
-Without `--stamp` the braces are stripped (e.g. `0.1.0+GIT_COMMIT`) so the chart
+Without `--stamp` the braces are stripped (e.g. `0.1.0-GIT_COMMIT`) so the chart
 still lints/templates — but release builds should pass `--stamp`. Image digests
 are stamped independently of this flag (they always reflect the built image), and
 the published image tags themselves already embed the git commit.
@@ -46,15 +51,27 @@ bazel test //charts/...
 
 ## Install
 
+From the local Bazel build:
+
 ```bash
 bazel run //charts/agent:agent.install
 bazel run //charts/registrar:registrar.install
 # Counterparts: .upgrade, .uninstall
 ```
 
+From the published OCI registry (use the semver `+`/`-` form for `--version`;
+helm maps it to the dash-separated tag):
+
+```bash
+helm install aether oci://ghcr.io/bpalermo/aether/charts/agent \
+  --version 0.1.0-<git-commit> -n aether-system
+helm install aether-registrar oci://ghcr.io/bpalermo/aether/charts/registrar \
+  --version 0.1.0-<git-commit> -n aether-system
+```
+
 ## Multiple instances & labels
 
-Resource names are release-prefixed (`<release>-aether-agent`, …) and
+Resource names are release-prefixed (`<release>-agent`, …) and
 cluster-scoped resources (ClusterRole/ClusterRoleBinding) additionally include
 the namespace, so several releases coexist without collisions. Customize naming
 with `nameOverride` / `fullnameOverride`, and target a namespace with

--- a/charts/agent/BUILD.bazel
+++ b/charts/agent/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_helm//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
 
-# aether-agent Helm chart.
+# agent Helm chart (published as ghcr.io/bpalermo/aether/charts/agent).
 #
 # `images` wires the in-repo image_push targets into the chart so that:
 #   * the `{@//...:image_push}` placeholders in values.yaml are substituted with

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
-name: aether-agent
+name: agent
 description: |
   Aether service mesh node agent. Deploys the agent DaemonSet (which manages
   the Envoy xDS control plane and installs the CNI plugin) and, optionally, the
   per-node Envoy proxy DaemonSet.
 type: application
 # Stamped at package time when built with `--stamp`:
-#   version    -> 0.1.0+<git-commit> (SemVer build metadata)
+#   version    -> 0.1.0-<git-commit> (SemVer pre-release; yields a dash-separated
+#                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.1.0+{GIT_COMMIT}"
+version: "0.1.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Chart name, optionally overridden via nameOverride.
 */}}
-{{- define "aether-agent.name" -}}
+{{- define "agent.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -9,7 +9,7 @@ Chart name, optionally overridden via nameOverride.
 Fully qualified, release-prefixed name. Used for namespaced resource names so
 multiple releases can coexist. Honours fullnameOverride / nameOverride.
 */}}
-{{- define "aether-agent.fullname" -}}
+{{- define "agent.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -25,14 +25,14 @@ multiple releases can coexist. Honours fullnameOverride / nameOverride.
 {{/*
 Proxy fullname.
 */}}
-{{- define "aether-agent.proxy.fullname" -}}
-{{- printf "%s-proxy" (include "aether-agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- define "agent.proxy.fullname" -}}
+{{- printf "%s-proxy" (include "agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Namespace the chart deploys into. Defaults to the release namespace.
 */}}
-{{- define "aether-agent.namespace" -}}
+{{- define "agent.namespace" -}}
 {{- default .Release.Namespace .Values.namespace.name -}}
 {{- end -}}
 
@@ -40,47 +40,47 @@ Namespace the chart deploys into. Defaults to the release namespace.
 Name for cluster-scoped resources (ClusterRole/ClusterRoleBinding). Includes the
 namespace so two releases of the same name in different namespaces don't collide.
 */}}
-{{- define "aether-agent.clusterScopedName" -}}
-{{- printf "%s-%s" (include "aether-agent.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- define "agent.clusterScopedName" -}}
+{{- printf "%s-%s" (include "agent.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 ServiceAccount names.
 */}}
-{{- define "aether-agent.serviceAccountName" -}}
-{{- include "aether-agent.fullname" . -}}
+{{- define "agent.serviceAccountName" -}}
+{{- include "agent.fullname" . -}}
 {{- end -}}
 
-{{- define "aether-agent.proxy.serviceAccountName" -}}
-{{- include "aether-agent.proxy.fullname" . -}}
+{{- define "agent.proxy.serviceAccountName" -}}
+{{- include "agent.proxy.fullname" . -}}
 {{- end -}}
 
 {{/*
 Proxy config ConfigMap name.
 */}}
-{{- define "aether-agent.proxy.configMapName" -}}
-{{- printf "%s-config" (include "aether-agent.proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- define "agent.proxy.configMapName" -}}
+{{- printf "%s-config" (include "agent.proxy.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 AWS credentials Secret name. Defaults to a release-derived name.
 */}}
-{{- define "aether-agent.awsSecretName" -}}
-{{- default (printf "%s-aws-credentials" (include "aether-agent.fullname" .)) .Values.awsCredentials.secretName -}}
+{{- define "agent.awsSecretName" -}}
+{{- default (printf "%s-aws-credentials" (include "agent.fullname" .)) .Values.awsCredentials.secretName -}}
 {{- end -}}
 
 {{/*
 Chart label value (name-version).
 */}}
-{{- define "aether-agent.chart" -}}
+{{- define "agent.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Agent selector labels (immutable subset).
 */}}
-{{- define "aether-agent.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "aether-agent.name" . }}
+{{- define "agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: agent
 {{- end -}}
@@ -88,9 +88,9 @@ app.kubernetes.io/component: agent
 {{/*
 Agent common labels.
 */}}
-{{- define "aether-agent.labels" -}}
-helm.sh/chart: {{ include "aether-agent.chart" . }}
-{{ include "aether-agent.selectorLabels" . }}
+{{- define "agent.labels" -}}
+helm.sh/chart: {{ include "agent.chart" . }}
+{{ include "agent.selectorLabels" . }}
 app.kubernetes.io/part-of: aether
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Chart.AppVersion }}
@@ -101,7 +101,7 @@ app.kubernetes.io/version: {{ . | quote }}
 {{/*
 Proxy selector labels (immutable subset).
 */}}
-{{- define "aether-agent.proxy.selectorLabels" -}}
+{{- define "agent.proxy.selectorLabels" -}}
 app.kubernetes.io/name: aether-proxy
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: proxy
@@ -110,9 +110,9 @@ app.kubernetes.io/component: proxy
 {{/*
 Proxy common labels.
 */}}
-{{- define "aether-agent.proxy.labels" -}}
-helm.sh/chart: {{ include "aether-agent.chart" . }}
-{{ include "aether-agent.proxy.selectorLabels" . }}
+{{- define "agent.proxy.labels" -}}
+helm.sh/chart: {{ include "agent.chart" . }}
+{{ include "agent.proxy.selectorLabels" . }}
 app.kubernetes.io/part-of: aether
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Chart.AppVersion }}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "aether-agent.proxy.configMapName" . }}
-  namespace: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.proxy.configMapName" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
-    {{- include "aether-agent.proxy.labels" . | nindent 4 }}
+    {{- include "agent.proxy.labels" . | nindent 4 }}
 data:
   envoy.yaml: |
     admin:

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -1,23 +1,23 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "aether-agent.fullname" . }}
-  namespace: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
-    {{- include "aether-agent.labels" . | nindent 4 }}
+    {{- include "agent.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "aether-agent.selectorLabels" . | nindent 6 }}
+      {{- include "agent.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        {{- include "aether-agent.labels" . | nindent 8 }}
+        {{- include "agent.labels" . | nindent 8 }}
     spec:
       hostNetwork: true
-      serviceAccountName: {{ include "aether-agent.serviceAccountName" . }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
       priorityClassName: system-node-critical
       initContainers:
         - name: cni-install
@@ -91,12 +91,12 @@ spec:
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "aether-agent.awsSecretName" . }}
+                  name: {{ include "agent.awsSecretName" . }}
                   key: AWS_ACCESS_KEY_ID
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "aether-agent.awsSecretName" . }}
+                  name: {{ include "agent.awsSecretName" . }}
                   key: AWS_SECRET_ACCESS_KEY
           securityContext:
             readOnlyRootFilesystem: true

--- a/charts/agent/templates/namespace.yaml
+++ b/charts/agent/templates/namespace.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.namespace" . }}
   labels:
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged
-    {{- include "aether-agent.labels" . | nindent 4 }}
+    {{- include "agent.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -2,24 +2,24 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: {{ include "aether-agent.proxy.fullname" . }}
-  namespace: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.proxy.fullname" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
-    {{- include "aether-agent.proxy.labels" . | nindent 4 }}
+    {{- include "agent.proxy.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      {{- include "aether-agent.proxy.selectorLabels" . | nindent 6 }}
+      {{- include "agent.proxy.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        {{- include "aether-agent.proxy.labels" . | nindent 8 }}
+        {{- include "agent.proxy.labels" . | nindent 8 }}
     spec:
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
-      serviceAccountName: {{ include "aether-agent.proxy.serviceAccountName" . }}
+      serviceAccountName: {{ include "agent.proxy.serviceAccountName" . }}
       priorityClassName: system-node-critical
       containers:
         - name: proxy
@@ -82,7 +82,7 @@ spec:
       volumes:
         - name: proxy-config
           configMap:
-            name: {{ include "aether-agent.proxy.configMapName" . }}
+            name: {{ include "agent.proxy.configMapName" . }}
             items:
               - key: envoy.yaml
                 path: envoy.yaml

--- a/charts/agent/templates/rbac.yaml
+++ b/charts/agent/templates/rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "aether-agent.clusterScopedName" . }}
+  name: {{ include "agent.clusterScopedName" . }}
   labels:
-    {{- include "aether-agent.labels" . | nindent 4 }}
+    {{- include "agent.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -15,14 +15,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "aether-agent.clusterScopedName" . }}
+  name: {{ include "agent.clusterScopedName" . }}
   labels:
-    {{- include "aether-agent.labels" . | nindent 4 }}
+    {{- include "agent.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "aether-agent.clusterScopedName" . }}
+  name: {{ include "agent.clusterScopedName" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "aether-agent.serviceAccountName" . }}
-    namespace: {{ include "aether-agent.namespace" . }}
+    name: {{ include "agent.serviceAccountName" . }}
+    namespace: {{ include "agent.namespace" . }}

--- a/charts/agent/templates/secret.yaml
+++ b/charts/agent/templates/secret.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "aether-agent.awsSecretName" . }}
-  namespace: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.awsSecretName" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
-    {{- include "aether-agent.labels" . | nindent 4 }}
+    {{- include "agent.labels" . | nindent 4 }}
 type: Opaque
 stringData:
   AWS_ACCESS_KEY_ID: {{ required "awsCredentials.accessKeyId is required when awsCredentials.create is true" .Values.awsCredentials.accessKeyId | quote }}

--- a/charts/agent/templates/serviceaccount.yaml
+++ b/charts/agent/templates/serviceaccount.yaml
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "aether-agent.serviceAccountName" . }}
-  namespace: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.serviceAccountName" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
-    {{- include "aether-agent.labels" . | nindent 4 }}
+    {{- include "agent.labels" . | nindent 4 }}
 {{- if .Values.proxy.enabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "aether-agent.proxy.serviceAccountName" . }}
-  namespace: {{ include "aether-agent.namespace" . }}
+  name: {{ include "agent.proxy.serviceAccountName" . }}
+  namespace: {{ include "agent.namespace" . }}
   labels:
-    {{- include "aether-agent.proxy.labels" . | nindent 4 }}
+    {{- include "agent.proxy.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -1,4 +1,4 @@
-# Default values for the aether-agent chart.
+# Default values for the agent chart.
 
 # Override the chart name / fully-qualified resource name. Resource names are
 # release-prefixed so multiple releases can coexist; use these to customize that.

--- a/charts/registrar/BUILD.bazel
+++ b/charts/registrar/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_helm//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
 
-# aether-registrar Helm chart.
+# registrar Helm chart (published as ghcr.io/bpalermo/aether/charts/registrar).
 #
 # Publish targets (GitHub Container Registry, OCI):
 #   bazel run //charts/registrar:registrar.push           # chart + image

--- a/charts/registrar/Chart.yaml
+++ b/charts/registrar/Chart.yaml
@@ -1,15 +1,16 @@
 apiVersion: v2
-name: aether-registrar
+name: registrar
 description: |
   Aether service mesh registrar. Deploys the in-cluster Registrar Deployment that
   proxies registry operations, caches an endpoint snapshot, and streams changes to
   node agents over gRPC.
 type: application
 # Stamped at package time when built with `--stamp`:
-#   version    -> 0.1.0+<git-commit> (SemVer build metadata)
+#   version    -> 0.1.0-<git-commit> (SemVer pre-release; yields a dash-separated
+#                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.1.0+{GIT_COMMIT}"
+version: "0.1.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/registrar/templates/_helpers.tpl
+++ b/charts/registrar/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Chart name, optionally overridden via nameOverride.
 */}}
-{{- define "aether-registrar.name" -}}
+{{- define "registrar.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -9,7 +9,7 @@ Chart name, optionally overridden via nameOverride.
 Fully qualified, release-prefixed name. Used for namespaced resource names so
 multiple releases can coexist. Honours fullnameOverride / nameOverride.
 */}}
-{{- define "aether-registrar.fullname" -}}
+{{- define "registrar.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -25,7 +25,7 @@ multiple releases can coexist. Honours fullnameOverride / nameOverride.
 {{/*
 Namespace the chart deploys into. Defaults to the release namespace.
 */}}
-{{- define "aether-registrar.namespace" -}}
+{{- define "registrar.namespace" -}}
 {{- default .Release.Namespace .Values.namespace.name -}}
 {{- end -}}
 
@@ -33,29 +33,29 @@ Namespace the chart deploys into. Defaults to the release namespace.
 Name for cluster-scoped resources (ClusterRole/ClusterRoleBinding). Includes the
 namespace so two releases of the same name in different namespaces don't collide.
 */}}
-{{- define "aether-registrar.clusterScopedName" -}}
-{{- printf "%s-%s" (include "aether-registrar.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
+{{- define "registrar.clusterScopedName" -}}
+{{- printf "%s-%s" (include "registrar.fullname" .) .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 ServiceAccount name.
 */}}
-{{- define "aether-registrar.serviceAccountName" -}}
-{{- include "aether-registrar.fullname" . -}}
+{{- define "registrar.serviceAccountName" -}}
+{{- include "registrar.fullname" . -}}
 {{- end -}}
 
 {{/*
 Chart label value (name-version).
 */}}
-{{- define "aether-registrar.chart" -}}
+{{- define "registrar.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Selector labels (immutable subset).
 */}}
-{{- define "aether-registrar.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "aether-registrar.name" . }}
+{{- define "registrar.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "registrar.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/component: registrar
 {{- end -}}
@@ -63,9 +63,9 @@ app.kubernetes.io/component: registrar
 {{/*
 Common labels.
 */}}
-{{- define "aether-registrar.labels" -}}
-helm.sh/chart: {{ include "aether-registrar.chart" . }}
-{{ include "aether-registrar.selectorLabels" . }}
+{{- define "registrar.labels" -}}
+helm.sh/chart: {{ include "registrar.chart" . }}
+{{ include "registrar.selectorLabels" . }}
 app.kubernetes.io/part-of: aether
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- with .Chart.AppVersion }}

--- a/charts/registrar/templates/deployment.yaml
+++ b/charts/registrar/templates/deployment.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "aether-registrar.fullname" . }}
-  namespace: {{ include "aether-registrar.namespace" . }}
+  name: {{ include "registrar.fullname" . }}
+  namespace: {{ include "registrar.namespace" . }}
   labels:
-    {{- include "aether-registrar.labels" . | nindent 4 }}
+    {{- include "registrar.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{- include "aether-registrar.selectorLabels" . | nindent 6 }}
+      {{- include "registrar.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{- include "aether-registrar.labels" . | nindent 8 }}
+        {{- include "registrar.labels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "aether-registrar.serviceAccountName" . }}
+      serviceAccountName: {{ include "registrar.serviceAccountName" . }}
       containers:
         - name: registrar
           image: {{ .Values.image.ref | quote }}

--- a/charts/registrar/templates/namespace.yaml
+++ b/charts/registrar/templates/namespace.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ include "aether-registrar.namespace" . }}
+  name: {{ include "registrar.namespace" . }}
   labels:
-    {{- include "aether-registrar.labels" . | nindent 4 }}
+    {{- include "registrar.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/registrar/templates/rbac.yaml
+++ b/charts/registrar/templates/rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "aether-registrar.clusterScopedName" . }}
+  name: {{ include "registrar.clusterScopedName" . }}
   labels:
-    {{- include "aether-registrar.labels" . | nindent 4 }}
+    {{- include "registrar.labels" . | nindent 4 }}
 rules:
   - apiGroups: [""]
     resources: ["pods"]
@@ -15,14 +15,14 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "aether-registrar.clusterScopedName" . }}
+  name: {{ include "registrar.clusterScopedName" . }}
   labels:
-    {{- include "aether-registrar.labels" . | nindent 4 }}
+    {{- include "registrar.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "aether-registrar.clusterScopedName" . }}
+  name: {{ include "registrar.clusterScopedName" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "aether-registrar.serviceAccountName" . }}
-    namespace: {{ include "aether-registrar.namespace" . }}
+    name: {{ include "registrar.serviceAccountName" . }}
+    namespace: {{ include "registrar.namespace" . }}

--- a/charts/registrar/templates/service.yaml
+++ b/charts/registrar/templates/service.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "aether-registrar.fullname" . }}
-  namespace: {{ include "aether-registrar.namespace" . }}
+  name: {{ include "registrar.fullname" . }}
+  namespace: {{ include "registrar.namespace" . }}
   labels:
-    {{- include "aether-registrar.labels" . | nindent 4 }}
+    {{- include "registrar.labels" . | nindent 4 }}
 spec:
   selector:
-    {{- include "aether-registrar.selectorLabels" . | nindent 4 }}
+    {{- include "registrar.selectorLabels" . | nindent 4 }}
   ports:
     - name: grpc
       port: {{ .Values.service.port }}

--- a/charts/registrar/templates/serviceaccount.yaml
+++ b/charts/registrar/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "aether-registrar.serviceAccountName" . }}
-  namespace: {{ include "aether-registrar.namespace" . }}
+  name: {{ include "registrar.serviceAccountName" . }}
+  namespace: {{ include "registrar.namespace" . }}
   labels:
-    {{- include "aether-registrar.labels" . | nindent 4 }}
+    {{- include "registrar.labels" . | nindent 4 }}

--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -1,4 +1,4 @@
-# Default values for the aether-registrar chart.
+# Default values for the registrar chart.
 
 # Override the chart name / fully-qualified resource name. Resource names are
 # release-prefixed so multiple releases can coexist; use these to customize that.


### PR DESCRIPTION
## Problem
The previous publish put the charts at redundant paths:
`ghcr.io/bpalermo/aether/charts/**aether-agent**` — because the chart `name` was `aether-agent` while `registry_url` already ends in `aether/charts`. The OCI tag also came out underscore-separated (`0.1.0_<commit>`) because the version used `+build` metadata, which helm rewrites `+`→`_`.

## Fix
- **Rename charts** `aether-agent`→`agent`, `aether-registrar`→`registrar`, so they publish to the intended `ghcr.io/bpalermo/aether/charts/{agent,registrar}`.
- **Version** `0.1.0+{GIT_COMMIT}` → `0.1.0-{GIT_COMMIT}` (semver pre-release) → clean **dash**-separated OCI tag `0.1.0-<commit>`, directly installable via `--version`.

## Changes
- `Chart.yaml` (both): `name`, `version`, and the versioning comment.
- Templates: renamed helper `define`/`include` prefixes `aether-agent.`→`agent.`, `aether-registrar.`→`registrar.` — purely mechanical, no behavior change. Resource names still derive from the **release** name, so `helm install aether …` still yields `aether-agent`, `aether-agent-proxy`, `aether-registrar`, and the AWS secret default `aether-agent-aws-credentials`.
- `README.md`, `values.yaml`/`BUILD.bazel` comments updated; added OCI install examples.

## Verification
- `bazel test //charts/...` — pass.
- Packaged `Chart.yaml`: `name: agent` / `name: registrar`, `version: 0.1.0-<commit>`.
- `helm template aether …` renders `aether-agent*` resources, GHCR digest image refs, AWS secret `aether-agent-aws-credentials`.

On merge, the publish workflow republishes to the corrected paths/tags. (The old `aether/charts/aether-*` packages can be deleted from GHCR afterward.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)