### PR TITLE
fix(agent): give each pod's listeners unique names

### DIFF
--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -63,7 +63,7 @@ func generateInboundHTTPListener(cniPod *cniv1.CNIPod, trustDomain string) (*lis
 	validationContextName := fmt.Sprintf("spiffe://%s", trustDomain)
 
 	return &listenerv3.Listener{
-		Name: "inbound_http",
+		Name: fmt.Sprintf("inbound_http_%s", cniPod.GetName()),
 		Address: &corev3.Address{
 			Address: &corev3.Address_SocketAddress{
 				SocketAddress: &corev3.SocketAddress{
@@ -95,7 +95,7 @@ func generateOutboundHTTPListener(cniPod *cniv1.CNIPod) (*listenerv3.Listener, e
 	}
 
 	return &listenerv3.Listener{
-		Name: "outbound_http",
+		Name: fmt.Sprintf("outbound_http_%s", cniPod.GetName()),
 		Address: &corev3.Address{
 			Address: &corev3.Address_SocketAddress{
 				SocketAddress: &corev3.SocketAddress{

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -23,8 +23,8 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 				Name:             "test-pod",
 				NetworkNamespace: "/var/run/netns/test",
 			},
-			expectedInboundName:  "inbound_http",
-			expectedOutboundName: "outbound_http",
+			expectedInboundName:  "inbound_http_test-pod",
+			expectedOutboundName: "outbound_http_test-pod",
 			expectedError:        false,
 		},
 		{
@@ -46,8 +46,8 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 				Name:             "test-pod",
 				NetworkNamespace: "/var/run/netns/test",
 			},
-			expectedInboundName:  "inbound_http",
-			expectedOutboundName: "outbound_http",
+			expectedInboundName:  "inbound_http_test-pod",
+			expectedOutboundName: "outbound_http_test-pod",
 			expectedError:        false,
 		},
 	}
@@ -124,7 +124,7 @@ func TestGenerateInboundHTTPListener(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, listener)
-			assert.Equal(t, "inbound_http", listener.GetName())
+			assert.Equal(t, "inbound_http_"+tt.cniPod.GetName(), listener.GetName())
 			assert.Equal(t, tt.expectedStatPrefix, listener.GetStatPrefix())
 			assert.Equal(t, corev3.TrafficDirection_INBOUND, listener.GetTrafficDirection())
 
@@ -188,7 +188,7 @@ func TestGenerateOutboundHTTPListener(t *testing.T) {
 
 			require.NoError(t, err)
 			require.NotNil(t, listener)
-			assert.Equal(t, "outbound_http", listener.GetName())
+			assert.Equal(t, "outbound_http_"+tt.cniPod.GetName(), listener.GetName())
 			assert.Equal(t, tt.expectedStatPrefix, listener.GetStatPrefix())
 			assert.Equal(t, corev3.TrafficDirection_OUTBOUND, listener.GetTrafficDirection())
 


### PR DESCRIPTION
## Problem

Inbound/outbound listeners were hardcoded `Name: "inbound_http"` / `"outbound_http"` for **every** pod. xDS resources are keyed by name, so on a node with more than one managed pod the listeners **collided** in the snapshot — only the last-iterated pod's pair survived and every other pod's inbound listener was dropped, so its mesh address refused connections.

Confirmed live on talos-main: with `echo` and `client` on the same node, the proxy showed only 2 dynamic listeners (one netns) and `lds.update_failure`, and client→echo got `503 / connection refused` because echo's inbound listener (`:18080` in echo's netns) was never programmed.

## Fix

Name listeners per pod — `inbound_http_<pod>` / `outbound_http_<pod>` — matching the existing per-pod `StatPrefix`. The names aren't referenced anywhere (the Envoy admin readiness check matches by `network_namespace_filepath`, not name). Tests updated.