### PR TITLE
fix(agent): serialize snapshot generation (R1); merge localWorkloads on load (R3)

### DIFF
--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "cluster_test.go",
         "listener_test.go",
         "outbound_mtls_test.go",
+        "races_test.go",
         "snapshot_test.go",
         "version_test.go",
     ],

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -54,6 +54,13 @@ type SnapshotCache struct {
 	secretMu sync.RWMutex
 	secrets  map[string]*tlsv3.Secret // keyed by secret name (SPIFFE ID or trust domain)
 
+	// snapshotMu serializes generateSnapshot (version generation + map reads +
+	// SetSnapshot) across concurrent mutators. Without it, two callers can
+	// interleave so the snapshot with the OLDER version (and older content) is
+	// set last — Envoy sees a version change and applies the stale config,
+	// silently dropping the newer mutation until the next snapshot trigger.
+	snapshotMu sync.Mutex
+
 	localMu sync.RWMutex
 	// localWorkloads maps a local pod's network namespace to its SPIFFE ID. It
 	// drives the outbound clusters' transport-socket matcher so each upstream

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -139,8 +139,16 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 	}
 	c.listenerMu.Unlock()
 
+	// Merge (never replace) into localWorkloads: this load runs concurrently with
+	// the CNI server, and a wholesale replacement would wipe the netns→SPIFFE-ID
+	// mapping of a pod whose AddPod landed between the storage GetAll above and
+	// this write — silently downgrading that pod's outbound mTLS to the node
+	// certificate (the matcher's no-match path). At startup the map is empty, so
+	// merge and replace are otherwise equivalent.
 	c.localMu.Lock()
-	c.localWorkloads = local
+	for netns, id := range local {
+		c.localWorkloads[netns] = id
+	}
 	c.trustDomain = trustDomain
 	c.localMu.Unlock()
 

--- a/agent/internal/xds/cache/races_test.go
+++ b/agent/internal/xds/cache/races_test.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/storage"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConcurrentMutationsFinalSnapshotComplete is the R1 regression test
+// (docs/proposals/002): generateSnapshot serializes version generation, map reads
+// and SetSnapshot, so whichever caller publishes last has read the final map
+// state — the resulting snapshot must contain every concurrently added pod's
+// listeners. Without the serialization, a snapshot built from a stale read can
+// land last and silently drop newer mutations. Run under -race this also guards
+// the map-access discipline.
+func TestConcurrentMutationsFinalSnapshotComplete(t *testing.T) {
+	const pods = 50
+	c := newTestCache("node-1")
+
+	var wg sync.WaitGroup
+	for i := 0; i < pods; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			pod := makeCNIPod(fmt.Sprintf("pod-%d", i), "default", fmt.Sprintf("/proc/%d/ns/net", 1000+i))
+			pod.Ips = []string{fmt.Sprintf("10.0.0.%d", i+1)}
+			require.NoError(t, c.AddPod(context.Background(), pod, "example.org"))
+		}(i)
+	}
+	wg.Wait()
+
+	snap, err := c.GetSnapshot("node-1")
+	require.NoError(t, err)
+	listeners := snap.GetResources(resourcev3.ListenerType)
+	// Two listeners (inbound + outbound) per pod; a lost update would leave fewer.
+	assert.Len(t, listeners, 2*pods, "final snapshot must reflect every concurrent AddPod")
+}
+
+// TestLoadListenersFromStorageMergesLocalWorkloads is the R3 regression test
+// (docs/proposals/002): the startup storage load must merge into localWorkloads,
+// not replace it — a pod whose AddPod landed between the storage read and the
+// write would otherwise lose its netns→SPIFFE-ID mapping and present the node
+// certificate instead of its own SVID on outbound mTLS.
+func TestLoadListenersFromStorageMergesLocalWorkloads(t *testing.T) {
+	c := newTestCache("node-1")
+
+	// A pod added via CNI ADD that is not (yet) visible in the storage snapshot.
+	racer := makeCNIPod("racer", "default", "/proc/999/ns/net")
+	racer.Ips = []string{"10.0.0.99"}
+	require.NoError(t, c.AddPod(context.Background(), racer, "example.org"))
+
+	// The storage load sees only a different pod.
+	stored := makeCNIPod("stored", "default", "/proc/100/ns/net")
+	stored.Ips = []string{"10.0.0.1"}
+	store := storage.NewMockStorageWithGetAll[*cniv1.CNIPod](func(_ context.Context) ([]*cniv1.CNIPod, error) {
+		return []*cniv1.CNIPod{stored}, nil
+	})
+	require.NoError(t, c.LoadListenersFromStorage(context.Background(), store, "example.org"))
+
+	c.localMu.RLock()
+	defer c.localMu.RUnlock()
+	assert.Contains(t, c.localWorkloads, "/proc/999/ns/net", "concurrently added pod's workload mapping must survive the storage load")
+	assert.Contains(t, c.localWorkloads, "/proc/100/ns/net", "stored pod's workload mapping must be present")
+}

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -22,7 +22,16 @@ const snapshotVersionLabel = "snapshot"
 // resource type (e.g. only listeners) drops every other type from Envoy — which
 // makes listener, cluster and secret updates clobber one another. Resources are
 // read from the in-memory maps (nothing is rebuilt), so a full snapshot is cheap.
+//
+// snapshotMu serializes the whole version-generate + read + SetSnapshot sequence:
+// concurrent callers would otherwise interleave so the snapshot carrying the
+// older version (and older content) lands last, replacing newer config in Envoy
+// until the next trigger. Serialization also guarantees the last snapshot set
+// always reflects the final state of every map.
 func (c *SnapshotCache) generateSnapshot(ctx context.Context) error {
+	c.snapshotMu.Lock()
+	defer c.snapshotMu.Unlock()
+
 	v := generateSnapshotVersion(snapshotVersionLabel, c.version)
 
 	listeners := c.Listeners()


### PR DESCRIPTION
## Summary

Implements the two xDS-cache findings from the concurrency audit (`docs/proposals/002`, #108):

- **R1 (HIGH) — snapshot lost-update:** `generateSnapshot` is called concurrently from CNI add/remove, the registry refresher, SPIRE rotations, and `SetNodeIdentity`. The version-generate + map-read + `SetSnapshot` sequence wasn't serialized, so a snapshot built from a stale read could land *after* a newer one — Envoy sees a version change and applies the stale config (resurrected listener, missing rotated SVID) until the next trigger. A `snapshotMu` now serializes the sequence: version order == content order, and the last snapshot always reflects final map state.
- **R3 (MEDIUM) — `localWorkloads` wipe:** `LoadListenersFromStorage` (xDS PreListen) wholesale-replaced `localWorkloads` while the CNI server may be concurrently adding pods; a pod added between the storage read and the write lost its netns→SPIFFE-ID mapping and presented the **node** certificate instead of its SVID on outbound mTLS. Now merges.

## Tests

- `TestConcurrentMutationsFinalSnapshotComplete` — 50 concurrent `AddPod`s; final snapshot must contain all 100 listeners (R1 regression; also exercises map discipline under `-race`).
- `TestLoadListenersFromStorageMergesLocalWorkloads` — AddPod for a pod absent from storage, then the storage load; both mappings must survive (R3 regression).
- `bazel test //agent/internal/xds/cache:cache_test` ✅ (also with `--@rules_go//go/config:race` ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)