### PR TITLE
feat(agent): answer node-live probe via health_check HTTP filter

### DIFF
--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/router/v3:router",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/listener/tls_inspector/v3:tls_inspector",

--- a/agent/internal/xds/proxy/connectlistener.go
+++ b/agent/internal/xds/proxy/connectlistener.go
@@ -12,6 +12,7 @@ import (
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	commonsetfsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/common/set_filter_state/v3"
+	healthcheckv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	httpsetfsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/set_filter_state/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -33,6 +34,9 @@ const (
 	// NodeLivePath is the readiness path a peer proxy's reachability health check
 	// hits on the node CONNECT listener; it is answered locally, never tunneled.
 	NodeLivePath = "/-/-/node/live"
+	// nodeLiveHealthCheckFilterName is the HTTP health-check filter that answers
+	// NodeLivePath locally (non-pass-through), short-circuiting it before the router.
+	nodeLiveHealthCheckFilterName = "envoy.filters.http.health_check"
 
 	// peerURIFilterStateKey carries the verified tunnel peer (the originating
 	// client pod) SPIFFE ID from the CONNECT-terminating listener across the
@@ -98,6 +102,9 @@ func buildNodeConnectListener(localPods []*cniv1.CNIPod, nodeSpiffeID, validatio
 		HttpFilters: []*http_connection_managerv3.HttpFilter{
 			// Capture the verified peer (client pod) SPIFFE ID for the inner HCM.
 			buildPeerURICaptureFilter(),
+			// Answer the peer reachability probe (NodeLivePath) locally; CONNECT
+			// tunnels carry no :path and pass straight through to the router.
+			buildNodeLiveHealthCheckFilter(),
 			routerHttpFilter(),
 		},
 		RouteSpecifier: &http_connection_managerv3.HttpConnectionManager_RouteConfig{
@@ -161,27 +168,35 @@ func buildPeerURICaptureFilter() *http_connection_managerv3.HttpFilter {
 	}
 }
 
-// buildNodeConnectRouteConfiguration builds the route table for the node CONNECT
-// listener: a local-only readiness route, then one CONNECT route per local pod
-// keyed on the destination pod's IP (:authority) that terminates the tunnel and
-// forwards to that pod's inner HCM listener.
-func buildNodeConnectRouteConfiguration(localPods []*cniv1.CNIPod) *routev3.RouteConfiguration {
-	routes := make([]*routev3.Route, 0, len(localPods)+1)
-
-	// Reachability health check, answered locally (never tunneled to an app).
-	routes = append(routes, &routev3.Route{
-		Match: &routev3.RouteMatch{
-			PathSpecifier: &routev3.RouteMatch_Path{Path: NodeLivePath},
-		},
-		Action: &routev3.Route_DirectResponse{
-			DirectResponse: &routev3.DirectResponseAction{
-				Status: 200,
-				Body: &corev3.DataSource{
-					Specifier: &corev3.DataSource_InlineString{InlineString: "node-alive\n"},
+// buildNodeLiveHealthCheckFilter answers the peer reachability probe (a GET on
+// NodeLivePath) locally with 200, short-circuiting it before the router so it
+// needs no route. Non-pass-through mode also wires up the proxy admin
+// /healthcheck/fail|ok toggles, letting a node be drained gracefully (peers' HCs
+// then see 503 and shift traffic off this node). CONNECT requests carry no :path
+// pseudo-header, so they never match and fall through to the router.
+func buildNodeLiveHealthCheckFilter() *http_connection_managerv3.HttpFilter {
+	return httpFilter(nodeLiveHealthCheckFilterName, &healthcheckv3.HealthCheck{
+		PassThroughMode: wrapperspb.Bool(false),
+		Headers: []*routev3.HeaderMatcher{
+			{
+				Name: ":path",
+				HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+					StringMatch: &matcherv3.StringMatcher{
+						MatchPattern: &matcherv3.StringMatcher_Exact{Exact: NodeLivePath},
+					},
 				},
 			},
 		},
 	})
+}
+
+// buildNodeConnectRouteConfiguration builds the route table for the node CONNECT
+// listener: one CONNECT route per local pod keyed on the destination pod's IP
+// (:authority) that terminates the tunnel and forwards to that pod's inner HCM
+// listener. The reachability probe (NodeLivePath) is handled by the health_check
+// HTTP filter, not a route here.
+func buildNodeConnectRouteConfiguration(localPods []*cniv1.CNIPod) *routev3.RouteConfiguration {
+	routes := make([]*routev3.Route, 0, len(localPods))
 
 	for _, pod := range localPods {
 		ips := pod.GetIps()

--- a/agent/internal/xds/proxy/connectlistener_test.go
+++ b/agent/internal/xds/proxy/connectlistener_test.go
@@ -6,7 +6,6 @@ import (
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -40,14 +39,15 @@ func TestGenerateNodeConnectResources(t *testing.T) {
 	assert.True(t, hcm.GetHttp2ProtocolOptions().GetAllowConnect(), "must allow CONNECT")
 	// Captures the verified peer identity into filter state for the inner HCM.
 	assert.Equal(t, "envoy.filters.http.set_filter_state", hcm.GetHttpFilters()[0].GetName())
+	// The reachability probe is answered by the health_check filter, not a route.
+	assert.Equal(t, "envoy.filters.http.health_check", hcm.GetHttpFilters()[1].GetName())
 
 	routes := hcm.GetRouteConfig().GetVirtualHosts()[0].GetRoutes()
-	require.Len(t, routes, 3) // node-live + 2 pods
-	assert.Equal(t, NodeLivePath, routes[0].GetMatch().GetPath())
+	require.Len(t, routes, 2) // one CONNECT route per pod; node-live is on the filter
 
 	// Each pod's CONNECT route (keyed on its IP) targets its inner-demux cluster.
 	byCluster := map[string]string{}
-	for _, r := range routes[1:] {
+	for _, r := range routes {
 		require.NotNil(t, r.GetMatch().GetConnectMatcher())
 		authority := r.GetMatch().GetHeaders()[0].GetStringMatch().GetExact()
 		require.Equal(t, "CONNECT", r.GetRoute().GetUpgradeConfigs()[0].GetUpgradeType())
@@ -77,10 +77,7 @@ func TestBuildNodeConnectRouteConfiguration_Empty(t *testing.T) {
 	rc := buildNodeConnectRouteConfiguration(nil)
 	assert.False(t, rc.GetValidateClusters().GetValue(), "validation off so churn doesn't wedge node_connect")
 	routes := rc.GetVirtualHosts()[0].GetRoutes()
-	require.Len(t, routes, 1, "only the node-live route when there are no pods")
-	assert.Equal(t, NodeLivePath, routes[0].GetMatch().GetPath())
-	_, ok := routes[0].GetAction().(*routev3.Route_DirectResponse)
-	assert.True(t, ok)
+	require.Empty(t, routes, "no routes when there are no pods; node-live is on the health_check filter")
 }
 
 func findListener(ls []*listenerv3.Listener, name string) *listenerv3.Listener {


### PR DESCRIPTION
## What

Replace the hand-rolled `/-/-/node/live` `direct_response` route on the `node_connect` listener with the **`envoy.filters.http.health_check`** filter in non-pass-through mode, matching on `:path == NodeLivePath`.

## Why

- **Decouples the reachability probe from RDS.** `node_connect`'s route table now contains *only* the per-pod CONNECT routes — the enabling first step for the ingress consolidation (collapsing per-pod `inner_<pod>` listeners + `inner_demux_<pod>` clusters into a single matcher-based demux).
- **Graceful node drain for free.** Non-pass-through mode wires up the proxy admin `/healthcheck/fail` + `/healthcheck/ok` toggles, so a node can be flipped to failing → peers' reachability HCs see 503 → traffic shifts off this node, without touching any pod.
- More idiomatic than a magic route + `direct_response`.

## Correctness

CONNECT tunnels carry no `:path` pseudo-header (RFC 7540 omits it for the CONNECT method), so they never match the filter's header matcher and fall straight through to the router. The per-pod CONNECT routes are untouched. Behavior is unchanged: `NodeLivePath` still returns 200 by default.

## Tests

- `TestGenerateNodeConnectResources` — asserts the `health_check` filter is present at `http_filters[1]` and the route table is now CONNECT-routes-only (2 pods → 2 routes, no node-live route).
- `TestBuildNodeConnectRouteConfiguration_Empty` — no routes when there are no pods.
- `bazel test //agent/...` green; `make format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)