### PR TITLE
fix(proxy-supervisor): don't externally kill the old hot-restart epoch (talos-validated)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"335699bc-1efe-4c42-97f3-0c1076dd5880","pid":177814,"procStart":"1993073","acquiredAt":1781047739290}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"335699bc-1efe-4c42-97f3-0c1076dd5880","pid":177814,"procStart":"1993073","acquiredAt":1781047739290}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ secrets.yaml
 .claude/settings.local.json
 # Claude Code per-project memory store — local only, must never be committed.
 .claude/projects/
+
+# Local Claude Code scheduler state — never commit.
+.claude/scheduled_tasks.lock

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -194,23 +194,12 @@ func (s *Supervisor) hotRestart() error {
 		}
 	}()
 
-	if epoch > 0 {
-		go s.scheduleParentShutdown(epoch - 1)
-	}
+	// Do NOT externally terminate the previous epoch: Envoy coordinates parent
+	// shutdown itself over the hot-restart IPC socket, driven by the new epoch's
+	// --parent-shutdown-time-s. Killing the parent out from under that protocol
+	// makes the new epoch's sendmsg to the parent fail (errno 111) and Envoy
+	// aborts. The old epoch exits on its own; Run reaps it as a non-newest exit.
 	return nil
-}
-
-// scheduleParentShutdown SIGTERMs the given (draining) epoch after
-// ParentShutdownTime, unless the supervisor is shutting down first.
-func (s *Supervisor) scheduleParentShutdown(epoch int) {
-	t := time.NewTimer(s.cfg.ParentShutdownTime)
-	defer t.Stop()
-	select {
-	case <-t.C:
-		s.log.Info("parent shutdown timer elapsed, terminating drained epoch", "epoch", epoch)
-		s.signalEpoch(epoch, syscall.SIGTERM)
-	case <-s.done:
-	}
 }
 
 // watchConfig watches the directory holding ConfigPath and emits a trigger on any

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -1,6 +1,6 @@
 # Proposal: Hot Restart for the aether-proxy Envoy (Spike)
 
-**Status:** Spike — implementing Strategy A; **target is Strategy B**
+**Status:** Spike — Strategy A **validated GREEN on talos-main**; target is Strategy B
 **Author:** Bruno Palermo
 **Date:** 2026-06-09
 
@@ -139,6 +139,9 @@ First on-cluster run (rev 29, `proxy.hotRestart.enabled=true` fleet-wide):
 - Supervisor deploys cleanly as the proxy entrypoint via the self-install initContainer; Envoy comes up at **epoch 0**, `hot_restart_generation: 1`, 4 listeners, watching `/etc/envoy`.
 - A ConfigMap edit propagated (~2 min) and the supervisor performed a hot restart: **epoch 0 → 1**, **`hot_restart_generation` 1 → 2**, listeners/sockets handed over, `server.live` stayed 1 — all in-place (`restartCount` was still 0 at that point).
 - **Bug found:** ~70s later the *new* epoch crashed with `hot restart sendmsg() ... errno 111 (connection refused)` → `assert ... Aborted`, and the container restarted (epoch reset to 0). Root cause: the supervisor was externally SIGTERMing the old epoch at `parent-shutdown-time`, racing Envoy's own hot-restart IPC. **Fix:** remove the supervisor's parent-kill; Envoy terminates the old epoch itself via `--parent-shutdown-time-s` and the supervisor only reaps it. (Matches `hot-restarter.py`, which never signals the parent.)
+- **Re-validated GREEN (rev 30, fixed image):** hot restart epoch 0 → 1, `hot_restart_generation` 1 → 2, 4 listeners preserved, `server.live` held. The old epoch was terminated by Envoy's own parent-shutdown (~76s) and reaped cleanly — **no external SIGTERM, no crash, `restartCount` stayed 0** through ~104s past the restart (the window that previously crashed). Strategy A's exit criterion is met.
+
+**Caveat (test workloads):** the `aether-test` `client`/`echo`/`svc-a` pods were not exercising the mesh data path on their app port during this run (`client→echo:8080` showed zero delta on the `echo`/`app_echo` clusters — direct pod-to-pod, no XFCC), so an application-level zero-dropped-request assertion could not be made here. The hot-restart guarantees were instead proven via Envoy's own signals (listener/socket handover, `server.live` continuity, in-place `restartCount: 0`). A follow-up should restore a known mesh-intercepted request path for an end-to-end zero-drop assertion.
 
 ## Risks / Open Questions
 

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -132,6 +132,14 @@ C is the end state once an Istio-grade proxy-upgrade operator is justified — n
 - **Image-upgrade proof (B):** roll the DaemonSet image with `maxSurge=1`; confirm overlap + handoff + zero drop.
 - **Crash proof:** `kill -9` the child; supervisor exits non-zero and Kubernetes recreates the pod.
 
+## Spike Findings (talos-main, 2026-06-09)
+
+First on-cluster run (rev 29, `proxy.hotRestart.enabled=true` fleet-wide):
+
+- Supervisor deploys cleanly as the proxy entrypoint via the self-install initContainer; Envoy comes up at **epoch 0**, `hot_restart_generation: 1`, 4 listeners, watching `/etc/envoy`.
+- A ConfigMap edit propagated (~2 min) and the supervisor performed a hot restart: **epoch 0 → 1**, **`hot_restart_generation` 1 → 2**, listeners/sockets handed over, `server.live` stayed 1 — all in-place (`restartCount` was still 0 at that point).
+- **Bug found:** ~70s later the *new* epoch crashed with `hot restart sendmsg() ... errno 111 (connection refused)` → `assert ... Aborted`, and the container restarted (epoch reset to 0). Root cause: the supervisor was externally SIGTERMing the old epoch at `parent-shutdown-time`, racing Envoy's own hot-restart IPC. **Fix:** remove the supervisor's parent-kill; Envoy terminates the old epoch itself via `--parent-shutdown-time-s` and the supervisor only reaps it. (Matches `hot-restarter.py`, which never signals the parent.)
+
 ## Risks / Open Questions
 
 - **`/dev/shm` capacity** — container default is 64Mi tmpfs; Envoy's hot-restart shmem holds all gauges/counters. The spike sizes the memory `emptyDir` from measured usage.


### PR DESCRIPTION
## Summary

Follow-up to #104. The merged Strategy-A supervisor had a bug that **talos-main e2e caught**: after a successful hot restart, the **new** epoch crashed ~70s later and the container restarted.

```
hot_restarting_base.cc] hot restart sendmsg() ... errno 111 (connection refused)
assert failure ... Caught Aborted
Error: envoy epoch 1 exited unexpectedly: signal: aborted
```

**Root cause:** the supervisor externally SIGTERMed the old epoch at `--parent-shutdown-time`, racing Envoy's own hot-restart IPC. Envoy already terminates the parent itself (as `hot-restarter.py` relies on); the supervisor must only **reap** it.

**Fix:** remove `scheduleParentShutdown` / the supervisor's parent-kill. `--parent-shutdown-time-s` is still passed to Envoy, which drives parent termination.

## Validation (talos-main, rev 30, fixed image)

- Hot restart **epoch 0 → 1**, `hot_restart_generation` **1 → 2**, 4 listeners preserved, `server.live` held.
- Old epoch reaped by **Envoy's own** parent-shutdown (~76s) — no external SIGTERM, no crash.
- **`restartCount` stayed 0** through ~104s past the restart (the window that previously crashed). In-place, no pod restart.

Doc updated with the finding + the GREEN re-validation and a test-workload caveat (the `aether-test` app path wasn't mesh-intercepted during the run, so guarantees were proven via Envoy's own signals rather than an app-level zero-drop curl).

## Test plan
- `bazel test //agent/internal/proxy/hotrestart/...` ✅
- Deployed + hot-restarted on talos-main, validated stable past parent-shutdown ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)