### PR TITLE
fix(spire): name validation-context secret with SPIFFE URI

### DIFF
--- a/agent/internal/spire/converter.go
+++ b/agent/internal/spire/converter.go
@@ -58,8 +58,11 @@ func SVIDToTLSCertificateSecret(svid *delegatedidentityv1.X509SVIDWithKey) (*tls
 }
 
 // BundleToValidationContextSecret converts a trust domain's CA certificates
-// to an Envoy validation context Secret. The secret name is the trust domain
-// URI (e.g., "spiffe://example.org"). The DER-encoded CA certs are PEM-encoded.
+// to an Envoy validation context Secret. trustDomain is the bare SPIFFE trust
+// domain (e.g., "example.org", as keyed in the SPIRE bundle response); the
+// secret name is its SPIFFE URI form (e.g., "spiffe://example.org") to match
+// the validation context name referenced by inbound listeners and the URI
+// naming used for SVID certificate secrets. The DER-encoded CA certs are PEM-encoded.
 func BundleToValidationContextSecret(trustDomain string, derCACerts []byte) (*tlsv3.Secret, error) {
 	caPEM, err := derBundleToPEM(derCACerts)
 	if err != nil {
@@ -67,7 +70,7 @@ func BundleToValidationContextSecret(trustDomain string, derCACerts []byte) (*tl
 	}
 
 	return &tlsv3.Secret{
-		Name: trustDomain,
+		Name: fmt.Sprintf("spiffe://%s", trustDomain),
 		Type: &tlsv3.Secret_ValidationContext{
 			ValidationContext: &tlsv3.CertificateValidationContext{
 				TrustedCa: &corev3.DataSource{

--- a/agent/internal/spire/converter_test.go
+++ b/agent/internal/spire/converter_test.go
@@ -266,46 +266,46 @@ func TestBundleToValidationContextSecret(t *testing.T) {
 		wantName    string
 	}{
 		{
-			name:        "converts valid DER CA bundle to validation context secret",
-			trustDomain: "spiffe://example.org",
+			name:        "names the secret with the SPIFFE URI form of the trust domain",
+			trustDomain: "example.org",
 			derCACerts:  validDERCert,
 			wantErr:     false,
 			wantName:    "spiffe://example.org",
 		},
 		{
-			name:        "uses trust domain as secret name verbatim",
-			trustDomain: "example.org",
+			name:        "names a dotted trust domain with the spiffe:// scheme",
+			trustDomain: "cluster.local",
 			derCACerts:  validDERCert,
 			wantErr:     false,
-			wantName:    "example.org",
+			wantName:    "spiffe://cluster.local",
 		},
 		{
 			name:        "returns error when CA bundle is empty",
-			trustDomain: "spiffe://example.org",
+			trustDomain: "example.org",
 			derCACerts:  []byte{},
 			wantErr:     true,
 			wantErrMsg:  "converting CA bundle to PEM",
 		},
 		{
 			name:        "returns error when CA bundle is nil",
-			trustDomain: "spiffe://example.org",
+			trustDomain: "example.org",
 			derCACerts:  nil,
 			wantErr:     true,
 			wantErrMsg:  "converting CA bundle to PEM",
 		},
 		{
 			name:        "returns error when CA bundle contains malformed DER data",
-			trustDomain: "spiffe://example.org",
+			trustDomain: "example.org",
 			derCACerts:  []byte("not-valid-der-data"),
 			wantErr:     true,
 			wantErrMsg:  "converting CA bundle to PEM",
 		},
 		{
 			name:        "includes trust domain in error message on failure",
-			trustDomain: "spiffe://bad-domain.io",
+			trustDomain: "bad-domain.io",
 			derCACerts:  []byte("garbage"),
 			wantErr:     true,
-			wantErrMsg:  "spiffe://bad-domain.io",
+			wantErrMsg:  "bad-domain.io",
 		},
 	}
 


### PR DESCRIPTION
## Problem

Inbound mTLS never completes: the validation-context SDS secret stays stuck *warming* in Envoy.

`BundleToValidationContextSecret` named the Envoy validation-context secret with the **bare** trust domain (e.g. `ROOTCA`, the map key from SPIRE's `SubscribeToX509Bundles` response). But:
- Inbound listeners request the validation context by its **SPIFFE URI**: `fmt.Sprintf("spiffe://%s", trustDomain)` → `spiffe://ROOTCA`.
- SVID certificate secrets already use the URI form (`spiffe://<trustDomain>/ns/<ns>/sa/<sa>`).

So Envoy asks for `spiffe://ROOTCA`, the cache only has `ROOTCA`, and the secret never resolves. The function's own doc comment even says the name should be `spiffe://example.org` — the code didn't match it.

## Evidence

On a live cluster, the agent-proxy `config_dump` showed `dynamic_active_secrets: 0` with both the validation context (`spiffe://ROOTCA`) and the workload cert in `dynamic_warming_secrets`.

## Fix

Name the validation-context secret `spiffe://<trustDomain>`, matching the listener reference and the SVID naming convention. The bridge already passes the bare trust domain, so only the converter changes. Tests updated.

`bazel test //agent/internal/spire:spire_test` passes.

## Note

This fixes the *validation context* half of inbound SDS. The *workload SVID* half is still blocked separately by the agent skipping the delegated-identity subscription when the CNI doesn't supply a container PID (`skipping SVID subscription: PID not available`) — tracked in a follow-up.