### PR TITLE
feat(agent): node-level CONNECT-terminating listener (R2 PR 3/6)

### DIFF
--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -36,6 +36,14 @@ type SecretStore interface {
 	SetSecrets(ctx context.Context, secrets []*tlsv3.Secret) error
 }
 
+// NodeIdentitySink receives the agent's node SPIFFE ID when the node SVID is
+// served, so resources that reference it (the node CONNECT listener) can be
+// generated. The xDS snapshot cache satisfies it; the bridge calls it only when
+// its store also implements this interface.
+type NodeIdentitySink interface {
+	SetNodeIdentity(ctx context.Context, nodeSpiffeID string) error
+}
+
 // X509SVIDSource provides the agent's own node SVID. It is satisfied by the
 // go-spiffe Workload API X509Source the agent already uses for registrar mTLS.
 type X509SVIDSource interface {
@@ -356,8 +364,20 @@ func (b *Bridge) refreshNodeSVID(ctx context.Context) error {
 		return nil // unchanged; avoid a no-op snapshot bump
 	}
 	b.secrets[secret.GetName()] = secret
+	firstServe := b.nodeSpiffeID == ""
 	b.nodeSpiffeID = secret.GetName()
 	b.mu.Unlock()
+
+	// Inform the cache of the node identity so the node CONNECT listener (which
+	// references it as its server cert) is generated. Only needed once: the
+	// SPIFFE ID is stable across rotations.
+	if firstServe {
+		if sink, ok := b.store.(NodeIdentitySink); ok {
+			if err := sink.SetNodeIdentity(ctx, secret.GetName()); err != nil {
+				b.log.Error(err, "setting node identity on cache", "spiffeID", secret.GetName())
+			}
+		}
+	}
 
 	b.log.V(1).Info("served node SVID", "spiffeID", secret.GetName())
 	return b.pushSecrets(ctx)

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -19,6 +19,7 @@ package cache
 import (
 	"sync"
 
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -62,6 +63,10 @@ type SnapshotCache struct {
 	// trustDomain is the workload trust domain captured from listener loads,
 	// used to name the upstream mTLS validation context.
 	trustDomain string
+	// nodeSpiffeID is the agent's node identity (set by the SPIRE bridge once the
+	// node SVID is served). It is the downstream server-cert secret name for the
+	// node CONNECT listener; while empty, that listener is not generated.
+	nodeSpiffeID string
 
 	version *atomic.Uint64
 }
@@ -76,6 +81,9 @@ type listenerEntry struct {
 	inbound    types.Resource
 	outbound   types.Resource
 	appCluster types.Resource
+	// pod is retained so the node-level CONNECT listener can be (re)built with a
+	// route per local pod (keyed on the pod IP) to its app cluster.
+	pod *cniv1.CNIPod
 }
 
 // clusterEntry holds a cluster definition, its pre-built load assignment,

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/agent/storage"
@@ -31,6 +32,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 		inbound:    inbound,
 		outbound:   outbound,
 		appCluster: appCluster,
+		pod:        cniPod,
 	}
 	c.listenerMu.Unlock()
 
@@ -71,6 +73,38 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 		resources = append(resources, entry.inbound, entry.outbound)
 	}
 	return resources
+}
+
+// nodeConnectListener builds the node-level CONNECT-terminating listener from the
+// current local pods and the node identity. It returns nil when no node SVID has
+// been served yet (the listener references it as its server certificate). Building
+// it from the cached pods keeps the R2 tunnel ingress in sync with pod adds and
+// removes without disturbing the per-pod R1 inbound listeners. Thread-safe.
+func (c *SnapshotCache) nodeConnectListener() types.Resource {
+	c.localMu.RLock()
+	nodeSpiffeID := c.nodeSpiffeID
+	trustDomain := c.trustDomain
+	c.localMu.RUnlock()
+
+	if nodeSpiffeID == "" {
+		return nil
+	}
+
+	c.listenerMu.RLock()
+	pods := make([]*cniv1.CNIPod, 0, len(c.listeners))
+	for _, entry := range c.listeners {
+		if entry.pod != nil {
+			pods = append(pods, entry.pod)
+		}
+	}
+	c.listenerMu.RUnlock()
+
+	validationContextName := fmt.Sprintf("spiffe://%s", trustDomain)
+	l := proxy.GenerateNodeConnectListener(pods, nodeSpiffeID, validationContextName)
+	if l == nil {
+		return nil
+	}
+	return l
 }
 
 // appClusters returns the per-pod application clusters (one per managed pod)
@@ -129,6 +163,7 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 			inbound:    inbound,
 			outbound:   outbound,
 			appCluster: appCluster,
+			pod:        pod,
 		}
 		local[netns] = proxy.SpiffeIDFromPod(pod, trustDomain)
 	}

--- a/agent/internal/xds/cache/secret.go
+++ b/agent/internal/xds/cache/secret.go
@@ -20,6 +20,22 @@ func (c *SnapshotCache) SetSecrets(ctx context.Context, secrets []*tlsv3.Secret)
 	return c.generateSecretSnapshot(ctx)
 }
 
+// SetNodeIdentity records the agent's node SPIFFE ID (served by the SPIRE bridge
+// as the node SVID) and regenerates the snapshot. The node CONNECT listener uses
+// it as its downstream server-certificate secret name; until it is set, that
+// listener is omitted. Idempotent: a no-op when the value is unchanged.
+func (c *SnapshotCache) SetNodeIdentity(ctx context.Context, nodeSpiffeID string) error {
+	c.localMu.Lock()
+	if c.nodeSpiffeID == nodeSpiffeID {
+		c.localMu.Unlock()
+		return nil
+	}
+	c.nodeSpiffeID = nodeSpiffeID
+	c.localMu.Unlock()
+
+	return c.generateSnapshot(ctx)
+}
+
 // generateSecretSnapshot regenerates the node snapshot after a secret change.
 // It delegates to generateSnapshot, which emits a complete snapshot of all
 // resource types so secret updates do not clobber listeners or clusters.

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -26,6 +26,11 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) error {
 	v := generateSnapshotVersion(snapshotVersionLabel, c.version)
 
 	listeners := c.Listeners()
+	// The node-level CONNECT listener (R2 tunnel ingress) is built from the
+	// current local pods + node identity; nil until the node SVID is served.
+	if nodeConnect := c.nodeConnectListener(); nodeConnect != nil {
+		listeners = append(listeners, nodeConnect)
+	}
 	clusters, endpoints, vhosts := c.clustersEndpointsAndVhosts()
 
 	// Per-pod application clusters live alongside listeners (not in the

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "proxy",
     srcs = [
         "cluster.go",
+        "connectlistener.go",
         "endpoint.go",
         "filterchain.go",
         "httpfilter.go",
@@ -36,6 +37,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/matching/common_inputs/transport_socket/v3:transport_socket",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
+        "@com_github_envoyproxy_go_control_plane_envoy//type/matcher/v3:matcher",
         "@com_github_envoyproxy_go_control_plane_envoy//type/v3:type",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
@@ -49,6 +51,7 @@ go_test(
     name = "proxy_test",
     srcs = [
         "cluster_test.go",
+        "connectlistener_test.go",
         "endpoint_test.go",
         "filterchain_test.go",
         "httpfilter_test.go",

--- a/agent/internal/xds/proxy/connectlistener.go
+++ b/agent/internal/xds/proxy/connectlistener.go
@@ -1,0 +1,149 @@
+package proxy
+
+import (
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+)
+
+const (
+	// NodeConnectListenerName is the name of the node-level CONNECT-terminating
+	// listener that receives HBONE-style tunnels from peer node proxies.
+	NodeConnectListenerName = "node_connect"
+	// defaultNodeConnectPort is the host port the node CONNECT listener binds.
+	// It is node-level (host network namespace), distinct from the per-pod
+	// inbound listeners on 18080, so the R2 tunnel data path can be introduced
+	// without disturbing the existing R1 inbound path.
+	defaultNodeConnectPort = 15008
+	// NodeLivePath is the readiness path a peer proxy's reachability health check
+	// hits on the node CONNECT listener; it is answered locally, never tunneled.
+	NodeLivePath = "/-/-/node/live"
+)
+
+// GenerateNodeConnectListener builds the node-level CONNECT-terminating listener.
+// Peer node proxies open an mTLS HTTP/2 CONNECT tunnel to it; the listener routes
+// each tunnel by its :authority (the destination pod's IP) to that pod's app
+// cluster, delivering the decrypted stream to the pod's application on loopback.
+// A non-tunneled GET on NodeLivePath is answered locally with 200 so peers can
+// health-check node reachability without hitting any application.
+//
+// Downstream mTLS presents the node identity (nodeSpiffeID) and requires and
+// validates the caller's workload SVID against the trust domain
+// (validationContextName); the verified peer identity — the originating client
+// pod — is exposed to the application via XFCC. nodeSpiffeID may be empty before
+// the node SVID is served, in which case no listener is produced.
+func GenerateNodeConnectListener(localPods []*cniv1.CNIPod, nodeSpiffeID, validationContextName string) *listenerv3.Listener {
+	if nodeSpiffeID == "" {
+		return nil
+	}
+
+	hcm := &http_connection_managerv3.HttpConnectionManager{
+		StatPrefix: NodeConnectListenerName,
+		CodecType:  http_connection_managerv3.HttpConnectionManager_HTTP2,
+		Http2ProtocolOptions: &corev3.Http2ProtocolOptions{
+			AllowConnect: true,
+		},
+		HttpFilters: []*http_connection_managerv3.HttpFilter{
+			routerHttpFilter(),
+		},
+		// Expose the tunnel-verified caller (the client pod) to the application.
+		ForwardClientCertDetails: http_connection_managerv3.HttpConnectionManager_SANITIZE_SET,
+		SetCurrentClientCertDetails: &http_connection_managerv3.HttpConnectionManager_SetCurrentClientCertDetails{
+			Uri: true,
+		},
+		RouteSpecifier: &http_connection_managerv3.HttpConnectionManager_RouteConfig{
+			RouteConfig: buildNodeConnectRouteConfiguration(localPods),
+		},
+	}
+
+	return &listenerv3.Listener{
+		Name: NodeConnectListenerName,
+		Address: &corev3.Address{
+			Address: &corev3.Address_SocketAddress{
+				SocketAddress: &corev3.SocketAddress{
+					Protocol: corev3.SocketAddress_TCP,
+					Address:  defaultInboundAddress,
+					PortSpecifier: &corev3.SocketAddress_PortValue{
+						PortValue: defaultNodeConnectPort,
+					},
+				},
+			},
+		},
+		StatPrefix:       NodeConnectListenerName,
+		TrafficDirection: corev3.TrafficDirection_INBOUND,
+		ListenerFilters:  buildInboundListenerFilters(),
+		FilterChains: []*listenerv3.FilterChain{
+			{
+				Name:            NodeConnectListenerName,
+				Filters:         []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
+				TransportSocket: DownstreamTransportSocket(nodeSpiffeID, validationContextName),
+			},
+		},
+	}
+}
+
+// buildNodeConnectRouteConfiguration builds the route table for the node CONNECT
+// listener: a local-only readiness route, then one CONNECT route per local pod
+// keyed on the destination pod's IP (:authority) that terminates the tunnel and
+// forwards to that pod's app cluster.
+func buildNodeConnectRouteConfiguration(localPods []*cniv1.CNIPod) *routev3.RouteConfiguration {
+	routes := make([]*routev3.Route, 0, len(localPods)+1)
+
+	// Reachability health check, answered locally (never tunneled to an app).
+	routes = append(routes, &routev3.Route{
+		Match: &routev3.RouteMatch{
+			PathSpecifier: &routev3.RouteMatch_Path{Path: NodeLivePath},
+		},
+		Action: &routev3.Route_DirectResponse{
+			DirectResponse: &routev3.DirectResponseAction{
+				Status: 200,
+				Body: &corev3.DataSource{
+					Specifier: &corev3.DataSource_InlineString{InlineString: "node-alive\n"},
+				},
+			},
+		},
+	})
+
+	for _, pod := range localPods {
+		ips := pod.GetIps()
+		if len(ips) == 0 {
+			continue
+		}
+		routes = append(routes, &routev3.Route{
+			Match: &routev3.RouteMatch{
+				PathSpecifier: &routev3.RouteMatch_ConnectMatcher_{
+					ConnectMatcher: &routev3.RouteMatch_ConnectMatcher{},
+				},
+				Headers: []*routev3.HeaderMatcher{
+					{
+						Name: ":authority",
+						HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+							StringMatch: &matcherv3.StringMatcher{
+								MatchPattern: &matcherv3.StringMatcher_Exact{Exact: ips[0]},
+							},
+						},
+					},
+				},
+			},
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: AppClusterName(pod)},
+					UpgradeConfigs: []*routev3.RouteAction_UpgradeConfig{
+						{
+							UpgradeType:   "CONNECT",
+							ConnectConfig: &routev3.RouteAction_UpgradeConfig_ConnectConfig{},
+						},
+					},
+				},
+			},
+		})
+	}
+
+	return &routev3.RouteConfiguration{
+		Name:         NodeConnectListenerName,
+		VirtualHosts: []*routev3.VirtualHost{{Name: "tunnel", Domains: []string{"*"}, Routes: routes}},
+	}
+}

--- a/agent/internal/xds/proxy/connectlistener_test.go
+++ b/agent/internal/xds/proxy/connectlistener_test.go
@@ -1,0 +1,72 @@
+package proxy
+
+import (
+	"testing"
+
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateNodeConnectListener_NoNodeIdentity(t *testing.T) {
+	l := GenerateNodeConnectListener(nil, "", "spiffe://example.org")
+	assert.Nil(t, l, "no listener without a node identity")
+}
+
+func TestGenerateNodeConnectListener(t *testing.T) {
+	pods := []*cniv1.CNIPod{
+		{Name: "pod-a", Ips: []string{"10.0.0.1"}},
+		{Name: "pod-b", Ips: []string{"10.0.0.2"}},
+		{Name: "no-ip"}, // skipped: no IP
+	}
+
+	l := GenerateNodeConnectListener(pods, "spiffe://example.org/ns/aether-system/sa/aether-agent", "spiffe://example.org")
+	require.NotNil(t, l)
+	assert.Equal(t, NodeConnectListenerName, l.GetName())
+	assert.Equal(t, uint32(defaultNodeConnectPort), l.GetAddress().GetSocketAddress().GetPortValue())
+
+	fc := l.GetFilterChains()
+	require.Len(t, fc, 1)
+	assert.NotNil(t, fc[0].GetTransportSocket(), "node CONNECT listener must have downstream mTLS")
+
+	// Decode the HCM and assert CONNECT + routing.
+	require.Len(t, fc[0].GetFilters(), 1)
+	hcm := &http_connection_managerv3.HttpConnectionManager{}
+	require.NoError(t, fc[0].GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
+	assert.True(t, hcm.GetHttp2ProtocolOptions().GetAllowConnect(), "must allow CONNECT")
+	assert.Equal(t, http_connection_managerv3.HttpConnectionManager_SANITIZE_SET, hcm.GetForwardClientCertDetails())
+	assert.True(t, hcm.GetSetCurrentClientCertDetails().GetUri(), "must forward caller URI SAN")
+
+	routes := hcm.GetRouteConfig().GetVirtualHosts()[0].GetRoutes()
+	// node-live + one route per pod with an IP (2 of 3 pods).
+	require.Len(t, routes, 3)
+	assert.Equal(t, NodeLivePath, routes[0].GetMatch().GetPath())
+	assert.Equal(t, uint32(200), routes[0].GetDirectResponse().GetStatus())
+
+	// Each pod route is a CONNECT match on the pod IP -> its app cluster.
+	byCluster := map[string]string{} // cluster -> authority match
+	for _, r := range routes[1:] {
+		require.NotNil(t, r.GetMatch().GetConnectMatcher())
+		require.Len(t, r.GetMatch().GetHeaders(), 1)
+		authority := r.GetMatch().GetHeaders()[0].GetStringMatch().GetExact()
+		ra := r.GetRoute()
+		require.NotNil(t, ra)
+		require.Len(t, ra.GetUpgradeConfigs(), 1)
+		assert.Equal(t, "CONNECT", ra.GetUpgradeConfigs()[0].GetUpgradeType())
+		assert.NotNil(t, ra.GetUpgradeConfigs()[0].GetConnectConfig())
+		byCluster[ra.GetCluster()] = authority
+	}
+	assert.Equal(t, "10.0.0.1", byCluster[AppClusterName(pods[0])])
+	assert.Equal(t, "10.0.0.2", byCluster[AppClusterName(pods[1])])
+}
+
+func TestBuildNodeConnectRouteConfiguration_Empty(t *testing.T) {
+	rc := buildNodeConnectRouteConfiguration(nil)
+	routes := rc.GetVirtualHosts()[0].GetRoutes()
+	require.Len(t, routes, 1, "only the node-live route when there are no pods")
+	assert.Equal(t, NodeLivePath, routes[0].GetMatch().GetPath())
+	_, ok := routes[0].GetAction().(*routev3.Route_DirectResponse)
+	assert.True(t, ok)
+}


### PR DESCRIPTION
## Stack
- PR 2/6 — node SVID (#84) ← base
- **PR 3/6 (this) — dest CONNECT listener** ← stacked on #84
- PR 4/6 — client tunnel plumbing
- PR 5/6 — health checks
- PR 6/6 — EDS metadata wiring

> Targets `feat/r2-node-svid`; rebase onto `main` once #84 merges.

## What
Adds the node-level CONNECT-terminating listener — the R2 tunnel **ingress**. Peer node proxies open an mTLS HTTP/2 CONNECT tunnel to it; it routes each tunnel by `:authority` (the destination pod's IP) to that pod's `app_<pod>` cluster, delivering the decrypted stream to the app on loopback. A non-tunneled `GET /-/-/node/live` is answered locally with 200 for peer reachability health checks.

## Safety: additive
- Node-level on host port **15008**, separate from the per-pod R1 inbound on `18080`. The live mesh is undisturbed; clients are flipped over in PR 4.
- Downstream mTLS presents the **node identity** (PR 2) and validates the caller's **workload SVID**; the verified **client pod** is exposed to the app via XFCC (`SANITIZE_SET` + URI) — matching the identity model proven in the spike (dest sees the client pod, not the node).

## Wiring
- The SPIRE bridge notifies the cache of the node SPIFFE ID via `NodeIdentitySink` once the node SVID is served; until then the listener is omitted.
- The route table is rebuilt from the cached local pods on every pod add/remove.

## Tests
New `connectlistener` tests (CONNECT routing, per-pod IP→app-cluster, node-live, mTLS, no-identity → nil); full agent suite (12/12) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)