### PR TITLE
feat(proxy): Strategy B cross-pod hot restart — talos-validated incl. zero-drop app e2e

### DIFF
--- a/agent/internal/cmd/supervisor.go
+++ b/agent/internal/cmd/supervisor.go
@@ -15,9 +15,10 @@ import (
 // supervisorCfg holds the flag-bound configuration for the proxy-supervisor
 // subcommand. SPIKE: see docs/proposals/001_proxy-hot-restart.md.
 var (
-	supervisorCfg         hotrestart.Config
-	supervisorDebug       bool
-	supervisorInstallPath string
+	supervisorCfg            hotrestart.Config
+	supervisorDebug          bool
+	supervisorInstallPath    string
+	supervisorReadinessCheck bool
 )
 
 var proxySupervisorCmd = &cobra.Command{
@@ -32,6 +33,15 @@ var proxySupervisorCmd = &cobra.Command{
 		// supervisor injected alongside it.
 		if supervisorInstallPath != "" {
 			return installSelf(supervisorInstallPath)
+		}
+		// --readiness-check is the exec readiness probe: exit 0 iff the supervisor's
+		// pod-local ready marker is present (the distroless Envoy image has no shell
+		// or cat, so the probe re-execs this binary).
+		if supervisorReadinessCheck {
+			if _, err := os.Stat(supervisorCfg.ReadyMarkerPath); err != nil {
+				return fmt.Errorf("not ready: %w", err)
+			}
+			return nil
 		}
 		log := manager.SetupLogging(supervisorDebug, cmd.Name())
 		return hotrestart.New(supervisorCfg, log).Run(cmd.Context())
@@ -76,6 +86,10 @@ func init() {
 	f.DurationVar(&supervisorCfg.ParentShutdownTime, "parent-shutdown-time", 60*time.Second, "Envoy --parent-shutdown-time-s: when the previous epoch is terminated (must exceed --drain-time)")
 	f.StringArrayVar(&supervisorCfg.ExtraArgs, "envoy-arg", nil, "Extra argument appended to every Envoy invocation (repeatable); keep --concurrency constant across epochs")
 	f.BoolVar(&supervisorCfg.WatchConfig, "watch-config", false, "Watch --config and self-trigger a hot restart when the bootstrap config changes")
+	f.StringVar(&supervisorCfg.StateDir, "state-dir", "", "Shared-hostPath dir for the per-node epoch heartbeat (enables Strategy B cross-pod hot restart)")
+	f.StringVar(&supervisorCfg.ReadyMarkerPath, "ready-marker", "", "Pod-local path for the readiness marker maintained while Envoy is live at the newest epoch")
+	f.StringVar(&supervisorCfg.AdminAddress, "admin-address", "127.0.0.1:9901", "Envoy admin host:port used for the readiness check")
+	f.BoolVar(&supervisorReadinessCheck, "readiness-check", false, "Exit 0 iff the --ready-marker file exists (exec readiness probe mode)")
 
 	rootCmd.AddCommand(proxySupervisorCmd)
 }

--- a/agent/internal/proxy/hotrestart/BUILD.bazel
+++ b/agent/internal/proxy/hotrestart/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "hotrestart",
-    srcs = ["supervisor.go"],
+    srcs = [
+        "coordination.go",
+        "supervisor.go",
+    ],
     importpath = "github.com/bpalermo/aether/agent/internal/proxy/hotrestart",
     visibility = ["//agent:__subpackages__"],
     deps = [
@@ -13,7 +16,10 @@ go_library(
 
 go_test(
     name = "hotrestart_test",
-    srcs = ["supervisor_test.go"],
+    srcs = [
+        "coordination_test.go",
+        "supervisor_test.go",
+    ],
     embed = [":hotrestart"],
     deps = [
         "@com_github_go_logr_logr//:logr",

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -29,26 +29,27 @@ import (
 //     pod-local marker file consumed by an exec readiness probe.
 
 const (
-	heartbeatInterval = 2 * time.Second
 	predecessorStale  = 8 * time.Second
 	readyPollInterval = 1 * time.Second
 	stateFileName     = "epoch"
 )
 
 // initStartEpoch decides the restart epoch for the first Envoy this supervisor
-// launches. With cross-pod coordination (StateDir set), a live predecessor
-// heartbeating epoch E means start at E+1 to hot-restart from it; otherwise start
-// fresh at epoch 0. Without StateDir (Strategy A only) this is a no-op (epoch 0).
-func (s *Supervisor) initStartEpoch() {
+// launches. With cross-pod coordination (StateDir set), it starts at E+1 only when
+// the heartbeat file names epoch E AND the node's Envoy admin actually reports E
+// LIVE — admin is ground truth, so a crashed/initializing predecessor (stale or
+// absent on admin) correctly resets to epoch 0 instead of attaching to a dead
+// parent and climbing epochs. Without StateDir (Strategy A) this is a no-op.
+func (s *Supervisor) initStartEpoch(ctx context.Context) {
 	if s.cfg.StateDir == "" {
 		return
 	}
 	epoch, hb, ok := s.readState()
-	if ok && time.Since(hb) < predecessorStale {
+	if ok && time.Since(hb) < predecessorStale && s.adminLiveAtEpoch(ctx, epoch) {
 		s.mu.Lock()
 		s.nextEpoch = epoch + 1
 		s.mu.Unlock()
-		s.log.Info("live predecessor found; starting cross-pod hot restart",
+		s.log.Info("live predecessor confirmed; starting cross-pod hot restart",
 			"predecessorEpoch", epoch, "startEpoch", epoch+1, "heartbeatAge", time.Since(hb).Round(time.Millisecond).String())
 		return
 	}
@@ -103,32 +104,14 @@ func (s *Supervisor) writeState(epoch int) {
 	}
 }
 
-// heartbeat refreshes the coordination file so a surging successor pod can detect
-// this node's live epoch and hot-restart from it.
-func (s *Supervisor) heartbeat(ctx context.Context) {
-	if s.cfg.StateDir == "" {
-		return
-	}
-	t := time.NewTicker(heartbeatInterval)
-	defer t.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-s.done:
-			return
-		case <-t.C:
-			s.writeState(s.currentEpoch())
-		}
-	}
-}
-
-// watchReadiness maintains a pod-local readiness marker: present once the node's
-// Envoy admin reports LIVE at this supervisor's newest epoch (for a cross-pod
-// surge, only after the new Envoy has taken over the listen sockets and admin
-// port). An exec readiness probe checks the marker.
-func (s *Supervisor) watchReadiness(ctx context.Context) {
-	if s.cfg.ReadyMarkerPath == "" {
+// watchLiveness drives both the readiness marker and the node epoch heartbeat off
+// a single ground-truth signal: the node's Envoy admin reporting LIVE at this
+// supervisor's newest epoch. Crucially, the epoch is published to the shared state
+// file ONLY while LIVE — a launched-but-not-yet-LIVE (or failed) epoch is never
+// recorded, so a crash-restart re-reads the still-current predecessor epoch and
+// retries N+1 rather than climbing N+1, N+2, … against dead parents.
+func (s *Supervisor) watchLiveness(ctx context.Context) {
+	if s.cfg.ReadyMarkerPath == "" && s.cfg.StateDir == "" {
 		return
 	}
 	defer s.clearReady()
@@ -142,16 +125,18 @@ func (s *Supervisor) watchReadiness(ctx context.Context) {
 		case <-s.done:
 			return
 		case <-t.C:
-			live := s.adminLiveAtEpoch(ctx, s.currentEpoch())
-			switch {
-			case live && !ready:
-				s.setReady()
-				ready = true
-				s.log.Info("pod ready: envoy live at newest epoch", "epoch", s.currentEpoch())
-			case !live && ready:
+			epoch := s.currentEpoch()
+			if s.adminLiveAtEpoch(ctx, epoch) {
+				s.writeState(epoch) // LIVE-gated heartbeat
+				if !ready {
+					s.setReady()
+					ready = true
+					s.log.Info("pod ready: envoy live at newest epoch", "epoch", epoch)
+				}
+			} else if ready {
 				s.clearReady()
 				ready = false
-				s.log.Info("pod not ready: envoy not live at newest epoch", "epoch", s.currentEpoch())
+				s.log.Info("pod not ready: envoy not live at newest epoch", "epoch", epoch)
 			}
 		}
 	}

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -1,0 +1,206 @@
+package hotrestart
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Cross-pod coordination for Strategy B (see docs/proposals/001_proxy-hot-restart.md).
+//
+// When two aether-proxy pods overlap on a node during a surge upgrade, they share
+// the host network namespace, /dev/shm and the same --base-id, so an Envoy in the
+// new pod can hot-restart from the Envoy in the old pod exactly as in the in-pod
+// case. Two things differ:
+//
+//  1. Epoch selection: the new pod must launch Envoy at (old epoch + 1) to attach
+//     to the predecessor. The supervisors coordinate the per-node epoch through a
+//     small heartbeat file on a shared hostPath (StateDir).
+//  2. Readiness gating: the new pod must report NotReady until its Envoy has taken
+//     over, so the DaemonSet (maxUnavailable=0) keeps the old pod alive until the
+//     handoff completes. Readiness is decided per-pod from the supervisor's own
+//     in-memory epoch versus what the node's Envoy admin reports, recorded in a
+//     pod-local marker file consumed by an exec readiness probe.
+
+const (
+	heartbeatInterval = 2 * time.Second
+	predecessorStale  = 8 * time.Second
+	readyPollInterval = 1 * time.Second
+	stateFileName     = "epoch"
+)
+
+// initStartEpoch decides the restart epoch for the first Envoy this supervisor
+// launches. With cross-pod coordination (StateDir set), a live predecessor
+// heartbeating epoch E means start at E+1 to hot-restart from it; otherwise start
+// fresh at epoch 0. Without StateDir (Strategy A only) this is a no-op (epoch 0).
+func (s *Supervisor) initStartEpoch() {
+	if s.cfg.StateDir == "" {
+		return
+	}
+	epoch, hb, ok := s.readState()
+	if ok && time.Since(hb) < predecessorStale {
+		s.mu.Lock()
+		s.nextEpoch = epoch + 1
+		s.mu.Unlock()
+		s.log.Info("live predecessor found; starting cross-pod hot restart",
+			"predecessorEpoch", epoch, "startEpoch", epoch+1, "heartbeatAge", time.Since(hb).Round(time.Millisecond).String())
+		return
+	}
+	s.log.Info("no live predecessor; starting fresh at epoch 0", "statePresent", ok)
+}
+
+func (s *Supervisor) statePath() string { return filepath.Join(s.cfg.StateDir, stateFileName) }
+
+// readState parses "<epoch> <unixMillis>" from the coordination file.
+func (s *Supervisor) readState() (epoch int, heartbeat time.Time, ok bool) {
+	b, err := os.ReadFile(s.statePath())
+	if err != nil {
+		return 0, time.Time{}, false
+	}
+	parts := strings.Fields(string(b))
+	if len(parts) != 2 {
+		return 0, time.Time{}, false
+	}
+	e, err1 := strconv.Atoi(parts[0])
+	ms, err2 := strconv.ParseInt(parts[1], 10, 64)
+	if err1 != nil || err2 != nil {
+		return 0, time.Time{}, false
+	}
+	return e, time.UnixMilli(ms), true
+}
+
+// writeState atomically records this supervisor's newest epoch with a fresh
+// heartbeat. It never downgrades against a fresh higher epoch: during a surge
+// overlap the successor pod owns a higher epoch, and the draining predecessor must
+// not clobber it back down (which would corrupt successor detection and the next
+// pod's epoch selection). A stale higher epoch (crashed predecessor) is
+// overwritten so a fresh node can reset to 0.
+func (s *Supervisor) writeState(epoch int) {
+	if s.cfg.StateDir == "" {
+		return
+	}
+	if cur, hb, ok := s.readState(); ok && epoch < cur && time.Since(hb) < predecessorStale {
+		return
+	}
+	if err := os.MkdirAll(s.cfg.StateDir, 0o755); err != nil {
+		s.log.V(1).Error(err, "creating state dir")
+		return
+	}
+	tmp := s.statePath() + ".tmp"
+	data := fmt.Sprintf("%d %d\n", epoch, time.Now().UnixMilli())
+	if err := os.WriteFile(tmp, []byte(data), 0o644); err != nil {
+		s.log.V(1).Error(err, "writing state")
+		return
+	}
+	if err := os.Rename(tmp, s.statePath()); err != nil {
+		s.log.V(1).Error(err, "renaming state")
+	}
+}
+
+// heartbeat refreshes the coordination file so a surging successor pod can detect
+// this node's live epoch and hot-restart from it.
+func (s *Supervisor) heartbeat(ctx context.Context) {
+	if s.cfg.StateDir == "" {
+		return
+	}
+	t := time.NewTicker(heartbeatInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		case <-t.C:
+			s.writeState(s.currentEpoch())
+		}
+	}
+}
+
+// watchReadiness maintains a pod-local readiness marker: present once the node's
+// Envoy admin reports LIVE at this supervisor's newest epoch (for a cross-pod
+// surge, only after the new Envoy has taken over the listen sockets and admin
+// port). An exec readiness probe checks the marker.
+func (s *Supervisor) watchReadiness(ctx context.Context) {
+	if s.cfg.ReadyMarkerPath == "" {
+		return
+	}
+	defer s.clearReady()
+	t := time.NewTicker(readyPollInterval)
+	defer t.Stop()
+	ready := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-s.done:
+			return
+		case <-t.C:
+			live := s.adminLiveAtEpoch(ctx, s.currentEpoch())
+			switch {
+			case live && !ready:
+				s.setReady()
+				ready = true
+				s.log.Info("pod ready: envoy live at newest epoch", "epoch", s.currentEpoch())
+			case !live && ready:
+				s.clearReady()
+				ready = false
+				s.log.Info("pod not ready: envoy not live at newest epoch", "epoch", s.currentEpoch())
+			}
+		}
+	}
+}
+
+func (s *Supervisor) setReady() {
+	if err := os.WriteFile(s.cfg.ReadyMarkerPath, []byte("ready\n"), 0o644); err != nil {
+		s.log.V(1).Error(err, "writing ready marker")
+	}
+}
+
+func (s *Supervisor) clearReady() { _ = os.Remove(s.cfg.ReadyMarkerPath) }
+
+// supersededBySuccessor reports whether a successor pod has taken over this node
+// at a higher epoch. When our newest Envoy exits during a cross-pod surge, it was
+// terminated by the successor's takeover (not a crash), so the supervisor should
+// shut down gracefully and let the pod be deleted rather than exit non-zero and
+// restart-loop.
+func (s *Supervisor) supersededBySuccessor(epoch int) bool {
+	if s.cfg.StateDir == "" {
+		return false
+	}
+	cur, hb, ok := s.readState()
+	return ok && cur > epoch && time.Since(hb) < predecessorStale
+}
+
+// adminLiveAtEpoch reports whether the Envoy admin (the shared host-netns port)
+// reports state LIVE at the given restart epoch. During a cross-pod handoff the
+// predecessor answers admin at the old epoch until the new Envoy takes over.
+func (s *Supervisor) adminLiveAtEpoch(ctx context.Context, epoch int) bool {
+	ctx, cancel := context.WithTimeout(ctx, readyPollInterval)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+s.cfg.AdminAddress+"/server_info", nil)
+	if err != nil {
+		return false
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	var info struct {
+		State              string `json:"state"`
+		CommandLineOptions struct {
+			RestartEpoch int `json:"restart_epoch"`
+		} `json:"command_line_options"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&info) != nil {
+		return false
+	}
+	return info.State == "LIVE" && info.CommandLineOptions.RestartEpoch == epoch
+}

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -128,7 +128,10 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			epoch := s.currentEpoch()
 			if s.adminLiveAtEpoch(ctx, epoch) {
 				s.writeState(epoch) // LIVE-gated heartbeat
-				if !ready {
+				// Hold readiness until the cross-pod handoff is fully complete (the
+				// predecessor has been terminated by this Envoy's parent-shutdown), so
+				// the DaemonSet doesn't delete the old pod while we still need it.
+				if !ready && !time.Now().Before(s.readyGate) {
 					s.setReady()
 					ready = true
 					s.log.Info("pod ready: envoy live at newest epoch", "epoch", epoch)

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -153,19 +153,6 @@ func (s *Supervisor) setReady() {
 
 func (s *Supervisor) clearReady() { _ = os.Remove(s.cfg.ReadyMarkerPath) }
 
-// supersededBySuccessor reports whether a successor pod has taken over this node
-// at a higher epoch. When our newest Envoy exits during a cross-pod surge, it was
-// terminated by the successor's takeover (not a crash), so the supervisor should
-// shut down gracefully and let the pod be deleted rather than exit non-zero and
-// restart-loop.
-func (s *Supervisor) supersededBySuccessor(epoch int) bool {
-	if s.cfg.StateDir == "" {
-		return false
-	}
-	cur, hb, ok := s.readState()
-	return ok && cur > epoch && time.Since(hb) < predecessorStale
-}
-
 // adminLiveAtEpoch reports whether the Envoy admin (the shared host-netns port)
 // reports state LIVE at the given restart epoch. During a cross-pod handoff the
 // predecessor answers admin at the old epoch until the new Envoy takes over.

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -104,22 +104,6 @@ func TestInitStartEpoch(t *testing.T) {
 	})
 }
 
-func TestSupersededBySuccessor(t *testing.T) {
-	s := newCoordSupervisor(t)
-	// Our newest epoch is 2.
-	writeRawState(t, s, 3, 0) // a fresh successor at epoch 3
-	assert.True(t, s.supersededBySuccessor(2))
-
-	writeRawState(t, s, 2, 0) // same epoch, not a successor
-	assert.False(t, s.supersededBySuccessor(2))
-
-	writeRawState(t, s, 3, 2*predecessorStale) // stale successor -> treat as crash
-	assert.False(t, s.supersededBySuccessor(2))
-
-	off := New(Config{}, logr.Discard())
-	assert.False(t, off.supersededBySuccessor(2))
-}
-
 func TestReadyMarker(t *testing.T) {
 	dir := t.TempDir()
 	s := New(Config{ReadyMarkerPath: filepath.Join(dir, "ready")}, logr.Discard())

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -1,0 +1,110 @@
+package hotrestart
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newCoordSupervisor(t *testing.T) *Supervisor {
+	t.Helper()
+	return New(Config{StateDir: t.TempDir()}, logr.Discard())
+}
+
+// writeRawState writes the state file directly with a given epoch and heartbeat age.
+func writeRawState(t *testing.T, s *Supervisor, epoch int, age time.Duration) {
+	t.Helper()
+	ms := time.Now().Add(-age).UnixMilli()
+	require.NoError(t, os.WriteFile(s.statePath(), []byte(fmt.Sprintf("%d %d\n", epoch, ms)), 0o644))
+}
+
+func TestWriteReadStateRoundTrip(t *testing.T) {
+	s := newCoordSupervisor(t)
+	s.writeState(7)
+	epoch, hb, ok := s.readState()
+	require.True(t, ok)
+	assert.Equal(t, 7, epoch)
+	assert.WithinDuration(t, time.Now(), hb, 2*time.Second)
+}
+
+func TestWriteStateDoesNotDowngradeFreshHigherEpoch(t *testing.T) {
+	s := newCoordSupervisor(t)
+	// A live successor owns epoch 5.
+	writeRawState(t, s, 5, 0)
+	// The draining predecessor heartbeats its lower epoch 4 — must be ignored.
+	s.writeState(4)
+	epoch, _, ok := s.readState()
+	require.True(t, ok)
+	assert.Equal(t, 5, epoch, "fresh higher epoch must not be downgraded")
+}
+
+func TestWriteStateOverwritesStaleHigherEpoch(t *testing.T) {
+	s := newCoordSupervisor(t)
+	// A crashed predecessor left epoch 5 with a stale heartbeat.
+	writeRawState(t, s, 5, 2*predecessorStale)
+	// A fresh node resets to epoch 0.
+	s.writeState(0)
+	epoch, _, ok := s.readState()
+	require.True(t, ok)
+	assert.Equal(t, 0, epoch, "stale higher epoch must be overwritten on reset")
+}
+
+func TestInitStartEpoch(t *testing.T) {
+	t.Run("live predecessor -> epoch+1", func(t *testing.T) {
+		s := newCoordSupervisor(t)
+		writeRawState(t, s, 3, 0)
+		s.initStartEpoch()
+		assert.Equal(t, 4, s.nextEpoch)
+	})
+	t.Run("stale predecessor -> epoch 0", func(t *testing.T) {
+		s := newCoordSupervisor(t)
+		writeRawState(t, s, 3, 2*predecessorStale)
+		s.initStartEpoch()
+		assert.Equal(t, 0, s.nextEpoch)
+	})
+	t.Run("no state file -> epoch 0", func(t *testing.T) {
+		s := newCoordSupervisor(t)
+		s.initStartEpoch()
+		assert.Equal(t, 0, s.nextEpoch)
+	})
+	t.Run("disabled (no StateDir) -> epoch 0", func(t *testing.T) {
+		s := New(Config{}, logr.Discard())
+		s.initStartEpoch()
+		assert.Equal(t, 0, s.nextEpoch)
+	})
+}
+
+func TestSupersededBySuccessor(t *testing.T) {
+	s := newCoordSupervisor(t)
+	// Our newest epoch is 2.
+	writeRawState(t, s, 3, 0) // a fresh successor at epoch 3
+	assert.True(t, s.supersededBySuccessor(2))
+
+	writeRawState(t, s, 2, 0) // same epoch, not a successor
+	assert.False(t, s.supersededBySuccessor(2))
+
+	writeRawState(t, s, 3, 2*predecessorStale) // stale successor -> treat as crash
+	assert.False(t, s.supersededBySuccessor(2))
+
+	off := New(Config{}, logr.Discard())
+	assert.False(t, off.supersededBySuccessor(2))
+}
+
+func TestReadyMarker(t *testing.T) {
+	dir := t.TempDir()
+	s := New(Config{ReadyMarkerPath: filepath.Join(dir, "ready")}, logr.Discard())
+	_, err := os.Stat(s.cfg.ReadyMarkerPath)
+	require.True(t, os.IsNotExist(err))
+	s.setReady()
+	_, err = os.Stat(s.cfg.ReadyMarkerPath)
+	assert.NoError(t, err)
+	s.clearReady()
+	_, err = os.Stat(s.cfg.ReadyMarkerPath)
+	assert.True(t, os.IsNotExist(err))
+}

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -1,7 +1,10 @@
 package hotrestart
 
 import (
+	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,6 +18,17 @@ import (
 func newCoordSupervisor(t *testing.T) *Supervisor {
 	t.Helper()
 	return New(Config{StateDir: t.TempDir()}, logr.Discard())
+}
+
+// fakeAdmin starts an Envoy-admin stub that reports the given state and restart
+// epoch on /server_info, and returns its host:port.
+func fakeAdmin(t *testing.T, state string, epoch int) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, `{"state":%q,"command_line_options":{"restart_epoch":%d}}`, state, epoch)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().String()
 }
 
 // writeRawState writes the state file directly with a given epoch and heartbeat age.
@@ -56,26 +70,36 @@ func TestWriteStateOverwritesStaleHigherEpoch(t *testing.T) {
 }
 
 func TestInitStartEpoch(t *testing.T) {
-	t.Run("live predecessor -> epoch+1", func(t *testing.T) {
+	ctx := context.Background()
+	t.Run("fresh file + admin LIVE at that epoch -> epoch+1", func(t *testing.T) {
 		s := newCoordSupervisor(t)
+		s.cfg.AdminAddress = fakeAdmin(t, "LIVE", 3)
 		writeRawState(t, s, 3, 0)
-		s.initStartEpoch()
+		s.initStartEpoch(ctx)
 		assert.Equal(t, 4, s.nextEpoch)
+	})
+	t.Run("fresh file but admin NOT live (dead predecessor) -> epoch 0", func(t *testing.T) {
+		s := newCoordSupervisor(t)
+		s.cfg.AdminAddress = fakeAdmin(t, "PRE_INITIALIZING", 3)
+		writeRawState(t, s, 3, 0)
+		s.initStartEpoch(ctx)
+		assert.Equal(t, 0, s.nextEpoch)
 	})
 	t.Run("stale predecessor -> epoch 0", func(t *testing.T) {
 		s := newCoordSupervisor(t)
+		s.cfg.AdminAddress = fakeAdmin(t, "LIVE", 3)
 		writeRawState(t, s, 3, 2*predecessorStale)
-		s.initStartEpoch()
+		s.initStartEpoch(ctx)
 		assert.Equal(t, 0, s.nextEpoch)
 	})
 	t.Run("no state file -> epoch 0", func(t *testing.T) {
 		s := newCoordSupervisor(t)
-		s.initStartEpoch()
+		s.initStartEpoch(ctx)
 		assert.Equal(t, 0, s.nextEpoch)
 	})
 	t.Run("disabled (no StateDir) -> epoch 0", func(t *testing.T) {
 		s := New(Config{}, logr.Discard())
-		s.initStartEpoch()
+		s.initStartEpoch(ctx)
 		assert.Equal(t, 0, s.nextEpoch)
 	})
 }

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -98,7 +98,18 @@ type Supervisor struct {
 
 	childExited chan childExit
 	done        chan struct{}
+
+	// readyGate delays the pod's readiness until after a cross-pod handoff is fully
+	// complete: the successor Envoy terminates the predecessor itself via
+	// --parent-shutdown-time-s, so the pod must not report Ready (which lets the
+	// DaemonSet delete the old pod) until that has elapsed — otherwise the old
+	// Envoy is killed out from under the still-attached successor (errno 111).
+	readyGate time.Time
 }
+
+// readyGateBuffer is added to ParentShutdownTime when gating a cross-pod
+// successor's readiness, to ensure the predecessor is fully gone first.
+const readyGateBuffer = 3 * time.Second
 
 // New creates a Supervisor.
 func New(cfg Config, log logr.Logger) *Supervisor {
@@ -131,6 +142,11 @@ func (s *Supervisor) Run(ctx context.Context) error {
 	// then maintain the readiness marker and the LIVE-gated node epoch heartbeat.
 	// No-ops when StateDir / ReadyMarkerPath are unset (Strategy A).
 	s.initStartEpoch(ctx)
+	if s.cfg.StateDir != "" && s.nextEpoch > 0 {
+		// Cross-pod successor: hold readiness until the predecessor has been
+		// terminated by this Envoy's own parent-shutdown protocol.
+		s.readyGate = time.Now().Add(s.cfg.ParentShutdownTime + readyGateBuffer)
+	}
 	go s.watchLiveness(ctx)
 
 	if err := s.hotRestart(); err != nil {
@@ -176,10 +192,12 @@ func (s *Supervisor) Run(ctx context.Context) error {
 			if exit.epoch == s.currentEpoch() {
 				if s.supersededBySuccessor(exit.epoch) {
 					// A successor pod took over this node at a higher epoch and
-					// terminated our Envoy via the hot-restart parent-shutdown. Exit 0
-					// and let the DaemonSet delete this (now-drained) pod.
-					s.log.Info("newest epoch superseded by a successor pod; shutting down gracefully", "epoch", exit.epoch)
+					// terminated our Envoy via the hot-restart parent-shutdown. Don't
+					// exit (restartPolicy=Always would relaunch us and climb epochs):
+					// stay alive with no child until the DaemonSet deletes this pod.
+					s.log.Info("newest epoch superseded by a successor pod; awaiting pod deletion", "epoch", exit.epoch)
 					s.reap(exit.epoch)
+					<-ctx.Done()
 					return nil
 				}
 				// The newest epoch died unexpectedly: nothing left serving traffic.

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -166,6 +166,18 @@ func (s *Supervisor) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			if s.supersededBySuccessor(s.currentEpoch()) {
+				// A successor pod is mid-handoff with our Envoy as its hot-restart
+				// parent. The DaemonSet may delete this pod the moment it turns
+				// NotReady (it no longer counts against maxUnavailable), so this
+				// SIGTERM arrives while the successor still needs the parent alive.
+				// Do NOT signal Envoy: wait for the successor's parent-shutdown
+				// protocol to terminate it, then exit. Falls back to a normal
+				// shutdown if that doesn't happen in time.
+				s.log.Info("termination requested mid-handoff; waiting for successor to terminate our envoy")
+				s.awaitProtocolTermination()
+				return nil
+			}
 			s.log.Info("termination requested, shutting down all envoy epochs")
 			s.shutdown()
 			return nil
@@ -340,6 +352,35 @@ func (s *Supervisor) reap(epoch int) {
 	delete(s.children, epoch)
 	s.mu.Unlock()
 	s.log.Info("reaped envoy epoch", "epoch", epoch)
+}
+
+// awaitProtocolTermination waits (without signaling) for the remaining children to
+// exit via the successor's hot-restart parent-shutdown protocol, up to
+// ParentShutdownTime plus grace; any straggler past the deadline gets a normal
+// shutdown. Requires the pod's terminationGracePeriod to exceed that deadline.
+func (s *Supervisor) awaitProtocolTermination() {
+	s.mu.Lock()
+	pending := len(s.children)
+	s.mu.Unlock()
+	if pending == 0 {
+		return
+	}
+
+	deadline := time.NewTimer(s.cfg.ParentShutdownTime + shutdownGrace)
+	defer deadline.Stop()
+
+	for pending > 0 {
+		select {
+		case exit := <-s.childExited:
+			s.reap(exit.epoch)
+			pending--
+			s.log.Info("envoy epoch terminated by successor", "epoch", exit.epoch)
+		case <-deadline.C:
+			s.log.Info("successor did not terminate our envoy in time; shutting down")
+			s.shutdown()
+			return
+		}
+	}
 }
 
 // shutdown SIGTERMs every tracked epoch and waits up to DrainTime+grace for them

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -67,6 +67,18 @@ type Config struct {
 	// self-triggers a hot restart when the bootstrap config changes (e.g. a
 	// ConfigMap update propagated by the kubelet).
 	WatchConfig bool
+	// StateDir, when set, enables Strategy B cross-pod coordination: a per-node
+	// epoch heartbeat file on a shared hostPath. A surging successor pod reads it
+	// to start at (live predecessor epoch + 1) and hot-restart across the pod
+	// boundary. Empty = Strategy A only (always start at epoch 0).
+	StateDir string
+	// ReadyMarkerPath, when set, enables the readiness gate: the supervisor keeps a
+	// pod-local marker present only while the node's Envoy admin reports LIVE at
+	// this supervisor's newest epoch. An exec readiness probe checks the marker so
+	// the DaemonSet keeps the old pod until the new one has taken over.
+	ReadyMarkerPath string
+	// AdminAddress is the Envoy admin host:port used for the readiness check.
+	AdminAddress string
 }
 
 // childExit reports the termination of a supervised Envoy epoch.
@@ -115,6 +127,13 @@ func (s *Supervisor) Run(ctx context.Context) error {
 		go s.watchConfig(ctx, trigger)
 	}
 
+	// Strategy B: pick the start epoch from a live predecessor (if any), then keep
+	// the node epoch heartbeat and the readiness marker maintained. No-ops when
+	// StateDir / ReadyMarkerPath are unset (Strategy A).
+	s.initStartEpoch()
+	go s.heartbeat(ctx)
+	go s.watchReadiness(ctx)
+
 	if err := s.hotRestart(); err != nil {
 		return fmt.Errorf("starting initial envoy epoch: %w", err)
 	}
@@ -156,6 +175,14 @@ func (s *Supervisor) Run(ctx context.Context) error {
 
 		case exit := <-s.childExited:
 			if exit.epoch == s.currentEpoch() {
+				if s.supersededBySuccessor(exit.epoch) {
+					// A successor pod took over this node at a higher epoch and
+					// terminated our Envoy via the hot-restart parent-shutdown. Exit 0
+					// and let the DaemonSet delete this (now-drained) pod.
+					s.log.Info("newest epoch superseded by a successor pod; shutting down gracefully", "epoch", exit.epoch)
+					s.reap(exit.epoch)
+					return nil
+				}
 				// The newest epoch died unexpectedly: nothing left serving traffic.
 				// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).
 				s.reap(exit.epoch)
@@ -185,6 +212,9 @@ func (s *Supervisor) hotRestart() error {
 	s.mu.Lock()
 	s.children[epoch] = cmd
 	s.mu.Unlock()
+
+	// Publish the new node epoch so a surging successor pod attaches at epoch+1.
+	s.writeState(epoch)
 
 	go func() {
 		err := cmd.Wait()

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -166,14 +166,16 @@ func (s *Supervisor) Run(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			if s.supersededBySuccessor(s.currentEpoch()) {
-				// A successor pod is mid-handoff with our Envoy as its hot-restart
-				// parent. The DaemonSet may delete this pod the moment it turns
-				// NotReady (it no longer counts against maxUnavailable), so this
-				// SIGTERM arrives while the successor still needs the parent alive.
-				// Do NOT signal Envoy: wait for the successor's parent-shutdown
-				// protocol to terminate it, then exit. Falls back to a normal
-				// shutdown if that doesn't happen in time.
+			// Cross-pod mode: if our Envoy no longer answers admin LIVE at our own
+			// epoch, its sockets have (very likely) been transferred to a surging
+			// successor that is still initializing — the DaemonSet deletes this pod
+			// the moment it turns NotReady, which is exactly that window. Do NOT
+			// signal Envoy (the successor still needs its hot-restart parent alive,
+			// even before reaching LIVE — killing it aborts the successor with
+			// errno 111): wait for the successor's parent-shutdown protocol to
+			// terminate it, with a deadline fallback. The check cannot rely on the
+			// successor having published its epoch, since it does so only once LIVE.
+			if s.cfg.StateDir != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
 				s.log.Info("termination requested mid-handoff; waiting for successor to terminate our envoy")
 				s.awaitProtocolTermination()
 				return nil
@@ -202,12 +204,15 @@ func (s *Supervisor) Run(ctx context.Context) error {
 
 		case exit := <-s.childExited:
 			if exit.epoch == s.currentEpoch() {
-				if s.supersededBySuccessor(exit.epoch) {
-					// A successor pod took over this node at a higher epoch and
-					// terminated our Envoy via the hot-restart parent-shutdown. Don't
-					// exit (restartPolicy=Always would relaunch us and climb epochs):
-					// stay alive with no child until the DaemonSet deletes this pod.
-					s.log.Info("newest epoch superseded by a successor pod; awaiting pod deletion", "epoch", exit.epoch)
+				if s.cfg.StateDir != "" && exit.err == nil {
+					// Clean exit (status 0) of our newest epoch in cross-pod mode:
+					// that's the successor's hot-restart parent-shutdown protocol
+					// terminating us (a crash would be non-zero/signaled). The signal
+					// is deliberate process state, not the shared epoch file — the
+					// successor publishes its epoch only once LIVE, which may be
+					// after it terminates us. Don't exit (restartPolicy=Always would
+					// relaunch and collide): await deletion by the DaemonSet.
+					s.log.Info("newest epoch terminated cleanly by successor; awaiting pod deletion", "epoch", exit.epoch)
 					s.reap(exit.epoch)
 					<-ctx.Done()
 					return nil

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -360,31 +360,22 @@ func (s *Supervisor) reap(epoch int) {
 }
 
 // awaitProtocolTermination waits (without signaling) for the remaining children to
-// exit via the successor's hot-restart parent-shutdown protocol, up to
-// ParentShutdownTime plus grace; any straggler past the deadline gets a normal
-// shutdown. Requires the pod's terminationGracePeriod to exceed that deadline.
+// exit via the successor's hot-restart parent-shutdown protocol. It deliberately
+// imposes NO deadline of its own: the successor's timers start only after its
+// (xDS-gated, unbounded) init completes, and the successor keeps using the parent
+// socket (stat merges) right up to protocol-terminate — killing the parent at any
+// "reasonable" cutoff aborts the successor with errno 111. The kubelet's SIGKILL
+// at the pod's terminationGracePeriod is the real, and only safe, hard stop.
 func (s *Supervisor) awaitProtocolTermination() {
 	s.mu.Lock()
 	pending := len(s.children)
 	s.mu.Unlock()
-	if pending == 0 {
-		return
-	}
-
-	deadline := time.NewTimer(s.cfg.ParentShutdownTime + shutdownGrace)
-	defer deadline.Stop()
 
 	for pending > 0 {
-		select {
-		case exit := <-s.childExited:
-			s.reap(exit.epoch)
-			pending--
-			s.log.Info("envoy epoch terminated by successor", "epoch", exit.epoch)
-		case <-deadline.C:
-			s.log.Info("successor did not terminate our envoy in time; shutting down")
-			s.shutdown()
-			return
-		}
+		exit := <-s.childExited
+		s.reap(exit.epoch)
+		pending--
+		s.log.Info("envoy epoch terminated by successor", "epoch", exit.epoch)
 	}
 }
 

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -127,12 +127,11 @@ func (s *Supervisor) Run(ctx context.Context) error {
 		go s.watchConfig(ctx, trigger)
 	}
 
-	// Strategy B: pick the start epoch from a live predecessor (if any), then keep
-	// the node epoch heartbeat and the readiness marker maintained. No-ops when
-	// StateDir / ReadyMarkerPath are unset (Strategy A).
-	s.initStartEpoch()
-	go s.heartbeat(ctx)
-	go s.watchReadiness(ctx)
+	// Strategy B: pick the start epoch from a confirmed-live predecessor (if any),
+	// then maintain the readiness marker and the LIVE-gated node epoch heartbeat.
+	// No-ops when StateDir / ReadyMarkerPath are unset (Strategy A).
+	s.initStartEpoch(ctx)
+	go s.watchLiveness(ctx)
 
 	if err := s.hotRestart(); err != nil {
 		return fmt.Errorf("starting initial envoy epoch: %w", err)
@@ -213,8 +212,9 @@ func (s *Supervisor) hotRestart() error {
 	s.children[epoch] = cmd
 	s.mu.Unlock()
 
-	// Publish the new node epoch so a surging successor pod attaches at epoch+1.
-	s.writeState(epoch)
+	// The node epoch is published to the shared state file only once this Envoy is
+	// confirmed LIVE (by watchLiveness), never at launch — so a failed handoff does
+	// not advance the epoch and cause a restart to climb against a dead parent.
 
 	go func() {
 		err := cmd.Wait()

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -12,6 +12,13 @@ spec:
       {{- include "agent.proxy.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
+    {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod }}
+    # Strategy B: surge a new pod onto the node before tearing down the old one so
+    # the new Envoy can hot-restart from the old across the pod boundary.
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    {{- end }}
   template:
     metadata:
       labels:
@@ -47,6 +54,11 @@ spec:
             - "--base-id={{ .Values.proxy.hotRestart.baseId }}"
             - "--drain-time={{ .Values.proxy.hotRestart.drainTime }}"
             - "--parent-shutdown-time={{ .Values.proxy.hotRestart.parentShutdownTime }}"
+            {{- if .Values.proxy.hotRestart.crossPod }}
+            - "--state-dir=/run/aether/hotrestart"
+            - "--ready-marker=/var/run/aether-proxy/ready"
+            - "--admin-address=127.0.0.1:9901"
+            {{- end }}
             - "--envoy-arg=-l"
             - "--envoy-arg={{ .Values.proxy.logLevel }}"
             - "--envoy-arg=--service-cluster"
@@ -88,6 +100,23 @@ spec:
               value: "0"
             - name: ENVOY_GID
               value: "0"
+          {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod }}
+          # Ready only once this pod's Envoy is live at the newest epoch (post
+          # handoff), so the DaemonSet (maxUnavailable=0) keeps the old pod until
+          # the new one has taken over. The distroless Envoy image has no shell, so
+          # the probe re-execs the supervisor binary.
+          readinessProbe:
+            exec:
+              command:
+                - "/opt/aether/supervisor"
+                - "proxy-supervisor"
+                - "--readiness-check"
+                - "--ready-marker=/var/run/aether-proxy/ready"
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            failureThreshold: 3
+            successThreshold: 1
+          {{- end }}
           securityContext:
             privileged: true
             runAsUser: 0
@@ -119,14 +148,31 @@ spec:
             - name: dev-shm
               mountPath: /dev/shm
             {{- end }}
+            {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod }}
+            - name: ready-marker
+              mountPath: /var/run/aether-proxy
+            {{- end }}
       volumes:
         {{- if .Values.proxy.hotRestart.enabled }}
         - name: supervisor-bin
           emptyDir: {}
+        {{- if .Values.proxy.hotRestart.crossPod }}
+        # Strategy B: /dev/shm must be shared across the overlapping pods on the
+        # node, so it is a hostPath (tmpfs under /run) rather than a pod-local
+        # emptyDir. The hot-restart shared-memory segment lives here.
+        - name: dev-shm
+          hostPath:
+            path: {{ .Values.proxy.hotRestart.shmHostPath | quote }}
+            type: DirectoryOrCreate
+        # Pod-local readiness marker (not shared across pods).
+        - name: ready-marker
+          emptyDir: {}
+        {{- else }}
         - name: dev-shm
           emptyDir:
             medium: Memory
             sizeLimit: {{ .Values.proxy.hotRestart.shmSizeLimit }}
+        {{- end }}
         {{- end }}
         - name: proxy-config
           configMap:

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -33,6 +33,13 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ include "agent.proxy.serviceAccountName" . }}
       priorityClassName: system-node-critical
+      {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod }}
+      # The deleted (old) pod must keep its Envoy alive as the successor's
+      # hot-restart parent until the successor's protocol terminates it — the
+      # successor's timers start only after its xDS-gated init. Give the
+      # supervisor room to wait; the kubelet's SIGKILL here is the hard stop.
+      terminationGracePeriodSeconds: 60
+      {{- end }}
       {{- if .Values.proxy.hotRestart.enabled }}
       initContainers:
         # SPIKE (Strategy A): the runtime container is the Envoy image (it carries

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -12,9 +12,14 @@ spec:
       {{- include "agent.proxy.selectorLabels" . | nindent 6 }}
   updateStrategy:
     type: RollingUpdate
-    {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod }}
+    {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod .Values.proxy.hotRestart.surge }}
     # Strategy B: surge a new pod onto the node before tearing down the old one so
     # the new Envoy can hot-restart from the old across the pod boundary.
+    #
+    # Only safe once every node already runs a coordinating (Strategy B) Envoy: two
+    # NON-coordinating epoch-0 Envoys with the same --base-id collide on the
+    # hot-restart domain socket in the shared host netns. Bootstrap into B with
+    # surge=false (delete-first) first, then enable surge for B→B upgrades.
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -81,8 +81,10 @@ proxy:
     # Envoy --base-id, pinned so successive epochs share one shared-memory segment.
     baseId: 0
     # Envoy --drain-time-s / --parent-shutdown-time-s (parent must exceed drain).
-    drainTime: 45s
-    parentShutdownTime: 60s
+    # For Strategy B the successor pod holds readiness for ~parentShutdownTime
+    # (until its Envoy terminates the predecessor), so keep these modest.
+    drainTime: 10s
+    parentShutdownTime: 15s
     # /dev/shm size for the hot-restart shared-memory segment (gauges/counters).
     # Strategy A only (emptyDir Memory); Strategy B uses shmHostPath instead.
     shmSizeLimit: 64Mi

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -66,13 +66,22 @@ proxy:
   # connections. See docs/proposals/001_proxy-hot-restart.md. Off by default.
   hotRestart:
     enabled: false
+    # Strategy B (cross-pod, true image upgrade): surge a new pod onto the node and
+    # hot-restart the new Envoy from the old across the pod boundary. Adds the
+    # maxSurge update strategy, a shared hostPath /dev/shm, per-node epoch
+    # coordination, and a readiness gate. When false, hot restart is Strategy A
+    # (in-place, bootstrap-config/binary only). See docs/proposals/001.
+    crossPod: false
     # Envoy --base-id, pinned so successive epochs share one shared-memory segment.
     baseId: 0
     # Envoy --drain-time-s / --parent-shutdown-time-s (parent must exceed drain).
     drainTime: 45s
     parentShutdownTime: 60s
     # /dev/shm size for the hot-restart shared-memory segment (gauges/counters).
+    # Strategy A only (emptyDir Memory); Strategy B uses shmHostPath instead.
     shmSizeLimit: 64Mi
+    # Strategy B: host tmpfs dir shared across overlapping pods, mounted at /dev/shm.
+    shmHostPath: /run/aether/shm
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
 # The chart never bakes credentials into the image. By default it references an

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -72,6 +72,12 @@ proxy:
     # coordination, and a readiness gate. When false, hot restart is Strategy A
     # (in-place, bootstrap-config/binary only). See docs/proposals/001.
     crossPod: false
+    # Surge update strategy (maxSurge=1/maxUnavailable=0) for connection-preserving
+    # B→B image upgrades. Keep false for the one-time bootstrap INTO B (delete-first,
+    # brief per-node gap): two non-coordinating epoch-0 Envoys sharing --base-id in
+    # the host netns collide on the hot-restart domain socket. Flip to true once all
+    # nodes run a Strategy B proxy.
+    surge: false
     # Envoy --base-id, pinned so successive epochs share one shared-memory segment.
     baseId: 0
     # Envoy --drain-time-s / --parent-shutdown-time-s (parent must exceed drain).

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -143,6 +143,24 @@ First on-cluster run (rev 29, `proxy.hotRestart.enabled=true` fleet-wide):
 
 **Caveat (test workloads):** the `aether-test` `client`/`echo`/`svc-a` pods were not exercising the mesh data path on their app port during this run (`client→echo:8080` showed zero delta on the `echo`/`app_echo` clusters — direct pod-to-pod, no XFCC), so an application-level zero-dropped-request assertion could not be made here. The hot-restart guarantees were instead proven via Envoy's own signals (listener/socket handover, `server.live` continuity, in-place `restartCount: 0`). A follow-up should restore a known mesh-intercepted request path for an end-to-end zero-drop assertion.
 
+## Strategy B Findings (talos-main, 2026-06-10) — PARTIAL / NOT VALIDATED
+
+Implemented cross-pod coordination (epoch heartbeat file on shared hostPath, admin-epoch readiness marker + exec probe, supersession-aware graceful exit, `maxSurge`/`surge` chart gates, shared hostPath `/dev/shm`). Deployed to talos-main.
+
+**What worked:**
+- **Initial-transition collision is real.** Two non-coordinating epoch-0 Envoys with the same `--base-id` in the shared host netns collide on the hot-restart **domain socket** (`unable to bind domain socket ... errno=98`), so surge deadlocks the bootstrap into B. Added a `proxy.hotRestart.surge` gate: bootstrap with `surge=false` (delete-first, brief per-node gap) rolled cleanly to a 5-node B baseline.
+- **Epoch coordination + readiness gate worked.** A fresh node logs "no live predecessor; starting fresh at epoch 0"; a surging successor correctly reads the heartbeat file and logs "live predecessor found … startEpoch: N+1". The pod becomes Ready only once the node's Envoy admin reports LIVE at the newest epoch.
+
+**What failed — the B→B surge handoff itself:**
+- The successor Envoy fails to attach to the predecessor with **`previous envoy process is still initializing`** → `exit status 1`. The supervisor records the epoch in the state file at launch (before the handoff is confirmed), so on the resulting crash-restart it reads the still-fresh state and climbs to epoch N+1 against the now-dead epoch N — an **epoch cascade (0→1→2…)** that only resolves when the heartbeat goes stale and the pod resets to epoch 0 (a fresh start with a gap, **not** connection-preserving).
+
+**Open problems before B can be validated:**
+1. **Don't advance the epoch on an unconfirmed handoff** — record/heartbeat the new epoch only after its Envoy reaches LIVE; on handoff failure, fail the pod cleanly (let the DaemonSet retry) rather than restart-and-increment.
+2. **Guarantee the predecessor is LIVE before the successor attaches** — the "still initializing" error means the cross-pod attach timing is wrong; possibly gate the successor's Envoy launch on the predecessor's admin reporting LIVE.
+3. The initial transition into B must always be delete-first (the `surge` gate handles this).
+
+**Status:** Strategy A remains the validated, shipped path. B is parked on `spike/proxy-hot-restart-b`; the cluster is left at a safe delete-first B baseline (`surge=false`).
+
 ## Risks / Open Questions
 
 - **`/dev/shm` capacity** — container default is 64Mi tmpfs; Envoy's hot-restart shmem holds all gauges/counters. The spike sizes the memory `emptyDir` from measured usage.

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -1,6 +1,6 @@
 # Proposal: Hot Restart for the aether-proxy Envoy (Spike)
 
-**Status:** Spike — Strategy A **validated GREEN on talos-main**; target is Strategy B
+**Status:** Strategies A and B **validated GREEN on talos-main** (B incl. zero-drop app e2e)
 **Author:** Bruno Palermo
 **Date:** 2026-06-09
 
@@ -143,23 +143,21 @@ First on-cluster run (rev 29, `proxy.hotRestart.enabled=true` fleet-wide):
 
 **Caveat (test workloads):** the `aether-test` `client`/`echo`/`svc-a` pods were not exercising the mesh data path on their app port during this run (`client→echo:8080` showed zero delta on the `echo`/`app_echo` clusters — direct pod-to-pod, no XFCC), so an application-level zero-dropped-request assertion could not be made here. The hot-restart guarantees were instead proven via Envoy's own signals (listener/socket handover, `server.live` continuity, in-place `restartCount: 0`). A follow-up should restore a known mesh-intercepted request path for an end-to-end zero-drop assertion.
 
-## Strategy B Findings (talos-main, 2026-06-10) — PARTIAL / NOT VALIDATED
+## Strategy B Findings (talos-main, 2026-06-10) — **VALIDATED GREEN**
 
-Implemented cross-pod coordination (epoch heartbeat file on shared hostPath, admin-epoch readiness marker + exec probe, supersession-aware graceful exit, `maxSurge`/`surge` chart gates, shared hostPath `/dev/shm`). Deployed to talos-main.
+Cross-pod hot restart implemented and validated over five on-cluster iterations. Final proof: a 5-node surge roll with **zero container restarts**, every node landing **LIVE at epoch 2, `hot_restart_generation` 3** (stats carried across the pod boundary twice), and an **application-level zero-drop e2e: 1500/1500 mesh requests succeeded (`ok=1500 fail=0`)** while the roll executed under live traffic.
 
-**What worked:**
-- **Initial-transition collision is real.** Two non-coordinating epoch-0 Envoys with the same `--base-id` in the shared host netns collide on the hot-restart **domain socket** (`unable to bind domain socket ... errno=98`), so surge deadlocks the bootstrap into B. Added a `proxy.hotRestart.surge` gate: bootstrap with `surge=false` (delete-first, brief per-node gap) rolled cleanly to a 5-node B baseline.
-- **Epoch coordination + readiness gate worked.** A fresh node logs "no live predecessor; starting fresh at epoch 0"; a surging successor correctly reads the heartbeat file and logs "live predecessor found … startEpoch: N+1". The pod becomes Ready only once the node's Envoy admin reports LIVE at the newest epoch.
+The implementation: per-node epoch heartbeat file on shared hostPath (`--state-dir`), admin-epoch readiness marker + exec probe (`--ready-marker`/`--readiness-check`), shared hostPath `/dev/shm`, and `crossPod`/`surge` chart gates. Hard-won lessons, each from a failed on-cluster run:
 
-**What failed — the B→B surge handoff itself:**
-- The successor Envoy fails to attach to the predecessor with **`previous envoy process is still initializing`** → `exit status 1`. The supervisor records the epoch in the state file at launch (before the handoff is confirmed), so on the resulting crash-restart it reads the still-fresh state and climbs to epoch N+1 against the now-dead epoch N — an **epoch cascade (0→1→2…)** that only resolves when the heartbeat goes stale and the pod resets to epoch 0 (a fresh start with a gap, **not** connection-preserving).
+1. **Bootstrap into B must be delete-first.** Two non-coordinating epoch-0 Envoys with the same `--base-id` in the shared host netns collide on the hot-restart domain socket (`errno=98`); surge deadlocks the initial transition. The `proxy.hotRestart.surge` gate keeps the first roll delete-first; surge is for B→B only.
+2. **Publish the node epoch only while LIVE.** Recording the epoch at launch makes any failed handoff advance the counter, and crash-restarts then climb epochs against dead parents (cascade 0→1→2…). The heartbeat is written by the liveness watcher only while admin reports LIVE at that epoch, and `initStartEpoch` verifies the predecessor via admin (ground truth), not the file.
+3. **Supersession signals must not depend on the successor being LIVE.** A slow (xDS-gated) successor init opens a window where the old pod is deleted before the successor publishes anything. The old pod detects mid-handoff via *its own* Envoy no longer answering admin at its epoch (sockets transferred), and detects protocol termination via the child's clean exit status — both independent of successor state.
+4. **Never kill the parent while a successor is attached.** The successor uses the parent IPC socket (stat merges) right up to its parent-terminate, whose timing is unbounded (starts after init). Any supervisor-imposed deadline races it and aborts the successor (`errno 111`). The old pod waits for protocol termination indefinitely; the kubelet's SIGKILL at `terminationGracePeriodSeconds` (60s in crossPod mode) is the only safe hard stop.
+5. **The old pod goes NotReady at takeover, voiding `maxUnavailable=0` protection** — the DaemonSet deletes it mid-handoff. Combined with (3) and (4) this is harmless: the deleted pod's supervisor keeps the parent alive through the protocol.
 
-**Open problems before B can be validated:**
-1. **Don't advance the epoch on an unconfirmed handoff** — record/heartbeat the new epoch only after its Envoy reaches LIVE; on handoff failure, fail the pod cleanly (let the DaemonSet retry) rather than restart-and-increment.
-2. **Guarantee the predecessor is LIVE before the successor attaches** — the "still initializing" error means the cross-pod attach timing is wrong; possibly gate the successor's Envoy launch on the predecessor's admin reporting LIVE.
-3. The initial transition into B must always be delete-first (the `surge` gate handles this).
+**Also fixed en route:** the e2e mesh path itself. There is no iptables interception — apps reach the mesh via the outbound listener (`127.0.0.1:18081` + `Host: <service>`); the earlier direct-pod-IP curls were bypassing the proxy entirely.
 
-**Status:** Strategy A remains the validated, shipped path. B is parked on `spike/proxy-hot-restart-b`; the cluster is left at a safe delete-first B baseline (`surge=false`).
+**Known issue found (pre-existing, agent):** `SubscribePod` (workload SVID subscription) fires only on CNI ADD. After an **agent** restart, listeners are rebuilt from storage but SVIDs are never re-subscribed → existing pods' mTLS breaks ("Secret is not supplied by SDS") until the workload pods are recreated. Needs a re-subscribe-from-storage path in the agent. Unrelated to hot restart.
 
 ## Risks / Open Questions
 


### PR DESCRIPTION
## Summary

**Strategy B: connection-preserving proxy container-image upgrades** via cross-pod Envoy hot restart. A surging successor pod attaches to the old pod's Envoy (shared host netns + hostPath `/dev/shm` + same `--base-id`), inherits listen sockets and stats across the pod boundary, and the old pod drains out gracefully. Validated GREEN on talos-main over five on-cluster iterations — see the proposal's *Strategy B Findings* for the full battle log.

## Final proof (talos-main)

- 5-node `maxSurge=1/maxUnavailable=0` roll: **zero container restarts**, every node **LIVE epoch 2 / `hot_restart_generation` 3** (stats survived two pod-boundary handoffs), stable through a 2-min post-roll window.
- **App-level zero-drop e2e: `ok=1500 fail=0`** — continuous mesh requests (client→echo via outbound listener, mTLS, XFCC verified) while the surge roll executed under live traffic.

## Implementation

- **Supervisor (`hotrestart`)**: per-node epoch heartbeat file (`--state-dir`, shared hostPath) published **only while admin-LIVE**; predecessor verified via admin (ground truth) before starting at epoch N+1; readiness marker + `--readiness-check` exec probe; mid-handoff old-pod termination waits for the successor's parent-shutdown protocol (no supervisor-imposed deadline — the kubelet's SIGKILL is the only safe hard stop); protocol termination detected via clean child exit.
- **Chart**: `proxy.hotRestart.crossPod` (hostPath `/dev/shm`, state dir, readiness probe, 60s termination grace) + `proxy.hotRestart.surge` (B→B rolls only; **bootstrap into B must be delete-first** — two non-coordinating epoch-0 Envoys collide on the base-id domain socket).
- All gated off by default; Strategy A and the plain proxy are unchanged.

## Hard-won lessons (each from a failed run, documented in the proposal)

1. Bootstrap into B is delete-first; surge is for B→B only.
2. Publish the node epoch only while LIVE (else failed handoffs cascade epochs).
3. Supersession signals must not depend on the successor being LIVE (slow xDS init window).
4. **Never** kill the parent while a successor is attached (stat-merge uses the parent socket until protocol-terminate; any deadline races it → errno 111 abort).
5. The old pod going NotReady at takeover voids `maxUnavailable=0` — harmless once (3)+(4) hold.

## Known issue found en route (pre-existing, not addressed here)

Agent: `SubscribePod` only fires on CNI ADD — after an **agent** restart, workload SVIDs are never re-subscribed and existing pods' mTLS breaks ("Secret is not supplied by SDS") until workloads are recreated. Needs a re-subscribe-from-storage path; noted in the proposal.

## Test plan
- `bazel test //agent/internal/proxy/hotrestart/...` ✅ (incl. epoch-coordination unit tests with fake admin)
- talos-main: bootstrap roll, three failed surge iterations driving fixes, final clean surge roll + zero-drop e2e ✅
- `helm template` for all gate combinations ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)