### PR TITLE
fix(agent): probe app health on a separate cluster, not app_<pod>

### DIFF
--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -54,7 +54,7 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, last map[string]regis
 		if isIgnorablePod(pod) {
 			continue
 		}
-		healthy, known := appHealth[proxy.AppClusterName(pod)]
+		healthy, known := appHealth[proxy.HealthProbeClusterName(pod)]
 		if !known {
 			continue // app cluster not yet programmed / health-checked
 		}

--- a/agent/internal/envoy/admin/clusters.go
+++ b/agent/internal/envoy/admin/clusters.go
@@ -11,15 +11,15 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 )
 
-// appClusterPrefix marks the per-pod application clusters whose active health
-// check reflects the pod's app readiness (delegated liveness).
-const appClusterPrefix = "app_"
+// healthProbeClusterPrefix marks the per-pod health-probe clusters whose active
+// health check reflects the pod's app readiness (delegated liveness).
+const healthProbeClusterPrefix = "health_"
 
 // AppClusterHealth queries the Envoy admin /clusters endpoint and returns, for
-// each per-pod application cluster (app_<pod>), whether its host currently passes
-// the active health check. The map is keyed by the app cluster name. A cluster
-// whose host has not yet been health-checked is reported healthy (optimistic) so
-// freshly added pods are not transiently marked down.
+// each per-pod health-probe cluster (health_<pod>), whether its host currently
+// passes the active health check. The map is keyed by the probe cluster name. A
+// cluster whose host has not yet been health-checked is reported healthy
+// (optimistic) so freshly added pods are not transiently marked down.
 func (c *Client) AppClusterHealth(ctx context.Context) (map[string]bool, error) {
 	url := fmt.Sprintf("http://%s/clusters?format=json", c.address)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
@@ -49,7 +49,7 @@ func (c *Client) AppClusterHealth(ctx context.Context) (map[string]bool, error) 
 
 	health := make(map[string]bool)
 	for _, cs := range clusters.GetClusterStatuses() {
-		if !strings.HasPrefix(cs.GetName(), appClusterPrefix) {
+		if !strings.HasPrefix(cs.GetName(), healthProbeClusterPrefix) {
 			continue
 		}
 		health[cs.GetName()] = appHostsHealthy(cs)

--- a/agent/internal/envoy/admin/clusters_test.go
+++ b/agent/internal/envoy/admin/clusters_test.go
@@ -12,8 +12,8 @@ import (
 func TestAppClusterHealth(t *testing.T) {
 	// Two app clusters (one failing its HC, one passing) and a non-app cluster.
 	const body = `{"cluster_statuses":[
-		{"name":"app_pod-a","host_statuses":[{"health_status":{"failed_active_health_check":false}}]},
-		{"name":"app_pod-b","host_statuses":[{"health_status":{"failed_active_health_check":true}}]},
+		{"name":"health_pod-a","host_statuses":[{"health_status":{"failed_active_health_check":false}}]},
+		{"name":"health_pod-b","host_statuses":[{"health_status":{"failed_active_health_check":true}}]},
 		{"name":"echo","host_statuses":[{"health_status":{"failed_active_health_check":true}}]}
 	]}`
 
@@ -27,8 +27,8 @@ func TestAppClusterHealth(t *testing.T) {
 	health, err := c.AppClusterHealth(t.Context())
 	require.NoError(t, err)
 
-	assert.True(t, health["app_pod-a"], "pod-a passes its HC")
-	assert.False(t, health["app_pod-b"], "pod-b fails its HC")
+	assert.True(t, health["health_pod-a"], "pod-a passes its HC")
+	assert.False(t, health["health_pod-b"], "pod-b fails its HC")
 	_, ok := health["echo"]
 	assert.False(t, ok, "non-app clusters are excluded")
 }

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -81,6 +81,10 @@ type listenerEntry struct {
 	inbound    types.Resource
 	outbound   types.Resource
 	appCluster types.Resource
+	// healthCluster is the unrouted per-pod cluster carrying the app's active
+	// health check (delegated liveness), kept separate from appCluster so the HC
+	// does not gate the delivery path.
+	healthCluster types.Resource
 	// pod is retained so the node-level CONNECT listener can be (re)built with a
 	// route per local pod (keyed on the pod IP) to its app cluster.
 	pod *cniv1.CNIPod

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -19,7 +19,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	netns := cniPod.GetNetworkNamespace()
 	c.log.V(2).Info("adding listeners for pod", "pod", cniPod.GetName(), "namespace", cniPod.GetNamespace(), "netns", netns)
 
-	inbound, outbound, appCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain)
+	inbound, outbound, appCluster, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain)
 	if err != nil {
 		return err
 	}
@@ -29,10 +29,11 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 		c.listeners = make(map[string]listenerEntry)
 	}
 	c.listeners[netns] = listenerEntry{
-		inbound:    inbound,
-		outbound:   outbound,
-		appCluster: appCluster,
-		pod:        cniPod,
+		inbound:       inbound,
+		outbound:      outbound,
+		appCluster:    appCluster,
+		healthCluster: healthCluster,
+		pod:           cniPod,
 	}
 	c.listenerMu.Unlock()
 
@@ -125,10 +126,13 @@ func (c *SnapshotCache) appClusters() []types.Resource {
 	c.listenerMu.RLock()
 	defer c.listenerMu.RUnlock()
 
-	resources := make([]types.Resource, 0, len(c.listeners))
+	resources := make([]types.Resource, 0, 2*len(c.listeners))
 	for _, entry := range c.listeners {
 		if entry.appCluster != nil {
 			resources = append(resources, entry.appCluster)
+		}
+		if entry.healthCluster != nil {
+			resources = append(resources, entry.healthCluster)
 		}
 	}
 	return resources
@@ -161,7 +165,7 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 		netns := pod.GetNetworkNamespace()
 		c.log.V(2).Info("generating listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace(), "netns", netns)
 
-		inbound, outbound, appCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain)
+		inbound, outbound, appCluster, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain)
 		if listenerErr != nil {
 			c.log.V(1).Error(listenerErr, "failed to generate listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 			errs = append(errs, listenerErr)
@@ -169,10 +173,11 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 		}
 
 		c.listeners[netns] = listenerEntry{
-			inbound:    inbound,
-			outbound:   outbound,
-			appCluster: appCluster,
-			pod:        pod,
+			inbound:       inbound,
+			outbound:      outbound,
+			appCluster:    appCluster,
+			healthCluster: healthCluster,
+			pod:           pod,
 		}
 		local[netns] = proxy.SpiffeIDFromPod(pod, trustDomain)
 	}

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -34,6 +34,12 @@ const (
 	// defaultAppHealthPath is the readiness path the app cluster health-checks when
 	// the pod does not specify one.
 	defaultAppHealthPath = "/"
+	// healthProbeClusterPrefix marks the per-pod health-probe clusters (active HC
+	// of the app, separate from the app_<pod> delivery cluster).
+	healthProbeClusterPrefix = "health_"
+	// appHealthCheckHost is the Host header sent on the app readiness HTTP health
+	// check (HTTP/1.1 requires a Host).
+	appHealthCheckHost = "localhost"
 )
 
 // AppHealthPathFromPod returns the HTTP path used to health-check the pod's
@@ -74,29 +80,11 @@ func AppPortFromPod(cniPod *cniv1.CNIPod) uint16 {
 // application container, not the agent. This is the only cleartext hop in the
 // mesh: it is intra-pod (Envoy -> app on loopback), never pod-to-pod. The app
 // is assumed to speak HTTP/1.1, so no explicit HTTP/2 protocol options are set.
-func NewAppCluster(name, netns string, port uint16, healthPath string) *clusterv3.Cluster {
+func NewAppCluster(name, netns string, port uint16) *clusterv3.Cluster {
 	return &clusterv3.Cluster{
 		Name: name,
 		ClusterDiscoveryType: &clusterv3.Cluster_Type{
 			Type: clusterv3.Cluster_STATIC,
-		},
-		// Active health check of the pod's application (delegated liveness): the
-		// node-local agent scrapes this cluster's host health from the proxy admin
-		// and reflects it into the registry so the endpoint is marked unhealthy in
-		// every client's EDS while the app is not serving.
-		HealthChecks: []*corev3.HealthCheck{
-			{
-				Timeout:            durationpb.New(1 * time.Second),
-				Interval:           durationpb.New(5 * time.Second),
-				HealthyThreshold:   wrapperspb.UInt32(1),
-				UnhealthyThreshold: wrapperspb.UInt32(2),
-				HealthChecker: &corev3.HealthCheck_HttpHealthCheck_{
-					HttpHealthCheck: &corev3.HealthCheck_HttpHealthCheck{
-						Path:            healthPath,
-						CodecClientType: typev3.CodecClientType_HTTP1,
-					},
-				},
-			},
 		},
 		LoadAssignment: &endpointv3.ClusterLoadAssignment{
 			ClusterName: name,
@@ -134,6 +122,38 @@ func NewAppCluster(name, netns string, port uint16, healthPath string) *clusterv
 			},
 		},
 	}
+}
+
+// HealthProbeClusterName returns the name of the per-pod health-probe cluster.
+func HealthProbeClusterName(cniPod *cniv1.CNIPod) string {
+	return fmt.Sprintf("%s%s", healthProbeClusterPrefix, cniPod.GetName())
+}
+
+// NewAppHealthProbeCluster builds a per-pod cluster that only exists to actively
+// health-check the pod's application at 127.0.0.1:<port> (delegated liveness). It
+// is NOT referenced by any route — the agent scrapes its host health from the
+// proxy admin and reflects it into the registry. The active HC must live on this
+// separate cluster, not on app_<pod>: an active HC removes failing/pending hosts
+// from load balancing, which would gate (break) the real delivery path through
+// app_<pod> at startup and whenever the probe fails.
+func NewAppHealthProbeCluster(name, netns string, port uint16, healthPath string) *clusterv3.Cluster {
+	c := NewAppCluster(name, netns, port)
+	c.HealthChecks = []*corev3.HealthCheck{
+		{
+			Timeout:            durationpb.New(1 * time.Second),
+			Interval:           durationpb.New(5 * time.Second),
+			HealthyThreshold:   wrapperspb.UInt32(1),
+			UnhealthyThreshold: wrapperspb.UInt32(2),
+			HealthChecker: &corev3.HealthCheck_HttpHealthCheck_{
+				HttpHealthCheck: &corev3.HealthCheck_HttpHealthCheck{
+					Host:            appHealthCheckHost,
+					Path:            healthPath,
+					CodecClientType: typev3.CodecClientType_HTTP1,
+				},
+			},
+		},
+	}
+	return c
 }
 
 // NewClusterForService creates an Envoy cluster for a service.

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -28,20 +28,25 @@ const (
 // loopback). Outbound listeners route traffic destined for other services.
 // Both listeners use HTTP protocol and include appropriate filter chains.
 // The trustDomain is the SPIFFE trust domain URI used for SDS validation context.
-func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, appCluster *clusterv3.Cluster, err error) {
+func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, appCluster *clusterv3.Cluster, healthCluster *clusterv3.Cluster, err error) {
 	inbound, err = generateInboundHTTPListener(cniPod, trustDomain)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	outbound, err = generateOutboundHTTPListener(cniPod)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	appCluster = NewAppCluster(AppClusterName(cniPod), cniPod.GetNetworkNamespace(), AppPortFromPod(cniPod), AppHealthPathFromPod(cniPod))
+	netns := cniPod.GetNetworkNamespace()
+	port := AppPortFromPod(cniPod)
+	appCluster = NewAppCluster(AppClusterName(cniPod), netns, port)
+	// Separate, unrouted cluster carrying the active app health check (delegated
+	// liveness); keeping the HC off app_<pod> avoids gating the delivery path.
+	healthCluster = NewAppHealthProbeCluster(HealthProbeClusterName(cniPod), netns, port, AppHealthPathFromPod(cniPod))
 
-	return inbound, outbound, appCluster, nil
+	return inbound, outbound, appCluster, healthCluster, nil
 }
 
 // SpiffeIDFromPod returns the SPIFFE ID for the pod. It first checks the

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -54,7 +54,7 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inbound, outbound, appCluster, err := GenerateListenersFromRegistryPod(tt.cniPod, "example.org")
+			inbound, outbound, appCluster, healthCluster, err := GenerateListenersFromRegistryPod(tt.cniPod, "example.org")
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -65,6 +65,10 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 			require.NotNil(t, inbound)
 			require.NotNil(t, outbound)
 			require.NotNil(t, appCluster)
+			require.NotNil(t, healthCluster)
+			assert.Equal(t, HealthProbeClusterName(tt.cniPod), healthCluster.GetName())
+			require.Len(t, healthCluster.GetHealthChecks(), 1, "probe cluster carries the HC")
+			require.Empty(t, appCluster.GetHealthChecks(), "delivery cluster must NOT carry the HC")
 			assert.Equal(t, tt.expectedInboundName, inbound.GetName())
 			assert.Equal(t, tt.expectedOutboundName, outbound.GetName())
 		})

--- a/agent/internal/xds/server/server_integration_test.go
+++ b/agent/internal/xds/server/server_integration_test.go
@@ -121,7 +121,7 @@ func setConsistentSnapshot(t *testing.T, ctx context.Context, snapshotCache cach
 		Ips:              []string{"10.0.0.1"},
 	}
 
-	inbound, outbound, appCluster, err := proxy.GenerateListenersFromRegistryPod(pod, "example.org")
+	inbound, outbound, appCluster, _, err := proxy.GenerateListenersFromRegistryPod(pod, "example.org")
 	require.NoError(t, err)
 
 	serviceName := "my-service"


### PR DESCRIPTION
## What
#92 put the delegated-liveness active HC on `app_<pod>` — the **delivery** cluster the inner HCM routes to. An active HC removes failing/**pending** hosts from load balancing, so at startup (before the first successful HC) and whenever the probe fails, delivery through `app_<pod>` had no healthy host → **503**.

## Fix
Move the HC to a separate, **unrouted** `health_<pod>` cluster (same netns-bound loopback endpoint). `app_<pod>` stays HC-free so delivery is never gated; the agent scrapes `health_<pod>` host health for liveness. Also send a `Host` header on the HTTP/1.1 readiness check.

## Caught by
The R2 e2e on talos-main: every endpoint went `HEALTH_UNHEALTHY` and `client→echo` 503'd. This unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)