### PR TITLE
fix(cloudmap): carry node_ip through Cloud Map instance attributes

### DIFF
--- a/registry/internal/cloudmap/attrs.go
+++ b/registry/internal/cloudmap/attrs.go
@@ -26,6 +26,7 @@ const (
 	attrK8sNamespace = "AETHER_K8S_NAMESPACE"
 	attrK8sPod       = "AETHER_K8S_POD"
 	attrK8sNode      = "AETHER_K8S_NODE"
+	attrK8sNodeIP    = "AETHER_K8S_NODE_IP"
 	attrContainerID  = "AETHER_CONTAINER_ID"
 	attrNetworkNS    = "AETHER_NETWORK_NS"
 	attrMetadata     = "AETHER_METADATA"
@@ -70,6 +71,9 @@ func marshalAttrs(protocol registryv1.Service_Protocol, ep *registryv1.ServiceEn
 		}
 		if km.GetNodeName() != "" {
 			attrs[attrK8sNode] = km.GetNodeName()
+		}
+		if km.GetNodeIp() != "" {
+			attrs[attrK8sNodeIP] = km.GetNodeIp()
 		}
 	}
 
@@ -116,12 +120,13 @@ func unmarshalEndpoint(attrs map[string]string) (*registryv1.ServiceEndpoint, er
 		}
 	}
 
-	k8sNs, k8sPod, k8sNode := attrs[attrK8sNamespace], attrs[attrK8sPod], attrs[attrK8sNode]
-	if k8sNs != "" || k8sPod != "" || k8sNode != "" {
+	k8sNs, k8sPod, k8sNode, k8sNodeIP := attrs[attrK8sNamespace], attrs[attrK8sPod], attrs[attrK8sNode], attrs[attrK8sNodeIP]
+	if k8sNs != "" || k8sPod != "" || k8sNode != "" || k8sNodeIP != "" {
 		ep.KubernetesMetadata = &registryv1.ServiceEndpoint_KubernetesMetadata{
 			Namespace: k8sNs,
 			PodName:   k8sPod,
 			NodeName:  k8sNode,
+			NodeIp:    k8sNodeIP,
 		}
 	}
 

--- a/registry/internal/cloudmap/attrs_test.go
+++ b/registry/internal/cloudmap/attrs_test.go
@@ -33,6 +33,7 @@ func fullEndpoint() *registryv1.ServiceEndpoint {
 			Namespace: "default",
 			PodName:   "my-pod-xyz",
 			NodeName:  "node-1",
+			NodeIp:    "192.168.0.60",
 		},
 	}
 }


### PR DESCRIPTION
## What
The Cloud Map attribute mapping (`registry/internal/cloudmap/attrs.go`) is hand-coded and dropped the new `KubernetesMetadata.node_ip` (added in #87) on the round-trip — so R2 tunnel consumers saw an empty tunnel target (`node ":15008"` → `ORIGINAL_DST` "Invalid argument"). Marshal/unmarshal it as `AETHER_K8S_NODE_IP`.

## Why
Caught during R2 e2e on talos-main: the agent stamps `node_ip` correctly, but it was lost through the cloudmap registrar round-trip, breaking the tunnel.

## Tests
Extended the cloudmap marshal/unmarshal round-trip test with `node_ip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)