### PR TITLE
fix(agent chart): register internal_listener bootstrap extension

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -14,6 +14,15 @@ data:
           address: 127.0.0.1
           port_value: 9901
 
+    # Required for the HBONE-style tunnel egress: the outbound service clusters
+    # route to an internal listener (tunnel_internal) that encapsulates the
+    # stream into a CONNECT tunnel. Internal listeners need this bootstrap
+    # extension registered, even when the listener itself is delivered via LDS.
+    bootstrap_extensions:
+      - name: envoy.bootstrap.internal_listener
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.bootstrap.internal_listener.v3.InternalListener
+
     dynamic_resources:
       ads_config:
         api_type: DELTA_GRPC


### PR DESCRIPTION
## What
Registers `envoy.bootstrap.internal_listener` in the proxy bootstrap (`charts/agent/templates/configmap.yaml`).

## Why
The R2 tunnel egress routes outbound service clusters to an internal listener (`tunnel_internal`) that encapsulates the stream into a CONNECT tunnel. Internal listeners require this bootstrap extension **even when the listener is delivered via LDS** — without it, connecting to `envoy://tunnel_internal/` fails with "Invalid argument" and outbound traffic 503s. Found during R2 e2e on talos-main; with it, client→pod over the tunnel returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)