### PR TITLE
fix(cloudmap): resolve HTTP namespace by name; wire registrar AWS creds

### DIFF
--- a/charts/registrar/Chart.yaml
+++ b/charts/registrar/Chart.yaml
@@ -6,11 +6,11 @@ description: |
   node agents over gRPC.
 type: application
 # Stamped at package time when built with `--stamp`:
-#   version    -> 0.1.0-<git-commit> (SemVer pre-release; yields a dash-separated
+#   version    -> 0.2.0-<git-commit> (SemVer pre-release; yields a dash-separated
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.1.0-{GIT_COMMIT}"
+version: "0.2.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/registrar/templates/deployment.yaml
+++ b/charts/registrar/templates/deployment.yaml
@@ -24,6 +24,9 @@ spec:
             - "--debug={{ .Values.debug }}"
             - "--cluster-name={{ .Values.clusterName }}"
             - "--registry-backend={{ .Values.registryBackend }}"
+            {{- if eq .Values.registryBackend "cloudmap" }}
+            - "--cloudmap-namespace={{ .Values.cloudMap.namespace }}"
+            {{- end }}
             - "--grpc-address=:{{ .Values.service.targetPort }}"
             - "--spire-enabled={{ .Values.spire.enabled }}"
             {{- if .Values.spire.enabled }}
@@ -54,7 +57,16 @@ spec:
               port: health
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- with .Values.aws.credentialsSecret }}
+          envFrom:
+            - secretRef:
+                name: {{ . }}
+          {{- end }}
           env:
+            {{- with .Values.aws.region }}
+            - name: AWS_REGION
+              value: {{ . | quote }}
+            {{- end }}
             - name: GOMEMLIMIT
               valueFrom:
                 resourceFieldRef:

--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -18,6 +18,20 @@ clusterName: talos-main
 # Registry backend (`--registry-backend`): kubernetes, dynamodb, etcd, cloudmap.
 registryBackend: kubernetes
 
+# AWS configuration for the dynamodb / cloudmap registry backends.
+aws:
+  # Region for AWS SDK clients. NOTE: the registrar binary currently forces
+  # us-east-1 internally; this is wired for forward-compat and clarity.
+  region: us-east-1
+  # Name of an existing Secret holding AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
+  # Empty = inject nothing (rely on IRSA / instance role / ambient credentials).
+  credentialsSecret: ""
+
+# Cloud Map settings (used when registryBackend == cloudmap).
+cloudMap:
+  # Cloud Map HTTP namespace name (`--cloudmap-namespace`).
+  namespace: aether
+
 # Enable verbose logging (`--debug`).
 debug: true
 

--- a/registry/internal/cloudmap/cloudmap.go
+++ b/registry/internal/cloudmap/cloudmap.go
@@ -231,16 +231,13 @@ func (r *CloudMapRegistry) ListAllEndpoints(ctx context.Context, protocol regist
 }
 
 // resolveNamespaceID finds the Cloud Map namespace ID for the configured namespace name.
+//
+// We list namespaces unfiltered and match by name client-side rather than using a
+// server-side NamespaceFilter. The only ListNamespaces filter is TYPE
+// (DNS_PUBLIC/DNS_PRIVATE/HTTP) — there is no name filter — so filtering by the
+// namespace name server-side matches nothing and the lookup silently fails.
 func (r *CloudMapRegistry) resolveNamespaceID(ctx context.Context) (string, error) {
-	paginator := servicediscovery.NewListNamespacesPaginator(r.client, &servicediscovery.ListNamespacesInput{
-		Filters: []types.NamespaceFilter{
-			{
-				Name:      types.NamespaceFilterNameType,
-				Values:    []string{r.namespace},
-				Condition: types.FilterConditionEq,
-			},
-		},
-	})
+	paginator := servicediscovery.NewListNamespacesPaginator(r.client, &servicediscovery.ListNamespacesInput{})
 
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)

--- a/registry/internal/cloudmap/fake_client_test.go
+++ b/registry/internal/cloudmap/fake_client_test.go
@@ -50,28 +50,15 @@ func (f *fakeClient) addNamespace(name, id string) {
 	}
 }
 
-func (f *fakeClient) ListNamespaces(_ context.Context, input *servicediscovery.ListNamespacesInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.ListNamespacesOutput, error) {
+func (f *fakeClient) ListNamespaces(_ context.Context, _ *servicediscovery.ListNamespacesInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.ListNamespacesOutput, error) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	var nsList []types.NamespaceSummary
+	// Cloud Map's ListNamespaces only supports a TYPE filter (no name filter), so
+	// the registry lists unfiltered and matches by name client-side. Mirror that
+	// here by returning every namespace regardless of any filters on the input.
+	nsList := make([]types.NamespaceSummary, 0, len(f.namespaces))
 	for name, id := range f.namespaces {
-		// Apply filter if present
-		if len(input.Filters) > 0 {
-			match := false
-			for _, filter := range input.Filters {
-				if filter.Name == types.NamespaceFilterNameType {
-					for _, v := range filter.Values {
-						if v == name {
-							match = true
-						}
-					}
-				}
-			}
-			if !match {
-				continue
-			}
-		}
 		nsList = append(nsList, types.NamespaceSummary{
 			Name: aws.String(name),
 			Id:   aws.String(id),


### PR DESCRIPTION
## What

Two related changes that make the AWS Cloud Map registry backend actually work end-to-end:

### 1. Bug fix — Cloud Map namespace never resolved
`CloudMapRegistry.resolveNamespaceID` filtered `ListNamespaces` with `NamespaceFilterNameType` (`"TYPE"`) while passing the namespace **name** as the filter value. AWS interpreted this as "namespaces whose *type* == `aether`", which matches nothing, so `Initialize` always failed with:

```
failed to resolve namespace "aether": namespace "aether" not found
```

`ListNamespaces` has no name filter (only `TYPE`), so we now list unfiltered and match by name client-side (the loop already did the name match). The existing unit tests missed this because the **fake client mirrored the same wrong assumption** — it compared the namespace *name* against a `TYPE` filter value. The fake now faithfully returns all namespaces regardless of filters.

### 2. Make the cloudmap/dynamodb backends deployable via the registrar chart
The registrar chart had no way to inject AWS credentials (`env`/`envFrom` were absent), so the cloudmap and dynamodb backends couldn't authenticate. Added:
- `aws.credentialsSecret` → `envFrom` a Secret with `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
- `aws.region` → `AWS_REGION` env
- `cloudMap.namespace` → `--cloudmap-namespace` arg (only when `registryBackend=cloudmap`)
- chart version bump `0.1.0` → `0.2.0`

## Validation

End-to-end on a live cluster against **real AWS Cloud Map**:
- Registrar initializes against the HTTP namespace (`Cloud Map registry initialized namespaceID=ns-...`).
- Managed pods register as Cloud Map instances — confirmed directly via `discover-instances` (instance `<cluster>/<ip>`, port + Aether attributes).
- Registrar sync reads them back (`services:N`) and broadcasts to agents.
- `bazel test //registry/internal/cloudmap:cloudmap_test //charts/registrar:registrar_lint_test //charts/registrar:registrar_template_test` all pass.

## Out of scope / follow-up

During the same e2e, live pod-to-pod traffic surfaced a **separate, backend-agnostic gap**: the agent builds clusters/endpoints/vhosts only once at startup (`PreListen → LoadClustersFromRegistry`); `AddPod` refreshes only the listener snapshot, so a service registered *after* the agent started has no route until the agent restarts. Tracked separately for a dynamic-refresh fix.