### PR TITLE
feat(registry): per-pod health-check mode annotation (active|eds)

### DIFF
--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -116,28 +116,36 @@ func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceE
 		locality = &corev3.Locality{Region: loc.GetRegion(), Zone: loc.GetZone()}
 	}
 
+	ep := &endpointv3.Endpoint{
+		Address: &corev3.Address{
+			Address: &corev3.Address_SocketAddress{
+				SocketAddress: &corev3.SocketAddress{
+					Protocol: corev3.SocketAddress_TCP,
+					// The destination pod's mesh inbound; reached by the pod's own
+					// netns-bound inbound listener.
+					Address: endpoint.GetIp(),
+					PortSpecifier: &corev3.SocketAddress_PortValue{
+						PortValue: defaultInboundPort,
+					},
+				},
+			},
+		},
+	}
+	// In EDS mode (set per pod by annotation) this endpoint opts out of the cluster's
+	// active readiness health check and relies on the EDS health status pushed by the
+	// node-local agent (delegated liveness) instead.
+	if endpoint.GetHealthCheckMode() == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS {
+		ep.HealthCheckConfig = &endpointv3.Endpoint_HealthCheckConfig{
+			DisableActiveHealthCheck: true,
+		}
+	}
+
 	return &endpointv3.LocalityLbEndpoints{
 		LbEndpoints: []*endpointv3.LbEndpoint{
 			{
-				HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
-					Endpoint: &endpointv3.Endpoint{
-						Address: &corev3.Address{
-							Address: &corev3.Address_SocketAddress{
-								SocketAddress: &corev3.SocketAddress{
-									Protocol: corev3.SocketAddress_TCP,
-									// The destination pod's mesh inbound; reached by the
-									// pod's own netns-bound inbound listener.
-									Address: endpoint.GetIp(),
-									PortSpecifier: &corev3.SocketAddress_PortValue{
-										PortValue: defaultInboundPort,
-									},
-								},
-							},
-						},
-					},
-				},
-				Metadata:     md,
-				HealthStatus: endpointHealthStatus(endpoint),
+				HostIdentifier: &endpointv3.LbEndpoint_Endpoint{Endpoint: ep},
+				Metadata:       md,
+				HealthStatus:   endpointHealthStatus(endpoint),
 			},
 		},
 		Locality: locality,

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -80,6 +80,19 @@ func TestServiceLocalityLbEndpointFromRegistryEndpoint(t *testing.T) {
 	assert.Equal(t, "svc-a-1", lb[subsetPodNameKey].GetStringValue())
 
 	assert.Equal(t, corev3.HealthStatus_HEALTHY, lle.GetLbEndpoints()[0].GetHealthStatus())
+	// Default mode (unspecified) keeps the cluster's active readiness HC.
+	assert.False(t, lle.GetLbEndpoints()[0].GetEndpoint().GetHealthCheckConfig().GetDisableActiveHealthCheck(),
+		"default endpoints are actively health-checked")
+}
+
+func TestServiceLocalityLbEndpointFromRegistryEndpoint_EDSMode(t *testing.T) {
+	ep := &registryv1.ServiceEndpoint{
+		Ip:              "10.0.0.5",
+		HealthCheckMode: registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS,
+	}
+	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep)
+	assert.True(t, lle.GetLbEndpoints()[0].GetEndpoint().GetHealthCheckConfig().GetDisableActiveHealthCheck(),
+		"EDS-mode endpoints opt out of active health checking and rely on EDS health")
 }
 
 func TestEndpointHealthStatus(t *testing.T) {

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -55,4 +55,18 @@ message ServiceEndpoint {
   }
 
   Health health = 9;
+
+  // HealthCheckMode selects how client proxies determine this endpoint's health.
+  // ACTIVE (the default, including UNSPECIFIED): each client proxy actively
+  // HTTP-health-checks the endpoint's mesh readiness path. EDS: clients instead
+  // rely on the EDS health status pushed by the node-local agent (delegated
+  // liveness) and do not probe the endpoint themselves. Set per pod via the
+  // endpoint.aether.io/health-check-mode annotation.
+  enum HealthCheckMode {
+    HEALTH_CHECK_MODE_UNSPECIFIED = 0;
+    HEALTH_CHECK_MODE_ACTIVE = 1;
+    HEALTH_CHECK_MODE_EDS = 2;
+  }
+
+  HealthCheckMode health_check_mode = 10;
 }

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -19,6 +19,16 @@ const (
 	// agent active-health-checks on the pod's application (delegated liveness).
 	AnnotationEndpointHealthPath = annotationAetherEndpointPrefix + "health-path"
 
+	// AnnotationEndpointHealthCheckMode is the pod annotation key selecting how
+	// client proxies determine this endpoint's health. Unset or "active" (default)
+	// makes each client actively health-check the endpoint's mesh readiness path;
+	// "eds" makes clients rely on the EDS health status pushed by the node-local
+	// agent (delegated liveness) instead of probing the endpoint.
+	AnnotationEndpointHealthCheckMode = annotationAetherEndpointPrefix + "health-check-mode"
+	// HealthCheckModeActive / HealthCheckModeEDS are the accepted annotation values.
+	HealthCheckModeActive = "active"
+	HealthCheckModeEDS    = "eds"
+
 	// AnnotationAetherEndpointMetadataPrefix is the prefix for endpoint metadata annotations
 	AnnotationAetherEndpointMetadataPrefix = "metadata." + annotationAetherEndpointPrefix
 

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -32,11 +32,12 @@ func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeIP st
 	}
 
 	endpoint := &registryv1.ServiceEndpoint{
-		Ip:          cniPod.GetIps()[0],
-		ClusterName: clusterName,
-		Port:        uint32(port),
-		Weight:      weight,
-		Metadata:    getEndpointMetadataFromAnnotations(cniPod.GetAnnotations()),
+		Ip:              cniPod.GetIps()[0],
+		ClusterName:     clusterName,
+		Port:            uint32(port),
+		Weight:          weight,
+		Metadata:        getEndpointMetadataFromAnnotations(cniPod.GetAnnotations()),
+		HealthCheckMode: healthCheckModeFromAnnotations(cniPod.GetAnnotations()),
 		ContainerMetadata: &registryv1.ServiceEndpoint_ContainerMetadata{
 			ContainerId:      cniPod.GetContainerId(),
 			NetworkNamespace: cniPod.GetNetworkNamespace(),
@@ -104,6 +105,21 @@ func getWeightFromAnnotations(annotations map[string]string) (uint32, error) {
 	}
 
 	return uint32(weight), nil
+}
+
+// healthCheckModeFromAnnotations maps the endpoint.aether.io/health-check-mode
+// annotation to the ServiceEndpoint health-check mode. "eds" yields EDS; "active"
+// yields ACTIVE; unset yields UNSPECIFIED, which consumers treat as active (the
+// default).
+func healthCheckModeFromAnnotations(annotations map[string]string) registryv1.ServiceEndpoint_HealthCheckMode {
+	switch annotations[constants.AnnotationEndpointHealthCheckMode] {
+	case constants.HealthCheckModeEDS:
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS
+	case constants.HealthCheckModeActive:
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_ACTIVE
+	default:
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_UNSPECIFIED
+	}
 }
 
 // getEndpointMetadataFromAnnotations extracts endpoint metadata from pod annotations.

--- a/registry/internal/cloudmap/attrs.go
+++ b/registry/internal/cloudmap/attrs.go
@@ -18,20 +18,21 @@ const (
 	attrPort = "AWS_INSTANCE_PORT"
 
 	// Aether-specific attributes
-	attrCluster      = "AETHER_CLUSTER"
-	attrProtocol     = "AETHER_PROTOCOL"
-	attrWeight       = "AETHER_WEIGHT"
-	attrRegion       = "AETHER_REGION"
-	attrZone         = "AETHER_ZONE"
-	attrK8sNamespace = "AETHER_K8S_NAMESPACE"
-	attrK8sPod       = "AETHER_K8S_POD"
-	attrK8sNode      = "AETHER_K8S_NODE"
-	attrK8sNodeIP    = "AETHER_K8S_NODE_IP"
-	attrHealth       = "AETHER_HEALTH"
-	attrContainerID  = "AETHER_CONTAINER_ID"
-	attrNetworkNS    = "AETHER_NETWORK_NS"
-	attrMetadata     = "AETHER_METADATA"
-	attrController   = "AETHER_CONTROLLER"
+	attrCluster         = "AETHER_CLUSTER"
+	attrProtocol        = "AETHER_PROTOCOL"
+	attrWeight          = "AETHER_WEIGHT"
+	attrRegion          = "AETHER_REGION"
+	attrZone            = "AETHER_ZONE"
+	attrK8sNamespace    = "AETHER_K8S_NAMESPACE"
+	attrK8sPod          = "AETHER_K8S_POD"
+	attrK8sNode         = "AETHER_K8S_NODE"
+	attrK8sNodeIP       = "AETHER_K8S_NODE_IP"
+	attrHealth          = "AETHER_HEALTH"
+	attrHealthCheckMode = "AETHER_HEALTH_CHECK_MODE"
+	attrContainerID     = "AETHER_CONTAINER_ID"
+	attrNetworkNS       = "AETHER_NETWORK_NS"
+	attrMetadata        = "AETHER_METADATA"
+	attrController      = "AETHER_CONTROLLER"
 
 	// controllerName identifies instances managed by Aether.
 	controllerName = "aether"
@@ -98,6 +99,11 @@ func marshalAttrs(protocol registryv1.Service_Protocol, ep *registryv1.ServiceEn
 		attrs[attrHealth] = h.String()
 	}
 
+	// Only persist an explicit mode; absence means the default (active).
+	if m := ep.GetHealthCheckMode(); m != registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_UNSPECIFIED {
+		attrs[attrHealthCheckMode] = m.String()
+	}
+
 	return attrs
 }
 
@@ -153,6 +159,10 @@ func unmarshalEndpoint(attrs map[string]string) (*registryv1.ServiceEndpoint, er
 
 	if h, ok := registryv1.ServiceEndpoint_Health_value[attrs[attrHealth]]; ok {
 		ep.Health = registryv1.ServiceEndpoint_Health(h)
+	}
+
+	if m, ok := registryv1.ServiceEndpoint_HealthCheckMode_value[attrs[attrHealthCheckMode]]; ok {
+		ep.HealthCheckMode = registryv1.ServiceEndpoint_HealthCheckMode(m)
 	}
 
 	return ep, nil

--- a/registry/internal/cloudmap/attrs_test.go
+++ b/registry/internal/cloudmap/attrs_test.go
@@ -35,7 +35,8 @@ func fullEndpoint() *registryv1.ServiceEndpoint {
 			NodeName:  "node-1",
 			NodeIp:    "192.168.0.60",
 		},
-		Health: registryv1.ServiceEndpoint_HEALTH_UNHEALTHY,
+		Health:          registryv1.ServiceEndpoint_HEALTH_UNHEALTHY,
+		HealthCheckMode: registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS,
 	}
 }
 

--- a/registry/internal/k8s/kubernetes.go
+++ b/registry/internal/k8s/kubernetes.go
@@ -225,7 +225,8 @@ func (r *KubernetesRegistry) podToEndpoint(pod *corev1.Pod, nodeLocalities map[s
 		// This backend derives endpoints from the API server rather than receiving
 		// agent registrations, so health comes from the pod's readiness condition
 		// (the delegated active-HC path applies only to the write-based backends).
-		Health: podHealth(pod),
+		Health:          podHealth(pod),
+		HealthCheckMode: healthCheckModeFromAnnotations(pod.Annotations),
 	}
 
 	if loc, ok := nodeLocalities[pod.Spec.NodeName]; ok {
@@ -261,6 +262,21 @@ func podHealth(pod *corev1.Pod) registryv1.ServiceEndpoint_Health {
 		}
 	}
 	return registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED
+}
+
+// healthCheckModeFromAnnotations maps the endpoint.aether.io/health-check-mode
+// annotation to the ServiceEndpoint health-check mode. "eds" yields EDS; "active"
+// yields ACTIVE; unset yields UNSPECIFIED, which consumers treat as active (the
+// default).
+func healthCheckModeFromAnnotations(annotations map[string]string) registryv1.ServiceEndpoint_HealthCheckMode {
+	switch annotations[constants.AnnotationEndpointHealthCheckMode] {
+	case constants.HealthCheckModeEDS:
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS
+	case constants.HealthCheckModeActive:
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_ACTIVE
+	default:
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_UNSPECIFIED
+	}
 }
 
 // getPortFromAnnotations extracts the endpoint port from pod annotations.

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -449,6 +449,40 @@ func TestListEndpoints(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:        "pod with eds health-check-mode annotation sets EDS mode",
+			clusterName: "test-cluster",
+			objects: []any{
+				func() *corev1.Pod {
+					p := managedPod("pod-a", "default", "my-service", "10.0.0.1", "node-1")
+					p.Annotations[constants.AnnotationEndpointHealthCheckMode] = constants.HealthCheckModeEDS
+					return p
+				}(),
+				topologyNode("node-1", "us-east-1", "us-east-1a"),
+			},
+			service:  "my-service",
+			protocol: registryv1.Service_PROTOCOL_HTTP,
+			expected: []*registryv1.ServiceEndpoint{
+				{
+					Ip:          "10.0.0.1",
+					ClusterName: "test-cluster",
+					Port:        uint32(constants.DefaultEndpointPort),
+					Weight:      constants.DefaultEndpointWeight,
+					Metadata:    map[string]string{},
+					KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+						Namespace: "default",
+						PodName:   "pod-a",
+						NodeName:  "node-1",
+					},
+					Locality: &registryv1.ServiceEndpoint_Locality{
+						Region: "us-east-1",
+						Zone:   "us-east-1a",
+					},
+					HealthCheckMode: registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name:        "pod with invalid port annotation is skipped without error",
 			clusterName: "test-cluster",
 			objects: []any{


### PR DESCRIPTION
## What

Adds the `endpoint.aether.io/health-check-mode` pod annotation so each pod chooses how client proxies determine its health:

- **unset / `active`** (default): clients keep the service cluster's **active readiness HC** — each client proxy probes the endpoint's `/-/-/ready` directly.
- **`eds`**: the endpoint opts out of active health checking (`endpoint.health_check_config.disable_active_health_check`) and clients rely on the **EDS health status** pushed by the node-local agent (delegated liveness) instead.

## How

- New `ServiceEndpoint.HealthCheckMode` enum (field 10; `UNSPECIFIED` is treated as active, so existing endpoints/tests are unaffected).
- Stamped from the annotation in both the CNI register path (`NewServiceEndpointFromCNIPod`) and the kubernetes derive path (`podToEndpoint`).
- Serialized through cloudmap (`AETHER_HEALTH_CHECK_MODE`); etcd/ddb carry it automatically.
- The agent sets `disable_active_health_check` per endpoint in `ServiceLocalityLbEndpointFromRegistryEndpoint` when the mode is `EDS`.

## Validation

Spike (envoy v1.38): an EDS-mode endpoint (`disable_active_health_check` + EDS `HEALTHY`) routes on EDS health alone, **even with the cluster's `ignore_new_hosts_until_first_hc` set** — so the two modes coexist on the same cluster without the EDS-mode endpoint getting stuck pending a (never-run) first HC. The active mode was validated end-to-end in the transport PR's `client_ready` spike.

`bazel test //...` green (the active-HC machinery itself landed in #98); `make format` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)