### PR TITLE
chore(agent chart): bump Envoy proxy to distroless-v1.38.0

### DIFF
--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -57,8 +57,8 @@ proxy:
   image:
     # Envoy is an upstream image; pin it explicitly (not built by this repo).
     repository: docker.io/envoyproxy/envoy
-    # envoyproxy/envoy:distroless-v1.37.0
-    digest: sha256:92fdb97b9fdb47da82fbe3651b83bd1419e544966d264632af4864004652685f
+    # envoyproxy/envoy:distroless-v1.38.0
+    digest: sha256:a7a56545102f7a682e0cafea2c9b8448af1b09ebb710eab688dfb931e3ec7ff6
   logLevel: info
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).


### PR DESCRIPTION
## What

Bumps the per-node Envoy proxy image pin in `charts/agent/values.yaml`:

- `distroless-v1.37.0` (`sha256:92fdb97b…`) → `distroless-v1.38.0` (`sha256:a7a56545…`)
- Envoy `f1dd21b16c244bda00edfb5ffce577e12d0d2ec2/1.38.0/Clean/RELEASE/BoringSSL`

## Why

Foundation (PR 1) for the Round 2 HBONE-style CONNECT-tunnel data plane. Doing the upgrade first means every subsequent R2 PR is built and validated on the version we ship.

## De-risking

The full R2 tunnel mechanics were re-validated end-to-end on 1.38 in a two-node local spike before this bump:
- CONNECT encap/decap → 200
- subset affinity (client picks the pod)
- per-endpoint CONNECT authority via the `internal_upstream` transport socket's metadata passthrough
- per-endpoint tunnel target (node) via an `ORIGINAL_DST` cluster + `original_dst_lb_config.metadata_key`
- multi-node routing (each pod tunnels to its own node)
- native reachability health check + structural partition gating

No code changes — pin + comment only. `agent_lint_test` and `agent_template_test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)