### PR TITLE
fix(agent): remaining concurrency-audit findings (R2, R4–R8)

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "liveness_test.go",
         "pod_test.go",
         "resubscribe_test.go",
         "server_integration_test.go",

--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"github.com/bpalermo/aether/agent/types"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/registry"
 )
@@ -81,7 +82,22 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, last map[string]regis
 			continue
 		}
 		endpoint.Health = want
-		if err := s.registry.RegisterEndpoint(ctx, serviceName, protocol, endpoint); err != nil {
+
+		// Re-check the pod still exists in storage under lifecycleMu before
+		// re-registering: the pods slice is a snapshot from the start of this
+		// tick, and a concurrent RemovePod (which holds lifecycleMu across
+		// unregister + storage delete) may have removed the pod — re-registering
+		// then would resurrect a deleted endpoint in the registry permanently.
+		s.lifecycleMu.Lock()
+		if _, getErr := s.storage.GetResource(ctx, types.ContainerID(pod.GetContainerId())); getErr != nil {
+			s.lifecycleMu.Unlock()
+			delete(last, key)
+			s.log.V(1).Info("liveness: pod no longer in storage; skipping health update", "pod", pod.GetName())
+			continue
+		}
+		err = s.registry.RegisterEndpoint(ctx, serviceName, protocol, endpoint)
+		s.lifecycleMu.Unlock()
+		if err != nil {
 			s.log.Error(err, "liveness: failed to re-register endpoint health", "pod", pod.GetName())
 			continue
 		}

--- a/agent/internal/cni/server/liveness_test.go
+++ b/agent/internal/cni/server/liveness_test.go
@@ -1,0 +1,82 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/storage"
+	"github.com/bpalermo/aether/agent/types"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingRegistry counts RegisterEndpoint calls on top of testRegistry.
+type recordingRegistry struct {
+	testRegistry
+	registered int
+}
+
+func (r *recordingRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, _ *registryv1.ServiceEndpoint) error {
+	r.registered++
+	return nil
+}
+
+// fakeClustersAdmin serves an Envoy /clusters dump where the given health-probe
+// cluster fails its active health check (an UNHEALTHY transition for liveness).
+func fakeClustersAdmin(t *testing.T, probeCluster string) *httptest.Server {
+	t.Helper()
+	body := `{"cluster_statuses":[{"name":"` + probeCluster + `","host_statuses":[{"health_status":{"failed_active_health_check":true}}]}]}`
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestReconcileLivenessSkipsRemovedPod is the R4 regression test
+// (docs/proposals/002): a pod observed in the tick's GetAll snapshot but removed
+// from storage before the health re-registration (a concurrent RemovePod) must
+// NOT be re-registered — doing so would resurrect a deleted endpoint in the
+// registry permanently.
+func TestReconcileLivenessSkipsRemovedPod(t *testing.T) {
+	pod := validCNIPod("pod-a", "default", "container-a")
+
+	srv := fakeClustersAdmin(t, "health_pod-a")
+	defer srv.Close()
+
+	t.Run("pod gone from storage -> no re-register", func(t *testing.T) {
+		// GetAll returns the pod (the tick's snapshot), but the backing resources
+		// map is empty, so the GetResource re-check fails — the removal landed
+		// in between.
+		store := storage.NewMockStorageWithGetAll[*cniv1.CNIPod](func(_ context.Context) ([]*cniv1.CNIPod, error) {
+			return []*cniv1.CNIPod{pod}, nil
+		})
+		reg := &recordingRegistry{}
+		srvr := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), srv.Listener.Addr().String())
+
+		last := make(map[string]registryv1.ServiceEndpoint_Health)
+		srvr.reconcileLiveness(context.Background(), last)
+
+		assert.Zero(t, reg.registered, "deleted pod's endpoint must not be re-registered")
+		assert.NotContains(t, last, pod.GetContainerId())
+	})
+
+	t.Run("pod present in storage -> health transition re-registers", func(t *testing.T) {
+		store := storage.NewMockStorageWithGetAll[*cniv1.CNIPod](func(_ context.Context) ([]*cniv1.CNIPod, error) {
+			return []*cniv1.CNIPod{pod}, nil
+		})
+		require.NoError(t, store.AddResource(context.Background(), types.ContainerID(pod.GetContainerId()), pod))
+		reg := &recordingRegistry{}
+		srvr := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), srv.Listener.Addr().String())
+
+		last := make(map[string]registryv1.ServiceEndpoint_Health)
+		srvr.reconcileLiveness(context.Background(), last)
+
+		assert.Equal(t, 1, reg.registered, "healthy->unhealthy transition must re-register")
+		assert.Equal(t, registryv1.ServiceEndpoint_HEALTH_UNHEALTHY, last[pod.GetContainerId()])
+	})
+}

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -115,8 +115,15 @@ func (s *CNIServer) RemovePod(ctx context.Context, req *cniv1.RemovePodRequest) 
 		return &cniv1.RemovePodResponse{Result: cniv1.RemovePodResponse_RESULT_SUCCESS}, nil
 	}
 
+	// Hold lifecycleMu from unregistration through storage removal so the
+	// liveness loop cannot interleave a health re-registration of a pod whose
+	// endpoint was just unregistered (which would resurrect it in the registry
+	// permanently).
+	s.lifecycleMu.Lock()
+
 	serviceName, ips, err := registry.ExtractCNIPodInformation(storedPod)
 	if err = s.registry.UnregisterEndpoints(ctx, serviceName, ips); err != nil {
+		s.lifecycleMu.Unlock()
 		return nil, status.Errorf(codes.Internal, "failed to unregister endpoints from service: %v", err)
 	}
 
@@ -129,13 +136,16 @@ func (s *CNIServer) RemovePod(ctx context.Context, req *cniv1.RemovePodRequest) 
 
 	// Remove listener from xDS first
 	if err = s.snapshotCache.RemovePod(ctx, storedPod.GetNetworkNamespace()); err != nil {
+		s.lifecycleMu.Unlock()
 		return nil, status.Errorf(codes.Internal, "failed to remove listener: %v", err)
 	}
 
 	// Remove from the local storage
 	if err = s.storage.RemoveResource(ctx, containerID); err != nil {
+		s.lifecycleMu.Unlock()
 		return nil, status.Errorf(codes.Internal, "failed to remove pod from storage: %v", err)
 	}
+	s.lifecycleMu.Unlock()
 
 	// Best-effort: wait for Envoy to remove the listener configuration
 	adminCtx, adminCancel := context.WithTimeout(ctx, envoyAdminTimeout)

--- a/agent/internal/cni/server/resubscribe.go
+++ b/agent/internal/cni/server/resubscribe.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/spire"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"github.com/bpalermo/aether/agent/types"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -56,6 +57,18 @@ func (s *CNIServer) runResubscribeStoredPods(ctx context.Context) {
 		selectors := spire.PodSelectors(pod.GetNamespace(), pod.GetServiceAccount(), pod.GetName(), string(k8sPod.UID))
 		if err := s.spireBridge.SubscribePod(pod.GetNetworkNamespace(), spiffeID, selectors); err != nil {
 			log.Error(err, "resubscribe: failed to subscribe SVID", "spiffeID", spiffeID)
+			continue
+		}
+
+		// Close the remove race: if the pod's CNI DEL ran between the GetAll above
+		// and the SubscribePod (its UnsubscribePod saw nothing to remove), the
+		// subscription just created would leak for the agent's lifetime. Re-check
+		// storage and undo if the pod is gone.
+		if _, getErr := s.storage.GetResource(ctx, types.ContainerID(pod.GetContainerId())); getErr != nil {
+			log.V(1).Info("resubscribe: pod removed concurrently; unsubscribing", "spiffeID", spiffeID)
+			if unsubErr := s.spireBridge.UnsubscribePod(ctx, pod.GetNetworkNamespace()); unsubErr != nil {
+				log.Error(unsubErr, "resubscribe: failed to unsubscribe removed pod")
+			}
 			continue
 		}
 		resubscribed++

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"buf.build/go/protovalidate"
 	"github.com/bpalermo/aether/agent/internal/envoy/admin"
@@ -43,6 +44,13 @@ type CNIServer struct {
 
 	storage  storage.Storage[*cniv1.CNIPod]
 	registry registry.Registry
+
+	// lifecycleMu serializes pod removal (unregister + storage delete) against the
+	// liveness loop's health re-registrations. Without it, the 5s liveness tick can
+	// observe a pod after RemovePod unregistered its endpoint but before the pod
+	// left storage, and re-register it — a permanent ghost endpoint in the registry
+	// that nothing unregisters again.
+	lifecycleMu sync.Mutex
 
 	snapshotCache *cache.SnapshotCache
 	spireBridge   *spire.Bridge

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -86,11 +87,23 @@ func (s *Supervisor) writeState(epoch int) {
 	if s.cfg.StateDir == "" {
 		return
 	}
-	if cur, hb, ok := s.readState(); ok && epoch < cur && time.Since(hb) < predecessorStale {
-		return
-	}
 	if err := os.MkdirAll(s.cfg.StateDir, 0o755); err != nil {
 		s.log.V(1).Error(err, "creating state dir")
+		return
+	}
+
+	// flock the read-check-write: during a surge overlap the draining pod's
+	// heartbeat and the successor's first write can interleave so the file briefly
+	// regresses to the lower epoch, misleading a third starter. Best-effort — a
+	// lock failure falls back to the unlocked (pre-existing) behavior.
+	if lock, err := os.OpenFile(s.statePath()+".lock", os.O_CREATE|os.O_RDWR, 0o644); err == nil {
+		if flockErr := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); flockErr == nil {
+			defer func() { _ = syscall.Flock(int(lock.Fd()), syscall.LOCK_UN) }()
+		}
+		defer func() { _ = lock.Close() }()
+	}
+
+	if cur, hb, ok := s.readState(); ok && epoch < cur && time.Since(hb) < predecessorStale {
 		return
 	}
 	tmp := s.statePath() + ".tmp"

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -197,6 +197,17 @@ func (s *Supervisor) Run(ctx context.Context) error {
 
 		case <-debounceC:
 			debounceC = nil
+			// Defer the restart while the current epoch is still initializing:
+			// forking epoch N+1 against a not-yet-LIVE N makes Envoy exit with
+			// "previous envoy process is still initializing", which the main loop
+			// treats as a fatal newest-epoch death (container restart, brief node
+			// data-plane gap). Re-arm and retry once N is LIVE. Skipped when no
+			// admin address is configured.
+			if s.cfg.AdminAddress != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
+				s.log.V(1).Info("current epoch not yet live; deferring hot restart", "epoch", s.currentEpoch())
+				arm("deferred: current epoch not live")
+				continue
+			}
 			s.log.Info("performing hot restart")
 			if err := s.hotRestart(); err != nil {
 				s.log.Error(err, "hot restart failed; keeping current epoch")

--- a/agent/internal/proxy/hotrestart/supervisor_test.go
+++ b/agent/internal/proxy/hotrestart/supervisor_test.go
@@ -123,3 +123,50 @@ func TestSupervisorConfigChangeTriggersHotRestart(t *testing.T) {
 		t.Fatal("supervisor did not return after context cancel")
 	}
 }
+
+// TestHotRestartDeferredWhileEpochNotLive is the R7 regression test
+// (docs/proposals/002): a hot-restart trigger must be deferred while the current
+// epoch is still initializing — forking N+1 against a not-yet-LIVE N makes Envoy
+// exit fatally and restarts the container.
+func TestHotRestartDeferredWhileEpochNotLive(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available in this sandbox")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "envoy.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("v0\n"), 0o644))
+	recordPath := filepath.Join(t.TempDir(), "epochs.txt")
+
+	s := New(Config{
+		EnvoyPath:          stubEnvoy(t, recordPath),
+		ConfigPath:         configPath,
+		DrainTime:          time.Second,
+		ParentShutdownTime: time.Second,
+		WatchConfig:        true,
+		// Admin reports the current epoch as still initializing.
+		AdminAddress: fakeAdmin(t, "PRE_INITIALIZING", 0),
+	}, logr.Discard())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return len(recordedEpochs(t, recordPath)) >= 1
+	}, 5*time.Second, 50*time.Millisecond, "epoch 0 never started")
+
+	// Trigger a restart; with the epoch not LIVE it must be deferred, not forked.
+	require.NoError(t, os.WriteFile(configPath, []byte("v1\n"), 0o644))
+	require.Never(t, func() bool {
+		return len(recordedEpochs(t, recordPath)) >= 2
+	}, 2*time.Second, 100*time.Millisecond, "hot restart must be deferred while current epoch is not LIVE")
+
+	cancel()
+	select {
+	case <-runErr:
+	case <-time.After(5 * time.Second):
+		t.Fatal("supervisor did not return after cancel")
+	}
+}

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -205,7 +205,12 @@ func PodSelectors(namespace, serviceAccount, podName, uid string) []*apitypes.Se
 // if the bridge has not been started yet or the netns is already subscribed. The
 // subscription is bound to the bridge's lifetime, not any request context.
 func (b *Bridge) SubscribePod(netns, spiffeID string, selectors []*apitypes.Selector) error {
-	if b.client == nil {
+	// Gate on the started channel rather than a bare b.client nil-check: the
+	// close(b.started) in Start happens-after the client/ctx assignments, so this
+	// select also synchronizes their reads (a plain nil-check is a data race).
+	select {
+	case <-b.started:
+	default:
 		b.log.V(1).Info("bridge not started, skipping SVID subscription", "spiffeID", spiffeID)
 		return nil
 	}
@@ -261,7 +266,10 @@ func (b *Bridge) SubscribePod(netns, spiffeID string, selectors []*apitypes.Sele
 // runs two same-identity pods never drops the live SVID. No-op if the bridge has
 // not been started or the netns is not subscribed.
 func (b *Bridge) UnsubscribePod(ctx context.Context, netns string) error {
-	if b.client == nil {
+	// See SubscribePod: the started gate synchronizes client/ctx reads.
+	select {
+	case <-b.started:
+	default:
 		return nil
 	}
 

--- a/agent/internal/spire/bridge_test.go
+++ b/agent/internal/spire/bridge_test.go
@@ -16,3 +16,17 @@ func TestBridgeStartedNotClosedBeforeStart(t *testing.T) {
 	default:
 	}
 }
+
+// TestSubscribePodNoopBeforeStart verifies SubscribePod is a synchronized no-op
+// before Start has connected (the started-channel gate, not a racy nil-check).
+func TestSubscribePodNoopBeforeStart(t *testing.T) {
+	b := NewBridge("/nonexistent/socket", nil, nil, logr.Discard())
+	if err := b.SubscribePod("/proc/1/ns/net", "spiffe://example.org/x", nil); err != nil {
+		t.Fatalf("SubscribePod before Start must be a no-op, got: %v", err)
+	}
+	b.subsMu.Lock()
+	defer b.subsMu.Unlock()
+	if len(b.subscriptions) != 0 {
+		t.Fatalf("no subscription must be recorded before Start, got %d", len(b.subscriptions))
+	}
+}

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     name = "cache_test",
     srcs = [
         "cache_test.go",
+        "cluster_alias_test.go",
         "cluster_test.go",
         "listener_test.go",
         "outbound_mtls_test.go",

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -34,12 +34,16 @@ func (c *SnapshotCache) RemoveEndpoint(ctx context.Context, clusterName string, 
 
 	delete(entry.endpoints, ip)
 
-	// Rebuild the load assignment endpoints slice from the map.
-	endpoints := make([]*endpointv3.LocalityLbEndpoints, 0, len(entry.endpoints))
+	// Build a NEW load assignment rather than mutating the existing one in place:
+	// the current proto is aliased into snapshots already set on go-control-plane,
+	// which xDS server goroutines marshal without holding clusterMu — an in-place
+	// mutation is a data race (torn marshal). The LocalityLbEndpoints values are
+	// never mutated after creation, so sharing them between assignments is safe.
+	cla := proxy.NewClusterLoadAssignment(clusterName)
 	for _, ep := range entry.endpoints {
-		endpoints = append(endpoints, ep)
+		cla.Endpoints = append(cla.Endpoints, ep)
 	}
-	entry.loadAssignment.Endpoints = endpoints
+	entry.loadAssignment = cla
 
 	c.clusters[clusterName] = entry
 	c.clusterMu.Unlock()

--- a/agent/internal/xds/cache/cluster_alias_test.go
+++ b/agent/internal/xds/cache/cluster_alias_test.go
@@ -1,0 +1,47 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveEndpointDoesNotMutateAliasedLoadAssignment is the R2 regression test
+// (docs/proposals/002): load assignments handed to previous snapshots are
+// marshaled by xDS server goroutines without holding clusterMu, so RemoveEndpoint
+// must build a new load assignment rather than mutating the aliased one in place.
+func TestRemoveEndpointDoesNotMutateAliasedLoadAssignment(t *testing.T) {
+	c := newTestCache("node-1")
+
+	ep1 := &endpointv3.LocalityLbEndpoints{}
+	ep2 := &endpointv3.LocalityLbEndpoints{}
+	c.clusters["svc"] = clusterEntry{
+		cluster: &clusterv3.Cluster{Name: "svc"},
+		loadAssignment: &endpointv3.ClusterLoadAssignment{
+			ClusterName: "svc",
+			Endpoints:   []*endpointv3.LocalityLbEndpoints{ep1, ep2},
+		},
+		endpoints: map[string]*endpointv3.LocalityLbEndpoints{
+			"10.0.0.1": ep1,
+			"10.0.0.2": ep2,
+		},
+	}
+
+	// Simulate a previously published snapshot holding the current proto.
+	aliased, ok := c.Endpoints("svc")[0].(*endpointv3.ClusterLoadAssignment)
+	require.True(t, ok)
+	require.Len(t, aliased.Endpoints, 2)
+
+	require.NoError(t, c.RemoveEndpoint(context.Background(), "svc", "10.0.0.1"))
+
+	assert.Len(t, aliased.Endpoints, 2, "load assignment aliased into a prior snapshot must not be mutated")
+
+	current, ok := c.Endpoints("svc")[0].(*endpointv3.ClusterLoadAssignment)
+	require.True(t, ok)
+	assert.Len(t, current.Endpoints, 1, "current load assignment must reflect the removal")
+	assert.NotSame(t, aliased, current, "removal must produce a new load assignment")
+}


### PR DESCRIPTION
## Summary

Implements the rest of the concurrency audit (`docs/proposals/002`, #108); complements #109 (R1+R3).

| # | Fix |
|---|-----|
| **R2** (HIGH, data race) | `RemoveEndpoint` now builds a **new** load assignment instead of mutating the proto aliased into already-set snapshots (xDS goroutines marshal those without `clusterMu`). `LocalityLbEndpoints` values are immutable post-creation, so sharing them across assignments is safe. |
| **R4** (MEDIUM) | New `lifecycleMu` serializes `RemovePod` (unregister → storage delete) against the liveness loop, which now re-checks storage under the lock before re-registering — a deleted pod's endpoint can no longer be resurrected in the registry. |
| **R5** (LOW) | `SubscribePod`/`UnsubscribePod` gate on the `started` channel (whose close happens-after the `client`/`ctx` assignments) instead of a racy nil-check. |
| **R6** (LOW) | The SVID resubscriber re-checks storage after subscribing and undoes the subscription if the pod's CNI DEL ran in between (was a lifetime leak). |
| **R7** (LOW) | The supervisor defers hot-restart triggers while the current epoch is not admin-LIVE (forking against an initializing epoch is a fatal Envoy exit → container restart). Debounce re-arms until LIVE; skipped when no admin address is configured. |
| **R8** (LOW) | Best-effort `flock` around the epoch state-file read-check-write (brief epoch regression during surge overlap). |

## Tests

- `TestRemoveEndpointDoesNotMutateAliasedLoadAssignment` (R2)
- `TestReconcileLivenessSkipsRemovedPod` — both the removed-pod skip and the healthy→unhealthy re-register path (R4)
- `TestSubscribePodNoopBeforeStart` (R5)
- `TestHotRestartDeferredWhileEpochNotLive` (R7)
- All affected packages pass, including with `--@rules_go//go/config:race` ✅

## Note

R7 touches the supervisor's restart path; recommend the usual talos re-pin + a surge-roll sanity check after merge (happy to run it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)