### PR TITLE
fix(agent): derive SDS trust domain from SPIRE, not the auth sentinel

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -138,7 +138,29 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	reg, err := setupRegistrarClient(ctx)
+	// When SPIRE is enabled, open the Workload API source and resolve the real
+	// trust domain SPIRE issues into (e.g. "aether.internal"). That trust domain
+	// names the SDS resources / SPIFFE IDs the agent programs into Envoy so they
+	// match the secrets the SPIRE bridge delivers. The configured
+	// --spire-trust-domain governs only peer authorization and may be the
+	// RootCATrustDomain "authorize any" sentinel, which is not a real trust domain.
+	var spireSource *commonspire.Source
+	identityTrustDomain := cfg.SpireTrustDomain
+	if cfg.SpireEnabled {
+		spireSource, err = commonspire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
+		if err != nil {
+			return err
+		}
+		defer func() { retErr = errors.Join(retErr, spireSource.Close()) }()
+
+		identityTrustDomain, err = commonspire.TrustDomainFromSource(spireSource)
+		if err != nil {
+			return fmt.Errorf("failed to resolve SPIRE trust domain: %w", err)
+		}
+		l.Info("resolved workload trust domain from SPIRE", "trustDomain", identityTrustDomain)
+	}
+
+	reg, err := setupRegistrarClient(ctx, spireSource)
 	if err != nil {
 		return err
 	}
@@ -157,11 +179,11 @@ func runAgent(ctx context.Context) (retErr error) {
 		l.Info("SPIRE integration disabled")
 	}
 
-	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache); err != nil {
+	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache, identityTrustDomain); err != nil {
 		return err
 	}
 
-	if err = setupCNIServer(m, localStorage, reg, snapshotCache, spireBridge); err != nil {
+	if err = setupCNIServer(m, localStorage, reg, snapshotCache, spireBridge, identityTrustDomain); err != nil {
 		return err
 	}
 
@@ -185,9 +207,9 @@ func runAgent(ctx context.Context) (retErr error) {
 // setXDSServer creates and registers an Agent xDS server as a runnable with the Manager.
 // The server listens on a Unix domain socket and serves Envoy discovery service requests
 // (LDS, CDS, EDS, RDS, ADS) with resource snapshots generated from local pod storage and the registry.
-func setXDSServer(ctx context.Context, m ctrl.Manager, registry registry.Registry, localStorage storage.Storage[*cniv1.CNIPod], snapshotCache *cache.SnapshotCache) error {
+func setXDSServer(ctx context.Context, m ctrl.Manager, registry registry.Registry, localStorage storage.Storage[*cniv1.CNIPod], snapshotCache *cache.SnapshotCache, trustDomain string) error {
 	// Create xDS server
-	xdsSrv, err := xdsServer.NewAgentXdsServer(ctx, cfg.ClusterName, cfg.ProxyServiceNodeID, cfg.SpireTrustDomain, registry, localStorage, snapshotCache, l)
+	xdsSrv, err := xdsServer.NewAgentXdsServer(ctx, cfg.ClusterName, cfg.ProxyServiceNodeID, trustDomain, registry, localStorage, snapshotCache, l)
 	if err != nil {
 		return err
 	}
@@ -201,13 +223,13 @@ func setXDSServer(ctx context.Context, m ctrl.Manager, registry registry.Registr
 // setupCNIServer creates and registers a CNI gRPC server as a runnable with the Manager.
 // The server listens on a Unix domain socket and handles pod registration/deregistration
 // requests from the CNI plugin binary. It stores pod data locally and triggers xDS snapshot updates.
-func setupCNIServer(m ctrl.Manager, localStorage storage.Storage[*cniv1.CNIPod], registry registry.Registry, snapshotCache *cache.SnapshotCache, spireBridge *spire.Bridge) error {
+func setupCNIServer(m ctrl.Manager, localStorage storage.Storage[*cniv1.CNIPod], registry registry.Registry, snapshotCache *cache.SnapshotCache, spireBridge *spire.Bridge, trustDomain string) error {
 	// Create a registry and CNI server
 	cniSrv, err := cniServer.NewCNIServer(
 		cfg.ClusterName,
 		cfg.NodeName,
 		cfg.ProxyServiceNodeID,
-		cfg.SpireTrustDomain,
+		trustDomain,
 		localStorage,
 		registry,
 		snapshotCache,
@@ -247,7 +269,7 @@ func setupStorage(ctx context.Context, path string) (storage.Storage[*cniv1.CNIP
 // registration and discovery operations. When SPIRE is enabled, the connection
 // uses mTLS with an X.509 SVID fetched over the SPIRE Workload API socket;
 // otherwise, insecure transport is used.
-func setupRegistrarClient(ctx context.Context) (registry.Registry, error) {
+func setupRegistrarClient(ctx context.Context, src *commonspire.Source) (registry.Registry, error) {
 	regCfg := registry.RegistrarConfig{
 		Address:     cfg.RegistrarAddress,
 		ClusterName: cfg.ClusterName,
@@ -255,11 +277,9 @@ func setupRegistrarClient(ctx context.Context) (registry.Registry, error) {
 	}
 
 	if cfg.SpireEnabled {
-		src, err := commonspire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
-		if err != nil {
-			return nil, err
-		}
-		context.AfterFunc(ctx, func() { _ = src.Close() })
+		// Peer authorization uses the configured trust domain (which may be the
+		// RootCATrustDomain "authorize any" sentinel), independent of the workload
+		// trust domain used for SDS resource naming.
 		tlsCfg, err := commonspire.ClientTLSConfig(src, cfg.SpireTrustDomain)
 		if err != nil {
 			return nil, err

--- a/common/spire/tls.go
+++ b/common/spire/tls.go
@@ -38,6 +38,19 @@ func NewSource(ctx context.Context, socketPath string) (*Source, error) {
 // same way.
 const RootCATrustDomain = "ROOTCA"
 
+// TrustDomainFromSource returns the SPIFFE trust domain name of the workload SVID
+// served by src (e.g. "example.org"). Use it to construct SPIFFE IDs and SDS
+// resource names from the real trust domain SPIRE issues into, rather than from a
+// configured value (which may be the RootCATrustDomain authorization sentinel).
+// The source has already fetched its first SVID by the time NewSource returns.
+func TrustDomainFromSource(src *Source) (string, error) {
+	svid, err := src.GetX509SVID()
+	if err != nil {
+		return "", fmt.Errorf("fetching workload SVID for trust domain: %w", err)
+	}
+	return svid.ID.TrustDomain().Name(), nil
+}
+
 // ServerTLSConfig returns a mutual-TLS server config that presents the workload
 // SVID from src and authorizes peers belonging to trustDomain (or any valid peer
 // when trustDomain is empty / RootCATrustDomain).


### PR DESCRIPTION
## Problem

`--spire-trust-domain` was overloaded: it set both **peer authorization** (where the `RootCATrustDomain` = `ROOTCA` sentinel means "authorize any valid SVID") and the trust domain used to **construct SPIFFE IDs / SDS resource names** for Envoy listeners (`SpiffeIDFromPod`, validation context `spiffe://<td>`).

With the sentinel default, the agent named SDS secrets `spiffe://ROOTCA/...` while SPIRE — and the SPIRE bridge — issue `spiffe://<real-td>/...` (on talos-main, `aether.internal`). Envoy's SDS requests never matched the delivered secrets, so both the SVID and the validation context stayed *warming* and inbound mTLS failed (upstream `503 connection termination`).

Confirmed on talos-main: SPIRE issues `spiffe://aether.internal/ns/aether-test/sa/echo`; the agent requested `spiffe://ROOTCA/...`.

## Fix

Resolve the **real** workload trust domain from the SPIRE Workload API SVID at startup (`TrustDomainFromSource`) and use it for listener SDS naming (xDS + CNI servers). `--spire-trust-domain` now governs **only peer authorization**, as documented, and may remain the `RootCATrustDomain` sentinel. The Workload API source is opened once in `runAgent` and shared with the registrar client instead of being created per consumer.

## Note

This fixes the SDS **name mismatch**. Full inbound mTLS additionally depends on SPIRE issuing the workload SVID over the delegated API, which currently times out attesting the sandbox PID (separate issue — resolving the app-container PID rather than the pause PID).