### PR TITLE
feat(spire): serve the agent node SVID as an SDS secret (R2 PR 2/6)

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -171,7 +171,7 @@ func runAgent(ctx context.Context) (retErr error) {
 	// Optionally create and start the SPIRE bridge for SDS
 	var spireBridge *spire.Bridge
 	if cfg.SpireEnabled {
-		spireBridge = spire.NewBridge(cfg.SpireAdminSocketPath, snapshotCache, l)
+		spireBridge = spire.NewBridge(cfg.SpireAdminSocketPath, snapshotCache, spireSource, l)
 		if err = m.Add(spireBridge); err != nil {
 			return fmt.Errorf("failed to add SPIRE bridge: %w", err)
 		}

--- a/agent/internal/cni/server/pod_test.go
+++ b/agent/internal/cni/server/pod_test.go
@@ -91,7 +91,7 @@ func newTestCNIServer(k8sClient client.Client, stor storage.Storage[*cniv1.CNIPo
 		storage:       stor,
 		registry:      reg,
 		snapshotCache: sc,
-		spireBridge:   spire.NewBridge(agentconstants.DefaultSpireAdminSocketPath, sc, logr.Discard()),
+		spireBridge:   spire.NewBridge(agentconstants.DefaultSpireAdminSocketPath, sc, nil, logr.Discard()),
 		envoyAdmin:    admin.NewClient(envoyAdminAddr),
 		k8sClient:     k8sClient,
 	}

--- a/agent/internal/cni/server/server_integration_test.go
+++ b/agent/internal/cni/server/server_integration_test.go
@@ -64,7 +64,7 @@ func startCNIServer(t *testing.T, ctx context.Context, sockPath string, stor sto
 	sc := cache.NewSnapshotCache("test-node", logr.Discard())
 	cfg := &CNIServerConfig{SocketPath: sockPath}
 
-	srv, err := NewCNIServer("test-cluster", "test-node", "test-node", "example.org", stor, reg, sc, spire.NewBridge(agentconstants.DefaultSpireAdminSocketPath, sc, logr.Discard()), logr.Discard(), k8sClient, cfg)
+	srv, err := NewCNIServer("test-cluster", "test-node", "test-node", "example.org", stor, reg, sc, spire.NewBridge(agentconstants.DefaultSpireAdminSocketPath, sc, nil, logr.Discard()), logr.Discard(), k8sClient, cfg)
 	require.NoError(t, err)
 
 	errCh := make(chan error, 1)

--- a/agent/internal/spire/BUILD.bazel
+++ b/agent/internal/spire/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_go_logr_logr//:logr",
         "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/agent/delegatedidentity/v1:delegatedidentity",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/types",
         "@org_golang_google_grpc//:grpc",
@@ -23,9 +24,14 @@ go_library(
 
 go_test(
     name = "spire_test",
-    srcs = ["converter_test.go"],
+    srcs = [
+        "converter_test.go",
+        "node_svid_test.go",
+    ],
     embed = [":spire"],
     deps = [
+        "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/agent/delegatedidentity/v1:delegatedidentity",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/types",
         "@com_github_stretchr_testify//assert",

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -14,19 +14,32 @@
 package spire
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/go-logr/logr"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 	apitypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
 )
 
+// nodeSVIDRefreshInterval is how often the bridge re-reads its node SVID from
+// the Workload API source to pick up rotations and push the refreshed secret.
+const nodeSVIDRefreshInterval = 30 * time.Second
+
 // SecretStore is the interface for pushing secrets into the xDS snapshot cache.
 type SecretStore interface {
 	SetSecrets(ctx context.Context, secrets []*tlsv3.Secret) error
+}
+
+// X509SVIDSource provides the agent's own node SVID. It is satisfied by the
+// go-spiffe Workload API X509Source the agent already uses for registrar mTLS.
+type X509SVIDSource interface {
+	GetX509SVID() (*x509svid.SVID, error)
 }
 
 // Bridge connects the SPIRE Delegated Identity API to the xDS snapshot cache.
@@ -38,6 +51,12 @@ type Bridge struct {
 	client     *Client
 	store      SecretStore
 	log        logr.Logger
+
+	// nodeSource provides the agent's own SVID (the node identity). When set,
+	// the bridge serves it as an SDS secret named by its SPIFFE ID and refreshes
+	// it on rotation. nodeSpiffeID caches that name for config references.
+	nodeSource   X509SVIDSource
+	nodeSpiffeID string
 
 	mu      sync.RWMutex
 	secrets map[string]*tlsv3.Secret // keyed by secret name (SPIFFE ID or trust domain)
@@ -61,15 +80,27 @@ type podSubscription struct {
 	spiffeID string
 }
 
-// NewBridge creates a new SPIRE bridge.
-func NewBridge(socketPath string, store SecretStore, log logr.Logger) *Bridge {
+// NewBridge creates a new SPIRE bridge. nodeSource is the agent's own Workload
+// API SVID source used to serve the node identity; it may be nil to disable
+// node-SVID serving.
+func NewBridge(socketPath string, store SecretStore, nodeSource X509SVIDSource, log logr.Logger) *Bridge {
 	return &Bridge{
 		socketPath:    socketPath,
 		store:         store,
+		nodeSource:    nodeSource,
 		log:           log.WithName("spire-bridge"),
 		secrets:       make(map[string]*tlsv3.Secret),
 		subscriptions: make(map[string]podSubscription),
 	}
+}
+
+// NodeSpiffeID returns the SPIFFE ID of the agent's node identity once the node
+// SVID has been served, or "" if node-SVID serving is disabled or not yet ready.
+// It is the SDS secret name proxies reference for node-to-node tunnel mTLS.
+func (b *Bridge) NodeSpiffeID() string {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.nodeSpiffeID
 }
 
 // Start connects to the SPIRE agent and begins subscribing to trust bundles.
@@ -96,6 +127,15 @@ func (b *Bridge) Start(ctx context.Context) error {
 	}
 
 	b.log.Info("subscribed to X.509 bundles")
+
+	// Serve the agent's own node SVID (for node-to-node tunnel mTLS and the
+	// node-health listener) and keep it refreshed on rotation.
+	if b.nodeSource != nil {
+		if err := b.refreshNodeSVID(ctx); err != nil {
+			b.log.Error(err, "serving initial node SVID")
+		}
+		go b.runNodeSVIDRefresh(ctx)
+	}
 
 	for {
 		select {
@@ -273,6 +313,65 @@ func (b *Bridge) handleSVIDUpdate(ctx context.Context, resp *delegatedidentityv1
 	b.log.V(1).Info("processed SVID update", "svids", len(resp.GetX509Svids()))
 
 	return b.pushSecrets(ctx)
+}
+
+// runNodeSVIDRefresh periodically re-reads and re-serves the node SVID so
+// rotations are pushed to Envoy. It returns when the context is cancelled.
+func (b *Bridge) runNodeSVIDRefresh(ctx context.Context) {
+	ticker := time.NewTicker(nodeSVIDRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := b.refreshNodeSVID(ctx); err != nil {
+				b.log.V(1).Info("refreshing node SVID", "error", err)
+			}
+		}
+	}
+}
+
+// refreshNodeSVID reads the current node SVID from the Workload API source and,
+// if it changed, updates the cached secret and pushes it. It is a no-op when the
+// node source is unset.
+func (b *Bridge) refreshNodeSVID(ctx context.Context) error {
+	if b.nodeSource == nil {
+		return nil
+	}
+
+	svid, err := b.nodeSource.GetX509SVID()
+	if err != nil {
+		return fmt.Errorf("fetching node SVID: %w", err)
+	}
+
+	secret, err := X509SVIDToTLSCertificateSecret(svid)
+	if err != nil {
+		return fmt.Errorf("converting node SVID: %w", err)
+	}
+
+	b.mu.Lock()
+	if existing, ok := b.secrets[secret.GetName()]; ok && secretsEqual(existing, secret) {
+		b.mu.Unlock()
+		return nil // unchanged; avoid a no-op snapshot bump
+	}
+	b.secrets[secret.GetName()] = secret
+	b.nodeSpiffeID = secret.GetName()
+	b.mu.Unlock()
+
+	b.log.V(1).Info("served node SVID", "spiffeID", secret.GetName())
+	return b.pushSecrets(ctx)
+}
+
+// secretsEqual reports whether two TLS-certificate secrets carry the same cert
+// chain and key, used to skip pushing an unchanged node SVID.
+func secretsEqual(a, b *tlsv3.Secret) bool {
+	ac, bc := a.GetTlsCertificate(), b.GetTlsCertificate()
+	if ac == nil || bc == nil {
+		return false
+	}
+	return bytes.Equal(ac.GetCertificateChain().GetInlineBytes(), bc.GetCertificateChain().GetInlineBytes()) &&
+		bytes.Equal(ac.GetPrivateKey().GetInlineBytes(), bc.GetPrivateKey().GetInlineBytes())
 }
 
 // pushSecrets collects all current secrets and pushes them to the snapshot cache.

--- a/agent/internal/spire/converter.go
+++ b/agent/internal/spire/converter.go
@@ -15,6 +15,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 )
 
@@ -49,6 +50,36 @@ func SVIDToTLSCertificateSecret(svid *delegatedidentityv1.X509SVIDWithKey) (*tls
 			TlsCertificate: &tlsv3.TlsCertificate{
 				CertificateChain: &corev3.DataSource{
 					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: certChainPEM},
+				},
+				PrivateKey: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: keyPEM},
+				},
+			},
+		},
+	}, nil
+}
+
+// X509SVIDToTLSCertificateSecret converts a go-spiffe X.509 SVID (as returned by
+// the Workload API source) to an Envoy TLS certificate Secret. The secret name is
+// the full SPIFFE ID URI. This is used to serve the agent's own node identity to
+// the proxy for node-to-node tunnel mTLS and the node-health listener, distinct
+// from the per-pod workload SVIDs served via the Delegated Identity API.
+func X509SVIDToTLSCertificateSecret(svid *x509svid.SVID) (*tlsv3.Secret, error) {
+	if svid == nil {
+		return nil, fmt.Errorf("svid is nil")
+	}
+
+	certPEM, keyPEM, err := svid.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshaling X.509 SVID: %w", err)
+	}
+
+	return &tlsv3.Secret{
+		Name: svid.ID.String(),
+		Type: &tlsv3.Secret_TlsCertificate{
+			TlsCertificate: &tlsv3.TlsCertificate{
+				CertificateChain: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: certPEM},
 				},
 				PrivateKey: &corev3.DataSource{
 					Specifier: &corev3.DataSource_InlineBytes{InlineBytes: keyPEM},

--- a/agent/internal/spire/node_svid_test.go
+++ b/agent/internal/spire/node_svid_test.go
@@ -1,0 +1,76 @@
+package spire
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestX509SVID builds a minimal go-spiffe X.509 SVID with the given SPIFFE ID,
+// as the Workload API source would return for the agent's node identity.
+func newTestX509SVID(t *testing.T, id string) *x509svid.SVID {
+	t.Helper()
+
+	sid := spiffeid.RequireFromString(id)
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"SPIRE"}},
+		URIs:                  []*url.URL{sid.URL()},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return &x509svid.SVID{
+		ID:           sid,
+		Certificates: []*x509.Certificate{cert},
+		PrivateKey:   key,
+	}
+}
+
+func TestX509SVIDToTLSCertificateSecret(t *testing.T) {
+	id := "spiffe://example.org/ns/aether-system/sa/aether-agent"
+	secret, err := X509SVIDToTLSCertificateSecret(newTestX509SVID(t, id))
+	require.NoError(t, err)
+
+	assert.Equal(t, id, secret.GetName(), "secret name must be the node SPIFFE ID")
+	cert := secret.GetTlsCertificate()
+	require.NotNil(t, cert)
+	assert.Equal(t, "CERTIFICATE", pemBlockType(cert.GetCertificateChain().GetInlineBytes()))
+	assert.Equal(t, "PRIVATE KEY", pemBlockType(cert.GetPrivateKey().GetInlineBytes()))
+}
+
+func TestX509SVIDToTLSCertificateSecret_Nil(t *testing.T) {
+	_, err := X509SVIDToTLSCertificateSecret(nil)
+	require.Error(t, err)
+}
+
+func TestSecretsEqual(t *testing.T) {
+	a, err := X509SVIDToTLSCertificateSecret(newTestX509SVID(t, "spiffe://example.org/ns/x/sa/a"))
+	require.NoError(t, err)
+
+	assert.True(t, secretsEqual(a, a), "identical secrets compare equal")
+
+	b, err := X509SVIDToTLSCertificateSecret(newTestX509SVID(t, "spiffe://example.org/ns/x/sa/a"))
+	require.NoError(t, err)
+	assert.False(t, secretsEqual(a, b), "a rotated cert (new key) compares unequal")
+}


### PR DESCRIPTION
## Stack
Round 2 HBONE-style CONNECT-tunnel data plane, built as a stack:
- **PR 2/6 (this) — node SVID** ← base on `main`
- PR 3/6 — dest CONNECT listener (on this)
- PR 4/6 — client tunnel plumbing
- PR 5/6 — health checks
- PR 6/6 — EDS metadata wiring

## What
Serves the agent's own Workload-API SVID as an SDS secret so the proxy can present a **node identity** for node-to-node tunnel mTLS and the node-health listener.

- The agent already holds this SVID via the go-spiffe Workload API source used for registrar mTLS — **no new SPIRE registration or cross-pod identity resolution**.
- Served as a `TlsCertificate` secret named by its SPIFFE ID; `Bridge.NodeSpiffeID()` exposes the name for downstream config (PRs 3/5).
- Refreshed on rotation (30s poll), pushing only on change to avoid no-op snapshot bumps.

## Tests
New converter + equality tests; full agent suite passes. No behavior change to existing pod-SVID / bundle serving (the node secret coexists under a distinct name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)