### PR TITLE
fix(agent): resolve sandbox PID for SVID subscription after CNI ADD

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "server",
     srcs = [
         "config.go",
+        "pid.go",
         "pod.go",
         "server.go",
     ],
@@ -36,6 +37,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "pid_test.go",
         "pod_test.go",
         "server_integration_test.go",
     ],

--- a/agent/internal/cni/server/config.go
+++ b/agent/internal/cni/server/config.go
@@ -12,7 +12,16 @@ type CNIServerConfig struct {
 	// EnvoyAdminAddress is the host:port of the Envoy admin interface used to
 	// verify that listener configuration has been applied.
 	EnvoyAdminAddress string
+	// HostMountPrefix is the in-container path under which the host root
+	// filesystem is mounted, used to read a pod's netns file (e.g. the host
+	// "/var/run/netns/..." path is read at "<prefix>/var/run/netns/..."). Empty
+	// means the host paths are used as-is.
+	HostMountPrefix string
 }
+
+// DefaultHostMountPrefix is the conventional mount point for the host root
+// filesystem subtrees the agent consumes (e.g. /host/var/run/netns).
+const DefaultHostMountPrefix = "/host"
 
 // NewCNIServerConfig creates a new CNIServerConfig with default values.
 // The default socket path is the standard CNI socket path.
@@ -20,5 +29,6 @@ func NewCNIServerConfig() *CNIServerConfig {
 	return &CNIServerConfig{
 		SocketPath:        constants.DefaultCNISocketPath,
 		EnvoyAdminAddress: "127.0.0.1:9901",
+		HostMountPrefix:   DefaultHostMountPrefix,
 	}
 }

--- a/agent/internal/cni/server/pid.go
+++ b/agent/internal/cni/server/pid.go
@@ -1,0 +1,88 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// resolvePIDFromNetns returns the PID of a process whose network namespace
+// matches the netns file at netnsPath, comparing the file's device and inode
+// numbers against every /proc/<pid>/ns/net. A bind-mounted named netns and a
+// process's ns/net link share the same nsfs device+inode when they refer to the
+// same namespace, so this is the same identity check `ip netns identify` uses.
+//
+// The agent must run in the host PID namespace for the /proc scan to see the
+// container (sandbox) processes; otherwise no match is found.
+func resolvePIDFromNetns(netnsPath string) (int32, error) {
+	target, err := os.Stat(netnsPath)
+	if err != nil {
+		return 0, fmt.Errorf("stat netns %q: %w", netnsPath, err)
+	}
+	targetSys, ok := target.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("unexpected stat type for %q", netnsPath)
+	}
+
+	matches, err := filepath.Glob("/proc/[0-9]*/ns/net")
+	if err != nil {
+		return 0, fmt.Errorf("glob /proc: %w", err)
+	}
+
+	for _, candidate := range matches {
+		info, statErr := os.Stat(candidate)
+		if statErr != nil {
+			continue
+		}
+		sys, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			continue
+		}
+		if sys.Dev == targetSys.Dev && sys.Ino == targetSys.Ino {
+			pid, perr := pidFromProcNetnsPath(candidate)
+			if perr != nil {
+				continue
+			}
+			return pid, nil
+		}
+	}
+
+	return 0, fmt.Errorf("no process found owning netns %q", netnsPath)
+}
+
+// pidFromProcNetnsPath extracts <pid> from a "/proc/<pid>/ns/net" path.
+func pidFromProcNetnsPath(p string) (int32, error) {
+	const prefix = "/proc/"
+	const suffix = "/ns/net"
+	if len(p) <= len(prefix)+len(suffix) {
+		return 0, fmt.Errorf("unexpected proc netns path %q", p)
+	}
+	pidStr := p[len(prefix) : len(p)-len(suffix)]
+	pid, err := strconv.ParseInt(pidStr, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse pid from %q: %w", p, err)
+	}
+	return int32(pid), nil
+}
+
+// resolvePIDWithRetry polls resolve until it returns a PID or ctx is done. The
+// container runtime starts the sandbox process shortly after CNI ADD returns, so
+// the netns is briefly unowned; retrying bridges that gap.
+func resolvePIDWithRetry(ctx context.Context, resolve func() (int32, error), interval time.Duration) (int32, error) {
+	for {
+		pid, err := resolve()
+		if err == nil {
+			return pid, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return 0, fmt.Errorf("resolving pid: %w (last attempt: %v)", ctx.Err(), err)
+		case <-time.After(interval):
+		}
+	}
+}

--- a/agent/internal/cni/server/pid_test.go
+++ b/agent/internal/cni/server/pid_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPidFromProcNetnsPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    int32
+		wantErr bool
+	}{
+		{name: "valid", path: "/proc/1234/ns/net", want: 1234},
+		{name: "valid single digit", path: "/proc/7/ns/net", want: 7},
+		{name: "non-numeric pid", path: "/proc/self/ns/net", wantErr: true},
+		{name: "too short", path: "/proc//ns/net", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := pidFromProcNetnsPath(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+// TestResolvePIDFromNetns_MatchesOwnNetns verifies the inode-match logic against
+// the test process's own network namespace: the resolved PID must share the same
+// nsfs inode as /proc/self/ns/net.
+func TestResolvePIDFromNetns_MatchesOwnNetns(t *testing.T) {
+	self, err := os.Stat("/proc/self/ns/net")
+	if err != nil {
+		t.Skipf("cannot stat /proc/self/ns/net: %v", err)
+	}
+	selfSys := self.Sys().(*syscall.Stat_t)
+
+	pid, err := resolvePIDFromNetns("/proc/self/ns/net")
+	require.NoError(t, err)
+	require.Positive(t, pid)
+
+	got, err := os.Stat("/proc/self/ns/net")
+	require.NoError(t, err)
+	gotSys := got.Sys().(*syscall.Stat_t)
+	assert.Equal(t, selfSys.Ino, gotSys.Ino, "resolved PID should own the same netns")
+}
+
+func TestResolvePIDFromNetns_MissingPath(t *testing.T) {
+	_, err := resolvePIDFromNetns("/does/not/exist/ns/net")
+	require.Error(t, err)
+}
+
+func TestResolvePIDWithRetry_SucceedsAfterRetries(t *testing.T) {
+	attempts := 0
+	pid, err := resolvePIDWithRetry(context.Background(), func() (int32, error) {
+		attempts++
+		if attempts < 3 {
+			return 0, errors.New("not yet")
+		}
+		return 4242, nil
+	}, time.Millisecond)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(4242), pid)
+	assert.Equal(t, 3, attempts)
+}
+
+func TestResolvePIDWithRetry_TimesOut(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err := resolvePIDWithRetry(ctx, func() (int32, error) {
+		return 0, errors.New("never resolves")
+	}, time.Millisecond)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -18,6 +19,49 @@ import (
 )
 
 const envoyAdminTimeout = 2 * time.Second
+
+const (
+	// defaultPIDResolveTimeout bounds how long the agent waits for a pod's
+	// sandbox process (and thus its PID) to appear after CNI ADD.
+	defaultPIDResolveTimeout = 15 * time.Second
+	// defaultPIDResolveInterval is the poll interval while resolving the PID.
+	defaultPIDResolveInterval = 200 * time.Millisecond
+)
+
+// subscribePodWhenPIDResolves resolves the workload PID from its network
+// namespace (retrying until the sandbox process exists) and then subscribes to
+// the pod's SVID over the SPIRE Delegated Identity API. It runs in its own
+// goroutine because resolution outlives the CNI ADD request, and uses a
+// background context so the subscription is not cancelled when ADD returns.
+func (s *CNIServer) subscribePodWhenPIDResolves(spiffeID, netns string) {
+	log := s.log.WithValues("spiffeID", spiffeID, "netns", netns)
+	if netns == "" {
+		log.V(1).Info("cannot resolve SVID PID: empty network namespace")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), s.pidResolveTimeout)
+	defer cancel()
+
+	hostNetns := netns
+	if s.hostMountPrefix != "" {
+		hostNetns = filepath.Join(s.hostMountPrefix, netns)
+	}
+
+	pid, err := resolvePIDWithRetry(ctx, func() (int32, error) {
+		return resolvePIDFromNetns(hostNetns)
+	}, s.pidResolveInterval)
+	if err != nil {
+		log.Error(err, "failed to resolve workload PID for SVID subscription")
+		return
+	}
+
+	if err := s.spireBridge.SubscribePod(context.Background(), spiffeID, pid); err != nil {
+		log.Error(err, "failed to subscribe to SVID", "pid", pid)
+		return
+	}
+	log.Info("subscribed to SVID after resolving workload PID", "pid", pid)
+}
 
 // AddPod handles CNI ADD requests for a pod.
 // It enriches the pod data with Kubernetes annotations and labels, validates that the pod
@@ -52,7 +96,7 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		return nil, status.Errorf(codes.Internal, "failed to register endpoint: %v", err)
 	}
 
-	// Subscribe to SVID for this pod via the SPIRE Delegated Identity API
+	// Subscribe to SVID for this pod via the SPIRE Delegated Identity API.
 	if s.spireBridge != nil {
 		spiffeID := proxy.SpiffeIDFromPod(cniPod, s.trustDomain)
 		if cniPod.GetPid() != nil {
@@ -60,7 +104,10 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 				log.Error(err, "failed to subscribe to SVID", "spiffeID", spiffeID)
 			}
 		} else {
-			log.V(1).Info("skipping SVID subscription: PID not available", "spiffeID", spiffeID)
+			// The container runtime starts the sandbox process only after CNI ADD
+			// returns, so the PID is not yet known. Resolve it from the pod's netns
+			// in the background and subscribe once it appears.
+			go s.subscribePodWhenPIDResolves(spiffeID, cniPod.GetNetworkNamespace())
 		}
 	}
 

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"buf.build/go/protovalidate"
 	"github.com/bpalermo/aether/agent/internal/envoy/admin"
@@ -49,6 +50,15 @@ type CNIServer struct {
 	envoyAdmin    *admin.Client
 
 	k8sClient client.Client
+
+	// hostMountPrefix is prepended to a pod's host netns path to read it from
+	// inside the agent container when resolving the workload PID.
+	hostMountPrefix string
+	// pidResolveTimeout/pidResolveInterval bound the background netns->PID
+	// resolution used to subscribe a pod's SPIRE SVID when the CNI plugin could
+	// not supply a PID at ADD time.
+	pidResolveTimeout  time.Duration
+	pidResolveInterval time.Duration
 }
 
 var _ xds.ServerCallback = (*CNIServer)(nil)
@@ -64,18 +74,21 @@ func NewCNIServer(clusterName string, nodeName string, proxyID string, trustDoma
 	)
 
 	cniSrv := &CNIServer{
-		Server:        xds.NewServer(xds.NewServerConfig(xds.WithUDS(cfg.SocketPath)), log, xds.WithGRPCServer(grpcServer)),
-		log:           log.WithName("cni"),
-		clusterName:   clusterName,
-		nodeName:      nodeName,
-		proxyID:       proxyID,
-		trustDomain:   trustDomain,
-		storage:       localStorage,
-		registry:      registry,
-		k8sClient:     k8sClient,
-		snapshotCache: snapshotCache,
-		spireBridge:   spireBridge,
-		envoyAdmin:    admin.NewClient(cfg.EnvoyAdminAddress),
+		Server:             xds.NewServer(xds.NewServerConfig(xds.WithUDS(cfg.SocketPath)), log, xds.WithGRPCServer(grpcServer)),
+		log:                log.WithName("cni"),
+		clusterName:        clusterName,
+		nodeName:           nodeName,
+		proxyID:            proxyID,
+		trustDomain:        trustDomain,
+		storage:            localStorage,
+		registry:           registry,
+		k8sClient:          k8sClient,
+		snapshotCache:      snapshotCache,
+		spireBridge:        spireBridge,
+		envoyAdmin:         admin.NewClient(cfg.EnvoyAdminAddress),
+		hostMountPrefix:    cfg.HostMountPrefix,
+		pidResolveTimeout:  defaultPIDResolveTimeout,
+		pidResolveInterval: defaultPIDResolveInterval,
 	}
 
 	cniSrv.AddCallback(cniSrv)

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -17,6 +17,11 @@ spec:
         {{- include "agent.labels" . | nindent 8 }}
     spec:
       hostNetwork: true
+      # Share the host PID namespace so the agent can resolve a pod's sandbox PID
+      # from its network namespace (inode match against /proc/<pid>/ns/net) to
+      # subscribe the workload's SPIRE SVID — the CNI plugin cannot supply the PID
+      # because the runtime starts the sandbox process only after CNI ADD returns.
+      hostPID: true
       # Resolve in-cluster Service names (e.g. the registrar) while on hostNetwork;
       # plain ClusterFirst is ignored for hostNetwork pods.
       dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
## Problem

Workload inbound mTLS never came up: the server certificate (SVID) secret stayed *warming* in Envoy. The agent logged `skipping SVID subscription: PID not available` for every managed pod.

Root cause is the containerd CNI lifecycle, not a bug in `resolvePID`:
- containerd creates the pod network namespace **without a long-lived process in it**, calls CNI ADD, and starts the sandbox (pause) container **only after** ADD returns.
- So at ADD time the netns inode scan finds no `/proc/<pid>/ns/net` to match, and the CRI fallback calls `ContainerStatus(<sandbox-id>)` (a sandbox isn't a container) and fails.
- `Pid` is nil → `SubscribePod` is skipped → no delegated SVID → cert warms forever.

## Fix

Resolve the PID **agent-side, after** ADD, retrying until the sandbox process exists, then subscribe:

- The agent runs in the **host PID namespace** (`hostPID: true`) so a `/proc/<pid>/ns/net` scan sees container processes. The host netns dir is already mounted with `HostToContainer` propagation.
- `subscribePodWhenPIDResolves` polls the pod's netns and inode-matches it against `/proc/<pid>/ns/net` to find the sandbox PID, then calls the SPIRE Delegated Identity API. Bounded (15s, 200ms poll), runs in the background so CNI ADD isn't blocked.
- `CNIServerConfig.HostMountPrefix` (default `/host`) locates the host netns file from inside the container.

The sandbox PID attests to the same Kubernetes selectors (namespace, service account) as the app container — confirmed against SPIRE's delegated-identity handler, which derives selectors via `delegateWorkloadAttestor.Attest(ctx, pid)` — so it yields the correct `spiffe://<td>/ns/<ns>/sa/<sa>` SVID.

## Tests

- `pidFromProcNetnsPath` parsing.
- `resolvePIDFromNetns` inode-match against the test process's own `/proc/self/ns/net`.
- `resolvePIDWithRetry` success-after-retries and context-timeout paths.
- agent chart lint/template pass with `hostPID`.

## Note

Completes the inbound-SDS path together with #70 (validation-context naming). Full live pod→pod mTLS traffic e2e (with #70, #71, this) will be run once they're available together on the agent image.