### PR TITLE
feat(agent chart): wire SPIRE workload + admin sockets

### DIFF
--- a/.claude/projects/-home-palermo-code-bpalermo-aether/memory/project_spire_admin_socket_followup.md
+++ b/.claude/projects/-home-palermo-code-bpalermo-aether/memory/project_spire_admin_socket_followup.md
@@ -1,0 +1,35 @@
+---
+name: project-spire-admin-socket-followup
+description: Pending follow-up PR to wire the agent's SPIRE admin socket / Delegated Identity API
+metadata:
+  type: project
+---
+
+The Helm-charts/SPIRE work (PRs #60, #62, #63, #64) is mostly done and the
+**registrar** is validated working on the local `talos-main` cluster (SVID over
+the `csi.spiffe.io` Workload API socket via go-spiffe `workloadapi`, mTLS gRPC
+server up).
+
+**Still pending — a separate PR:** the **agent** is not yet functional. It needs
+the SPIRE **agent admin socket** (`/tmp/spire-agent/private/admin.sock`) for the
+**Delegated Identity API**, which the agent uses to mint SVIDs for the
+services/proxies (the `spire.NewBridge(SpireAdminSocketPath, …)` SDS bridge).
+
+Scope of that PR:
+- agent chart: mount the admin socket (hostPath) + the `csi.spiffe.io` workload
+  socket; set `--spire-enabled`, `--spire-trust-domain`, `--spire-admin-socket`,
+  `--spire-workload-socket` via a `spire:` values block (mirroring the registrar).
+- **SPIRE-side prerequisite (outside the aether charts):** on `talos-main` the
+  spire-agent admin socket is currently an emptyDir (pod-local, not exposed on a
+  hostPath), and `authorized_delegates` lists `…/sa/aether-proxy`, not
+  `aether-agent`. The admin socket must be exposed on a hostPath and the
+  aether-agent SVID added as an authorized delegate, plus registration entries.
+
+Cluster facts: trust domain `aether.internal`; SPIRE server in `spire-server` ns,
+spire-agent + spire-spiffe-csi-driver in `spire-system`. Charts default the trust
+domain to empty → omits `--spire-trust-domain` → binary uses the `ROOTCA`
+sentinel (authorize-any). The `aether-agent-aws-credentials` secret in
+`aether-system` is real and must be preserved across reinstalls.
+
+Cleanup nit: an orphan `ghcr.io/bpalermo/aether/registrar:spire-test` image tag
+was pushed during pre-merge prep; safe to delete (needs `write:packages`).

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -45,6 +45,14 @@ spec:
             - "--proxy-id=$(NODE_NAME)"
             - "--cluster-name={{ .Values.clusterName }}"
             - "--node-name=$(NODE_NAME)"
+            - "--spire-enabled={{ .Values.spire.enabled }}"
+            {{- if .Values.spire.enabled }}
+            {{- with .Values.spire.trustDomain }}
+            - "--spire-trust-domain={{ . }}"
+            {{- end }}
+            - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
+            - "--spire-admin-socket={{ .Values.spire.adminSocket.mountPath }}/{{ .Values.spire.adminSocket.socketName }}"
+            {{- end }}
           ports:
             - name: metrics
               containerPort: 8080
@@ -122,6 +130,14 @@ spec:
               readOnly: true
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.spire.enabled }}
+            - name: spire-workload-socket
+              mountPath: /run/secrets/workload-spiffe-uds
+              readOnly: true
+            - name: spire-admin-socket
+              mountPath: {{ .Values.spire.adminSocket.mountPath }}
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.agent.resources | nindent 12 }}
       volumes:
@@ -157,3 +173,13 @@ spec:
             type: Socket
         - name: tmp
           emptyDir: {}
+        {{- if .Values.spire.enabled }}
+        - name: spire-workload-socket
+          csi:
+            driver: csi.spiffe.io
+            readOnly: true
+        - name: spire-admin-socket
+          hostPath:
+            path: {{ .Values.spire.adminSocket.hostPath }}
+            type: DirectoryOrCreate
+        {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -71,3 +71,25 @@ awsCredentials:
   secretName: ""
   accessKeyId: ""
   secretAccessKey: ""
+
+# SPIRE integration. When enabled, the agent:
+#   * fetches its own X.509 SVID over the csi.spiffe.io Workload API socket for
+#     mTLS to the registrar (workloadSocketPath), and
+#   * connects to the SPIRE agent admin socket and uses the Delegated Identity
+#     API to mint SVIDs for the local Envoy proxies, serving them over SDS.
+spire:
+  enabled: true
+  # SPIFFE trust domain authorized for mTLS peers. Leave empty to omit the flag
+  # and let the binary default (ROOTCA) authorize any peer chaining to the SPIRE
+  # root CA; set e.g. "aether.internal" to restrict peers to that trust domain.
+  trustDomain: ""
+  # Workload API socket (the csi.spiffe.io mount + socket filename).
+  workloadSocketPath: /run/secrets/workload-spiffe-uds/socket
+  # SPIRE agent admin socket (Delegated Identity API). Requires the SPIRE agent
+  # to expose its admin socket on the host and to authorize the agent's SVID as a
+  # delegate. `hostPath` is the node directory exposing the admin socket; it is
+  # bind-mounted at `mountPath`, and the socket file is `mountPath/socketName`.
+  adminSocket:
+    hostPath: /run/spire/admin-sockets
+    mountPath: /run/spire/admin-sockets
+    socketName: admin.sock


### PR DESCRIPTION
## Why
Follow-up to #64. The agent uses SPIRE in two ways when enabled, and the chart wired **neither** (so the agent crashed at startup):
1. **Workload API socket** (`csi.spiffe.io`) — fetch its own X.509 SVID for **registrar mTLS** (the go-spiffe client from #64).
2. **Admin socket** (SPIRE agent) — connect via the **Delegated Identity API** to mint X.509 SVIDs for the local Envoy proxies and serve them over **SDS** (`spire.NewBridge(adminSocket, …)`).

## Changes (chart only)
- **values**: new `spire:` block — `enabled`, `trustDomain` (empty ⇒ flag omitted ⇒ binary `ROOTCA` sentinel), `workloadSocketPath`, and `adminSocket.{hostPath,mountPath,socketName}`.
- **daemonset**: pass `--spire-enabled` / `--spire-workload-socket` / `--spire-admin-socket` (and `--spire-trust-domain` only when set, matching the registrar); mount the `csi.spiffe.io` workload socket and the admin-socket hostPath. All gated on `spire.enabled`.

Rendered (defaults):
```
--spire-enabled=true
--spire-workload-socket=/run/secrets/workload-spiffe-uds/socket
--spire-admin-socket=/run/spire/admin-sockets/admin.sock
volumes: spire-workload-socket (csi.spiffe.io), spire-admin-socket (hostPath /run/spire/admin-sockets)
```

## ⚠️ Cluster prerequisite (SPIRE side — not in this chart)
For the agent to run, the SPIRE deployment must:
- expose the spire-agent **admin socket on a hostPath** (`spire.adminSocket.hostPath`) — on `talos-main` it's currently a pod-local emptyDir;
- add the agent's SVID (`…/ns/aether-system/sa/aether-agent`) to the spire-agent **`authorized_delegates`** (currently lists the proxy).

## Test plan
- `bazel test //charts/...` — pass.
- `helm template` renders both sockets + the conditional trust-domain flag.
- Cluster validation pending the SPIRE-side admin-socket exposure above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)