### PR TITLE
fix(agent): initialize SnapshotCache resource maps to avoid nil-map panic

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -83,6 +83,12 @@ func NewSnapshotCache(nodeName string, log logr.Logger) *SnapshotCache {
 		SnapshotCache: cachev3.NewSnapshotCache(false, cachev3.IDHash{}, nil),
 		log:           log.WithName("cache"),
 		nodeName:      nodeName,
-		version:       atomic.NewUint64(0),
+		// Initialize the resource maps up front so callers never assign to a nil
+		// map. LoadListenersFromStorage assigns directly (no lazy init), which
+		// panics on agent restart when pods already exist in local storage.
+		listeners: make(map[string]listenerEntry),
+		clusters:  make(map[string]clusterEntry),
+		secrets:   make(map[string]*tlsv3.Secret),
+		version:   atomic.NewUint64(0),
 	}
 }

--- a/agent/internal/xds/cache/listener_test.go
+++ b/agent/internal/xds/cache/listener_test.go
@@ -310,6 +310,20 @@ func TestLoadListenersFromStorage_ValidPodsSucceeds(t *testing.T) {
 	assert.Len(t, c.listeners, 1)
 }
 
+// TestLoadListenersFromStorage_FreshCacheNoPanic loads pods from storage into a
+// freshly constructed cache without pre-initializing its maps. This reproduces
+// agent restart with pods already in local storage: NewSnapshotCache must
+// initialize the listeners map, otherwise the direct assignment panics.
+func TestLoadListenersFromStorage_FreshCacheNoPanic(t *testing.T) {
+	c := newTestCache("node-1")
+	store := storage.NewMockStorageWithGetAll[*cniv1.CNIPod](func(_ context.Context) ([]*cniv1.CNIPod, error) {
+		return []*cniv1.CNIPod{makeCNIPod("pod-a", "default", "/proc/100/ns/net")}, nil
+	})
+
+	require.NoError(t, c.LoadListenersFromStorage(context.Background(), store, "example.org"))
+	assert.Len(t, c.listeners, 1)
+}
+
 // TestLoadListenersFromStorage_ValidPods_NetnsKeyed verifies that the listener
 // entries are stored under the pod's network namespace key, and that both
 // inbound and outbound listeners are non-nil.


### PR DESCRIPTION
## Problem

The agent panics with `assignment to entry in nil map` on restart when pods already exist in local storage:

```
panic: assignment to entry in nil map
  cache.(*SnapshotCache).LoadListenersFromStorage  listener.go:113
  server.(*AgentXdsServer).PreListen               server.go:70
```

`LoadListenersFromStorage` assigns to `c.listeners` without a lazy nil-init (unlike `AddPod`, which guards it). `PreListen` runs it before any `AddPod`, so on a restart with persisted pods the map is still nil. It stayed latent because agents previously started with empty local storage, and the unit tests masked it by pre-initializing the map via a helper.

Surfaced deploying the merged agent to talos-main: the node that already had managed pods (`echo`/`client`) crash-looped, while empty nodes came up fine.

## Fix

Initialize `listeners`, `clusters`, and `secrets` in `NewSnapshotCache` so no path can assign to a nil map. Adds a regression test that loads pods into a freshly constructed cache (no manual init).