### PR TITLE
fix(agent chart): name the proxy DaemonSet aether-proxy

### DIFF
--- a/charts/agent/templates/_helpers.tpl
+++ b/charts/agent/templates/_helpers.tpl
@@ -23,10 +23,13 @@ multiple releases can coexist. Honours fullnameOverride / nameOverride.
 {{- end -}}
 
 {{/*
-Proxy fullname.
+Proxy fullname. The Envoy proxy is a distinct "aether-proxy" component — its
+selector labels and Envoy --service-cluster already use that name — so its
+DaemonSet, ServiceAccount and ConfigMap are named aether-proxy rather than
+"<agent-fullname>-proxy".
 */}}
 {{- define "agent.proxy.fullname" -}}
-{{- printf "%s-proxy" (include "agent.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- "aether-proxy" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
The Envoy proxy is a distinct component — its selector labels (`app.kubernetes.io/name: aether-proxy`) and Envoy `--service-cluster` already use `aether-proxy` — but its DaemonSet/ServiceAccount/ConfigMap were named `<agent-fullname>-proxy` (`aether-agent-proxy`), an inconsistency.

`agent.proxy.fullname` now resolves to `aether-proxy`, so the DaemonSet, ServiceAccount and ConfigMap are named consistently: `aether-proxy`, `aether-proxy`, `aether-proxy-config`. The `aether-agent` DaemonSet and the agent selectors are unchanged.

On upgrade, helm replaces the old `aether-agent-proxy` DaemonSet with the new `aether-proxy` one (different resource name), avoiding the immutable-selector issue.

Lint + template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)