### PR TITLE
fix(spire): correct inbound SDS secret delivery (bundle name + subscription context)

### DIFF
--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -61,7 +61,7 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 	if s.spireBridge != nil {
 		spiffeID := proxy.SpiffeIDFromPod(cniPod, s.trustDomain)
 		selectors := spire.PodSelectors(cniPod.GetNamespace(), cniPod.GetServiceAccount(), cniPod.GetName(), podUID)
-		if err = s.spireBridge.SubscribePod(ctx, spiffeID, selectors); err != nil {
+		if err = s.spireBridge.SubscribePod(spiffeID, selectors); err != nil {
 			log.Error(err, "failed to subscribe to SVID", "spiffeID", spiffeID)
 		}
 	}

--- a/agent/internal/spire/BUILD.bazel
+++ b/agent/internal/spire/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_go_logr_logr//:logr",
+        "@com_github_spiffe_go_spiffe_v2//spiffeid",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/agent/delegatedidentity/v1:delegatedidentity",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/types",
         "@org_golang_google_grpc//:grpc",

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -129,8 +129,9 @@ func PodSelectors(namespace, serviceAccount, podName, uid string) []*apitypes.Se
 // The SPIRE agent returns the SVIDs of every registration entry whose selectors
 // are satisfied — no process attestation, so no container PID is required. The
 // SPIFFE ID is used as the secret name for Envoy. It is a no-op if the bridge
-// has not been started yet.
-func (b *Bridge) SubscribePod(ctx context.Context, spiffeID string, selectors []*apitypes.Selector) error {
+// has not been started yet. The subscription is bound to the bridge's lifetime,
+// not any request context.
+func (b *Bridge) SubscribePod(spiffeID string, selectors []*apitypes.Selector) error {
 	if b.client == nil {
 		b.log.V(1).Info("bridge not started, skipping SVID subscription", "spiffeID", spiffeID)
 		return nil
@@ -167,7 +168,11 @@ func (b *Bridge) SubscribePod(ctx context.Context, spiffeID string, selectors []
 					b.log.Info("SVID subscription stream closed", "spiffeID", spiffeID)
 					return
 				}
-				if handleErr := b.handleSVIDUpdate(ctx, resp); handleErr != nil {
+				// Use subCtx (tied to the bridge/subscription lifetime), not the
+				// caller's request context: SubscribePod is called synchronously
+				// from CmdAdd, whose context is cancelled as soon as it returns —
+				// pushing the SVID into the snapshot must outlive that request.
+				if handleErr := b.handleSVIDUpdate(subCtx, resp); handleErr != nil {
 					b.log.Error(handleErr, "handling SVID update", "spiffeID", spiffeID)
 				}
 			}

--- a/agent/internal/spire/converter.go
+++ b/agent/internal/spire/converter.go
@@ -14,6 +14,7 @@ import (
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 )
 
@@ -57,20 +58,26 @@ func SVIDToTLSCertificateSecret(svid *delegatedidentityv1.X509SVIDWithKey) (*tls
 	}, nil
 }
 
-// BundleToValidationContextSecret converts a trust domain's CA certificates
-// to an Envoy validation context Secret. trustDomain is the bare SPIFFE trust
-// domain (e.g., "example.org", as keyed in the SPIRE bundle response); the
-// secret name is its SPIFFE URI form (e.g., "spiffe://example.org") to match
-// the validation context name referenced by inbound listeners and the URI
-// naming used for SVID certificate secrets. The DER-encoded CA certs are PEM-encoded.
+// BundleToValidationContextSecret converts a trust domain's CA certificates to
+// an Envoy validation context Secret. trustDomain may be a bare trust domain
+// name ("example.org") or a SPIFFE URI ("spiffe://example.org") — the SPIRE
+// Delegated Identity bundle map is keyed by the latter. Either way the secret is
+// named with the canonical SPIFFE URI (e.g. "spiffe://example.org") to match the
+// validation context name referenced by inbound listeners and the SVID secret
+// naming. The DER-encoded CA certs are PEM-encoded.
 func BundleToValidationContextSecret(trustDomain string, derCACerts []byte) (*tlsv3.Secret, error) {
+	td, err := spiffeid.TrustDomainFromString(trustDomain)
+	if err != nil {
+		return nil, fmt.Errorf("invalid trust domain %q: %w", trustDomain, err)
+	}
+
 	caPEM, err := derBundleToPEM(derCACerts)
 	if err != nil {
 		return nil, fmt.Errorf("converting CA bundle to PEM for %s: %w", trustDomain, err)
 	}
 
 	return &tlsv3.Secret{
-		Name: fmt.Sprintf("spiffe://%s", trustDomain),
+		Name: td.IDString(),
 		Type: &tlsv3.Secret_ValidationContext{
 			ValidationContext: &tlsv3.CertificateValidationContext{
 				TrustedCa: &corev3.DataSource{

--- a/agent/internal/spire/converter_test.go
+++ b/agent/internal/spire/converter_test.go
@@ -280,6 +280,15 @@ func TestBundleToValidationContextSecret(t *testing.T) {
 			wantName:    "spiffe://cluster.local",
 		},
 		{
+			// The Delegated Identity bundle map is keyed by the SPIFFE URI
+			// (td.IDString()); it must not be double-prefixed.
+			name:        "accepts an already-prefixed SPIFFE URI without doubling it",
+			trustDomain: "spiffe://aether.internal",
+			derCACerts:  validDERCert,
+			wantErr:     false,
+			wantName:    "spiffe://aether.internal",
+		},
+		{
 			name:        "returns error when CA bundle is empty",
 			trustDomain: "example.org",
 			derCACerts:  []byte{},


### PR DESCRIPTION
Two fixes that together let the workload mTLS SDS secrets reach Envoy active.

## 1. Validation-context name double-prefix

SPIRE's Delegated Identity `SubscribeToX509Bundles` keys `ca_certificates` by the trust domain's **SPIFFE URI** (`td.IDString()` → `spiffe://aether.internal`), not the bare name (the proto comment is misleading; verified in SPIRE `pkg/agent/api/delegatedidentity/v1/service.go`). `BundleToValidationContextSecret` then prepended `spiffe://` again → `spiffe://spiffe://aether.internal`, which never matched the listener's `spiffe://<td>` reference, so the validation context stayed *warming*. Normalized via `spiffeid.TrustDomainFromString(...).IDString()`.

## 2. SVID handling tied to the request context

`SubscribePod` is called synchronously from CmdAdd, whose context is cancelled when AddPod returns. The SVID goroutine used that context for `SetSnapshot`, so SVID updates failed with `context canceled` and the secret churned out of the snapshot, destabilizing the pod's listeners. Now uses the bridge/subscription context.

Confirmed live on talos-main: with these, both SVID certs and the validation context go active.