### PR TITLE
chore(agent): refresh stale tunnel/CONNECT comments, drop dead pod field

### DIFF
--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -37,9 +37,9 @@ type SecretStore interface {
 }
 
 // NodeIdentitySink receives the agent's node SPIFFE ID when the node SVID is
-// served, so resources that reference it (the node CONNECT listener) can be
-// generated. The xDS snapshot cache satisfies it; the bridge calls it only when
-// its store also implements this interface.
+// served, so resources that reference it (the outbound clusters' no-match upstream
+// client cert) can be generated. The xDS snapshot cache satisfies it; the bridge
+// calls it only when its store also implements this interface.
 type NodeIdentitySink interface {
 	SetNodeIdentity(ctx context.Context, nodeSpiffeID string) error
 }
@@ -104,7 +104,8 @@ func NewBridge(socketPath string, store SecretStore, nodeSource X509SVIDSource, 
 
 // NodeSpiffeID returns the SPIFFE ID of the agent's node identity once the node
 // SVID has been served, or "" if node-SVID serving is disabled or not yet ready.
-// It is the SDS secret name proxies reference for node-to-node tunnel mTLS.
+// It is the SDS secret name proxies reference for node-originated upstream mTLS
+// (the outbound clusters' no-match client cert) and the node-health listener.
 func (b *Bridge) NodeSpiffeID() string {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -136,7 +137,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 
 	b.log.Info("subscribed to X.509 bundles")
 
-	// Serve the agent's own node SVID (for node-to-node tunnel mTLS and the
+	// Serve the agent's own node SVID (for node-originated upstream mTLS and the
 	// node-health listener) and keep it refreshed on rotation.
 	if b.nodeSource != nil {
 		if err := b.refreshNodeSVID(ctx); err != nil {
@@ -368,9 +369,9 @@ func (b *Bridge) refreshNodeSVID(ctx context.Context) error {
 	b.nodeSpiffeID = secret.GetName()
 	b.mu.Unlock()
 
-	// Inform the cache of the node identity so the node CONNECT listener (which
-	// references it as its server cert) is generated. Only needed once: the
-	// SPIFFE ID is stable across rotations.
+	// Inform the cache of the node identity so outbound clusters (which reference
+	// it as the no-match upstream client cert) can be generated. Only needed once:
+	// the SPIFFE ID is stable across rotations.
 	if firstServe {
 		if sink, ok := b.store.(NodeIdentitySink); ok {
 			if err := sink.SetNodeIdentity(ctx, secret.GetName()); err != nil {

--- a/agent/internal/spire/converter.go
+++ b/agent/internal/spire/converter.go
@@ -62,7 +62,7 @@ func SVIDToTLSCertificateSecret(svid *delegatedidentityv1.X509SVIDWithKey) (*tls
 // X509SVIDToTLSCertificateSecret converts a go-spiffe X.509 SVID (as returned by
 // the Workload API source) to an Envoy TLS certificate Secret. The secret name is
 // the full SPIFFE ID URI. This is used to serve the agent's own node identity to
-// the proxy for node-to-node tunnel mTLS and the node-health listener, distinct
+// the proxy for node-originated upstream mTLS and the node-health listener, distinct
 // from the per-pod workload SVIDs served via the Delegated Identity API.
 func X509SVIDToTLSCertificateSecret(svid *x509svid.SVID) (*tlsv3.Secret, error) {
 	if svid == nil {

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -19,7 +19,6 @@ package cache
 import (
 	"sync"
 
-	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -64,8 +63,10 @@ type SnapshotCache struct {
 	// used to name the upstream mTLS validation context.
 	trustDomain string
 	// nodeSpiffeID is the agent's node identity (set by the SPIRE bridge once the
-	// node SVID is served). It is the downstream server-cert secret name for the
-	// node CONNECT listener; while empty, that listener is not generated.
+	// node SVID is served). Outbound clusters present it as the client certificate
+	// on the transport-socket matcher's no-match path (e.g. active health-check
+	// probes, which carry no source-pod filter state); while empty, upstream mTLS
+	// injection is skipped.
 	nodeSpiffeID string
 
 	version *atomic.Uint64
@@ -85,9 +86,6 @@ type listenerEntry struct {
 	// health check (delegated liveness), kept separate from appCluster so the HC
 	// does not gate the delivery path.
 	healthCluster types.Resource
-	// pod is retained so the node-level CONNECT listener can be (re)built with a
-	// route per local pod (keyed on the pod IP) to its app cluster.
-	pod *cniv1.CNIPod
 }
 
 // clusterEntry holds a cluster definition, its pre-built load assignment,

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -32,7 +32,6 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 		outbound:      outbound,
 		appCluster:    appCluster,
 		healthCluster: healthCluster,
-		pod:           cniPod,
 	}
 	c.listenerMu.Unlock()
 
@@ -135,7 +134,6 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 			outbound:      outbound,
 			appCluster:    appCluster,
 			healthCluster: healthCluster,
-			pod:           pod,
 		}
 		local[netns] = proxy.SpiffeIDFromPod(pod, trustDomain)
 	}

--- a/agent/internal/xds/cache/secret.go
+++ b/agent/internal/xds/cache/secret.go
@@ -21,9 +21,10 @@ func (c *SnapshotCache) SetSecrets(ctx context.Context, secrets []*tlsv3.Secret)
 }
 
 // SetNodeIdentity records the agent's node SPIFFE ID (served by the SPIRE bridge
-// as the node SVID) and regenerates the snapshot. The node CONNECT listener uses
-// it as its downstream server-certificate secret name; until it is set, that
-// listener is omitted. Idempotent: a no-op when the value is unchanged.
+// as the node SVID) and regenerates the snapshot. Outbound clusters reference it
+// as the no-match client-certificate secret for upstream mTLS (used by active
+// health-check probes and other node-originated connections); until it is set,
+// upstream mTLS injection is skipped. Idempotent: a no-op when the value is unchanged.
 func (c *SnapshotCache) SetNodeIdentity(ctx context.Context, nodeSpiffeID string) error {
 	c.localMu.Lock()
 	if c.nodeSpiffeID == nodeSpiffeID {


### PR DESCRIPTION
## Summary

Cleanup following the tunnel removal in #98/#101. No behavior change — comments and dead code only.

- **Stale comments (8 sites):** the HBONE tunnel / per-node CONNECT listener is gone, but `cache.go`, `secret.go`, `bridge.go`, and `converter.go` still described the node SPIFFE ID as the CONNECT listener's server cert / node-to-node tunnel identity. Updated to its actual role: the **no-match upstream client cert** presented by outbound clusters for node-originated connections (active health-check probes) plus the node-health listener.
- **Dead code:** removed `listenerEntry.pod`, which only existed to rebuild the removed CONNECT listener's per-pod routes — it was written in two places but never read. This also drops the now-unused `cni/v1` import in `cache.go`.

## Test plan

- `bazel build //agent/internal/xds/cache/... //agent/internal/spire/...` ✅
- `bazel test //agent/internal/xds/cache/... //agent/internal/spire/...` ✅
- `grep` confirms no remaining `CONNECT listener` / `node-to-node tunnel` references in Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)