### PR TITLE
spike(proxy): Envoy hot-restart — 3 upgrade strategies + Strategy A impl

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -5,12 +5,14 @@ go_library(
     srcs = [
         "config.go",
         "root.go",
+        "supervisor.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/cmd",
     visibility = ["//visibility:public"],
     deps = [
         "//agent/constants",
         "//agent/internal/cni/server",
+        "//agent/internal/proxy/hotrestart",
         "//agent/internal/spire",
         "//agent/internal/xds/cache",
         "//agent/internal/xds/server",

--- a/agent/internal/cmd/supervisor.go
+++ b/agent/internal/cmd/supervisor.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/proxy/hotrestart"
@@ -11,8 +15,9 @@ import (
 // supervisorCfg holds the flag-bound configuration for the proxy-supervisor
 // subcommand. SPIKE: see docs/proposals/001_proxy-hot-restart.md.
 var (
-	supervisorCfg   hotrestart.Config
-	supervisorDebug bool
+	supervisorCfg         hotrestart.Config
+	supervisorDebug       bool
+	supervisorInstallPath string
 )
 
 var proxySupervisorCmd = &cobra.Command{
@@ -21,21 +26,56 @@ var proxySupervisorCmd = &cobra.Command{
 	Long:         "Runs as the aether-proxy container entrypoint, forking and hot-restarting Envoy across restart epochs so bootstrap-config and binary upgrades happen without dropping connections.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		// --install-path lets this (statically linked) binary copy itself onto a
+		// shared volume from an initContainer, so the runtime container can be the
+		// Envoy image (which carries Envoy and its shared libraries) with the
+		// supervisor injected alongside it.
+		if supervisorInstallPath != "" {
+			return installSelf(supervisorInstallPath)
+		}
 		log := manager.SetupLogging(supervisorDebug, cmd.Name())
 		return hotrestart.New(supervisorCfg, log).Run(cmd.Context())
 	},
 }
 
+// installSelf copies the running executable to dest (0o755). Linux-only via
+// /proc/self/exe; the supervisor only ever runs on Linux nodes.
+func installSelf(dest string) error {
+	src, err := os.Open("/proc/self/exe")
+	if err != nil {
+		return fmt.Errorf("opening self: %w", err)
+	}
+	defer func() { _ = src.Close() }()
+
+	tmp := dest + ".tmp"
+	out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o755)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", tmp, err)
+	}
+	if _, err := io.Copy(out, src); err != nil {
+		_ = out.Close()
+		return fmt.Errorf("copying binary: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("closing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, filepath.Clean(dest)); err != nil {
+		return fmt.Errorf("installing to %s: %w", dest, err)
+	}
+	return nil
+}
+
 func init() {
 	f := proxySupervisorCmd.Flags()
 	f.BoolVar(&supervisorDebug, "debug", false, "Enable debug-level logging")
+	f.StringVar(&supervisorInstallPath, "install-path", "", "If set, copy this binary to the given path and exit (for initContainer self-install onto a shared volume)")
 	f.StringVar(&supervisorCfg.EnvoyPath, "envoy-path", "/usr/local/bin/envoy", "Path to the Envoy binary")
 	f.StringVar(&supervisorCfg.ConfigPath, "config", "/etc/envoy/envoy.yaml", "Envoy bootstrap config path (-c); a change to this file triggers a hot restart when --watch-config is set")
 	f.Uint32Var(&supervisorCfg.BaseID, "base-id", 0, "Envoy --base-id, pinned so successive epochs share one shared-memory segment")
 	f.DurationVar(&supervisorCfg.DrainTime, "drain-time", 45*time.Second, "Envoy --drain-time-s: graceful connection-close window for the draining epoch")
 	f.DurationVar(&supervisorCfg.ParentShutdownTime, "parent-shutdown-time", 60*time.Second, "Envoy --parent-shutdown-time-s: when the previous epoch is terminated (must exceed --drain-time)")
 	f.StringArrayVar(&supervisorCfg.ExtraArgs, "envoy-arg", nil, "Extra argument appended to every Envoy invocation (repeatable); keep --concurrency constant across epochs")
-	f.BoolVar(&supervisorCfg.WatchConfig, "watch-config", false, "Watch --config and self-trigger a hot restart on change (SPIKE: not yet implemented)")
+	f.BoolVar(&supervisorCfg.WatchConfig, "watch-config", false, "Watch --config and self-trigger a hot restart when the bootstrap config changes")
 
 	rootCmd.AddCommand(proxySupervisorCmd)
 }

--- a/agent/internal/cmd/supervisor.go
+++ b/agent/internal/cmd/supervisor.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/proxy/hotrestart"
+	"github.com/bpalermo/aether/common/manager"
+	"github.com/spf13/cobra"
+)
+
+// supervisorCfg holds the flag-bound configuration for the proxy-supervisor
+// subcommand. SPIKE: see docs/proposals/001_proxy-hot-restart.md.
+var (
+	supervisorCfg   hotrestart.Config
+	supervisorDebug bool
+)
+
+var proxySupervisorCmd = &cobra.Command{
+	Use:          "proxy-supervisor",
+	Short:        "Supervises the Envoy proxy with hot-restart support (SPIKE).",
+	Long:         "Runs as the aether-proxy container entrypoint, forking and hot-restarting Envoy across restart epochs so bootstrap-config and binary upgrades happen without dropping connections.",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		log := manager.SetupLogging(supervisorDebug, cmd.Name())
+		return hotrestart.New(supervisorCfg, log).Run(cmd.Context())
+	},
+}
+
+func init() {
+	f := proxySupervisorCmd.Flags()
+	f.BoolVar(&supervisorDebug, "debug", false, "Enable debug-level logging")
+	f.StringVar(&supervisorCfg.EnvoyPath, "envoy-path", "/usr/local/bin/envoy", "Path to the Envoy binary")
+	f.StringVar(&supervisorCfg.ConfigPath, "config", "/etc/envoy/envoy.yaml", "Envoy bootstrap config path (-c); a change to this file triggers a hot restart when --watch-config is set")
+	f.Uint32Var(&supervisorCfg.BaseID, "base-id", 0, "Envoy --base-id, pinned so successive epochs share one shared-memory segment")
+	f.DurationVar(&supervisorCfg.DrainTime, "drain-time", 45*time.Second, "Envoy --drain-time-s: graceful connection-close window for the draining epoch")
+	f.DurationVar(&supervisorCfg.ParentShutdownTime, "parent-shutdown-time", 60*time.Second, "Envoy --parent-shutdown-time-s: when the previous epoch is terminated (must exceed --drain-time)")
+	f.StringArrayVar(&supervisorCfg.ExtraArgs, "envoy-arg", nil, "Extra argument appended to every Envoy invocation (repeatable); keep --concurrency constant across epochs")
+	f.BoolVar(&supervisorCfg.WatchConfig, "watch-config", false, "Watch --config and self-trigger a hot restart on change (SPIKE: not yet implemented)")
+
+	rootCmd.AddCommand(proxySupervisorCmd)
+}

--- a/agent/internal/proxy/hotrestart/BUILD.bazel
+++ b/agent/internal/proxy/hotrestart/BUILD.bazel
@@ -1,9 +1,23 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "hotrestart",
     srcs = ["supervisor.go"],
     importpath = "github.com/bpalermo/aether/agent/internal/proxy/hotrestart",
     visibility = ["//agent:__subpackages__"],
-    deps = ["@com_github_go_logr_logr//:logr"],
+    deps = [
+        "@com_github_fsnotify_fsnotify//:fsnotify",
+        "@com_github_go_logr_logr//:logr",
+    ],
+)
+
+go_test(
+    name = "hotrestart_test",
+    srcs = ["supervisor_test.go"],
+    embed = [":hotrestart"],
+    deps = [
+        "@com_github_go_logr_logr//:logr",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/agent/internal/proxy/hotrestart/BUILD.bazel
+++ b/agent/internal/proxy/hotrestart/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "hotrestart",
+    srcs = ["supervisor.go"],
+    importpath = "github.com/bpalermo/aether/agent/internal/proxy/hotrestart",
+    visibility = ["//agent:__subpackages__"],
+    deps = ["@com_github_go_logr_logr//:logr"],
+)

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -1,0 +1,245 @@
+// Package hotrestart implements a supervisor that manages the aether-proxy Envoy
+// process and performs Envoy hot restarts across restart epochs, replicating the
+// behavior of Envoy's hot-restarter.py in Go.
+//
+// SPIKE: this package is a throwaway-quality starting point for the proxy
+// hot-restart spike (see docs/proposals/001_proxy-hot-restart.md). It is not yet
+// wired into production and the edge cases marked TODO are deliberately unhandled.
+//
+// Model: the supervisor is the proxy container's entrypoint (PID 1). It forks an
+// Envoy child with --restart-epoch 0 and a fixed --base-id. On a hot-restart
+// trigger (SIGHUP, or a watched bootstrap-config change) it forks a new Envoy with
+// the next epoch; Envoy's own shared-memory + abstract-domain-socket IPC transfers
+// the listen-socket FDs and stats to the new process, the old process drains, and
+// after --parent-shutdown-time-s the supervisor terminates it. The supervisor and
+// both epochs share the container's /dev/shm and PID/IPC namespace, which is what
+// makes the FD/stats handoff possible.
+package hotrestart
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// Config configures the Envoy hot-restart supervisor.
+type Config struct {
+	// EnvoyPath is the path to the Envoy binary.
+	EnvoyPath string
+	// ConfigPath is the Envoy bootstrap config (-c). A change to this file (when
+	// WatchConfig is set) triggers a hot restart.
+	ConfigPath string
+	// BaseID is Envoy's --base-id, pinned so successive epochs find the same
+	// shared-memory segment. Must be stable for the life of the container.
+	BaseID uint32
+	// DrainTime maps to Envoy --drain-time-s: how long the draining (old) epoch
+	// takes to gracefully close connections.
+	DrainTime time.Duration
+	// ParentShutdownTime maps to Envoy --parent-shutdown-time-s and gates when the
+	// supervisor SIGTERMs the previous epoch. Must exceed DrainTime.
+	ParentShutdownTime time.Duration
+	// ExtraArgs are appended to every Envoy invocation (e.g. -l, --service-cluster,
+	// --service-node, --service-zone, --concurrency). Concurrency must stay constant
+	// across epochs to avoid dropping accept-queue connections.
+	ExtraArgs []string
+	// WatchConfig enables an fsnotify watch on ConfigPath that self-triggers a hot
+	// restart when the bootstrap config changes.
+	//
+	// TODO(spike): wire the fsnotify watcher; for now restarts are driven by SIGHUP.
+	WatchConfig bool
+}
+
+// childExit reports the termination of a supervised Envoy epoch.
+type childExit struct {
+	epoch int
+	err   error
+}
+
+// Supervisor owns the Envoy process lifecycle and performs hot restarts.
+type Supervisor struct {
+	cfg Config
+	log logr.Logger
+
+	mu        sync.Mutex
+	children  map[int]*exec.Cmd // keyed by restart epoch
+	nextEpoch int
+
+	childExited chan childExit
+	done        chan struct{}
+}
+
+// New creates a Supervisor.
+func New(cfg Config, log logr.Logger) *Supervisor {
+	return &Supervisor{
+		cfg:         cfg,
+		log:         log.WithName("proxy-supervisor"),
+		children:    make(map[int]*exec.Cmd),
+		childExited: make(chan childExit, 4),
+		done:        make(chan struct{}),
+	}
+}
+
+// Run starts Envoy at epoch 0 and supervises it until ctx is canceled (SIGTERM/
+// SIGINT, which controller-runtime's signal handler maps to ctx.Done) or the
+// newest epoch exits unexpectedly. SIGHUP triggers a hot restart; SIGUSR1 is
+// forwarded to the current child for log reopen.
+func (s *Supervisor) Run(ctx context.Context) error {
+	sigCh := make(chan os.Signal, 4)
+	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGUSR1)
+	defer signal.Stop(sigCh)
+	defer close(s.done)
+
+	if err := s.hotRestart(); err != nil {
+		return fmt.Errorf("starting initial envoy epoch: %w", err)
+	}
+
+	// TODO(spike): if cfg.WatchConfig, start an fsnotify watcher on ConfigPath and
+	// fan its events into a hot restart (debounced), in addition to SIGHUP.
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.log.Info("termination requested, shutting down all envoy epochs")
+			s.terminateAll()
+			return nil
+
+		case sig := <-sigCh:
+			switch sig {
+			case syscall.SIGHUP:
+				s.log.Info("SIGHUP received, performing hot restart")
+				if err := s.hotRestart(); err != nil {
+					s.log.Error(err, "hot restart failed; keeping current epoch")
+				}
+			case syscall.SIGUSR1:
+				s.forwardToCurrent(syscall.SIGUSR1)
+			}
+
+		case exit := <-s.childExited:
+			if exit.epoch == s.currentEpoch() {
+				// The newest epoch died unexpectedly: nothing left serving traffic.
+				// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).
+				s.terminateAll()
+				return fmt.Errorf("envoy epoch %d exited unexpectedly: %w", exit.epoch, exit.err)
+			}
+			// An older epoch finished draining after a hot restart: expected. Reap it.
+			s.reap(exit.epoch)
+		}
+	}
+}
+
+// hotRestart forks a new Envoy child at the next restart epoch and schedules
+// shutdown of the previous one after ParentShutdownTime.
+func (s *Supervisor) hotRestart() error {
+	s.mu.Lock()
+	epoch := s.nextEpoch
+	s.nextEpoch++
+	s.mu.Unlock()
+
+	cmd := s.buildEnvoyCmd(epoch)
+	s.log.Info("starting envoy", "epoch", epoch, "args", cmd.Args)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.children[epoch] = cmd
+	s.mu.Unlock()
+
+	go func() {
+		err := cmd.Wait()
+		select {
+		case s.childExited <- childExit{epoch: epoch, err: err}:
+		case <-s.done:
+		}
+	}()
+
+	if epoch > 0 {
+		go s.scheduleParentShutdown(epoch - 1)
+	}
+	return nil
+}
+
+// scheduleParentShutdown SIGTERMs the given (draining) epoch after
+// ParentShutdownTime, unless the supervisor is shutting down first.
+func (s *Supervisor) scheduleParentShutdown(epoch int) {
+	t := time.NewTimer(s.cfg.ParentShutdownTime)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		s.log.Info("parent shutdown timer elapsed, terminating drained epoch", "epoch", epoch)
+		s.signalEpoch(epoch, syscall.SIGTERM)
+	case <-s.done:
+	}
+}
+
+// buildEnvoyCmd constructs the Envoy invocation for a given restart epoch.
+func (s *Supervisor) buildEnvoyCmd(epoch int) *exec.Cmd {
+	args := []string{
+		"-c", s.cfg.ConfigPath,
+		"--base-id", strconv.FormatUint(uint64(s.cfg.BaseID), 10),
+		"--restart-epoch", strconv.Itoa(epoch),
+		"--drain-time-s", strconv.Itoa(int(s.cfg.DrainTime.Seconds())),
+		"--parent-shutdown-time-s", strconv.Itoa(int(s.cfg.ParentShutdownTime.Seconds())),
+	}
+	args = append(args, s.cfg.ExtraArgs...)
+
+	cmd := exec.Command(s.cfg.EnvoyPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+// currentEpoch returns the highest (newest) epoch started so far.
+func (s *Supervisor) currentEpoch() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nextEpoch - 1
+}
+
+// signalEpoch sends sig to the child for the given epoch, if still tracked.
+func (s *Supervisor) signalEpoch(epoch int, sig syscall.Signal) {
+	s.mu.Lock()
+	cmd, ok := s.children[epoch]
+	s.mu.Unlock()
+	if !ok || cmd.Process == nil {
+		return
+	}
+	if err := cmd.Process.Signal(sig); err != nil {
+		s.log.Error(err, "failed to signal envoy epoch", "epoch", epoch, "signal", sig)
+	}
+}
+
+// forwardToCurrent forwards sig to the newest epoch (e.g. SIGUSR1 log reopen).
+func (s *Supervisor) forwardToCurrent(sig syscall.Signal) {
+	s.signalEpoch(s.currentEpoch(), sig)
+}
+
+// reap removes a finished epoch from tracking.
+func (s *Supervisor) reap(epoch int) {
+	s.mu.Lock()
+	delete(s.children, epoch)
+	s.mu.Unlock()
+	s.log.Info("reaped drained envoy epoch", "epoch", epoch)
+}
+
+// terminateAll SIGTERMs every tracked epoch. TODO(spike): wait for graceful exit
+// with a deadline, then SIGKILL stragglers.
+func (s *Supervisor) terminateAll() {
+	s.mu.Lock()
+	epochs := make([]int, 0, len(s.children))
+	for e := range s.children {
+		epochs = append(epochs, e)
+	}
+	s.mu.Unlock()
+	for _, e := range epochs {
+		s.signalEpoch(e, syscall.SIGTERM)
+	}
+}

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -2,18 +2,20 @@
 // process and performs Envoy hot restarts across restart epochs, replicating the
 // behavior of Envoy's hot-restarter.py in Go.
 //
-// SPIKE: this package is a throwaway-quality starting point for the proxy
-// hot-restart spike (see docs/proposals/001_proxy-hot-restart.md). It is not yet
-// wired into production and the edge cases marked TODO are deliberately unhandled.
+// SPIKE: this package is the Strategy-A implementation for the proxy hot-restart
+// spike (see docs/proposals/001_proxy-hot-restart.md). It supervises a single
+// long-lived Envoy in one container and performs an in-place hot restart when the
+// bootstrap config changes (fsnotify) or on SIGHUP. The cross-pod machinery for
+// Strategy B (epoch coordination file, live-predecessor probe) is intentionally
+// not here yet.
 //
 // Model: the supervisor is the proxy container's entrypoint (PID 1). It forks an
 // Envoy child with --restart-epoch 0 and a fixed --base-id. On a hot-restart
-// trigger (SIGHUP, or a watched bootstrap-config change) it forks a new Envoy with
-// the next epoch; Envoy's own shared-memory + abstract-domain-socket IPC transfers
-// the listen-socket FDs and stats to the new process, the old process drains, and
-// after --parent-shutdown-time-s the supervisor terminates it. The supervisor and
-// both epochs share the container's /dev/shm and PID/IPC namespace, which is what
-// makes the FD/stats handoff possible.
+// trigger it forks a new Envoy with the next epoch; Envoy's own shared-memory +
+// abstract-domain-socket IPC transfers the listen-socket FDs and stats to the new
+// process, the old process drains, and after --parent-shutdown-time-s the
+// supervisor terminates it. The supervisor and both epochs share the container's
+// /dev/shm and PID/IPC namespace, which is what makes the FD/stats handoff possible.
 package hotrestart
 
 import (
@@ -22,12 +24,23 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/go-logr/logr"
+)
+
+const (
+	// debounceDelay coalesces a flurry of triggers (config rewrites, repeated
+	// SIGHUPs) into a single hot restart.
+	debounceDelay = 500 * time.Millisecond
+	// shutdownGrace is added to DrainTime as the deadline for children to exit on
+	// SIGTERM before they are SIGKILLed.
+	shutdownGrace = 5 * time.Second
 )
 
 // Config configures the Envoy hot-restart supervisor.
@@ -50,10 +63,9 @@ type Config struct {
 	// --service-node, --service-zone, --concurrency). Concurrency must stay constant
 	// across epochs to avoid dropping accept-queue connections.
 	ExtraArgs []string
-	// WatchConfig enables an fsnotify watch on ConfigPath that self-triggers a hot
-	// restart when the bootstrap config changes.
-	//
-	// TODO(spike): wire the fsnotify watcher; for now restarts are driven by SIGHUP.
+	// WatchConfig enables an fsnotify watch on ConfigPath's directory that
+	// self-triggers a hot restart when the bootstrap config changes (e.g. a
+	// ConfigMap update propagated by the kubelet).
 	WatchConfig bool
 }
 
@@ -82,51 +94,72 @@ func New(cfg Config, log logr.Logger) *Supervisor {
 		cfg:         cfg,
 		log:         log.WithName("proxy-supervisor"),
 		children:    make(map[int]*exec.Cmd),
-		childExited: make(chan childExit, 4),
+		childExited: make(chan childExit, 8),
 		done:        make(chan struct{}),
 	}
 }
 
 // Run starts Envoy at epoch 0 and supervises it until ctx is canceled (SIGTERM/
 // SIGINT, which controller-runtime's signal handler maps to ctx.Done) or the
-// newest epoch exits unexpectedly. SIGHUP triggers a hot restart; SIGUSR1 is
-// forwarded to the current child for log reopen.
+// newest epoch exits unexpectedly. A watched-config change or SIGHUP triggers a
+// hot restart; SIGUSR1 is forwarded to the current child for log reopen.
 func (s *Supervisor) Run(ctx context.Context) error {
+	defer close(s.done)
+
 	sigCh := make(chan os.Signal, 4)
 	signal.Notify(sigCh, syscall.SIGHUP, syscall.SIGUSR1)
 	defer signal.Stop(sigCh)
-	defer close(s.done)
+
+	trigger := make(chan struct{}, 1)
+	if s.cfg.WatchConfig {
+		go s.watchConfig(ctx, trigger)
+	}
 
 	if err := s.hotRestart(); err != nil {
 		return fmt.Errorf("starting initial envoy epoch: %w", err)
 	}
 
-	// TODO(spike): if cfg.WatchConfig, start an fsnotify watcher on ConfigPath and
-	// fan its events into a hot restart (debounced), in addition to SIGHUP.
+	debounce := time.NewTimer(debounceDelay)
+	debounce.Stop()
+	var debounceC <-chan time.Time
+
+	arm := func(reason string) {
+		s.log.V(1).Info("hot restart armed", "reason", reason, "debounce", debounceDelay)
+		debounce.Reset(debounceDelay)
+		debounceC = debounce.C
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			s.log.Info("termination requested, shutting down all envoy epochs")
-			s.terminateAll()
+			s.shutdown()
 			return nil
 
 		case sig := <-sigCh:
 			switch sig {
 			case syscall.SIGHUP:
-				s.log.Info("SIGHUP received, performing hot restart")
-				if err := s.hotRestart(); err != nil {
-					s.log.Error(err, "hot restart failed; keeping current epoch")
-				}
+				arm("SIGHUP")
 			case syscall.SIGUSR1:
 				s.forwardToCurrent(syscall.SIGUSR1)
+			}
+
+		case <-trigger:
+			arm("config change")
+
+		case <-debounceC:
+			debounceC = nil
+			s.log.Info("performing hot restart")
+			if err := s.hotRestart(); err != nil {
+				s.log.Error(err, "hot restart failed; keeping current epoch")
 			}
 
 		case exit := <-s.childExited:
 			if exit.epoch == s.currentEpoch() {
 				// The newest epoch died unexpectedly: nothing left serving traffic.
 				// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).
-				s.terminateAll()
+				s.reap(exit.epoch)
+				s.shutdown()
 				return fmt.Errorf("envoy epoch %d exited unexpectedly: %w", exit.epoch, exit.err)
 			}
 			// An older epoch finished draining after a hot restart: expected. Reap it.
@@ -180,6 +213,48 @@ func (s *Supervisor) scheduleParentShutdown(epoch int) {
 	}
 }
 
+// watchConfig watches the directory holding ConfigPath and emits a trigger on any
+// change. Watching the directory (not the file) survives the atomic symlink swap
+// the kubelet uses to update ConfigMap mounts. Coalescing is handled downstream by
+// the debounce timer.
+func (s *Supervisor) watchConfig(ctx context.Context, trigger chan<- struct{}) {
+	w, err := fsnotify.NewWatcher()
+	if err != nil {
+		s.log.Error(err, "config watcher disabled")
+		return
+	}
+	defer func() { _ = w.Close() }()
+
+	dir := filepath.Dir(s.cfg.ConfigPath)
+	if err := w.Add(dir); err != nil {
+		s.log.Error(err, "failed to watch config dir; watcher disabled", "dir", dir)
+		return
+	}
+	s.log.Info("watching bootstrap config for changes", "dir", dir, "config", s.cfg.ConfigPath)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		case _, ok := <-w.Events:
+			if !ok {
+				return
+			}
+			select {
+			case trigger <- struct{}{}:
+			default: // a trigger is already pending; the debounce will coalesce.
+			}
+		case err, ok := <-w.Errors:
+			if !ok {
+				return
+			}
+			s.log.Error(err, "config watch error")
+		}
+	}
+}
+
 // buildEnvoyCmd constructs the Envoy invocation for a given restart epoch.
 func (s *Supervisor) buildEnvoyCmd(epoch int) *exec.Cmd {
 	args := []string{
@@ -213,7 +288,7 @@ func (s *Supervisor) signalEpoch(epoch int, sig syscall.Signal) {
 		return
 	}
 	if err := cmd.Process.Signal(sig); err != nil {
-		s.log.Error(err, "failed to signal envoy epoch", "epoch", epoch, "signal", sig)
+		s.log.V(1).Error(err, "failed to signal envoy epoch", "epoch", epoch, "signal", sig)
 	}
 }
 
@@ -227,19 +302,42 @@ func (s *Supervisor) reap(epoch int) {
 	s.mu.Lock()
 	delete(s.children, epoch)
 	s.mu.Unlock()
-	s.log.Info("reaped drained envoy epoch", "epoch", epoch)
+	s.log.Info("reaped envoy epoch", "epoch", epoch)
 }
 
-// terminateAll SIGTERMs every tracked epoch. TODO(spike): wait for graceful exit
-// with a deadline, then SIGKILL stragglers.
-func (s *Supervisor) terminateAll() {
+// shutdown SIGTERMs every tracked epoch and waits up to DrainTime+grace for them
+// to exit, SIGKILLing any straggler. It reads childExited directly because the
+// main loop has stopped selecting on it.
+func (s *Supervisor) shutdown() {
 	s.mu.Lock()
-	epochs := make([]int, 0, len(s.children))
+	pending := make(map[int]struct{}, len(s.children))
 	for e := range s.children {
-		epochs = append(epochs, e)
+		pending[e] = struct{}{}
 	}
 	s.mu.Unlock()
-	for _, e := range epochs {
+
+	for e := range pending {
 		s.signalEpoch(e, syscall.SIGTERM)
+	}
+	if len(pending) == 0 {
+		return
+	}
+
+	deadline := time.NewTimer(s.cfg.DrainTime + shutdownGrace)
+	defer deadline.Stop()
+
+	for len(pending) > 0 {
+		select {
+		case exit := <-s.childExited:
+			delete(pending, exit.epoch)
+			s.reap(exit.epoch)
+		case <-deadline.C:
+			for e := range pending {
+				s.log.Info("drain deadline elapsed, killing envoy epoch", "epoch", e)
+				s.signalEpoch(e, syscall.SIGKILL)
+				s.reap(e)
+			}
+			return
+		}
 	}
 }

--- a/agent/internal/proxy/hotrestart/supervisor_test.go
+++ b/agent/internal/proxy/hotrestart/supervisor_test.go
@@ -1,0 +1,125 @@
+package hotrestart
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildEnvoyCmd(t *testing.T) {
+	s := New(Config{
+		EnvoyPath:          "/usr/local/bin/envoy",
+		ConfigPath:         "/etc/envoy/envoy.yaml",
+		BaseID:             7,
+		DrainTime:          45 * time.Second,
+		ParentShutdownTime: 60 * time.Second,
+		ExtraArgs:          []string{"-l", "info", "--service-cluster", "aether-proxy"},
+	}, logr.Discard())
+
+	cmd := s.buildEnvoyCmd(3)
+
+	assert.Equal(t, "/usr/local/bin/envoy", cmd.Path)
+	want := []string{
+		"/usr/local/bin/envoy",
+		"-c", "/etc/envoy/envoy.yaml",
+		"--base-id", "7",
+		"--restart-epoch", "3",
+		"--drain-time-s", "45",
+		"--parent-shutdown-time-s", "60",
+		"-l", "info", "--service-cluster", "aether-proxy",
+	}
+	assert.Equal(t, want, cmd.Args)
+}
+
+// stubEnvoy writes a tiny shell script that records each invocation's
+// --restart-epoch to recordPath and then blocks until signaled, exiting 0 on
+// SIGTERM. It stands in for the Envoy binary so the supervisor's lifecycle can be
+// exercised without a real Envoy or its shared-memory IPC.
+func stubEnvoy(t *testing.T, recordPath string) string {
+	t.Helper()
+	script := "#!/bin/sh\n" +
+		"epoch=\"\"\n" +
+		"while [ $# -gt 0 ]; do\n" +
+		"  case \"$1\" in\n" +
+		"    --restart-epoch) epoch=\"$2\"; shift 2;;\n" +
+		"    *) shift;;\n" +
+		"  esac\n" +
+		"done\n" +
+		"echo \"$epoch\" >> \"" + recordPath + "\"\n" +
+		"trap 'exit 0' TERM INT\n" +
+		"while true; do sleep 0.05; done\n"
+
+	path := filepath.Join(t.TempDir(), "stub-envoy.sh")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+func recordedEpochs(t *testing.T, recordPath string) []string {
+	t.Helper()
+	b, err := os.ReadFile(recordPath)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, line := range strings.Split(strings.TrimSpace(string(b)), "\n") {
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// TestSupervisorConfigChangeTriggersHotRestart drives the full Strategy-A path:
+// start epoch 0, change the watched bootstrap config, and observe epoch 1 spawned,
+// then a clean shutdown on context cancellation.
+func TestSupervisorConfigChangeTriggersHotRestart(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available in this sandbox")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "envoy.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("v0\n"), 0o644))
+	recordPath := filepath.Join(t.TempDir(), "epochs.txt")
+
+	s := New(Config{
+		EnvoyPath:          stubEnvoy(t, recordPath),
+		ConfigPath:         configPath,
+		BaseID:             0,
+		DrainTime:          1 * time.Second,
+		ParentShutdownTime: 1 * time.Second,
+		WatchConfig:        true,
+	}, logr.Discard())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(ctx) }()
+
+	// Epoch 0 should come up.
+	require.Eventually(t, func() bool {
+		return len(recordedEpochs(t, recordPath)) >= 1
+	}, 5*time.Second, 50*time.Millisecond, "epoch 0 never started")
+
+	// Change the bootstrap config -> watcher fires -> debounced hot restart -> epoch 1.
+	require.NoError(t, os.WriteFile(configPath, []byte("v1\n"), 0o644))
+	require.Eventually(t, func() bool {
+		epochs := recordedEpochs(t, recordPath)
+		return len(epochs) >= 2 && epochs[0] == "0" && epochs[1] == "1"
+	}, 5*time.Second, 50*time.Millisecond, "config change did not trigger epoch 1")
+
+	// Cancellation drains and returns nil.
+	cancel()
+	select {
+	case err := <-runErr:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("supervisor did not return after context cancel")
+	}
+}

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -21,9 +21,41 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ include "agent.proxy.serviceAccountName" . }}
       priorityClassName: system-node-critical
+      {{- if .Values.proxy.hotRestart.enabled }}
+      initContainers:
+        # SPIKE (Strategy A): the runtime container is the Envoy image (it carries
+        # Envoy and its shared libraries); inject the statically linked supervisor
+        # from the agent image by having it self-copy onto a shared volume.
+        - name: install-supervisor
+          image: {{ .Values.agent.image.ref | quote }}
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          args: ["proxy-supervisor", "--install-path=/opt/aether/supervisor"]
+          volumeMounts:
+            - name: supervisor-bin
+              mountPath: /opt/aether
+      {{- end }}
       containers:
         - name: proxy
           image: "{{ .Values.proxy.image.repository }}@{{ .Values.proxy.image.digest }}"
+          {{- if .Values.proxy.hotRestart.enabled }}
+          command:
+            - "/opt/aether/supervisor"
+            - "proxy-supervisor"
+            - "--config=/etc/envoy/envoy.yaml"
+            - "--envoy-path=/usr/local/bin/envoy"
+            - "--watch-config=true"
+            - "--base-id={{ .Values.proxy.hotRestart.baseId }}"
+            - "--drain-time={{ .Values.proxy.hotRestart.drainTime }}"
+            - "--parent-shutdown-time={{ .Values.proxy.hotRestart.parentShutdownTime }}"
+            - "--envoy-arg=-l"
+            - "--envoy-arg={{ .Values.proxy.logLevel }}"
+            - "--envoy-arg=--service-cluster"
+            - "--envoy-arg=aether-proxy"
+            - "--envoy-arg=--service-node"
+            - "--envoy-arg=$(NODE_NAME)"
+            - "--envoy-arg=--service-zone"
+            - "--envoy-arg=$(ZONE)"
+          {{- else }}
           command:
             - "/usr/local/bin/envoy"
             - "-c"
@@ -36,6 +68,7 @@ spec:
             - "$(NODE_NAME)"
             - "--service-zone"
             - "$(ZONE)"
+          {{- end }}
           env:
             - name: NODE_NAME
               valueFrom:
@@ -79,7 +112,22 @@ spec:
             - name: workload-socket
               mountPath: /run/secrets/workload-spiffe-uds
               readOnly: true
+            {{- if .Values.proxy.hotRestart.enabled }}
+            - name: supervisor-bin
+              mountPath: /opt/aether
+              readOnly: true
+            - name: dev-shm
+              mountPath: /dev/shm
+            {{- end }}
       volumes:
+        {{- if .Values.proxy.hotRestart.enabled }}
+        - name: supervisor-bin
+          emptyDir: {}
+        - name: dev-shm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.proxy.hotRestart.shmSizeLimit }}
+        {{- end }}
         - name: proxy-config
           configMap:
             name: {{ include "agent.proxy.configMapName" . }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -60,6 +60,19 @@ proxy:
     # envoyproxy/envoy:distroless-v1.38.0
     digest: sha256:a7a56545102f7a682e0cafea2c9b8448af1b09ebb710eab688dfb931e3ec7ff6
   logLevel: info
+  # SPIKE (Strategy A): run the Envoy hot-restart supervisor (agent
+  # proxy-supervisor) as the proxy entrypoint instead of launching Envoy
+  # directly, so bootstrap-config changes hot-restart in place without dropping
+  # connections. See docs/proposals/001_proxy-hot-restart.md. Off by default.
+  hotRestart:
+    enabled: false
+    # Envoy --base-id, pinned so successive epochs share one shared-memory segment.
+    baseId: 0
+    # Envoy --drain-time-s / --parent-shutdown-time-s (parent must exceed drain).
+    drainTime: 45s
+    parentShutdownTime: 60s
+    # /dev/shm size for the hot-restart shared-memory segment (gauges/counters).
+    shmSizeLimit: 64Mi
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
 # The chart never bakes credentials into the image. By default it references an

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -1,6 +1,6 @@
 # Proposal: Hot Restart for the aether-proxy Envoy (Spike)
 
-**Status:** Spike (Proposed)
+**Status:** Spike — implementing Strategy A; **target is Strategy B**
 **Author:** Bruno Palermo
 **Date:** 2026-06-09
 
@@ -9,81 +9,139 @@
 `aether-proxy` runs Envoy **directly as the container entrypoint** (`charts/agent/templates/proxy.yaml`), bootstrapped from a static ConfigMap (`charts/agent/templates/configmap.yaml`). All listeners, clusters, endpoints, and routes are delivered live over ADS through the shared `/run/aether/xds.sock`. Consequently:
 
 - **Dynamic resources already update without a restart** — that is what xDS gives us. Hot restart buys nothing for them.
-- **The gap is bootstrap-level change and Envoy binary upgrade without dropping connections.** The static `envoy.yaml` (admin, the `agent_xds` ADS cluster, HTTP/2 keepalive tuning, future stats/tracing sinks) and the Envoy version can only change today via a `RollingUpdate`, which tears down the pod, drops every in-flight connection on the node, and resets all stats.
+- **The gap is bootstrap-level change and Envoy binary/image upgrade without dropping connections.** The static `envoy.yaml` (admin, the `agent_xds` ADS cluster, HTTP/2 keepalive tuning, future stats/tracing sinks) and the Envoy version can only change today via a `RollingUpdate`, which tears down the pod, drops every in-flight connection on the node, and resets all stats.
 
 Envoy's [hot restart](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/hot_restart) replaces that with an epoch-to-epoch handoff of listen-socket FDs and stats, draining the old process gracefully. This is the Istio `pilot-agent` model: a supervisor owns the Envoy lifecycle and performs epoch-based restarts.
 
-## The Constraint That Drives the Design
+## The Constraint That Drives Everything
 
 Hot restart hands off listen-socket FDs and stats from epoch *N* to *N+1* via:
 
 1. A **shared-memory segment** keyed by `--base-id`, living in `/dev/shm`.
-2. An **abstract** unix domain socket, also keyed by base-id (no filesystem write — `readOnlyRootFilesystem: true` survives).
+2. An **abstract** unix domain socket, also keyed by `--base-id`, which lives **in a network namespace** (no filesystem write — `readOnlyRootFilesystem: true` survives).
 
-Both processes must therefore share `/dev/shm` and the IPC/PID namespace. The clean guarantee: **both Envoy epochs are children of one supervisor in one container.** Envoy is PID 1 today with no supervisor, so there is nothing to fork epoch *N+1*. **Introducing that supervisor is the central change.**
+Both processes must therefore reach the same `/dev/shm` **and** the same network namespace at the same time. A default Kubernetes container-image upgrade deletes and recreates the Pod, giving the new process neither — no overlap, no shared memory. **Every strategy below is a different way to arrange that overlap.**
 
-## Proposed Solution (Spike)
+The current chart already helps: `aether-proxy` runs `hostNetwork: true`, so all proxy Pods on a node share the **host** network namespace — the abstract socket is mutually reachable. The remaining requirement is a shared `/dev/shm`.
 
-A Go hot-restart **supervisor** becomes the proxy container's entrypoint; Envoy becomes its managed child. We reimplement the logic of Envoy's [`hot-restarter.py`](https://www.envoyproxy.io/docs/envoy/latest/operations/hot_restarter) in Go, shipped as a new `agent proxy-supervisor` subcommand (reuses the existing build/image/release plumbing, logr setup, and the already-vendored `fsnotify`).
+## Common Building Block: The Supervisor
 
-```
-aether-proxy entrypoint:  agent proxy-supervisor --config /etc/envoy/envoy.yaml ...
-                                   │
-                                   ├─ fork/exec  envoy --restart-epoch 0 --base-id B ...   (epoch 0)
-                                   └─ on trigger fork/exec envoy --restart-epoch 1 --base-id B ... (epoch 1)
-                                          Envoy's own IPC transfers sockets+stats; epoch 0 drains; supervisor reaps it
-```
-
-The proxy keeps running as its **own DaemonSet/pod** — the agent pod is untouched; only the proxy container's `command` changes.
-
-### Supervision model (replicating hot-restarter.py)
+All three strategies share one component — a Go **hot-restart supervisor** (`agent/internal/proxy/hotrestart`, run via the `agent proxy-supervisor` subcommand) that reimplements Envoy's [`hot-restarter.py`](https://www.envoyproxy.io/docs/envoy/latest/operations/hot_restarter):
 
 | Trigger | Action |
 |---------|--------|
-| start | fork/exec child Envoy with `--restart-epoch 0`, fixed `--base-id`, `--drain-time-s`, `--parent-shutdown-time-s` |
-| **SIGHUP** | hot restart: fork/exec epoch *N+1*; after `--parent-shutdown-time-s`, SIGTERM epoch *N* |
+| start | fork/exec Envoy `--restart-epoch 0`, fixed `--base-id`, `--drain-time-s`, `--parent-shutdown-time-s` |
+| **SIGHUP** / watched config change | hot restart: fork/exec epoch *N+1*; after `--parent-shutdown-time-s`, SIGTERM epoch *N* |
 | **SIGTERM / SIGINT** | drain + terminate all children, exit 0 |
-| **child exits unexpectedly** (newest epoch) | terminate all, exit non-zero so k8s recreates the pod (the SIGCHLD-fatal behavior) |
-| **SIGUSR1** | forward to the current child (log reopen) |
+| **newest epoch exits unexpectedly** | terminate all, exit non-zero so Kubernetes recreates the pod |
+| **SIGUSR1** | forward to current child (log reopen) |
 
-In Go we use a `cmd.Wait()` goroutine per child reporting to a channel rather than raw SIGCHLD reaping; the newest epoch dying is fatal, an old epoch finishing its drain is expected.
+Concurrency must stay constant across epochs (a decrease drops accept-queue connections).
 
-### Restart trigger
+---
 
-fsnotify watch on the mounted bootstrap file: a ConfigMap update → kubelet rewrites the mount symlink → supervisor self-sends SIGHUP. External SIGHUP is also honored (manual / future agent-driven trigger).
+## Strategy A — In-place Envoy upgrade (no Pod replacement) — **SPIKE TARGET**
 
-### Chart changes
+Keep **one long-lived proxy Pod** whose supervisor is the stable entrypoint, and treat the **Envoy binary as data, not image**: the binary lives on a mutable volume. Upgrade = swap the binary + signal → supervisor forks epoch *N+1* **in the same container**, where `/dev/shm` and netns are trivially shared.
 
-- proxy container `command` → `agent proxy-supervisor ...` (Envoy flags moved into the supervisor's invocation).
-- `/dev/shm` sizing — see Risks; likely an `emptyDir{medium: Memory, sizeLimit}` at `/dev/shm`.
-- confirm abstract-socket IPC keeps `readOnlyRootFilesystem: true`.
+- **Pros:** simplest possible — textbook hot restart, no Kubernetes surgery, no surge scheduling.
+- **Cons:** upgrades only the **Envoy binary + bootstrap config**, not the proxy container image (base-layer CVEs, supervisor changes still need a real roll).
+- **Why we spike this first:** it is the minimal proof that the supervisor + hot-restart handoff actually works (epoch increments, zero dropped connections, stat continuity). The binary-delivery-without-pod-replacement mechanism (a host-local push of a versioned binary that the supervisor watches) is **production-A** and is *not* part of the spike — the spike triggers the handoff via a watched bootstrap-config change / SIGHUP, which exercises the identical code path.
 
-## What the Spike Builds (~3–5 days, throwaway-quality acceptable)
+### Spike packaging (A)
 
-1. `agent/internal/proxy/hotrestart` — the supervisor (started in this branch as a scaffold).
-2. `agent proxy-supervisor` cobra subcommand wiring it into the binary.
-3. Envoy invocation with `--restart-epoch`, `--base-id`, `--drain-time-s`, `--parent-shutdown-time-s`.
-4. fsnotify config-file trigger + external SIGHUP.
-5. Chart wiring (`/dev/shm`, command change).
+Gated behind `proxy.hotRestart.enabled` (off by default; the existing direct-Envoy path is unchanged):
+
+- **The runtime container stays the Envoy image** (it carries Envoy *and its shared libraries*). The Envoy binary is dynamically linked, so copying it alone into a distroless image would not run — we inject the supervisor into the Envoy image instead of the reverse.
+- An **initContainer runs the agent image and self-installs** the statically linked supervisor onto a shared `emptyDir` (`agent proxy-supervisor --install-path=/opt/aether/supervisor`).
+- The runtime container's command becomes `/opt/aether/supervisor proxy-supervisor --envoy-path=/usr/local/bin/envoy --watch-config ...`; the Envoy service flags are passed through as `--envoy-arg`.
+- A shared `emptyDir{medium: Memory}` mounted at `/dev/shm` carries the hot-restart shmem.
+- The supervisor watches the bootstrap config dir (fsnotify, debounced); a `kubectl edit`/touch of the ConfigMap (or `kill -SIGHUP`) triggers the in-place hot restart.
+
+The self-install seam is also what becomes "binary as data" in production-A: a host-local push of a new Envoy (or supervisor) onto the shared volume, followed by a watched-trigger restart.
+
+---
+
+## Strategy B — Cross-Pod hot restart (true image upgrade) — **TARGET**
+
+Let the **new and old Pods overlap on the node** and share the hot-restart primitives during that window, using native Kubernetes primitives.
+
+**Requirements:**
+- **DaemonSet surge update:** `updateStrategy.rollingUpdate.maxSurge: 1, maxUnavailable: 0` (k8s ≥1.22) — new Pod created before old is torn down.
+- **Shared `/dev/shm`:** a host path (host `/dev/shm` or a dedicated tmpfs) mounted at `/dev/shm` in both Pods.
+- **Same `--base-id`** in both Pods.
+- **hostNetwork: true** — already present; both Pods share the host netns where the abstract socket lives.
+- **Epoch coordination across Pods** via a small state file on the shared hostPath (`/run/aether/hotrestart/epoch`).
+
+**Upgrade sequence:**
+```
+node, before:   [old Pod: supervisor → envoy epoch 5]   serving, listeners bound into pod netns
+1. DaemonSet roll (maxSurge=1) schedules [new Pod] on the same node; old keeps serving.
+2. new supervisor reads epoch file = 5, starts envoy --restart-epoch 6 (same base-id, shared /dev/shm, host netns).
+3. envoy(6) fully initializes (xDS config, health checks).
+4. envoy(6) pulls listen-socket FDs + stats from envoy(5), starts listening, signals envoy(5) to drain.
+5. new Pod becomes Ready (readiness gate fires only after handoff completes).
+6. DaemonSet, seeing new Ready, deletes old Pod; old supervisor SIGTERMs envoy(5) after drain, exits 0.
+node, after:    [new Pod: supervisor → envoy epoch 6]   no dropped connection, stats carried over
+```
+
+- **Pros:** real container-image upgrade, zero dropped connections, stat continuity, **native rollout, no standing extra cost**.
+- **Cons / spike-must-prove:**
+  - **Admin port handoff** — both Envoys want `127.0.0.1:9901` in host netns; Envoy passes the admin listener FD via the same transfer, but verify.
+  - **Epoch edge case** — if the predecessor is gone (reboot/crash), the file says `5` but no epoch-5 process exists; starting at `6` hangs waiting for a parent. The supervisor must probe for a live predecessor and **reset to epoch 0** when absent.
+  - **Readiness gating** — new Pod stays NotReady until handoff succeeds, so `maxUnavailable: 0` keeps the old Pod alive if the new one fails.
+  - **maxSurge + hostNetwork co-scheduling** — confirm two proxy Pods co-schedule (admin is `127.0.0.1`, listeners are netns-bound, so no hostPort collision).
+
+---
+
+## Strategy C — Single Pod, dual-Envoy slots (in-place container patch)
+
+One Pod runs `supervisor + envoy-a + envoy-b` as **blue/green slots**, ping-ponging on each upgrade. Patching one container's image makes the kubelet restart **only that container** (the pod sandbox, netns, and shared `/dev/shm` survive); you always patch the **standby** slot, which then hot-restarts from the active.
+
+- **Cleanest hot-restart story:** all containers share the netns automatically, and a pod-level `emptyDir{medium: Memory}` at `/dev/shm` shares the segment — no hostPath, no surge scheduling, no `hostNetwork` requirement for the IPC.
+- **But it opts out of the DaemonSet model:** a DaemonSet reconciles whole Pods, so bumping an Envoy image in the template recreates the entire Pod. To patch a single container in place you must run the DS as `updateStrategy: OnDelete` (paused) **and build a custom operator** that patches standby containers node-by-node and orchestrates the handoff. Strategy C is effectively "Strategy A inside the Pod **+ your own per-node upgrade controller**."
+- **Lifecycle wrinkles:** Pod `restartPolicy: Always` auto-restarts the drained container (on its old image), so the two slots sit on different versions until each takes its turn; the supervisor must track which slot is active and ensure a freshly-restarted standby comes up *idle*. Native **sidecar containers** (stable ~1.29) help with ordering/lifecycle but add machinery.
+- **Standing cost:** **2× Envoy footprint on every node, forever**, for a capability used only at upgrade time.
+
+C is the end state once an Istio-grade proxy-upgrade operator is justified — not the first thing to build.
+
+---
+
+## Comparison
+
+| | A: in-place binary | **B: surge two Pods (target)** | C: dual-Envoy Pod |
+|---|---|---|---|
+| Upgrades the **container image** | ❌ (Envoy binary only) | ✅ | ✅ |
+| Shared `/dev/shm` mechanism | trivial (same container) | hostPath | emptyDir Memory (cleanest) |
+| Standing resource cost | 1× | 1× (2× only mid-roll) | 2× always |
+| Uses native rollout | ✅ | ✅ (`maxSurge`) | ❌ (custom operator + `OnDelete`) |
+| Connection-preserving | ✅ | ✅ | ✅ |
+| Spike order | **1st (proves handoff)** | **2nd (the goal)** | future |
+
+## Plan
+
+1. **Spike A** — supervisor as the proxy entrypoint, Envoy from a shared volume, shared `/dev/shm`; trigger via watched bootstrap-config change / SIGHUP. Prove the handoff on talos-main.
+2. **Build toward B** — once A is GREEN, add the cross-Pod pieces: `maxSurge` DaemonSet strategy, hostPath `/dev/shm`, the `/run/aether/hotrestart/epoch` coordination file (with the live-predecessor probe → epoch-0 reset), and a readiness gate that fires only after handoff.
+3. **C** — revisit only if B's transient surge or per-node behavior proves insufficient and an upgrade operator is warranted.
 
 ## Validation (talos-main)
 
 - **Stats proof:** after a trigger, `server.hot_restart_generation` / `server.hot_restarts` increments and counters carry over (`curl :9901/stats`).
 - **Zero-drop proof:** hold a long-lived streaming request through the mesh across a triggered restart; assert no reset. Re-run the mesh e2e (200 + XFCC URI SAN) against epoch *N+1*.
-- **Binary-upgrade proof:** swap the Envoy binary/layer and trigger; new epoch serves, old drains.
-- **Crash proof:** `kill -9` the child; supervisor exits non-zero and k8s recreates the pod.
+- **Binary-upgrade proof (A):** swap the Envoy binary on the shared volume and trigger; new epoch serves, old drains.
+- **Image-upgrade proof (B):** roll the DaemonSet image with `maxSurge=1`; confirm overlap + handoff + zero drop.
+- **Crash proof:** `kill -9` the child; supervisor exits non-zero and Kubernetes recreates the pod.
 
 ## Risks / Open Questions
 
-- **`/dev/shm` capacity** — container default is 64Mi tmpfs; Envoy's hot-restart shmem holds all gauges/counters. Spike measures actual usage; add a sized memory `emptyDir` if needed.
+- **`/dev/shm` capacity** — container default is 64Mi tmpfs; Envoy's hot-restart shmem holds all gauges/counters. The spike sizes the memory `emptyDir` from measured usage.
 - **hostNetwork + privileged FD handoff** — expected fine (Envoy passes the actual fd, no rebind); verify the netns-bound inbound listeners survive the handoff.
-- **Concurrency/accept-queue** — decreasing `--concurrency` across epochs can drop queued accepts; keep concurrency constant across restarts.
-- **Value vs. k8s rolling update** — an image upgrade *is* a pod replacement in k8s, so the realistic standalone trigger is a bootstrap-ConfigMap change. The spike must honestly assess whether that payoff justifies a supervised two-process container.
+- **Distroless Envoy image has no shell** — the initContainer that copies the binary needs a shell-bearing image (non-distroless Envoy), or the binary is baked into a combined image.
 
 ## Out of Scope (for the spike)
 
-Production hardening, the cross-container/shared-namespace variant, agent→supervisor RPC triggering, coordination with CNI pod add/remove, and supervisor self-observability.
+Production binary-delivery for A, the Strategy C operator, agent→supervisor RPC triggering, coordination with CNI pod add/remove, and supervisor self-observability.
 
 ## Exit Criteria → Decision
 
-**GREEN** if a triggered hot restart shows an incremented `hot_restart_generation`, zero dropped in-flight connections, and stat continuity on talos-main. Go/no-go: does bootstrap-change + binary-upgrade continuity justify making the proxy a supervised two-process container? If green, the follow-up is a real `pilot-agent`-style proxy manager.
+**A is GREEN** if a triggered hot restart shows an incremented `hot_restart_generation`, zero dropped in-flight connections, and stat continuity on talos-main. That unblocks building **B**, whose own exit criterion is a connection-preserving DaemonSet image roll. Go/no-go on the whole effort: does bootstrap-change + image-upgrade continuity justify the supervisor (A) and the surge/coordination machinery (B)?

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -1,0 +1,89 @@
+# Proposal: Hot Restart for the aether-proxy Envoy (Spike)
+
+**Status:** Spike (Proposed)
+**Author:** Bruno Palermo
+**Date:** 2026-06-09
+
+## Problem Statement
+
+`aether-proxy` runs Envoy **directly as the container entrypoint** (`charts/agent/templates/proxy.yaml`), bootstrapped from a static ConfigMap (`charts/agent/templates/configmap.yaml`). All listeners, clusters, endpoints, and routes are delivered live over ADS through the shared `/run/aether/xds.sock`. Consequently:
+
+- **Dynamic resources already update without a restart** — that is what xDS gives us. Hot restart buys nothing for them.
+- **The gap is bootstrap-level change and Envoy binary upgrade without dropping connections.** The static `envoy.yaml` (admin, the `agent_xds` ADS cluster, HTTP/2 keepalive tuning, future stats/tracing sinks) and the Envoy version can only change today via a `RollingUpdate`, which tears down the pod, drops every in-flight connection on the node, and resets all stats.
+
+Envoy's [hot restart](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/hot_restart) replaces that with an epoch-to-epoch handoff of listen-socket FDs and stats, draining the old process gracefully. This is the Istio `pilot-agent` model: a supervisor owns the Envoy lifecycle and performs epoch-based restarts.
+
+## The Constraint That Drives the Design
+
+Hot restart hands off listen-socket FDs and stats from epoch *N* to *N+1* via:
+
+1. A **shared-memory segment** keyed by `--base-id`, living in `/dev/shm`.
+2. An **abstract** unix domain socket, also keyed by base-id (no filesystem write — `readOnlyRootFilesystem: true` survives).
+
+Both processes must therefore share `/dev/shm` and the IPC/PID namespace. The clean guarantee: **both Envoy epochs are children of one supervisor in one container.** Envoy is PID 1 today with no supervisor, so there is nothing to fork epoch *N+1*. **Introducing that supervisor is the central change.**
+
+## Proposed Solution (Spike)
+
+A Go hot-restart **supervisor** becomes the proxy container's entrypoint; Envoy becomes its managed child. We reimplement the logic of Envoy's [`hot-restarter.py`](https://www.envoyproxy.io/docs/envoy/latest/operations/hot_restarter) in Go, shipped as a new `agent proxy-supervisor` subcommand (reuses the existing build/image/release plumbing, logr setup, and the already-vendored `fsnotify`).
+
+```
+aether-proxy entrypoint:  agent proxy-supervisor --config /etc/envoy/envoy.yaml ...
+                                   │
+                                   ├─ fork/exec  envoy --restart-epoch 0 --base-id B ...   (epoch 0)
+                                   └─ on trigger fork/exec envoy --restart-epoch 1 --base-id B ... (epoch 1)
+                                          Envoy's own IPC transfers sockets+stats; epoch 0 drains; supervisor reaps it
+```
+
+The proxy keeps running as its **own DaemonSet/pod** — the agent pod is untouched; only the proxy container's `command` changes.
+
+### Supervision model (replicating hot-restarter.py)
+
+| Trigger | Action |
+|---------|--------|
+| start | fork/exec child Envoy with `--restart-epoch 0`, fixed `--base-id`, `--drain-time-s`, `--parent-shutdown-time-s` |
+| **SIGHUP** | hot restart: fork/exec epoch *N+1*; after `--parent-shutdown-time-s`, SIGTERM epoch *N* |
+| **SIGTERM / SIGINT** | drain + terminate all children, exit 0 |
+| **child exits unexpectedly** (newest epoch) | terminate all, exit non-zero so k8s recreates the pod (the SIGCHLD-fatal behavior) |
+| **SIGUSR1** | forward to the current child (log reopen) |
+
+In Go we use a `cmd.Wait()` goroutine per child reporting to a channel rather than raw SIGCHLD reaping; the newest epoch dying is fatal, an old epoch finishing its drain is expected.
+
+### Restart trigger
+
+fsnotify watch on the mounted bootstrap file: a ConfigMap update → kubelet rewrites the mount symlink → supervisor self-sends SIGHUP. External SIGHUP is also honored (manual / future agent-driven trigger).
+
+### Chart changes
+
+- proxy container `command` → `agent proxy-supervisor ...` (Envoy flags moved into the supervisor's invocation).
+- `/dev/shm` sizing — see Risks; likely an `emptyDir{medium: Memory, sizeLimit}` at `/dev/shm`.
+- confirm abstract-socket IPC keeps `readOnlyRootFilesystem: true`.
+
+## What the Spike Builds (~3–5 days, throwaway-quality acceptable)
+
+1. `agent/internal/proxy/hotrestart` — the supervisor (started in this branch as a scaffold).
+2. `agent proxy-supervisor` cobra subcommand wiring it into the binary.
+3. Envoy invocation with `--restart-epoch`, `--base-id`, `--drain-time-s`, `--parent-shutdown-time-s`.
+4. fsnotify config-file trigger + external SIGHUP.
+5. Chart wiring (`/dev/shm`, command change).
+
+## Validation (talos-main)
+
+- **Stats proof:** after a trigger, `server.hot_restart_generation` / `server.hot_restarts` increments and counters carry over (`curl :9901/stats`).
+- **Zero-drop proof:** hold a long-lived streaming request through the mesh across a triggered restart; assert no reset. Re-run the mesh e2e (200 + XFCC URI SAN) against epoch *N+1*.
+- **Binary-upgrade proof:** swap the Envoy binary/layer and trigger; new epoch serves, old drains.
+- **Crash proof:** `kill -9` the child; supervisor exits non-zero and k8s recreates the pod.
+
+## Risks / Open Questions
+
+- **`/dev/shm` capacity** — container default is 64Mi tmpfs; Envoy's hot-restart shmem holds all gauges/counters. Spike measures actual usage; add a sized memory `emptyDir` if needed.
+- **hostNetwork + privileged FD handoff** — expected fine (Envoy passes the actual fd, no rebind); verify the netns-bound inbound listeners survive the handoff.
+- **Concurrency/accept-queue** — decreasing `--concurrency` across epochs can drop queued accepts; keep concurrency constant across restarts.
+- **Value vs. k8s rolling update** — an image upgrade *is* a pod replacement in k8s, so the realistic standalone trigger is a bootstrap-ConfigMap change. The spike must honestly assess whether that payoff justifies a supervised two-process container.
+
+## Out of Scope (for the spike)
+
+Production hardening, the cross-container/shared-namespace variant, agent→supervisor RPC triggering, coordination with CNI pod add/remove, and supervisor self-observability.
+
+## Exit Criteria → Decision
+
+**GREEN** if a triggered hot restart shows an incremented `hot_restart_generation`, zero dropped in-flight connections, and stat continuity on talos-main. Go/no-go: does bootstrap-change + binary-upgrade continuity justify making the proxy a supervised two-process container? If green, the follow-up is a real `pilot-agent`-style proxy manager.


### PR DESCRIPTION
## Summary

Hot-restart the aether-proxy Envoy so **bootstrap-config changes and image upgrades preserve in-flight connections** (dynamic listeners/clusters/endpoints already update live via xDS — hot restart is specifically for the static bootstrap + binary).

Full design: **`docs/proposals/001_proxy-hot-restart.md`**.

### Core constraint
Hot restart hands off listen-socket FDs + stats from epoch *N* → *N+1* via a shared `/dev/shm` (`--base-id`) and an abstract domain socket **in a shared netns**. A vanilla image bump deletes/recreates the Pod and shares neither — so each strategy is a different way to arrange that overlap. The existing `hostNetwork: true` already gives shared netns for free.

### Three strategies (documented + compared)
| | A: in-place binary | **B: surge two Pods (target)** | C: dual-Envoy Pod |
|---|---|---|---|
| Upgrades the container image | ❌ (Envoy binary only) | ✅ | ✅ |
| Standing cost | 1× | 1× (2× only mid-roll) | 2× always |
| Native rollout | ✅ | ✅ (`maxSurge`) | ❌ (operator + `OnDelete`) |
| Spike order | **1st (proves handoff)** | **2nd (goal)** | future |

### Strategy A — implemented in this PR
- **Supervisor** (`agent/internal/proxy/hotrestart`): forks Envoy per restart epoch; **fsnotify** bootstrap-config watch (debounced) self-triggers a hot restart; SIGHUP/SIGUSR1; newest-epoch-death → exit non-zero (k8s recreates pod); graceful shutdown with drain deadline + SIGKILL fallback.
- **`agent proxy-supervisor`** subcommand, plus `--install-path` so the *static* supervisor self-copies onto a shared volume from an initContainer — the runtime container stays the **Envoy image** (which carries Envoy + its shared libs) with the supervisor injected.
- **Chart**: `proxy.hotRestart.enabled` gate (off by default) wires the supervisor entrypoint, the self-install initContainer, a memory `/dev/shm` emptyDir, and routes Envoy service flags via `--envoy-arg`.
- **Tests**: `buildEnvoyCmd` args + a lifecycle test driving a stub Envoy through a config-change-triggered hot restart and clean shutdown.

### Not in this PR (next steps)
- talos-main validation: incremented `hot_restart_generation`, **zero dropped connections**, stat continuity.
- Strategy B: `maxSurge` DaemonSet, hostPath `/dev/shm`, `/run/aether/hotrestart/epoch` coordination (+ live-predecessor probe → epoch-0 reset), readiness gate.

## Test plan
- `bazel build //agent/...` ✅
- `bazel test //agent/internal/proxy/hotrestart/... //agent/internal/cmd/...` ✅
- `helm template` renders both gate states correctly (off = unchanged direct-Envoy; on = supervisor + initContainer + /dev/shm) ✅
- Not yet deployed; off by default, so no change to the running proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)