### PR TITLE
feat(agent): delegated pod liveness via EDS health (R2 PR 7)

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "server",
     srcs = [
         "config.go",
+        "liveness.go",
         "pod.go",
         "server.go",
     ],
@@ -18,6 +19,7 @@ go_library(
         "//agent/storage",
         "//agent/types",
         "//api/aether/cni/v1:cni",
+        "//api/aether/registry/v1:registry",
         "//common/constants",
         "//common/xds",
         "//registry",

--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/registry"
+)
+
+// livenessInterval is how often the agent reconciles local pod app health from
+// the proxy into the registry.
+const livenessInterval = 5 * time.Second
+
+// runLivenessLoop periodically reflects local pod application health (as actively
+// health-checked by the proxy, read from its admin interface) into the registry.
+// When a pod's app stops (or resumes) passing its health check, the agent
+// re-registers the endpoint with the updated health so every consumer marks it
+// unhealthy (or healthy) in their EDS — the delegated-liveness gate. It returns
+// when the context is cancelled.
+func (s *CNIServer) runLivenessLoop(ctx context.Context) {
+	ticker := time.NewTicker(livenessInterval)
+	defer ticker.Stop()
+
+	// last reported health per container, to re-register only on transitions.
+	last := make(map[string]registryv1.ServiceEndpoint_Health)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcileLiveness(ctx, last)
+		}
+	}
+}
+
+// reconcileLiveness scrapes the proxy for per-pod app health and re-registers any
+// endpoint whose health changed since the last report.
+func (s *CNIServer) reconcileLiveness(ctx context.Context, last map[string]registryv1.ServiceEndpoint_Health) {
+	appHealth, err := s.envoyAdmin.AppClusterHealth(ctx)
+	if err != nil {
+		s.log.V(1).Info("liveness: failed to read app cluster health", "error", err)
+		return
+	}
+
+	pods, err := s.storage.GetAll(ctx)
+	if err != nil {
+		s.log.V(1).Info("liveness: failed to list local pods", "error", err)
+		return
+	}
+
+	for _, pod := range pods {
+		if isIgnorablePod(pod) {
+			continue
+		}
+		healthy, known := appHealth[proxy.AppClusterName(pod)]
+		if !known {
+			continue // app cluster not yet programmed / health-checked
+		}
+
+		want := registryv1.ServiceEndpoint_HEALTH_HEALTHY
+		if !healthy {
+			want = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
+		}
+
+		// Absent prior state is treated as healthy (the registration default), so
+		// only a real transition triggers a re-register.
+		key := pod.GetContainerId()
+		prev, ok := last[key]
+		if !ok {
+			prev = registryv1.ServiceEndpoint_HEALTH_HEALTHY
+		}
+		if prev == want {
+			continue
+		}
+
+		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeIP, s.nodeRegion, s.nodeZone, pod)
+		if err != nil {
+			s.log.V(1).Info("liveness: failed to build endpoint", "pod", pod.GetName(), "error", err)
+			continue
+		}
+		endpoint.Health = want
+		if err := s.registry.RegisterEndpoint(ctx, serviceName, protocol, endpoint); err != nil {
+			s.log.Error(err, "liveness: failed to re-register endpoint health", "pod", pod.GetName())
+			continue
+		}
+		last[key] = want
+		s.log.V(1).Info("liveness: updated endpoint health", "pod", pod.GetName(), "health", want.String())
+	}
+}

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -100,6 +100,11 @@ func (s *CNIServer) PreListen(ctx context.Context) error {
 	s.nodeIP = nodeIP
 
 	s.log.V(1).Info("node metadata queried successfully", "region", region, "zone", zone, "nodeIP", nodeIP)
+
+	// Delegated liveness: reflect each local pod's app health (from the proxy's
+	// active health check) into the registry so it is marked unhealthy in every
+	// client's EDS while the app is not serving.
+	go s.runLivenessLoop(ctx)
 	return nil
 }
 

--- a/agent/internal/envoy/admin/BUILD.bazel
+++ b/agent/internal/envoy/admin/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "admin",
     srcs = [
         "admin.go",
+        "clusters.go",
         "config_dump.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/envoy/admin",
@@ -17,7 +18,10 @@ go_library(
 
 go_test(
     name = "admin_test",
-    srcs = ["admin_test.go"],
+    srcs = [
+        "admin_test.go",
+        "clusters_test.go",
+    ],
     embed = [":admin"],
     deps = [
         "@com_github_envoyproxy_go_control_plane_envoy//admin/v3:admin",

--- a/agent/internal/envoy/admin/clusters.go
+++ b/agent/internal/envoy/admin/clusters.go
@@ -1,0 +1,69 @@
+package admin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	adminv3 "github.com/envoyproxy/go-control-plane/envoy/admin/v3"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+// appClusterPrefix marks the per-pod application clusters whose active health
+// check reflects the pod's app readiness (delegated liveness).
+const appClusterPrefix = "app_"
+
+// AppClusterHealth queries the Envoy admin /clusters endpoint and returns, for
+// each per-pod application cluster (app_<pod>), whether its host currently passes
+// the active health check. The map is keyed by the app cluster name. A cluster
+// whose host has not yet been health-checked is reported healthy (optimistic) so
+// freshly added pods are not transiently marked down.
+func (c *Client) AppClusterHealth(ctx context.Context) (map[string]bool, error) {
+	url := fmt.Sprintf("http://%s/clusters?format=json", c.address)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query envoy admin clusters: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("envoy admin returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	var clusters adminv3.Clusters
+	if err := protojson.Unmarshal(body, &clusters); err != nil {
+		return nil, fmt.Errorf("failed to parse clusters: %w", err)
+	}
+
+	health := make(map[string]bool)
+	for _, cs := range clusters.GetClusterStatuses() {
+		if !strings.HasPrefix(cs.GetName(), appClusterPrefix) {
+			continue
+		}
+		health[cs.GetName()] = appHostsHealthy(cs)
+	}
+	return health, nil
+}
+
+// appHostsHealthy reports whether the app cluster's host passes the active health
+// check. With no hosts reported yet, it is optimistically healthy.
+func appHostsHealthy(cs *adminv3.ClusterStatus) bool {
+	for _, h := range cs.GetHostStatuses() {
+		if h.GetHealthStatus().GetFailedActiveHealthCheck() {
+			return false
+		}
+	}
+	return true
+}

--- a/agent/internal/envoy/admin/clusters_test.go
+++ b/agent/internal/envoy/admin/clusters_test.go
@@ -1,0 +1,34 @@
+package admin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAppClusterHealth(t *testing.T) {
+	// Two app clusters (one failing its HC, one passing) and a non-app cluster.
+	const body = `{"cluster_statuses":[
+		{"name":"app_pod-a","host_statuses":[{"health_status":{"failed_active_health_check":false}}]},
+		{"name":"app_pod-b","host_statuses":[{"health_status":{"failed_active_health_check":true}}]},
+		{"name":"echo","host_statuses":[{"health_status":{"failed_active_health_check":true}}]}
+	]}`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/clusters", r.URL.Path)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.Listener.Addr().String())
+	health, err := c.AppClusterHealth(t.Context())
+	require.NoError(t, err)
+
+	assert.True(t, health["app_pod-a"], "pod-a passes its HC")
+	assert.False(t, health["app_pod-b"], "pod-b fails its HC")
+	_, ok := health["echo"]
+	assert.False(t, ok, "non-app clusters are excluded")
+}

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -31,7 +31,20 @@ const (
 	// appLoopbackAddress is the loopback address the application listens on inside
 	// the pod's network namespace.
 	appLoopbackAddress = "127.0.0.1"
+	// defaultAppHealthPath is the readiness path the app cluster health-checks when
+	// the pod does not specify one.
+	defaultAppHealthPath = "/"
 )
+
+// AppHealthPathFromPod returns the HTTP path used to health-check the pod's
+// application, taken from the endpoint.aether.io/health-path annotation, defaulting
+// to "/" when unset.
+func AppHealthPathFromPod(cniPod *cniv1.CNIPod) string {
+	if p, ok := cniPod.GetAnnotations()[constants.AnnotationEndpointHealthPath]; ok && p != "" {
+		return p
+	}
+	return defaultAppHealthPath
+}
 
 // AppClusterName returns the name of the per-pod application cluster that the
 // pod's inbound listener forwards decrypted traffic to. It is unique per pod so
@@ -61,11 +74,29 @@ func AppPortFromPod(cniPod *cniv1.CNIPod) uint16 {
 // application container, not the agent. This is the only cleartext hop in the
 // mesh: it is intra-pod (Envoy -> app on loopback), never pod-to-pod. The app
 // is assumed to speak HTTP/1.1, so no explicit HTTP/2 protocol options are set.
-func NewAppCluster(name, netns string, port uint16) *clusterv3.Cluster {
+func NewAppCluster(name, netns string, port uint16, healthPath string) *clusterv3.Cluster {
 	return &clusterv3.Cluster{
 		Name: name,
 		ClusterDiscoveryType: &clusterv3.Cluster_Type{
 			Type: clusterv3.Cluster_STATIC,
+		},
+		// Active health check of the pod's application (delegated liveness): the
+		// node-local agent scrapes this cluster's host health from the proxy admin
+		// and reflects it into the registry so the endpoint is marked unhealthy in
+		// every client's EDS while the app is not serving.
+		HealthChecks: []*corev3.HealthCheck{
+			{
+				Timeout:            durationpb.New(1 * time.Second),
+				Interval:           durationpb.New(5 * time.Second),
+				HealthyThreshold:   wrapperspb.UInt32(1),
+				UnhealthyThreshold: wrapperspb.UInt32(2),
+				HealthChecker: &corev3.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &corev3.HealthCheck_HttpHealthCheck{
+						Path:            healthPath,
+						CodecClientType: typev3.CodecClientType_HTTP1,
+					},
+				},
+			},
 		},
 		LoadAssignment: &endpointv3.ClusterLoadAssignment{
 			ClusterName: name,

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -39,7 +39,7 @@ func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string) 
 		return nil, nil, nil, err
 	}
 
-	appCluster = NewAppCluster(AppClusterName(cniPod), cniPod.GetNetworkNamespace(), AppPortFromPod(cniPod))
+	appCluster = NewAppCluster(AppClusterName(cniPod), cniPod.GetNetworkNamespace(), AppPortFromPod(cniPod), AppHealthPathFromPod(cniPod))
 
 	return inbound, outbound, appCluster, nil
 }

--- a/agent/internal/xds/proxy/tunnel.go
+++ b/agent/internal/xds/proxy/tunnel.go
@@ -142,11 +142,22 @@ func TunnelLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEn
 						},
 					},
 				},
-				Metadata: md,
+				Metadata:     md,
+				HealthStatus: endpointHealthStatus(endpoint),
 			},
 		},
 		Locality: locality,
 	}
+}
+
+// endpointHealthStatus maps the registry endpoint's delegated-liveness health to
+// the Envoy EDS health status. Unknown/unspecified defaults to HEALTHY so older
+// agents and freshly registered endpoints route until proven unhealthy.
+func endpointHealthStatus(endpoint *registryv1.ServiceEndpoint) corev3.HealthStatus {
+	if endpoint.GetHealth() == registryv1.ServiceEndpoint_HEALTH_UNHEALTHY {
+		return corev3.HealthStatus_UNHEALTHY
+	}
+	return corev3.HealthStatus_HEALTHY
 }
 
 // NewTunnelInternalListener builds the internal listener that encapsulates a

--- a/agent/internal/xds/proxy/tunnel_test.go
+++ b/agent/internal/xds/proxy/tunnel_test.go
@@ -3,7 +3,9 @@ package proxy
 import (
 	"testing"
 
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	tcpproxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	internalupstreamv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/internal_upstream/v3"
 	"github.com/stretchr/testify/assert"
@@ -19,6 +21,16 @@ func TestTunnelEndpointMetadata(t *testing.T) {
 
 	lb := md.GetFilterMetadata()[envoyFilterMetadataSubsetNamespace].GetFields()
 	assert.Equal(t, "p1", lb["pod"].GetStringValue())
+}
+
+func TestEndpointHealthStatus(t *testing.T) {
+	assert.Equal(t, corev3.HealthStatus_UNHEALTHY,
+		endpointHealthStatus(&registryv1.ServiceEndpoint{Health: registryv1.ServiceEndpoint_HEALTH_UNHEALTHY}))
+	// Unspecified (older agents / fresh endpoints) and explicit healthy both route.
+	assert.Equal(t, corev3.HealthStatus_HEALTHY,
+		endpointHealthStatus(&registryv1.ServiceEndpoint{}))
+	assert.Equal(t, corev3.HealthStatus_HEALTHY,
+		endpointHealthStatus(&registryv1.ServiceEndpoint{Health: registryv1.ServiceEndpoint_HEALTH_HEALTHY}))
 }
 
 func TestNewTunnelInternalListener(t *testing.T) {

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -43,4 +43,16 @@ message ServiceEndpoint {
   }
 
   KubernetesMetadata kubernetes_metadata = 8;
+
+  // Health reflects whether the endpoint's application is serving, as actively
+  // health-checked by the node-local agent (delegated liveness). The default
+  // (HEALTH_UNSPECIFIED) is treated as healthy so endpoints from older agents and
+  // freshly registered endpoints route normally until proven otherwise.
+  enum Health {
+    HEALTH_UNSPECIFIED = 0;
+    HEALTH_HEALTHY = 1;
+    HEALTH_UNHEALTHY = 2;
+  }
+
+  Health health = 9;
 }

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -15,6 +15,9 @@ const (
 	AnnotationEndpointPort = annotationAetherEndpointPrefix + "port"
 	// AnnotationEndpointWeight is the pod annotation key for specifying endpoint weight in load balancing
 	AnnotationEndpointWeight = annotationAetherEndpointPrefix + "weight"
+	// AnnotationEndpointHealthPath is the pod annotation key for the HTTP path the
+	// agent active-health-checks on the pod's application (delegated liveness).
+	AnnotationEndpointHealthPath = annotationAetherEndpointPrefix + "health-path"
 
 	// AnnotationAetherEndpointMetadataPrefix is the prefix for endpoint metadata annotations
 	AnnotationAetherEndpointMetadataPrefix = "metadata." + annotationAetherEndpointPrefix

--- a/registry/internal/cloudmap/attrs.go
+++ b/registry/internal/cloudmap/attrs.go
@@ -27,6 +27,7 @@ const (
 	attrK8sPod       = "AETHER_K8S_POD"
 	attrK8sNode      = "AETHER_K8S_NODE"
 	attrK8sNodeIP    = "AETHER_K8S_NODE_IP"
+	attrHealth       = "AETHER_HEALTH"
 	attrContainerID  = "AETHER_CONTAINER_ID"
 	attrNetworkNS    = "AETHER_NETWORK_NS"
 	attrMetadata     = "AETHER_METADATA"
@@ -92,6 +93,11 @@ func marshalAttrs(protocol registryv1.Service_Protocol, ep *registryv1.ServiceEn
 		}
 	}
 
+	// Only persist an explicit health verdict; absence means "unknown" (healthy).
+	if h := ep.GetHealth(); h != registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED {
+		attrs[attrHealth] = h.String()
+	}
+
 	return attrs
 }
 
@@ -143,6 +149,10 @@ func unmarshalEndpoint(attrs map[string]string) (*registryv1.ServiceEndpoint, er
 		if err := json.Unmarshal([]byte(mdStr), &md); err == nil {
 			ep.Metadata = md
 		}
+	}
+
+	if h, ok := registryv1.ServiceEndpoint_Health_value[attrs[attrHealth]]; ok {
+		ep.Health = registryv1.ServiceEndpoint_Health(h)
 	}
 
 	return ep, nil

--- a/registry/internal/cloudmap/attrs_test.go
+++ b/registry/internal/cloudmap/attrs_test.go
@@ -35,6 +35,7 @@ func fullEndpoint() *registryv1.ServiceEndpoint {
 			NodeName:  "node-1",
 			NodeIp:    "192.168.0.60",
 		},
+		Health: registryv1.ServiceEndpoint_HEALTH_UNHEALTHY,
 	}
 }
 


### PR DESCRIPTION
## What
Marks an endpoint `UNHEALTHY` in every client's `<C>` EDS while the pod's **application** isn't serving — active health, no k8s-readiness dependency. The spike proved Envoy honors EDS `health_status` on the `internal_upstream`+subset tunnel cluster; this builds the pipeline that drives it.

## Pipeline
```
app_<pod> active HC ─► agent scrapes proxy /clusters ─► re-register endpoint w/ Health ─► registrar broadcast ─► every agent sets <C> EDS health_status
```
- **`ServiceEndpoint.Health`** proto enum (unspecified = healthy → backward-compatible).
- **`app_<pod>` active HC** on the app readiness path (`endpoint.aether.io/health-path`, default `/`), over the netns-bound loopback Envoy already uses for delivery.
- **Agent liveness loop** scrapes admin `/clusters` for each `app_<pod>` host's active-HC state; on a transition it re-registers the endpoint with the new `Health`.
- **Cloud Map** carries `Health` (`AETHER_HEALTH`) through the registrar round-trip.
- **EDS** sets `LbEndpoint.health_status` from `Health`.

## Scope note
Reachability (asymmetric partitions) intentionally omitted — delegated liveness covers dead pods + symmetric node-down, retries cover blips; outlier detection only earns its keep for the rare node-up-but-unreachable-from-one-client case.

## Tests
New: app-cluster admin-scrape parse, EDS health mapping, cloudmap health round-trip. Full agent + registry suites pass. Requires the registrar rebuilt (new proto) for the Cloud Map path — done for e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)