### PR TITLE
fix(registrar): unique watcher id per agent; harden Unsubscribe

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -81,8 +81,8 @@ func init() {
 	manager.RegisterFlags(rootCmd, &cfg.Config)
 
 	// Kubernetes and cluster identity (required)
-	rootCmd.Flags().StringVar(&cfg.NodeName, "node-name", constants.DefaultProxyID, "Kubernetes node name where the agent runs (required)")
-	rootCmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", constants.DefaultProxyID, "Kubernetes cluster name, used for service discovery (required)")
+	rootCmd.Flags().StringVar(&cfg.NodeName, "node-name", "", "Kubernetes node name where the agent runs (required)")
+	rootCmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", "", "Kubernetes cluster name, used for service discovery (required)")
 	rootCmd.Flags().StringVar(&cfg.ProxyServiceNodeID, "proxy-id", constants.DefaultProxyID, "Unique identifier for this Envoy proxy instance in the xDS server (required)")
 
 	// Local storage configuration
@@ -241,7 +241,9 @@ func setupStorage(ctx context.Context, path string) (storage.Storage[*cniv1.CNIP
 // otherwise, insecure transport is used.
 func setupRegistrarClient(ctx context.Context) (registry.Registry, error) {
 	regCfg := registry.RegistrarConfig{
-		Address: cfg.RegistrarAddress,
+		Address:     cfg.RegistrarAddress,
+		ClusterName: cfg.ClusterName,
+		NodeName:    cfg.NodeName,
 	}
 
 	if cfg.SpireEnabled {

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -46,16 +46,22 @@ func (b *Broadcaster) Subscribe(id string) <-chan *registrarv1.WatchEndpointsRes
 	return ch
 }
 
-// Unsubscribe removes a watcher and closes its channel.
-func (b *Broadcaster) Unsubscribe(id string) {
+// Unsubscribe removes a watcher and closes its channel. The channel returned by
+// the matching Subscribe call must be passed so that a stale caller (whose
+// subscription was already replaced by a reconnect with the same id) does not
+// close or delete the newer subscription's channel.
+func (b *Broadcaster) Unsubscribe(id string, ch <-chan *registrarv1.WatchEndpointsResponse) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if ch, exists := b.watchers[id]; exists {
-		close(ch)
-		delete(b.watchers, id)
-		b.log.V(1).Info("watcher unsubscribed", "id", id)
+	existing, exists := b.watchers[id]
+	if !exists || (<-chan *registrarv1.WatchEndpointsResponse)(existing) != ch {
+		return
 	}
+
+	close(existing)
+	delete(b.watchers, id)
+	b.log.V(1).Info("watcher unsubscribed", "id", id)
 }
 
 // Broadcast sends events to all watchers. Events are sent non-blocking;

--- a/registrar/internal/server/broadcaster_test.go
+++ b/registrar/internal/server/broadcaster_test.go
@@ -112,7 +112,7 @@ func TestBroadcaster_Unsubscribe(t *testing.T) {
 				}
 			}
 
-			b.Unsubscribe(tt.unsubscribeID)
+			b.Unsubscribe(tt.unsubscribeID, targetCh)
 
 			assert.Equal(t, tt.wantCount, b.WatcherCount())
 
@@ -131,7 +131,7 @@ func TestBroadcaster_Unsubscribe_UnknownID(t *testing.T) {
 	b.Subscribe("node-1")
 
 	// Must not panic.
-	b.Unsubscribe("does-not-exist")
+	b.Unsubscribe("does-not-exist", nil)
 
 	assert.Equal(t, 1, b.WatcherCount())
 }
@@ -142,8 +142,35 @@ func TestBroadcaster_Unsubscribe_EmptyBroadcaster(t *testing.T) {
 	b := NewBroadcaster(logr.Discard())
 
 	// Must not panic.
-	b.Unsubscribe("node-1")
+	b.Unsubscribe("node-1", nil)
 
+	assert.Equal(t, 0, b.WatcherCount())
+}
+
+// TestBroadcaster_Unsubscribe_StaleChannel verifies that a stale caller (whose
+// subscription was already replaced by a reconnect with the same id) cannot close
+// or remove the newer subscription's channel. This guards against a same-id
+// reconnect race that would otherwise drop the live watcher and double-close.
+func TestBroadcaster_Unsubscribe_StaleChannel(t *testing.T) {
+	b := NewBroadcaster(logr.Discard())
+
+	ch1 := b.Subscribe("node-1") // first connection; channel closed by re-Subscribe below
+	ch2 := b.Subscribe("node-1") // reconnect with the same id replaces ch1
+
+	// The stale caller unsubscribing with its old channel must be a no-op: ch2 is
+	// still the live subscription and must remain registered.
+	b.Unsubscribe("node-1", ch1)
+	assert.Equal(t, 1, b.WatcherCount(), "live subscription must survive a stale unsubscribe")
+
+	// ch2 must still be open (not closed by the stale unsubscribe).
+	select {
+	case _, open := <-ch2:
+		assert.True(t, open, "live channel must not be closed by a stale unsubscribe")
+	default:
+	}
+
+	// The live caller unsubscribing with the current channel removes it.
+	b.Unsubscribe("node-1", ch2)
 	assert.Equal(t, 0, b.WatcherCount())
 }
 
@@ -294,9 +321,9 @@ func TestBroadcaster_WatcherCount(t *testing.T) {
 		{
 			name: "count reflects unsubscriptions",
 			actions: func(b *Broadcaster) {
-				b.Subscribe("node-1")
+				ch1 := b.Subscribe("node-1")
 				b.Subscribe("node-2")
-				b.Unsubscribe("node-1")
+				b.Unsubscribe("node-1", ch1)
 			},
 			wantCount: 1,
 		},
@@ -312,17 +339,17 @@ func TestBroadcaster_WatcherCount(t *testing.T) {
 			name: "unsubscribe of unknown ID does not decrement count",
 			actions: func(b *Broadcaster) {
 				b.Subscribe("node-1")
-				b.Unsubscribe("node-99")
+				b.Unsubscribe("node-99", nil)
 			},
 			wantCount: 1,
 		},
 		{
 			name: "subscribe then unsubscribe all returns to zero",
 			actions: func(b *Broadcaster) {
-				b.Subscribe("node-1")
-				b.Subscribe("node-2")
-				b.Unsubscribe("node-1")
-				b.Unsubscribe("node-2")
+				ch1 := b.Subscribe("node-1")
+				ch2 := b.Subscribe("node-2")
+				b.Unsubscribe("node-1", ch1)
+				b.Unsubscribe("node-2", ch2)
 			},
 			wantCount: 0,
 		},

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -132,7 +132,7 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 
 	// Subscribe and stream incremental events.
 	ch := s.broadcaster.Subscribe(watcherID)
-	defer s.broadcaster.Unsubscribe(watcherID)
+	defer s.broadcaster.Unsubscribe(watcherID, ch)
 
 	for {
 		select {

--- a/registrar/internal/server/sync_test.go
+++ b/registrar/internal/server/sync_test.go
@@ -157,7 +157,7 @@ func TestSyncer_Start_BroadcastsChangesOnSubsequentSync(t *testing.T) {
 	cancel()
 
 	require.NoError(t, <-done)
-	bc.Unsubscribe("test-watcher")
+	bc.Unsubscribe("test-watcher", eventCh)
 
 	// Count buffered events. Use len() rather than ranging over the channel to
 	// avoid blocking; the broadcaster channel is buffered so events already
@@ -357,7 +357,7 @@ func TestSyncer_Start_NoEventsAfterInitialSync(t *testing.T) {
 	cancel()
 
 	require.NoError(t, <-done)
-	bc.Unsubscribe("no-change-watcher")
+	bc.Unsubscribe("no-change-watcher", eventCh)
 
 	// Because the state never changed after the first sync, no events should
 	// have been broadcast to the watcher.

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -31,6 +31,12 @@ const (
 type Config struct {
 	// Address is the gRPC address of the Registrar service.
 	Address string
+	// ClusterName identifies this agent's cluster to the Registrar. Together with
+	// NodeName it forms the unique watcher id; without it every agent collides on
+	// the same id and the Registrar evicts their watch streams in a reconnect loop.
+	ClusterName string
+	// NodeName identifies this agent's node to the Registrar. See ClusterName.
+	NodeName string
 	// DialOptions are additional gRPC dial options (e.g., TLS credentials).
 	// When empty, insecure credentials are used.
 	DialOptions []grpc.DialOption
@@ -202,6 +208,8 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 		}
 
 		stream, err := r.client.WatchEndpoints(ctx, &registrarv1.WatchEndpointsRequest{
+			ClusterName: r.config.ClusterName,
+			NodeName:    r.config.NodeName,
 			LastVersion: lastVersion,
 		})
 		if err != nil {


### PR DESCRIPTION
## Problem

Surfaced during cluster validation of #67. Once agents stopped crashing at startup, the registrar watch streams flapped at **~12 reconnects/sec/agent** (896 reconnects in ~70s across 5 nodes).

Root cause is a watcher-id collision:

- The agent's registrar watch client never set `ClusterName`/`NodeName` on `WatchEndpointsRequest` (`registry/internal/registrar/registrar.go`).
- The registrar therefore keyed every agent's watcher as `"/"` (`server.go:120`).
- `Broadcaster.Subscribe` closes any existing channel for a given id (`broadcaster.go`). With all agents on `"/"`, each reconnect evicted another agent's stream → that stream EOF'd → reconnected → re-evicted. Infinite storm.

It was invisible before because agents never reached the watch loop (they crashed on the DNS/admin-socket issues fixed in #67).

## Fix

- **client**: plumb `ClusterName`/`NodeName` through `registrar.Config` and send them on `WatchEndpointsRequest`, giving each agent a stable, unique watcher id.
- **agent**: populate the new fields from `cfg.ClusterName`/`cfg.NodeName`.
- **broadcaster**: `Unsubscribe` now takes the subscribed channel and only closes/removes it when it's still the live one. This prevents a stale caller (whose subscription was replaced by a same-id reconnect) from dropping the live watcher or double-closing the channel (a latent panic on legitimate reconnects).
- **flags**: drop the misleading `DefaultProxyID` default on the already-`MarkFlagRequired` `--node-name`/`--cluster-name` flags so "(required)" is honest and no unset value can silently fall through.

## Testing

- `bazel build //...` ✅
- `bazel test //...` ✅ (added `TestBroadcaster_Unsubscribe_StaleChannel` for the guard; updated existing broadcaster/sync tests for the new signature)
- Will validate on `talos-main` after the publish workflow produces the new chart/images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)