### PR TITLE
fix(agent): re-subscribe stored pods' SVIDs after agent restart

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "config.go",
         "liveness.go",
         "pod.go",
+        "resubscribe.go",
         "server.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/cni/server",
@@ -39,6 +40,7 @@ go_test(
     name = "server_test",
     srcs = [
         "pod_test.go",
+        "resubscribe_test.go",
         "server_integration_test.go",
     ],
     embed = [":server"],

--- a/agent/internal/cni/server/resubscribe.go
+++ b/agent/internal/cni/server/resubscribe.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+
+	"github.com/bpalermo/aether/agent/internal/spire"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// runResubscribeStoredPods restores SVID subscriptions for pods already present
+// in local storage when the agent (re)starts. Subscriptions are normally created
+// only on CNI ADD, so without this an agent restart rebuilds listeners from
+// storage but leaves existing pods' workload SVIDs unsubscribed — their mTLS
+// breaks ("Secret is not supplied by SDS") until the pods are recreated.
+//
+// It waits for the SPIRE bridge to connect (SubscribePod no-ops before then),
+// then re-subscribes every managed stored pod, re-fetching the pod UID from the
+// API server (the UID is needed for the SPIRE k8s:pod-uid selector and is not
+// persisted in storage). Idempotent: SubscribePod no-ops for an
+// already-subscribed network namespace, so racing a concurrent CNI ADD is safe.
+// Pods deleted while the agent was down fail the UID lookup and are skipped;
+// their CNI DEL cleans them up.
+func (s *CNIServer) runResubscribeStoredPods(ctx context.Context) {
+	if s.spireBridge == nil {
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-s.spireBridge.Started():
+	}
+
+	pods, err := s.storage.GetAll(ctx)
+	if err != nil {
+		s.log.Error(err, "resubscribe: failed to list stored pods")
+		return
+	}
+
+	resubscribed := 0
+	for _, pod := range pods {
+		if isIgnorablePod(pod) {
+			continue
+		}
+		log := s.log.WithValues("pod", pod.GetName(), "namespace", pod.GetNamespace())
+
+		var k8sPod corev1.Pod
+		if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: pod.GetNamespace(), Name: pod.GetName()}, &k8sPod); err != nil {
+			log.V(1).Info("resubscribe: pod not found in API server; skipping", "error", err)
+			continue
+		}
+
+		spiffeID := proxy.SpiffeIDFromPod(pod, s.trustDomain)
+		selectors := spire.PodSelectors(pod.GetNamespace(), pod.GetServiceAccount(), pod.GetName(), string(k8sPod.UID))
+		if err := s.spireBridge.SubscribePod(pod.GetNetworkNamespace(), spiffeID, selectors); err != nil {
+			log.Error(err, "resubscribe: failed to subscribe SVID", "spiffeID", spiffeID)
+			continue
+		}
+		resubscribed++
+		log.V(1).Info("resubscribed stored pod SVID", "spiffeID", spiffeID)
+	}
+
+	s.log.Info("resubscribed stored pod SVIDs", "count", resubscribed, "stored", len(pods))
+}

--- a/agent/internal/cni/server/resubscribe_test.go
+++ b/agent/internal/cni/server/resubscribe_test.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/storage"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRunResubscribeStoredPods(t *testing.T) {
+	t.Run("nil bridge returns immediately", func(t *testing.T) {
+		srv := newTestCNIServer(fake.NewClientBuilder().Build(), storage.NewMockStorage[*cniv1.CNIPod](), &testRegistry{}, cache.NewSnapshotCache("test-node", logr.Discard()), "")
+		srv.spireBridge = nil
+
+		done := make(chan struct{})
+		go func() {
+			srv.runResubscribeStoredPods(context.Background())
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("runResubscribeStoredPods did not return with a nil bridge")
+		}
+	})
+
+	t.Run("returns when context is canceled before the bridge starts", func(t *testing.T) {
+		srv := newTestCNIServer(fake.NewClientBuilder().Build(), storage.NewMockStorage[*cniv1.CNIPod](), &testRegistry{}, cache.NewSnapshotCache("test-node", logr.Discard()), "")
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		done := make(chan struct{})
+		go func() {
+			srv.runResubscribeStoredPods(ctx)
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("runResubscribeStoredPods did not return on canceled context while waiting for the bridge")
+		}
+	})
+}

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -103,6 +103,11 @@ func (s *CNIServer) PreListen(ctx context.Context) error {
 	// active health check) into the registry so it is marked unhealthy in every
 	// client's EDS while the app is not serving.
 	go s.runLivenessLoop(ctx)
+
+	// Restore SVID subscriptions for pods loaded from storage: subscriptions are
+	// otherwise created only on CNI ADD, so an agent restart would leave existing
+	// pods' workload SVIDs unsubscribed and their mTLS broken until recreation.
+	go s.runResubscribeStoredPods(ctx)
 	return nil
 }
 

--- a/agent/internal/spire/BUILD.bazel
+++ b/agent/internal/spire/BUILD.bazel
@@ -25,11 +25,13 @@ go_library(
 go_test(
     name = "spire_test",
     srcs = [
+        "bridge_test.go",
         "converter_test.go",
         "node_svid_test.go",
     ],
     embed = [":spire"],
     deps = [
+        "@com_github_go_logr_logr//:logr",
         "@com_github_spiffe_go_spiffe_v2//spiffeid",
         "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/agent/delegatedidentity/v1:delegatedidentity",

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -80,6 +80,10 @@ type Bridge struct {
 
 	// ctx is the bridge's root context, set during Start.
 	ctx context.Context
+
+	// started is closed once Start has connected to the SPIRE agent and the
+	// bridge can accept subscriptions (SubscribePod no-ops before then).
+	started chan struct{}
 }
 
 // podSubscription is an active delegated-identity subscription for one pod.
@@ -99,7 +103,16 @@ func NewBridge(socketPath string, store SecretStore, nodeSource X509SVIDSource, 
 		log:           log.WithName("spire-bridge"),
 		secrets:       make(map[string]*tlsv3.Secret),
 		subscriptions: make(map[string]podSubscription),
+		started:       make(chan struct{}),
 	}
+}
+
+// Started returns a channel that is closed once the bridge has connected to the
+// SPIRE agent and can accept subscriptions. Callers re-subscribing stored pods
+// after an agent restart wait on it (selecting on their context as well, since
+// the channel never closes if Start fails before connecting).
+func (b *Bridge) Started() <-chan struct{} {
+	return b.started
 }
 
 // NodeSpiffeID returns the SPIFFE ID of the agent's node identity once the node
@@ -129,6 +142,7 @@ func (b *Bridge) Start(ctx context.Context) error {
 	}()
 
 	b.log.Info("connected to SPIRE agent", "socket", b.socketPath)
+	close(b.started)
 
 	bundleCh, err := client.SubscribeBundles(ctx)
 	if err != nil {

--- a/agent/internal/spire/bridge_test.go
+++ b/agent/internal/spire/bridge_test.go
@@ -1,0 +1,18 @@
+package spire
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// TestBridgeStartedNotClosedBeforeStart verifies the Started channel only closes
+// once Start has connected to the SPIRE agent.
+func TestBridgeStartedNotClosedBeforeStart(t *testing.T) {
+	b := NewBridge("/nonexistent/socket", nil, nil, logr.Discard())
+	select {
+	case <-b.Started():
+		t.Fatal("Started() closed before Start was called")
+	default:
+	}
+}

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -157,7 +157,7 @@ The implementation: per-node epoch heartbeat file on shared hostPath (`--state-d
 
 **Also fixed en route:** the e2e mesh path itself. There is no iptables interception — apps reach the mesh via the outbound listener (`127.0.0.1:18081` + `Host: <service>`); the earlier direct-pod-IP curls were bypassing the proxy entirely.
 
-**Known issue found (pre-existing, agent):** `SubscribePod` (workload SVID subscription) fires only on CNI ADD. After an **agent** restart, listeners are rebuilt from storage but SVIDs are never re-subscribed → existing pods' mTLS breaks ("Secret is not supplied by SDS") until the workload pods are recreated. Needs a re-subscribe-from-storage path in the agent. Unrelated to hot restart.
+**Known issue found (pre-existing, agent) — FIXED:** `SubscribePod` (workload SVID subscription) fired only on CNI ADD. After an **agent** restart, listeners were rebuilt from storage but SVIDs were never re-subscribed → existing pods' mTLS broke ("Secret is not supplied by SDS") until the workload pods were recreated. Fixed by re-subscribing stored pods on agent startup (bridge `Started()` signal + `runResubscribeStoredPods` in the CNI server); validated on talos-main (agent roll → warming NONE, mesh 200 without workload recreation). Unrelated to hot restart.
 
 ## Risks / Open Questions
 


### PR DESCRIPTION
## Summary

Fixes the pre-existing bug found during the hot-restart e2e (#106): **SVID subscriptions were created only on CNI ADD**, so an agent restart rebuilt listeners from local storage but left existing pods' workload SVIDs unsubscribed. Envoy kept those secrets in *warming* forever and the pods' mTLS broke (`Secret is not supplied by SDS`) until the workloads were recreated. Every agent roll (e.g. any helm image bump) silently broke the data plane for existing pods.

## Fix

- **`spire.Bridge.Started()`** — channel closed once the bridge has connected to the SPIRE agent and can accept subscriptions (`SubscribePod` no-ops before then).
- **`CNIServer.runResubscribeStoredPods`** (spawned from `PreListen`, alongside the liveness loop) — waits for the bridge, lists stored pods, re-fetches each pod's UID from the API server (needed for the `k8s:pod-uid` selector; not persisted in storage), and re-subscribes. Idempotent with concurrent CNI ADDs (`SubscribePod` no-ops on an already-subscribed netns); pods deleted while the agent was down fail the UID lookup and are skipped (their CNI DEL cleans up).

## Validation (talos-main, rev 47)

Deployed the fix — the deploy itself is the regression scenario (agent DS rolls with existing `aether-test` workloads):

- agent log: `resubscribed stored pod SVIDs count=2 stored=2` (client + echo SPIFFE IDs)
- agent snapshot: `secrets: 4` (previously stuck at 2 after restart)
- proxy `config_dump`: warming **NONE**; `sa/client`, `sa/echo` active
- mesh request client→echo: **200 with XFCC, without recreating any workload** (previously failed with the SDS error)

## Test plan
- `bazel test //agent/internal/cni/server/... //agent/internal/spire/...` ✅ (new: nil-bridge + canceled-ctx resubscribe tests, bridge `Started()` gating test)
- talos-main end-to-end validation above ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)