### PR TITLE
feat(agent): refresh xDS clusters on registry changes

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -165,6 +165,14 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 
+	// Rebuild the cluster/endpoint/route snapshot when the registry reports
+	// endpoint changes, so services registered after startup become routable
+	// without restarting the agent. No-op if the registry can't notify.
+	refresher := xdsServer.NewRegistryRefresher(cfg.ClusterName, cfg.NodeName, snapshotCache, reg, l)
+	if err = m.Add(refresher); err != nil {
+		return fmt.Errorf("failed to add registry refresher: %w", err)
+	}
+
 	l.V(1).Info("waiting for local storage to be ready")
 	if err = localStorage.WaitUntilReady(ctx); err != nil {
 		return err

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -139,9 +139,10 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 	c.log.V(1).Info("found service endpoints in registry", "count", len(serviceEndpoints))
 
 	c.clusterMu.Lock()
-	if c.clusters == nil {
-		c.clusters = make(map[string]clusterEntry)
-	}
+	// Rebuild the cluster set from scratch so this method is idempotent and safe
+	// to call repeatedly (on registry changes, not just at startup): services and
+	// endpoints that disappeared from the registry are pruned rather than retained.
+	c.clusters = make(map[string]clusterEntry, len(serviceEndpoints))
 	for serviceName, endpoints := range serviceEndpoints {
 		cluster := proxy.NewClusterForService(serviceName)
 		cla := proxy.NewClusterLoadAssignment(serviceName)

--- a/agent/internal/xds/cache/cluster_test.go
+++ b/agent/internal/xds/cache/cluster_test.go
@@ -589,6 +589,35 @@ func TestLoadClustersFromRegistry_EndpointsReachable(t *testing.T) {
 	assert.Len(t, eps, 1)
 }
 
+// TestLoadClustersFromRegistry_RebuildPrunesStale verifies that reloading is a
+// full rebuild: a service that disappears from the registry between loads is
+// pruned from the cache rather than retained.
+func TestLoadClustersFromRegistry_RebuildPrunesStale(t *testing.T) {
+	c := newTestCache("node-1")
+	data := map[string][]*registryv1.ServiceEndpoint{
+		"keep":   {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
+		"remove": {makeEndpoint("10.0.0.2", "cluster-1", "node-2", 8080)},
+	}
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return data, nil
+		},
+	}
+
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	require.NotNil(t, c.Endpoints("keep"))
+	require.NotNil(t, c.Endpoints("remove"))
+
+	// The registry now reports only "keep"; a reload must drop "remove".
+	data = map[string][]*registryv1.ServiceEndpoint{
+		"keep": {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
+	}
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+
+	assert.NotNil(t, c.Endpoints("keep"))
+	assert.Nil(t, c.Endpoints("remove"), "stale cluster should be pruned on reload")
+}
+
 // TestLoadClustersFromRegistry_VirtualHostsPopulated verifies that after loading, VirtualHosts()
 // returns non-empty results for registered services.
 func TestLoadClustersFromRegistry_VirtualHostsPopulated(t *testing.T) {

--- a/agent/internal/xds/server/BUILD.bazel
+++ b/agent/internal/xds/server/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "server",
-    srcs = ["server.go"],
+    srcs = [
+        "refresh.go",
+        "server.go",
+    ],
     importpath = "github.com/bpalermo/aether/agent/internal/xds/server",
     visibility = ["//agent:__subpackages__"],
     deps = [
@@ -19,6 +22,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "refresh_test.go",
         "server_integration_test.go",
         "server_test.go",
     ],

--- a/agent/internal/xds/server/refresh.go
+++ b/agent/internal/xds/server/refresh.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/registry"
+	"github.com/go-logr/logr"
+)
+
+// defaultRefreshDebounce is how long the refresher waits for change signals to
+// settle before rebuilding the cluster snapshot, collapsing bursts (e.g. a full
+// snapshot replay) into a single reload.
+const defaultRefreshDebounce = 250 * time.Millisecond
+
+// RegistryRefresher is a controller-runtime runnable that rebuilds the xDS
+// cluster/endpoint/route snapshot whenever the registry reports endpoint
+// changes. It bridges a registry.ChangeNotifier to the snapshot cache's
+// LoadClustersFromRegistry, so services registered after the agent started
+// become routable without restarting the agent.
+//
+// If the registry does not implement registry.ChangeNotifier, the refresher is
+// a no-op for the lifetime of the process (the initial snapshot built during
+// the xDS server's PreListen still applies).
+type RegistryRefresher struct {
+	log      logr.Logger
+	cache    *cache.SnapshotCache
+	registry registry.Registry
+
+	clusterName string
+	nodeName    string
+	debounce    time.Duration
+}
+
+// NewRegistryRefresher creates a RegistryRefresher.
+func NewRegistryRefresher(clusterName, nodeName string, snapshotCache *cache.SnapshotCache, reg registry.Registry, log logr.Logger) *RegistryRefresher {
+	return &RegistryRefresher{
+		log:         log.WithName("registry-refresher"),
+		cache:       snapshotCache,
+		registry:    reg,
+		clusterName: clusterName,
+		nodeName:    nodeName,
+		debounce:    defaultRefreshDebounce,
+	}
+}
+
+// Start blocks until ctx is cancelled, rebuilding the cluster snapshot from the
+// registry on each (debounced) change notification. It implements
+// controller-runtime's manager.Runnable.
+func (r *RegistryRefresher) Start(ctx context.Context) error {
+	notifier, ok := r.registry.(registry.ChangeNotifier)
+	if !ok {
+		r.log.Info("registry does not support change notifications; clusters refresh only at startup")
+		<-ctx.Done()
+		return nil
+	}
+
+	changes := notifier.Changes()
+
+	// Debounce timer, created stopped: it is (re)armed on each change signal and
+	// fires once the signals settle, triggering a single reload.
+	timer := time.NewTimer(r.debounce)
+	if !timer.Stop() {
+		<-timer.C
+	}
+
+	r.log.V(1).Info("watching registry for endpoint changes")
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-changes:
+			// (Re)arm the debounce window. Stop+drain before Reset so a prior
+			// expiry doesn't leave a stale tick queued.
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			timer.Reset(r.debounce)
+		case <-timer.C:
+			if err := r.cache.LoadClustersFromRegistry(ctx, r.clusterName, r.nodeName, r.registry); err != nil {
+				r.log.Error(err, "failed to refresh clusters from registry")
+				continue
+			}
+			r.log.V(1).Info("refreshed clusters from registry")
+		}
+	}
+}

--- a/agent/internal/xds/server/refresh_test.go
+++ b/agent/internal/xds/server/refresh_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/registry"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+// notifyRegistry wraps mockRegistry to also implement registry.ChangeNotifier.
+type notifyRegistry struct {
+	*mockRegistry
+	ch chan struct{}
+}
+
+func (n *notifyRegistry) Changes() <-chan struct{} { return n.ch }
+
+var _ registry.ChangeNotifier = (*notifyRegistry)(nil)
+
+func TestRegistryRefresher_ReloadsOnChange(t *testing.T) {
+	c := cache.NewSnapshotCache("node-1", logr.Discard())
+
+	var mu sync.Mutex
+	data := map[string][]*registryv1.ServiceEndpoint{}
+	reg := &notifyRegistry{
+		mockRegistry: &mockRegistry{
+			listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				return data, nil
+			},
+		},
+		ch: make(chan struct{}, 1),
+	}
+
+	r := NewRegistryRefresher("cluster-1", "node-1", c, reg, logr.Discard())
+	r.debounce = 10 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	// No clusters until a change is published.
+	require.Nil(t, c.Endpoints("echo"))
+
+	mu.Lock()
+	data = map[string][]*registryv1.ServiceEndpoint{
+		"echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
+	}
+	mu.Unlock()
+	reg.ch <- struct{}{}
+
+	require.Eventually(t, func() bool {
+		return c.Endpoints("echo") != nil
+	}, 2*time.Second, 10*time.Millisecond, "refresher should rebuild the cluster after a change signal")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("refresher did not return after context cancel")
+	}
+}
+
+func TestRegistryRefresher_NoNotifier_StopsOnContext(t *testing.T) {
+	c := cache.NewSnapshotCache("node-1", logr.Discard())
+	// mockRegistry does not implement registry.ChangeNotifier.
+	r := NewRegistryRefresher("cluster-1", "node-1", c, &mockRegistry{}, logr.Discard())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- r.Start(ctx) }()
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("refresher did not return after context cancel")
+	}
+}

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -55,6 +55,11 @@ type RegistrarRegistry struct {
 	mu    sync.RWMutex
 	cache map[string][]*registryv1.ServiceEndpoint // keyed by serviceName
 
+	// notify coalesces endpoint-change signals for consumers (e.g. the agent
+	// xDS cache). It is buffered with capacity 1 and written non-blocking, so a
+	// burst of watch events collapses into a single pending signal.
+	notify chan struct{}
+
 	cancel context.CancelFunc
 }
 
@@ -64,6 +69,25 @@ func NewRegistrarRegistry(log logr.Logger, cfg Config) *RegistrarRegistry {
 		log:    log.WithName("registrar-registry"),
 		config: cfg,
 		cache:  make(map[string][]*registryv1.ServiceEndpoint),
+		notify: make(chan struct{}, 1),
+	}
+}
+
+// Changes returns a channel that receives a signal whenever the cached set of
+// endpoints changes (an endpoint is added, updated, or removed). Signals are
+// coalesced: consumers should treat each receive as "something changed, re-read
+// the registry" rather than a per-event notification. It satisfies the
+// registry.ChangeNotifier capability.
+func (r *RegistrarRegistry) Changes() <-chan struct{} {
+	return r.notify
+}
+
+// signalChange performs a non-blocking send on the notify channel, coalescing
+// bursts of events into a single pending signal.
+func (r *RegistrarRegistry) signalChange() {
+	select {
+	case r.notify <- struct{}{}:
+	default:
 	}
 }
 
@@ -282,6 +306,10 @@ func (r *RegistrarRegistry) applyEvent(event *registrarv1.WatchEndpointsResponse
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED:
 		r.removeLocked(svcName, ep.GetIp())
 	}
+
+	// Wake consumers (e.g. the agent xDS cache) so they re-read the registry and
+	// rebuild derived state. Coalesced and non-blocking.
+	r.signalChange()
 }
 
 // upsertLocked adds or updates an endpoint in the cache. Caller must hold mu.

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -391,3 +391,40 @@ func TestCache_MultipleServices(t *testing.T) {
 	_, exists := r.cache["svc-a"]
 	assert.False(t, exists, "svc-a key should be absent after all endpoints removed")
 }
+
+func TestApplyEvent_SignalsChange(t *testing.T) {
+	r := newTestRegistry()
+
+	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+		ServiceName: "svc-a",
+		Endpoint:    makeEndpoint("10.0.0.1", 8080),
+	})
+
+	select {
+	case <-r.Changes():
+	default:
+		t.Fatal("expected a change signal after applyEvent")
+	}
+}
+
+func TestSignalChange_Coalesces(t *testing.T) {
+	r := newTestRegistry()
+
+	// A burst of events must collapse into a single pending signal (the notify
+	// channel is buffered with capacity 1 and written non-blocking).
+	for range 5 {
+		r.applyEvent(&registrarv1.WatchEndpointsResponse{
+			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+			ServiceName: "svc-a",
+			Endpoint:    makeEndpoint("10.0.0.1", 8080),
+		})
+	}
+
+	<-r.Changes() // exactly one signal is pending
+	select {
+	case <-r.Changes():
+		t.Fatal("expected change signals to coalesce into one")
+	default:
+	}
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -28,3 +28,17 @@ type Registry interface {
 	// organized in a map keyed by service name.
 	ListAllEndpoints(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error)
 }
+
+// ChangeNotifier is an optional capability for Registry implementations that can
+// push change notifications. Backends that maintain a live view of the registry
+// (e.g. the registrar watch stream) implement it so consumers can rebuild derived
+// state — such as the agent's xDS cluster/endpoint/route snapshot — when endpoints
+// change, instead of only at startup.
+//
+// Signals are coalesced: each receive means "the endpoint set changed, re-read the
+// registry", not a per-event notification.
+type ChangeNotifier interface {
+	// Changes returns a channel that receives a signal whenever the set of
+	// endpoints changes.
+	Changes() <-chan struct{}
+}


### PR DESCRIPTION
## Problem

The agent built clusters/endpoints/virtual-hosts **only once**, in the xDS server's `PreListen` (`LoadClustersFromRegistry`). Nothing rebuilt them when the registry changed, and `RemoveEndpoint`/`RemoveCluster` were never called. So a service registered **after** the agent started had no cluster or route — outbound requests to it returned `404` — until the agent was restarted.

Surfaced during the Cloud Map full-traffic e2e: a managed `client` curling a managed `echo` (registered after agent start) got `404 server: envoy`, and the agent-proxy `config_dump` showed `dynamic_active_clusters: 0` / `dynamic_route_configs: 0` despite `echo` being live in the registry.

## Change

- **registrar registry** (`registry/internal/registrar`): emit a coalesced, non-blocking change signal on every applied watch event, exposed via `Changes()`. New optional capability `registry.ChangeNotifier`.
- **agent** (`agent/internal/xds/server/refresh.go`): `RegistryRefresher`, a `manager.Runnable` that debounces those signals and rebuilds the cluster snapshot via `LoadClustersFromRegistry`. No-op if the registry doesn't implement `ChangeNotifier` (the initial `PreListen` snapshot still applies).
- **`LoadClustersFromRegistry`** is now a full rebuild, so reloads prune services/endpoints that disappeared from the registry (previously it only accumulated).

## Tests

- registrar: `applyEvent` signals `Changes()`; bursts coalesce to one pending signal.
- cache: reload prunes stale clusters.
- refresher: rebuilds the cluster on a change signal (debounced); no-op + clean stop when the registry isn't a notifier.

`bazel test //registry/internal/registrar:... //agent/internal/xds/cache:... //agent/internal/xds/server:... //agent/internal/cmd:...` all pass.

## Note

This makes post-startup services routable. End-to-end pod→pod traffic also needs the inbound mTLS SDS secrets to resolve, which is addressed separately (validation-context naming in #70, and the CNI container-PID / workload-SVID subscription in a follow-up). Full live traffic e2e will be run once those land together.