### PR TITLE
fix(proxy-supervisor): re-probe a fresh predecessor instead of grabbing epoch 0

### DIFF
--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -35,26 +35,49 @@ const (
 	stateFileName     = "epoch"
 )
 
+// initProbeInterval is the delay between admin re-probes in initStartEpoch while
+// the heartbeat file is fresh but the admin has not yet confirmed the predecessor.
+const initProbeInterval = 500 * time.Millisecond
+
 // initStartEpoch decides the restart epoch for the first Envoy this supervisor
 // launches. With cross-pod coordination (StateDir set), it starts at E+1 only when
 // the heartbeat file names epoch E AND the node's Envoy admin actually reports E
-// LIVE — admin is ground truth, so a crashed/initializing predecessor (stale or
-// absent on admin) correctly resets to epoch 0 instead of attaching to a dead
-// parent and climbing epochs. Without StateDir (Strategy A) this is a no-op.
+// LIVE — admin is ground truth, so a crashed predecessor (stale heartbeat, dead on
+// admin) correctly resets to epoch 0 instead of attaching to a dead parent.
+//
+// The two signals must AGREE before a decision is made: the heartbeat is
+// LIVE-gated by construction, so a fresh heartbeat means the predecessor was
+// serving within the stale window — a single failed admin probe (transient
+// timeout under node load) must not send us to epoch 0, which bind-collides with
+// the live predecessor on the base-id domain socket (errno 98) and crash-loops.
+// While the file is fresh but admin unconfirmed, re-probe; the wait is bounded by
+// the heartbeat going stale. Without StateDir (Strategy A) this is a no-op.
 func (s *Supervisor) initStartEpoch(ctx context.Context) {
 	if s.cfg.StateDir == "" {
 		return
 	}
-	epoch, hb, ok := s.readState()
-	if ok && time.Since(hb) < predecessorStale && s.adminLiveAtEpoch(ctx, epoch) {
-		s.mu.Lock()
-		s.nextEpoch = epoch + 1
-		s.mu.Unlock()
-		s.log.Info("live predecessor confirmed; starting cross-pod hot restart",
-			"predecessorEpoch", epoch, "startEpoch", epoch+1, "heartbeatAge", time.Since(hb).Round(time.Millisecond).String())
-		return
+	for {
+		epoch, hb, ok := s.readState()
+		if !ok || time.Since(hb) >= predecessorStale {
+			s.log.Info("no live predecessor; starting fresh at epoch 0", "statePresent", ok)
+			return
+		}
+		if s.adminLiveAtEpoch(ctx, epoch) {
+			s.mu.Lock()
+			s.nextEpoch = epoch + 1
+			s.mu.Unlock()
+			s.log.Info("live predecessor confirmed; starting cross-pod hot restart",
+				"predecessorEpoch", epoch, "startEpoch", epoch+1, "heartbeatAge", time.Since(hb).Round(time.Millisecond).String())
+			return
+		}
+		s.log.V(1).Info("fresh heartbeat but admin not confirming predecessor; re-probing",
+			"epoch", epoch, "heartbeatAge", time.Since(hb).Round(time.Millisecond).String())
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(initProbeInterval):
+		}
 	}
-	s.log.Info("no live predecessor; starting fresh at epoch 0", "statePresent", ok)
 }
 
 func (s *Supervisor) statePath() string { return filepath.Join(s.cfg.StateDir, stateFileName) }

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -78,12 +79,32 @@ func TestInitStartEpoch(t *testing.T) {
 		s.initStartEpoch(ctx)
 		assert.Equal(t, 4, s.nextEpoch)
 	})
-	t.Run("fresh file but admin NOT live (dead predecessor) -> epoch 0", func(t *testing.T) {
+	t.Run("near-stale file and admin NOT live -> re-probes until stale, then epoch 0", func(t *testing.T) {
 		s := newCoordSupervisor(t)
 		s.cfg.AdminAddress = fakeAdmin(t, "PRE_INITIALIZING", 3)
-		writeRawState(t, s, 3, 0)
+		// Heartbeat about to go stale: the loop re-probes (fresh file must not be
+		// trusted to be dead on one failed probe) and exits to epoch 0 once stale.
+		writeRawState(t, s, 3, predecessorStale-200*time.Millisecond)
 		s.initStartEpoch(ctx)
 		assert.Equal(t, 0, s.nextEpoch)
+	})
+
+	t.Run("fresh file with transiently failing admin -> retries then epoch+1", func(t *testing.T) {
+		s := newCoordSupervisor(t)
+		// Admin fails the first two probes, then confirms LIVE at epoch 3.
+		var calls atomic.Int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if calls.Add(1) <= 2 {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			fmt.Fprintf(w, `{"state":"LIVE","command_line_options":{"restart_epoch":3}}`)
+		}))
+		t.Cleanup(srv.Close)
+		s.cfg.AdminAddress = srv.Listener.Addr().String()
+		writeRawState(t, s, 3, 0)
+		s.initStartEpoch(ctx)
+		assert.Equal(t, 4, s.nextEpoch, "transient admin failures must not abandon a fresh predecessor")
 	})
 	t.Run("stale predecessor -> epoch 0", func(t *testing.T) {
 		s := newCoordSupervisor(t)


### PR DESCRIPTION
## Summary

Found during the post-merge (rev-49) re-pin on talos-main, which rolled the **agent and proxy DaemonSets simultaneously**: under that load, a single 1s admin probe in `initStartEpoch` failed transiently, the new pod concluded "no live predecessor" and started at **epoch 0** — colliding with the live predecessor on the base-id hot-restart domain socket (`errno=98`) and crash-looping (`restartCount: 4` on one node) until the predecessor exited. Self-healing, but a crash-loop where a short wait should be.

## Fix

The heartbeat file is **LIVE-gated by construction** (written only while the writer's Envoy is admin-LIVE), so a fresh heartbeat is strong evidence the predecessor is alive. `initStartEpoch` now requires the two signals to **agree**: while the file is fresh but admin unconfirmed it re-probes (500ms interval), resolving to epoch+1 when admin confirms or to epoch 0 once the heartbeat goes stale (≤8s bound). One transient probe failure can no longer trigger the epoch-0 collision.

## Validation

- Updated/added unit tests: near-stale + dead admin → re-probes then epoch 0; fresh file + transiently failing admin (2 failures then LIVE) → epoch+1.
- talos: deployed and exercised with a simultaneous agent+proxy roll + traffic (results in PR thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)