### PR TITLE
fix(agent): R2 tunnel robustness — pending-HC + validate_clusters

### DIFF
--- a/agent/internal/envoy/admin/clusters.go
+++ b/agent/internal/envoy/admin/clusters.go
@@ -58,10 +58,14 @@ func (c *Client) AppClusterHealth(ctx context.Context) (map[string]bool, error) 
 }
 
 // appHostsHealthy reports whether the app cluster's host passes the active health
-// check. With no hosts reported yet, it is optimistically healthy.
+// check. A host is unhealthy only once it has actually failed a check — a host
+// still pending its first check (pending_active_hc) is reported healthy, so a
+// freshly added pod is not transiently marked down during health-check warm-up.
+// With no hosts reported yet, it is likewise optimistically healthy.
 func appHostsHealthy(cs *adminv3.ClusterStatus) bool {
 	for _, h := range cs.GetHostStatuses() {
-		if h.GetHealthStatus().GetFailedActiveHealthCheck() {
+		hs := h.GetHealthStatus()
+		if hs.GetFailedActiveHealthCheck() && !hs.GetPendingActiveHc() {
 			return false
 		}
 	}

--- a/agent/internal/envoy/admin/clusters_test.go
+++ b/agent/internal/envoy/admin/clusters_test.go
@@ -14,6 +14,7 @@ func TestAppClusterHealth(t *testing.T) {
 	const body = `{"cluster_statuses":[
 		{"name":"health_pod-a","host_statuses":[{"health_status":{"failed_active_health_check":false}}]},
 		{"name":"health_pod-b","host_statuses":[{"health_status":{"failed_active_health_check":true}}]},
+		{"name":"health_pod-c","host_statuses":[{"health_status":{"failed_active_health_check":true,"pending_active_hc":true}}]},
 		{"name":"echo","host_statuses":[{"health_status":{"failed_active_health_check":true}}]}
 	]}`
 
@@ -29,6 +30,7 @@ func TestAppClusterHealth(t *testing.T) {
 
 	assert.True(t, health["health_pod-a"], "pod-a passes its HC")
 	assert.False(t, health["health_pod-b"], "pod-b fails its HC")
+	assert.True(t, health["health_pod-c"], "pod-c is pending its first HC -> healthy")
 	_, ok := health["echo"]
 	assert.False(t, ok, "non-app clusters are excluded")
 }

--- a/agent/internal/xds/proxy/connectlistener.go
+++ b/agent/internal/xds/proxy/connectlistener.go
@@ -16,6 +16,7 @@ import (
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -216,8 +217,16 @@ func buildNodeConnectRouteConfiguration(localPods []*cniv1.CNIPod) *routev3.Rout
 	}
 
 	return &routev3.RouteConfiguration{
-		Name:         NodeConnectListenerName,
-		VirtualHosts: []*routev3.VirtualHost{{Name: "tunnel", Domains: []string{"*"}, Routes: routes}},
+		Name: NodeConnectListenerName,
+		// Per-pod inner-demux clusters churn on every pod restart (their names are
+		// pod-scoped). Without this, Envoy validates the inline route's cluster
+		// references at listener-load time and rejects the whole node_connect
+		// listener if a referenced cluster is momentarily not yet known (the
+		// delta-xDS make-before-break window) — wedging the node's tunnel ingress
+		// until a proxy restart. Disabling validation makes only the affected route
+		// transiently return 503 until its cluster arrives, leaving the listener up.
+		ValidateClusters: wrapperspb.Bool(false),
+		VirtualHosts:     []*routev3.VirtualHost{{Name: "tunnel", Domains: []string{"*"}, Routes: routes}},
 	}
 }
 

--- a/agent/internal/xds/proxy/connectlistener_test.go
+++ b/agent/internal/xds/proxy/connectlistener_test.go
@@ -75,6 +75,7 @@ func TestGenerateNodeConnectResources(t *testing.T) {
 
 func TestBuildNodeConnectRouteConfiguration_Empty(t *testing.T) {
 	rc := buildNodeConnectRouteConfiguration(nil)
+	assert.False(t, rc.GetValidateClusters().GetValue(), "validation off so churn doesn't wedge node_connect")
 	routes := rc.GetVirtualHosts()[0].GetRoutes()
 	require.Len(t, routes, 1, "only the node-live route when there are no pods")
 	assert.Equal(t, NodeLivePath, routes[0].GetMatch().GetPath())

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -17,6 +18,10 @@ const (
 func buildInboundRouteConfiguration(appClusterName string) *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name: "in_http",
+		// The per-pod app_<pod> cluster churns on pod restart; don't let the inline
+		// route's cluster reference wedge the listener if it is momentarily unknown
+		// during the delta-xDS make-before-break window (see node_connect).
+		ValidateClusters: wrapperspb.Bool(false),
 		VirtualHosts: []*routev3.VirtualHost{
 			{
 				Name:    "catch_all",

--- a/agent/internal/xds/proxy/route_test.go
+++ b/agent/internal/xds/proxy/route_test.go
@@ -14,6 +14,7 @@ func TestBuildInboundRouteConfiguration(t *testing.T) {
 
 	require.NotNil(t, routeConfig)
 	assert.Equal(t, "in_http", routeConfig.GetName())
+	assert.False(t, routeConfig.GetValidateClusters().GetValue(), "validation off so app_<pod> churn doesn't wedge the inner listener")
 	require.Len(t, routeConfig.GetVirtualHosts(), 1)
 
 	vhost := routeConfig.GetVirtualHosts()[0]


### PR DESCRIPTION
Two issues the delegated-liveness e2e surfaced on talos-main.

## 1. Pending-HC startup blip
Envoy marks a host `failed_active_health_check` *while pending its first check*, so the liveness scrape marked a freshly restarted pod `UNHEALTHY` for ~1 min until the first HC passed. Now: treat `pending_active_hc` hosts as healthy — only unhealthy once a check has actually failed.

## 2. `node_connect` wedged on pod-restart churn (the important one)
Per-pod `inner_demux_<pod>`/`app_<pod>` clusters are pod-name-scoped and churn on every restart. With **inline** route configs Envoy validates cluster references at listener-load and **rejected the whole `node_connect` (and inner) listener** when a referenced cluster was momentarily unknown (delta-xDS make-before-break window) — keeping the stale listener and **breaking the node's tunnel ingress until a proxy restart**. Fix: `validate_clusters=false` on those route configs, so only the affected route transiently 503s until its cluster arrives; the listener stays up.

## Tests
`appHostsHealthy` pending case; `validate_clusters` asserted on both route configs. Full agent suite passes. Validated on talos-main: pod restart no longer wedges the tunnel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)