### PR TITLE
docs: fix Go version, drop nonexistent make targets, mark registrar proposal implemented

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Aether is a Kubernetes service mesh data plane built in Go. It runs an **agent**
 
 ## Build System
 
-The project uses **Bazel 9.0.1** (via Bazelisk) with `rules_go` and Gazelle for Go, and `rules_img` for container images. Go module is `github.com/bpalermo/aether` with Go 1.26.0.
+The project uses **Bazel 9.0.1** (via Bazelisk) with `rules_go` and Gazelle for Go, and `rules_img` for container images. Go module is `github.com/bpalermo/aether` with Go 1.26.2.
 
 ### Common Commands
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ make test-race             # Run all tests with Go race detector
 make format                # Format all code (Go, protobuf, Starlark, shell)
 make format-check          # Check formatting (CI-friendly, fails on drift)
 make lint                  # Run linters (buf, buildifier, shellcheck)
-make fmt                   # Format Go code with gofmt
-make vet                   # Run go vet
 ```
 
 Formatting uses [gofumpt](https://github.com/mvdan/gofumpt), [buildifier](https://github.com/bazelbuild/buildtools), [shfmt](https://github.com/mvdan/sh), and [buf](https://buf.build) via [`aspect_rules_lint`](https://github.com/aspect-build/rules_lint). Linting runs buf (protobuf), buildifier (Starlark), and shellcheck (shell) as Bazel aspects. CI enforces lint violations with `--config=ci`.

--- a/docs/proposals/000_in-cluster-registrar.md
+++ b/docs/proposals/000_in-cluster-registrar.md
@@ -1,6 +1,6 @@
 # Proposal: In-Cluster Registrar Service
 
-**Status:** Draft
+**Status:** Implemented
 **Author:** Bruno Palermo
 **Date:** 2026-03-22
 


### PR DESCRIPTION
## Summary

Documentation drift fixes — no code changes.

- **`CLAUDE.md`:** Go version 1.26.0 → **1.26.2**, matching `go.mod` and `MODULE.bazel`.
- **`README.md`:** removed `make fmt` and `make vet` from the Code Quality section — neither target exists in the Makefile (`AGENTS.md` already omits them).
- **`docs/proposals/000_in-cluster-registrar.md`:** `Status: Draft` → **Implemented**. The registrar is shipped and is a headline component in the README architecture diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)