### PR TITLE
feat(registry): stamp node InternalIP on endpoints (R2 PR 5/6)

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "node_ip_test.go",
         "pod_test.go",
         "server_integration_test.go",
     ],

--- a/agent/internal/cni/server/node_ip_test.go
+++ b/agent/internal/cni/server/node_ip_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNodeInternalIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []corev1.NodeAddress
+		want      string
+	}{
+		{
+			name: "internal IP present among others",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "node-1"},
+				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.7"},
+			},
+			want: "10.0.0.7",
+		},
+		{
+			name:      "no internal IP",
+			addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}},
+			want:      "",
+		},
+		{
+			name:      "no addresses",
+			addresses: nil,
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &corev1.Node{Status: corev1.NodeStatus{Addresses: tt.addresses}}
+			assert.Equal(t, tt.want, nodeInternalIP(node))
+		})
+	}
+}

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -49,7 +49,7 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		return nil, status.Errorf(codes.Internal, "failed to add pod to storage: %v", err)
 	}
 
-	serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, cniPod)
+	serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeIP, s.nodeRegion, s.nodeZone, cniPod)
 	if err = s.registry.RegisterEndpoint(ctx, serviceName, protocol, sEndpoint); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to register endpoint: %v", err)
 	}

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -40,6 +40,7 @@ type CNIServer struct {
 	trustDomain string
 	nodeRegion  string
 	nodeZone    string
+	nodeIP      string
 
 	storage  storage.Storage[*cniv1.CNIPod]
 	registry registry.Registry
@@ -89,26 +90,40 @@ func NewCNIServer(clusterName string, nodeName string, proxyID string, trustDoma
 // It retrieves the region and zone labels from the node object.
 func (s *CNIServer) PreListen(ctx context.Context) error {
 	s.log.V(2).Info("querying node metadata")
-	region, zone, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
+	region, zone, nodeIP, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
 	if err != nil {
 		return err
 	}
 
 	s.nodeRegion = region
 	s.nodeZone = zone
+	s.nodeIP = nodeIP
 
-	s.log.V(1).Info("node metadata queried successfully", "region", region, "zone", zone)
+	s.log.V(1).Info("node metadata queried successfully", "region", region, "zone", zone, "nodeIP", nodeIP)
 	return nil
 }
 
-// queryNodeMetadata retrieves the region and zone labels from a Kubernetes node.
-// It returns the topology.kubernetes.io/region and topology.kubernetes.io/zone labels,
-// or empty strings if the labels are not present.
-func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (string, string, error) {
+// queryNodeMetadata retrieves the region and zone labels and the InternalIP from
+// a Kubernetes node. It returns the topology.kubernetes.io/region and
+// topology.kubernetes.io/zone labels (empty if absent) and the node's InternalIP
+// address, used as the HBONE tunnel target for endpoints on this node.
+func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (region, zone, nodeIP string, err error) {
 	node := &corev1.Node{}
 	if err := client.Get(ctx, types.NamespacedName{Name: proxyID}, node); err != nil {
-		return "", "", fmt.Errorf("failed to get node: %w", err)
+		return "", "", "", fmt.Errorf("failed to get node: %w", err)
 	}
 
-	return node.Labels[constants.AnnotationKubernetesNodeTopologyRegion], node.Labels[constants.AnnotationKubernetesNodeTopologyZone], nil
+	return node.Labels[constants.AnnotationKubernetesNodeTopologyRegion],
+		node.Labels[constants.AnnotationKubernetesNodeTopologyZone],
+		nodeInternalIP(node), nil
+}
+
+// nodeInternalIP returns the node's InternalIP address, or "" if none is present.
+func nodeInternalIP(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
 }

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -35,6 +35,11 @@ message ServiceEndpoint {
     string namespace = 1 [(buf.validate.field).string.min_len = 1];
     string pod_name = 2 [(buf.validate.field).string.min_len = 1];
     string node_name = 3 [(buf.validate.field).string.min_len = 1];
+    // node_ip is the InternalIP of the node hosting this endpoint. Consumers use
+    // it as the HBONE-style tunnel target (node_ip:15008) to reach the node's
+    // CONNECT listener, which forwards to the destination pod. Stamped by the
+    // node-local agent at registration.
+    string node_ip = 4;
   }
 
   KubernetesMetadata kubernetes_metadata = 8;

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -13,7 +13,7 @@ import (
 // It extracts the service name from the pod's labels and the port and weight from annotations.
 // The service protocol is always HTTP. Container and Kubernetes metadata are included
 // along with node locality information.
-func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
+func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeIP string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
 	protocol := registryv1.Service_PROTOCOL_HTTP
 
 	serviceName, err := getServiceName(cniPod)
@@ -45,6 +45,7 @@ func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegio
 			Namespace: cniPod.GetNamespace(),
 			PodName:   cniPod.GetName(),
 			NodeName:  nodeName,
+			NodeIp:    nodeIP,
 		},
 		Locality: &registryv1.ServiceEndpoint_Locality{
 			Region: nodeRegion,


### PR DESCRIPTION
## Stack
- PR 4/6 — tunnel-client generators (#86, now on `main`) ← base
- **PR 5/6 (this) — endpoint node_ip** ← stacked on #86
- PR 6/6 — `<C>` rewire (wires generators + node_ip into the live data path)

> Targets `feat/r2-tunnel-client-generators`; rebase onto `main` once #86 merges.

## What
Adds `KubernetesMetadata.node_ip` and populates it from the hosting node's **InternalIP** at registration. Consumers use it as the HBONE tunnel target (`node_ip:15008`) to reach the destination node's CONNECT listener (PR 3), which forwards to the destination pod.

## Why this way
The node-local agent already fetches its Node object in the CNI server's `PreListen` (for region/zone). This extends that single lookup to also capture the InternalIP, so **each agent stamps its own node IP** — no cross-node `name→IP` resolution on consumers.

## Tests
New `nodeInternalIP` test (picks InternalIP among address types, empty when absent); full agent + registry suites pass. Proto is bazel-generated, so the new field flows through automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)