### PR TITLE
feat(agent): wire outbound clusters onto the HBONE tunnel (R2 PR 6/6)

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "node_ip_test.go",
         "pod_test.go",
         "server_integration_test.go",
     ],

--- a/agent/internal/cni/server/node_ip_test.go
+++ b/agent/internal/cni/server/node_ip_test.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestNodeInternalIP(t *testing.T) {
+	tests := []struct {
+		name      string
+		addresses []corev1.NodeAddress
+		want      string
+	}{
+		{
+			name: "internal IP present among others",
+			addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeHostName, Address: "node-1"},
+				{Type: corev1.NodeExternalIP, Address: "1.2.3.4"},
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.7"},
+			},
+			want: "10.0.0.7",
+		},
+		{
+			name:      "no internal IP",
+			addresses: []corev1.NodeAddress{{Type: corev1.NodeExternalIP, Address: "1.2.3.4"}},
+			want:      "",
+		},
+		{
+			name:      "no addresses",
+			addresses: nil,
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &corev1.Node{Status: corev1.NodeStatus{Addresses: tt.addresses}}
+			assert.Equal(t, tt.want, nodeInternalIP(node))
+		})
+	}
+}

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -49,7 +49,7 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		return nil, status.Errorf(codes.Internal, "failed to add pod to storage: %v", err)
 	}
 
-	serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, cniPod)
+	serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeIP, s.nodeRegion, s.nodeZone, cniPod)
 	if err = s.registry.RegisterEndpoint(ctx, serviceName, protocol, sEndpoint); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to register endpoint: %v", err)
 	}

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -40,6 +40,7 @@ type CNIServer struct {
 	trustDomain string
 	nodeRegion  string
 	nodeZone    string
+	nodeIP      string
 
 	storage  storage.Storage[*cniv1.CNIPod]
 	registry registry.Registry
@@ -89,26 +90,40 @@ func NewCNIServer(clusterName string, nodeName string, proxyID string, trustDoma
 // It retrieves the region and zone labels from the node object.
 func (s *CNIServer) PreListen(ctx context.Context) error {
 	s.log.V(2).Info("querying node metadata")
-	region, zone, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
+	region, zone, nodeIP, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
 	if err != nil {
 		return err
 	}
 
 	s.nodeRegion = region
 	s.nodeZone = zone
+	s.nodeIP = nodeIP
 
-	s.log.V(1).Info("node metadata queried successfully", "region", region, "zone", zone)
+	s.log.V(1).Info("node metadata queried successfully", "region", region, "zone", zone, "nodeIP", nodeIP)
 	return nil
 }
 
-// queryNodeMetadata retrieves the region and zone labels from a Kubernetes node.
-// It returns the topology.kubernetes.io/region and topology.kubernetes.io/zone labels,
-// or empty strings if the labels are not present.
-func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (string, string, error) {
+// queryNodeMetadata retrieves the region and zone labels and the InternalIP from
+// a Kubernetes node. It returns the topology.kubernetes.io/region and
+// topology.kubernetes.io/zone labels (empty if absent) and the node's InternalIP
+// address, used as the HBONE tunnel target for endpoints on this node.
+func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (region, zone, nodeIP string, err error) {
 	node := &corev1.Node{}
 	if err := client.Get(ctx, types.NamespacedName{Name: proxyID}, node); err != nil {
-		return "", "", fmt.Errorf("failed to get node: %w", err)
+		return "", "", "", fmt.Errorf("failed to get node: %w", err)
 	}
 
-	return node.Labels[constants.AnnotationKubernetesNodeTopologyRegion], node.Labels[constants.AnnotationKubernetesNodeTopologyZone], nil
+	return node.Labels[constants.AnnotationKubernetesNodeTopologyRegion],
+		node.Labels[constants.AnnotationKubernetesNodeTopologyZone],
+		nodeInternalIP(node), nil
+}
+
+// nodeInternalIP returns the node's InternalIP address, or "" if none is present.
+func nodeInternalIP(node *corev1.Node) string {
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			return addr.Address
+		}
+	}
+	return ""
 }

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//api/aether/cni/v1:cni",
         "//api/aether/registry/v1:registry",
         "//registry",
-        "@com_github_cncf_xds_go//xds/type/matcher/v3:matcher",
         "@com_github_envoyproxy_go_control_plane//pkg/cache/types",
         "@com_github_envoyproxy_go_control_plane//pkg/cache/v3:cache",
         "@com_github_envoyproxy_go_control_plane//pkg/resource/v3:resource",
@@ -27,7 +26,6 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_go_logr_logr//:logr",
-        "@org_golang_google_protobuf//proto",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -3,17 +3,13 @@ package cache
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/registry"
-	matcherv3 "github.com/cncf/xds/go/xds/type/matcher/v3"
-	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
-	"google.golang.org/protobuf/proto"
 )
 
 // RemoveEndpoint removes a single endpoint by IP from the given cluster's
@@ -66,22 +62,12 @@ func (c *SnapshotCache) RemoveCluster(ctx context.Context, clusterName string) e
 	return c.generateClusterSnapshot(ctx)
 }
 
-// localClusterPrefix marks the same-node ("local_<service>") cluster variants,
-// which are excluded from upstream mTLS matcher injection.
-const localClusterPrefix = "local_"
-
-// clustersEndpointsAndVhosts returns all cached cluster, endpoint, and virtual host
-// resources as separate slices. It returns concrete vhost type to avoid boxing/unboxing
-// at the caller.
-//
-// Each regular (non-local) service cluster is cloned and given the upstream mTLS
-// transport-socket matcher/matches derived from the current local workloads, so
-// the cloned cluster presents the originating pod's client certificate. Cloning
-// avoids mutating the cached cluster pointer, which is rebuilt wholesale on
-// registry reloads.
+// clustersEndpointsAndVhosts returns all cached cluster, endpoint, and virtual
+// host resources as separate slices. It returns the concrete vhost type to avoid
+// boxing/unboxing at the caller. Service clusters tunnel via the internal_upstream
+// transport socket (set at build time); the per-source mTLS now lives on the
+// shared tunnel_originate cluster, so no per-cluster matcher injection is needed.
 func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.Resource, []*routev3.VirtualHost) {
-	matcher, matches := c.upstreamMTLS()
-
 	c.clusterMu.RLock()
 	defer c.clusterMu.RUnlock()
 
@@ -89,14 +75,7 @@ func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.
 	clas := make([]types.Resource, 0, len(c.clusters))
 	vhosts := make([]*routev3.VirtualHost, 0, len(c.clusters))
 	for _, entry := range c.clusters {
-		cluster := entry.cluster
-		if matcher != nil && !strings.HasPrefix(cluster.GetName(), localClusterPrefix) {
-			cloned, _ := proto.Clone(cluster).(*clusterv3.Cluster)
-			cloned.TransportSocketMatcher = matcher
-			cloned.TransportSocketMatches = matches
-			cluster = cloned
-		}
-		clusters = append(clusters, cluster)
+		clusters = append(clusters, entry.cluster)
 		if entry.loadAssignment != nil {
 			clas = append(clas, entry.loadAssignment)
 		}
@@ -107,11 +86,12 @@ func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.
 	return clusters, clas, vhosts
 }
 
-// upstreamMTLS builds the transport-socket matcher and matches for outbound
-// mTLS from the current local workload identities. Returns (nil, nil) when no
-// local workloads are known, leaving clusters without an upstream transport
-// socket (the pre-mTLS behavior).
-func (c *SnapshotCache) upstreamMTLS() (*matcherv3.Matcher, []*clusterv3.Cluster_TransportSocketMatch) {
+// tunnelOriginateCluster builds the shared ORIGINAL_DST cluster the HBONE tunnels
+// dial, with the per-source transport-socket matcher derived from the current
+// local workloads (each source pod presents its own SVID; on-no-match presents
+// the node identity for health-check tunnels). Returns nil before the node SVID
+// is served, since the matcher's on-no-match references it.
+func (c *SnapshotCache) tunnelOriginateCluster() types.Resource {
 	c.localMu.RLock()
 	netnsToID := make(map[string]string, len(c.localWorkloads))
 	ids := make([]string, 0, len(c.localWorkloads))
@@ -119,15 +99,30 @@ func (c *SnapshotCache) upstreamMTLS() (*matcherv3.Matcher, []*clusterv3.Cluster
 		netnsToID[netns] = id
 		ids = append(ids, id)
 	}
+	nodeSpiffeID := c.nodeSpiffeID
 	trustDomain := c.trustDomain
 	c.localMu.RUnlock()
 
-	if len(netnsToID) == 0 {
-		return nil, nil
+	if nodeSpiffeID == "" {
+		return nil
 	}
 
 	validationContextName := fmt.Sprintf("spiffe://%s", trustDomain)
-	return proxy.UpstreamTransportSocketMatcher(netnsToID), proxy.UpstreamTransportSocketMatches(ids, validationContextName)
+	return proxy.NewTunnelOriginateCluster(netnsToID, ids, nodeSpiffeID, validationContextName)
+}
+
+// tunnelInternalListener returns the internal listener that encapsulates outbound
+// streams into CONNECT tunnels. It is emitted alongside the originate cluster
+// (both gated on the node identity being available).
+func (c *SnapshotCache) tunnelInternalListener() types.Resource {
+	c.localMu.RLock()
+	nodeSpiffeID := c.nodeSpiffeID
+	c.localMu.RUnlock()
+
+	if nodeSpiffeID == "" {
+		return nil
+	}
+	return proxy.NewTunnelInternalListener()
 }
 
 // Endpoints returns the pre-built load assignment (cluster endpoints) for the given
@@ -178,32 +173,19 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 	// endpoints that disappeared from the registry are pruned rather than retained.
 	c.clusters = make(map[string]clusterEntry, len(serviceEndpoints))
 	for serviceName, endpoints := range serviceEndpoints {
-		cluster := proxy.NewClusterForService(serviceName)
+		// The outbound service cluster tunnels (HBONE-style): its endpoints are
+		// internal-listener addresses carrying per-endpoint tunnel metadata, and
+		// the tunnel's mTLS (presenting the originating pod identity) is at the
+		// shared tunnel_originate cluster.
+		cluster := proxy.NewTunnelServiceCluster(serviceName)
 		cla := proxy.NewClusterLoadAssignment(serviceName)
 		vhost := proxy.BuildOutboundClusterVirtualHost(serviceName)
 		epMap := make(map[string]*endpointv3.LocalityLbEndpoints, len(endpoints))
 
-		var localCluster *clusterv3.Cluster
-		var localCla *endpointv3.ClusterLoadAssignment
-		var localEpMap map[string]*endpointv3.LocalityLbEndpoints
 		for _, endpoint := range endpoints {
-			lbEp := proxy.LocalityLbEndpointFromRegistryEndpoint(endpoint)
+			lbEp := proxy.TunnelLocalityLbEndpointFromRegistryEndpoint(endpoint)
 			cla.Endpoints = append(cla.Endpoints, lbEp)
 			epMap[endpoint.GetIp()] = lbEp
-
-			if isLocal(clusterName, nodeName, endpoint) {
-				localClusterName := fmt.Sprintf("local_%s", serviceName)
-
-				if localCluster == nil {
-					localCluster = proxy.NewLocalClusterForService(localClusterName, endpoint)
-					localCla = proxy.NewClusterLoadAssignment(localClusterName)
-					localEpMap = make(map[string]*endpointv3.LocalityLbEndpoints)
-				}
-
-				localLbEp := proxy.LocalLocalityLbEndpointFromRegistryEndpoint(endpoint)
-				localCla.Endpoints = append(localCla.Endpoints, localLbEp)
-				localEpMap[endpoint.GetIp()] = localLbEp
-			}
 		}
 
 		c.clusters[serviceName] = clusterEntry{
@@ -211,15 +193,6 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 			loadAssignment: cla,
 			endpoints:      epMap,
 			vhost:          vhost,
-		}
-
-		if localCluster != nil {
-			localName := fmt.Sprintf("local_%s", serviceName)
-			c.clusters[localName] = clusterEntry{
-				cluster:        localCluster,
-				loadAssignment: localCla,
-				endpoints:      localEpMap,
-			}
 		}
 	}
 
@@ -236,10 +209,4 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 // listeners or secrets.
 func (c *SnapshotCache) generateClusterSnapshot(ctx context.Context) error {
 	return c.generateSnapshot(ctx)
-}
-
-// isLocal reports whether the given endpoint belongs to the local cluster and node.
-// It is used to identify endpoints that should be included in the local cluster variant.
-func isLocal(clusterName string, nodeName string, endpoint *registryv1.ServiceEndpoint) bool {
-	return clusterName == endpoint.GetClusterName() && nodeName == endpoint.GetKubernetesMetadata().GetNodeName()
 }

--- a/agent/internal/xds/cache/cluster_test.go
+++ b/agent/internal/xds/cache/cluster_test.go
@@ -323,108 +323,6 @@ func TestSnapshotCache_RemoveEndpoint_RemovesIP(t *testing.T) {
 	}
 }
 
-// TestIsLocal verifies the isLocal helper with all combinations of matching and
-// non-matching cluster name, node name, and endpoint metadata.
-func TestIsLocal(t *testing.T) {
-	tests := []struct {
-		name        string
-		clusterName string
-		nodeName    string
-		endpoint    *registryv1.ServiceEndpoint
-		want        bool
-	}{
-		{
-			name:        "returns true when cluster and node both match",
-			clusterName: "my-cluster",
-			nodeName:    "my-node",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName: "my-cluster",
-				KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
-					NodeName: "my-node",
-				},
-			},
-			want: true,
-		},
-		{
-			name:        "returns false when cluster name does not match",
-			clusterName: "other-cluster",
-			nodeName:    "my-node",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName: "my-cluster",
-				KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
-					NodeName: "my-node",
-				},
-			},
-			want: false,
-		},
-		{
-			name:        "returns false when node name does not match",
-			clusterName: "my-cluster",
-			nodeName:    "other-node",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName: "my-cluster",
-				KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
-					NodeName: "my-node",
-				},
-			},
-			want: false,
-		},
-		{
-			name:        "returns false when neither cluster nor node match",
-			clusterName: "other-cluster",
-			nodeName:    "other-node",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName: "my-cluster",
-				KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
-					NodeName: "my-node",
-				},
-			},
-			want: false,
-		},
-		{
-			name:        "returns false when kubernetes metadata is nil",
-			clusterName: "my-cluster",
-			nodeName:    "my-node",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName:        "my-cluster",
-				KubernetesMetadata: nil,
-			},
-			want: false,
-		},
-		{
-			name:        "returns false when args are empty but endpoint has non-empty values",
-			clusterName: "",
-			nodeName:    "",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName: "some-cluster",
-				KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
-					NodeName: "some-node",
-				},
-			},
-			want: false,
-		},
-		{
-			name:        "returns true when all values are empty strings",
-			clusterName: "",
-			nodeName:    "",
-			endpoint: &registryv1.ServiceEndpoint{
-				ClusterName: "",
-				KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
-					NodeName: "",
-				},
-			},
-			want: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isLocal(tt.clusterName, tt.nodeName, tt.endpoint)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
 // TestLoadClustersFromRegistry_RegistryError verifies that a registry error is
 // propagated before any snapshot operation occurs.
 func TestLoadClustersFromRegistry_RegistryError(t *testing.T) {
@@ -474,7 +372,7 @@ func TestLoadClustersFromRegistry_MapPopulation(t *testing.T) {
 			wantAbsentKeys: []string{"local_frontend"},
 		},
 		{
-			name:          "local endpoint creates both regular and local_ cluster variants",
+			name:          "local endpoint creates a single tunnel service cluster (no local_ variant)",
 			cacheNodeName: "node-1",
 			clusterName:   "cluster-1",
 			registryData: map[string][]*registryv1.ServiceEndpoint{
@@ -484,11 +382,11 @@ func TestLoadClustersFromRegistry_MapPopulation(t *testing.T) {
 			},
 			wantClusterKeys: []string{
 				"backend",
-				"local_backend",
 			},
+			wantAbsentKeys: []string{"local_backend"},
 		},
 		{
-			name:          "mixed local and remote endpoints creates both cluster variants",
+			name:          "mixed local and remote endpoints still create a single tunnel cluster",
 			cacheNodeName: "node-1",
 			clusterName:   "cluster-1",
 			registryData: map[string][]*registryv1.ServiceEndpoint{
@@ -499,8 +397,8 @@ func TestLoadClustersFromRegistry_MapPopulation(t *testing.T) {
 			},
 			wantClusterKeys: []string{
 				"api",
-				"local_api",
 			},
+			wantAbsentKeys: []string{"local_api"},
 		},
 		{
 			name:          "all-remote endpoints do not produce a local_ variant",

--- a/agent/internal/xds/cache/outbound_mtls_test.go
+++ b/agent/internal/xds/cache/outbound_mtls_test.go
@@ -12,11 +12,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestOutboundClusterMTLSMatcher verifies that once a local pod is known, regular
-// service clusters in the snapshot carry the upstream mTLS transport-socket
-// matcher/matches keyed on the pod's identity, while same-node ("local_") clusters
-// do not.
-func TestOutboundClusterMTLSMatcher(t *testing.T) {
+const (
+	nodeIdentity                  = "spiffe://aether.internal/ns/aether-system/sa/aether-agent"
+	internalUpstreamTransportName = "envoy.transport_sockets.internal_upstream"
+)
+
+// TestTunnelOriginateClusterMTLSMatcher verifies that once a local pod and the
+// node identity are known, the shared tunnel_originate cluster carries the
+// per-source mTLS matcher/matches (the originating pod's identity plus the node
+// identity for health-check tunnels), while the service cluster itself tunnels via
+// the internal_upstream transport socket rather than carrying a matcher.
+func TestTunnelOriginateClusterMTLSMatcher(t *testing.T) {
 	c := newTestCache("node-1")
 	ctx := context.Background()
 
@@ -28,12 +34,12 @@ func TestOutboundClusterMTLSMatcher(t *testing.T) {
 		NetworkNamespace: "/var/run/netns/cni-a",
 	}
 	require.NoError(t, c.AddPod(ctx, pod, "aether.internal"))
+	// The node SVID being served gates the tunnel originate cluster.
+	require.NoError(t, c.SetNodeIdentity(ctx, nodeIdentity))
 
 	reg := &mockRegistry{
 		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 			return map[string][]*registryv1.ServiceEndpoint{
-				// Local endpoint (same cluster+node) so a "local_echo" variant is
-				// also produced and can be checked for exclusion.
 				"echo": {makeEndpoint("10.0.0.9", "cluster-1", "node-1", 18080)},
 			}, nil
 		},
@@ -44,20 +50,28 @@ func TestOutboundClusterMTLSMatcher(t *testing.T) {
 	require.NoError(t, err)
 	clusters := snap.GetResources(resourcev3.ClusterType)
 
+	// The service cluster tunnels (internal_upstream), no per-cluster matcher.
 	echo, ok := clusters["echo"].(*clusterv3.Cluster)
 	require.True(t, ok, "echo cluster must be present")
-	require.NotNil(t, echo.GetTransportSocketMatcher(), "regular cluster must carry the mTLS matcher")
-	require.Len(t, echo.GetTransportSocketMatches(), 1)
-	assert.Equal(t, "spiffe://aether.internal/ns/aether-test/sa/echo", echo.GetTransportSocketMatches()[0].GetName())
+	assert.Nil(t, echo.GetTransportSocketMatcher(), "service cluster must not carry the matcher")
+	assert.Equal(t, internalUpstreamTransportName, echo.GetTransportSocket().GetName())
 
-	if local, ok := clusters["local_echo"].(*clusterv3.Cluster); ok {
-		assert.Nil(t, local.GetTransportSocketMatcher(), "local_ cluster must not carry the matcher")
+	// The shared tunnel_originate cluster carries the per-source matcher.
+	originate, ok := clusters["tunnel_originate"].(*clusterv3.Cluster)
+	require.True(t, ok, "tunnel_originate cluster must be present once the node SVID is served")
+	require.NotNil(t, originate.GetTransportSocketMatcher(), "tunnel_originate must carry the mTLS matcher")
+	names := map[string]bool{}
+	for _, m := range originate.GetTransportSocketMatches() {
+		names[m.GetName()] = true
 	}
+	assert.True(t, names["spiffe://aether.internal/ns/aether-test/sa/echo"], "match for the local pod identity")
+	assert.True(t, names[nodeIdentity], "match for the node identity (health-check tunnels)")
 }
 
-// TestOutboundClusterNoMatcherWithoutLocalPods verifies clusters stay plaintext
-// (no transport socket matcher) until a local pod is onboarded.
-func TestOutboundClusterNoMatcherWithoutLocalPods(t *testing.T) {
+// TestNoTunnelOriginateWithoutNodeIdentity verifies the tunnel originate cluster is
+// omitted until the node SVID is served (its on-no-match references the node
+// identity).
+func TestNoTunnelOriginateWithoutNodeIdentity(t *testing.T) {
 	c := newTestCache("node-1")
 	ctx := context.Background()
 
@@ -72,8 +86,6 @@ func TestOutboundClusterNoMatcherWithoutLocalPods(t *testing.T) {
 
 	snap, err := c.GetSnapshot("node-1")
 	require.NoError(t, err)
-	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo"].(*clusterv3.Cluster)
-	require.True(t, ok)
-	assert.Nil(t, echo.GetTransportSocketMatcher())
-	assert.Empty(t, echo.GetTransportSocketMatches())
+	_, present := snap.GetResources(resourcev3.ClusterType)["tunnel_originate"]
+	assert.False(t, present, "no tunnel_originate cluster before the node SVID is served")
 }

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -31,7 +31,18 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) error {
 	if nodeConnect := c.nodeConnectListener(); nodeConnect != nil {
 		listeners = append(listeners, nodeConnect)
 	}
+	// The internal listener that encapsulates outbound streams into CONNECT
+	// tunnels (R2 tunnel egress); nil until the node SVID is served.
+	if tunnelInternal := c.tunnelInternalListener(); tunnelInternal != nil {
+		listeners = append(listeners, tunnelInternal)
+	}
 	clusters, endpoints, vhosts := c.clustersEndpointsAndVhosts()
+
+	// The shared ORIGINAL_DST cluster the tunnels dial (carries the per-source
+	// mTLS); nil until the node SVID is served.
+	if tunnelOriginate := c.tunnelOriginateCluster(); tunnelOriginate != nil {
+		clusters = append(clusters, tunnelOriginate)
+	}
 
 	// Per-pod application clusters live alongside listeners (not in the
 	// registry-driven cluster map) so registry reloads never drop them. STATIC

--- a/agent/internal/xds/proxy/tunnel.go
+++ b/agent/internal/xds/proxy/tunnel.go
@@ -1,11 +1,14 @@
 package proxy
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tcpproxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	internalupstreamv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/internal_upstream/v3"
@@ -66,6 +69,83 @@ func TunnelEndpointMetadata(authority, nodeAddr string, subsetKeys map[string]st
 			tunnelMetadataNamespace:            tunnel,
 			envoyFilterMetadataSubsetNamespace: lb,
 		},
+	}
+}
+
+// NewTunnelServiceCluster builds the outbound service cluster for the tunnel data
+// path. Its endpoints (delivered via EDS) are internal-listener addresses carrying
+// per-endpoint tunnel metadata; the internal_upstream transport socket passes that
+// metadata across the internal-listener boundary. lb_subset_config enables per-pod
+// affinity (selection by endpoint IP) while defaulting to load balancing across all
+// endpoints. The cluster itself is not mTLS — the tunnel's mTLS is at the originate
+// cluster, presenting the originating pod's identity.
+func NewTunnelServiceCluster(serviceName string) *clusterv3.Cluster {
+	return &clusterv3.Cluster{
+		Name:           serviceName,
+		ConnectTimeout: durationpb.New(2 * time.Second),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_EDS,
+		},
+		EdsClusterConfig: &clusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: config.XDSConfigSourceADS(),
+		},
+		TransportSocket: InternalUpstreamTransportSocket(),
+		LbSubsetConfig: &clusterv3.Cluster_LbSubsetConfig{
+			FallbackPolicy: clusterv3.Cluster_LbSubsetConfig_ANY_ENDPOINT,
+			SubsetSelectors: []*clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector{
+				{Keys: []string{subsetIPKey}},
+			},
+		},
+	}
+}
+
+// TunnelLocalityLbEndpointFromRegistryEndpoint builds a tunnel endpoint: its
+// address is the internal tunnel listener, and its host metadata carries both the
+// envoy.lb subset keys (for affinity selection) and the tunnel coordinates — the
+// destination pod IP as the CONNECT authority and node_ip:15008 as the tunnel
+// target. The internal_upstream transport socket on the service cluster passes
+// this host metadata through to the tunnel.
+func TunnelLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEndpoint) *endpointv3.LocalityLbEndpoints {
+	subsetKeys := map[string]string{
+		subsetClusterKey: endpoint.GetClusterName(),
+		subsetIPKey:      endpoint.GetIp(),
+	}
+	if endpoint.GetKubernetesMetadata() != nil {
+		subsetKeys[subsetPodNamespaceKey] = endpoint.GetKubernetesMetadata().GetNamespace()
+		subsetKeys[subsetPodNameKey] = endpoint.GetKubernetesMetadata().GetPodName()
+	}
+	for k, v := range endpoint.GetMetadata() {
+		subsetKeys[k] = v
+	}
+
+	nodeAddr := fmt.Sprintf("%s:%d", endpoint.GetKubernetesMetadata().GetNodeIp(), defaultNodeConnectPort)
+	md := TunnelEndpointMetadata(endpoint.GetIp(), nodeAddr, subsetKeys)
+
+	var locality *corev3.Locality
+	if loc := endpoint.GetLocality(); loc != nil && loc.GetRegion() != "" && loc.GetZone() != "" {
+		locality = &corev3.Locality{Region: loc.GetRegion(), Zone: loc.GetZone()}
+	}
+
+	return &endpointv3.LocalityLbEndpoints{
+		LbEndpoints: []*endpointv3.LbEndpoint{
+			{
+				HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+					Endpoint: &endpointv3.Endpoint{
+						Address: &corev3.Address{
+							Address: &corev3.Address_EnvoyInternalAddress{
+								EnvoyInternalAddress: &corev3.EnvoyInternalAddress{
+									AddressNameSpecifier: &corev3.EnvoyInternalAddress_ServerListenerName{
+										ServerListenerName: TunnelInternalListenerName,
+									},
+								},
+							},
+						},
+					},
+				},
+				Metadata: md,
+			},
+		},
+		Locality: locality,
 	}
 }
 

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -35,6 +35,11 @@ message ServiceEndpoint {
     string namespace = 1 [(buf.validate.field).string.min_len = 1];
     string pod_name = 2 [(buf.validate.field).string.min_len = 1];
     string node_name = 3 [(buf.validate.field).string.min_len = 1];
+    // node_ip is the InternalIP of the node hosting this endpoint. Consumers use
+    // it as the HBONE-style tunnel target (node_ip:15008) to reach the node's
+    // CONNECT listener, which forwards to the destination pod. Stamped by the
+    // node-local agent at registration.
+    string node_ip = 4;
   }
 
   KubernetesMetadata kubernetes_metadata = 8;

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -13,7 +13,7 @@ import (
 // It extracts the service name from the pod's labels and the port and weight from annotations.
 // The service protocol is always HTTP. Container and Kubernetes metadata are included
 // along with node locality information.
-func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
+func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeIP string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
 	protocol := registryv1.Service_PROTOCOL_HTTP
 
 	serviceName, err := getServiceName(cniPod)
@@ -45,6 +45,7 @@ func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegio
 			Namespace: cniPod.GetNamespace(),
 			PodName:   cniPod.GetName(),
 			NodeName:  nodeName,
+			NodeIp:    nodeIP,
 		},
 		Locality: &registryv1.ServiceEndpoint_Locality{
 			Region: nodeRegion,


### PR DESCRIPTION
## Stack
- PR 5/6 — endpoint node_ip (#87, on `main`) ← base
- **PR 6/6 (this) — tunnel integration** ← stacked on #87

> Targets `feat/r2-endpoint-node-ip`; rebase onto `main` once #87 merges.

## What — this is the flip
Moves the outbound data path from direct `pod:18080` mTLS to the HBONE-style CONNECT tunnel, using the PR 4 generators + PR 5 `node_ip`:

- **Service clusters tunnel:** `NewTunnelServiceCluster` — EDS endpoints are internal-listener addresses carrying per-endpoint tunnel metadata (`tunnel.authority` = pod IP, `tunnel.node` = `node_ip:15008`, `envoy.lb` subset keys), with the `internal_upstream` transport socket and `lb_subset_config` for per-pod affinity.
- **Shared tunnel infra:** the `tunnel_internal` listener and `tunnel_originate` `ORIGINAL_DST` cluster are emitted once the node SVID is served. `tunnel_originate` carries the per-source mTLS matcher (originating pod identity; **on-no-match → node identity** for health-check tunnels) and `connection_pool_per_downstream_connection` — the leak-free identity path proven in the identity spike.
- The per-source mTLS moves off the service cluster onto `tunnel_originate`; `local_<C>` (and `isLocal`) are removed.

## Safety
Additive infra (PR 3's `:15008` ingress, PR 4 generators) is now consumed. The flip only affects the live mesh **on deploy** — to be done as a whole-stack validation on talos-main (client→pod over the tunnel, subset affinity, client-pod identity), after which per-pod `:18080` is retired (follow-up).

## Tests
`outbound_mtls_test` rewritten for the tunnel shape (matcher on `tunnel_originate`, `internal_upstream` on the service cluster, originate omitted until node SVID served); cluster map tests updated (single tunnel cluster, no `local_`). Full agent + registry suites pass.

## Remaining (post-stack)
PR 7 — health checks (reachability `/-/-/node/live` + liveness) for the structural `healthy ∧ reachable` gating; then deploy + validate the whole stack and retire `:18080`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)