### PR TITLE
fix(agent chart): grant SYS_PTRACE so the agent can resolve sandbox PIDs

### DIFF
--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -127,6 +127,10 @@ spec:
                 # Access the SPIRE agent admin socket (owned by the spire-agent
                 # uid) from this root-but-capability-dropped container.
                 - DAC_OVERRIDE
+                # Follow other pods' /proc/<pid>/ns/net magic symlinks (requires
+                # PTRACE_MODE_READ) to resolve a pod's sandbox PID from its netns
+                # for SPIRE SVID subscription.
+                - SYS_PTRACE
                 {{- end }}
           volumeMounts:
             - name: run-dir


### PR DESCRIPTION
Resolving a pod's sandbox PID from its netns (for SPIRE SVID subscription) requires following other processes' `/proc/<pid>/ns/net` magic symlinks, which needs `PTRACE_MODE_READ` (`CAP_SYS_PTRACE`). The agent dropped ALL caps and added only `NET_ADMIN`/`DAC_OVERRIDE`, so the netns inode scan found no match and SVID subscription failed with `no process found owning netns`.

Verified live on talos-main: with `SYS_PTRACE`, the agent resolves the sandbox PID and logs `subscribed to SVID after resolving workload PID`. Complements #72.