### PR TITLE
fix: hot-restart wedge watchdogs + netns pinning (e2e findings 1 & 2)

### DIFF
--- a/agent/internal/cmd/supervisor.go
+++ b/agent/internal/cmd/supervisor.go
@@ -90,6 +90,8 @@ func init() {
 	f.StringVar(&supervisorCfg.ReadyMarkerPath, "ready-marker", "", "Pod-local path for the readiness marker maintained while Envoy is live at the newest epoch")
 	f.StringVar(&supervisorCfg.AdminAddress, "admin-address", "127.0.0.1:9901", "Envoy admin host:port used for the readiness check")
 	f.BoolVar(&supervisorReadinessCheck, "readiness-check", false, "Exit 0 iff the --ready-marker file exists (exec readiness probe mode)")
+	f.DurationVar(&supervisorCfg.HandoffDeadline, "handoff-deadline", 0, "Watchdog: max time a hot-restart epoch may stay not-LIVE after launch before the supervisor exits non-zero (0 = 2m default)")
+	f.DurationVar(&supervisorCfg.AdminUnresponsiveDeadline, "admin-unresponsive-deadline", 0, "Watchdog: max time the Envoy admin may be unreachable (once previously LIVE) before the supervisor exits non-zero (0 = 30s default)")
 
 	rootCmd.AddCommand(proxySupervisorCmd)
 }

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -146,6 +146,20 @@ func (s *Supervisor) writeState(epoch int) {
 // file ONLY while LIVE — a launched-but-not-yet-LIVE (or failed) epoch is never
 // recorded, so a crash-restart re-reads the still-current predecessor epoch and
 // retries N+1 rather than climbing N+1, N+2, … against dead parents.
+// It also hosts the two wedge watchdogs (see docs/proposals/001, e2e findings
+// 2026-06-10): Envoy's hot-restart RPCs are blocking recvmsg on a datagram
+// socket with no timeout, so a parent dying between request and reply leaves
+// the successor's main thread blocked forever — child process alive and
+// workers serving, but admin never accepting and LIVE never reached. Nothing
+// inside Envoy recovers from that; the supervisor must diagnose it and exit
+// non-zero so Kubernetes recreates the pod.
+//
+//   - handoff watchdog: a hot-restart epoch (N>0) still not LIVE
+//     HandoffDeadline after launch, child still alive → wedged pre-LIVE.
+//   - admin watchdog: admin unreachable (connect/timeout, NOT "answers with a
+//     different epoch", which is the normal mid-handoff state) for
+//     AdminUnresponsiveDeadline once some epoch has been LIVE → wedged
+//     post-LIVE (parent died mid stats-merge).
 func (s *Supervisor) watchLiveness(ctx context.Context) {
 	if s.cfg.ReadyMarkerPath == "" && s.cfg.StateDir == "" {
 		return
@@ -154,6 +168,8 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 	t := time.NewTicker(readyPollInterval)
 	defer t.Stop()
 	ready := false
+	everLive := false
+	var unreachableSince time.Time
 	for {
 		select {
 		case <-ctx.Done():
@@ -162,7 +178,15 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			return
 		case <-t.C:
 			epoch := s.currentEpoch()
-			if s.adminLiveAtEpoch(ctx, epoch) {
+			live, reachable := s.adminProbe(ctx, epoch)
+			if reachable {
+				unreachableSince = time.Time{}
+			} else if unreachableSince.IsZero() {
+				unreachableSince = time.Now()
+			}
+			if live {
+				everLive = true
+				s.markEpochLive()
 				s.writeState(epoch) // LIVE-gated heartbeat
 				// Hold readiness until the cross-pod handoff is fully complete (the
 				// predecessor has been terminated by this Envoy's parent-shutdown), so
@@ -172,10 +196,26 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 					ready = true
 					s.log.Info("pod ready: envoy live at newest epoch", "epoch", epoch)
 				}
-			} else if ready {
+				continue
+			}
+			if ready {
 				s.clearReady()
 				ready = false
 				s.log.Info("pod not ready: envoy not live at newest epoch", "epoch", epoch)
+			}
+
+			launched, wasLive := s.epochProgress()
+			if epoch > 0 && !wasLive && s.childTracked(epoch) && time.Since(launched) > s.handoffDeadline() {
+				s.fireWatchdog(fmt.Errorf(
+					"hot-restart handoff watchdog: epoch %d not LIVE within %s of launch (parent likely died mid-handoff)",
+					epoch, s.handoffDeadline()))
+				return
+			}
+			if everLive && !reachable && s.childTracked(epoch) && time.Since(unreachableSince) > s.adminUnresponsiveDeadline() {
+				s.fireWatchdog(fmt.Errorf(
+					"admin watchdog: envoy admin %s unresponsive for %s with child alive at epoch %d",
+					s.cfg.AdminAddress, s.adminUnresponsiveDeadline(), epoch))
+				return
 			}
 		}
 	}
@@ -193,15 +233,24 @@ func (s *Supervisor) clearReady() { _ = os.Remove(s.cfg.ReadyMarkerPath) }
 // reports state LIVE at the given restart epoch. During a cross-pod handoff the
 // predecessor answers admin at the old epoch until the new Envoy takes over.
 func (s *Supervisor) adminLiveAtEpoch(ctx context.Context, epoch int) bool {
+	live, _ := s.adminProbe(ctx, epoch)
+	return live
+}
+
+// adminProbe distinguishes "admin answered but is not LIVE at epoch" (reachable,
+// the normal mid-handoff state) from "admin did not answer at all" (connect
+// failure or timeout — a wedged main thread leaves the admin socket bound but
+// never accepting, so requests time out). The admin watchdog keys off reachable.
+func (s *Supervisor) adminProbe(ctx context.Context, epoch int) (live, reachable bool) {
 	ctx, cancel := context.WithTimeout(ctx, readyPollInterval)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+s.cfg.AdminAddress+"/server_info", nil)
 	if err != nil {
-		return false
+		return false, false
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return false
+		return false, false
 	}
 	defer func() { _ = resp.Body.Close() }()
 	var info struct {
@@ -211,7 +260,7 @@ func (s *Supervisor) adminLiveAtEpoch(ctx context.Context, epoch int) bool {
 		} `json:"command_line_options"`
 	}
 	if json.NewDecoder(resp.Body).Decode(&info) != nil {
-		return false
+		return false, true
 	}
-	return info.State == "LIVE" && info.CommandLineOptions.RestartEpoch == epoch
+	return info.State == "LIVE" && info.CommandLineOptions.RestartEpoch == epoch, true
 }

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -137,3 +137,98 @@ func TestReadyMarker(t *testing.T) {
 	_, err = os.Stat(s.cfg.ReadyMarkerPath)
 	assert.True(t, os.IsNotExist(err))
 }
+
+// TestHandoffWatchdogFiresWhenSuccessorNeverLive reproduces the 2026-06-10 e2e
+// wedge: a cross-pod successor starts at epoch N+1 against a confirmed-live
+// predecessor, the predecessor then dies mid hot-restart RPC, and the successor's
+// main thread blocks forever — admin keeps answering with the old epoch (here: a
+// static fake), LIVE at the new epoch never arrives. The handoff watchdog must
+// bail out of Run with a non-nil error so the container restarts.
+func TestHandoffWatchdogFiresWhenSuccessorNeverLive(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available in this sandbox")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "envoy.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("v0\n"), 0o644))
+	recordPath := filepath.Join(t.TempDir(), "epochs.txt")
+
+	s := New(Config{
+		EnvoyPath:          stubEnvoy(t, recordPath),
+		ConfigPath:         configPath,
+		DrainTime:          time.Second,
+		ParentShutdownTime: time.Second,
+		StateDir:           t.TempDir(),
+		ReadyMarkerPath:    filepath.Join(t.TempDir(), "ready"),
+		// The "predecessor": admin permanently LIVE at epoch 0, so initStartEpoch
+		// selects epoch 1 — which then never reaches LIVE (the wedge).
+		AdminAddress:    fakeAdmin(t, "LIVE", 0),
+		HandoffDeadline: 1 * time.Second,
+	}, logr.Discard())
+	writeRawState(t, s, 0, 0)
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(context.Background()) }()
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "handoff watchdog")
+	case <-time.After(15 * time.Second):
+		t.Fatal("handoff watchdog did not fire")
+	}
+	// It must have attempted the cross-pod successor epoch, not a fresh epoch 0.
+	assert.Equal(t, []string{"1"}, recordedEpochs(t, recordPath))
+}
+
+// TestAdminWatchdogFiresWhenAdminUnreachableAfterLive covers the post-LIVE
+// variant of the wedge: Envoy reached LIVE (pod Ready), then the admin endpoint
+// stops answering entirely (main thread blocked in a hot-restart stats-merge
+// against a dead parent) while the child process stays alive. The admin watchdog
+// must bail out of Run with a non-nil error.
+func TestAdminWatchdogFiresWhenAdminUnreachableAfterLive(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available in this sandbox")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "envoy.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("v0\n"), 0o644))
+	recordPath := filepath.Join(t.TempDir(), "epochs.txt")
+	marker := filepath.Join(t.TempDir(), "ready")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, `{"state":"LIVE","command_line_options":{"restart_epoch":0}}`)
+	}))
+	defer srv.Close()
+
+	s := New(Config{
+		EnvoyPath:                 stubEnvoy(t, recordPath),
+		ConfigPath:                configPath,
+		DrainTime:                 time.Second,
+		ParentShutdownTime:        time.Second,
+		StateDir:                  t.TempDir(),
+		ReadyMarkerPath:           marker,
+		AdminAddress:              srv.Listener.Addr().String(),
+		AdminUnresponsiveDeadline: 1 * time.Second,
+	}, logr.Discard())
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(context.Background()) }()
+
+	// Wait for LIVE to be observed (ready marker present), then kill the admin.
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, 10*time.Second, 50*time.Millisecond, "pod never became ready")
+	srv.Close()
+
+	select {
+	case err := <-runErr:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "admin watchdog")
+	case <-time.After(15 * time.Second):
+		t.Fatal("admin watchdog did not fire")
+	}
+}

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -41,6 +41,20 @@ const (
 	// shutdownGrace is added to DrainTime as the deadline for children to exit on
 	// SIGTERM before they are SIGKILLed.
 	shutdownGrace = 5 * time.Second
+	// defaultHandoffDeadline bounds how long a hot-restart epoch (N>0) may stay
+	// not-LIVE after launch before the handoff watchdog declares it wedged. The
+	// observed failure mode (e2e 2026-06-10): the parent Envoy dies between a
+	// hot-restart RPC request and its reply, leaving the successor's main thread
+	// blocked forever in recvmsg on the hot-restart domain socket — admin bound
+	// but never accepting, pod NotReady forever, DaemonSet roll wedged.
+	defaultHandoffDeadline = 2 * time.Minute
+	// defaultAdminUnresponsiveDeadline bounds how long the Envoy admin endpoint
+	// may be unreachable (connect/timeout failures, not "answers with another
+	// epoch") once this supervisor has seen LIVE, before the admin watchdog
+	// fires. Covers the same recvmsg wedge striking after LIVE (a parent dying
+	// mid stats-merge). A reachable admin answering at a different epoch — the
+	// normal mid-handoff state — never trips this.
+	defaultAdminUnresponsiveDeadline = 30 * time.Second
 )
 
 // Config configures the Envoy hot-restart supervisor.
@@ -79,6 +93,12 @@ type Config struct {
 	ReadyMarkerPath string
 	// AdminAddress is the Envoy admin host:port used for the readiness check.
 	AdminAddress string
+	// HandoffDeadline overrides defaultHandoffDeadline (0 = default). Must be
+	// comfortably larger than ParentShutdownTime plus worst-case xDS-gated init.
+	HandoffDeadline time.Duration
+	// AdminUnresponsiveDeadline overrides defaultAdminUnresponsiveDeadline
+	// (0 = default).
+	AdminUnresponsiveDeadline time.Duration
 }
 
 // childExit reports the termination of a supervised Envoy epoch.
@@ -95,9 +115,18 @@ type Supervisor struct {
 	mu        sync.Mutex
 	children  map[int]*exec.Cmd // keyed by restart epoch
 	nextEpoch int
+	// epochLaunched / epochLive track the newest epoch's progress toward LIVE,
+	// feeding the handoff watchdog: launched records the fork time, live whether
+	// admin has confirmed LIVE at that epoch at least once.
+	epochLaunched time.Time
+	epochLive     bool
 
 	childExited chan childExit
 	done        chan struct{}
+	// watchdogFired carries a fatal diagnosis from watchLiveness to Run: the
+	// newest Envoy is wedged (handoff never LIVE, or admin unresponsive) and the
+	// container must exit non-zero so Kubernetes recreates the pod.
+	watchdogFired chan error
 
 	// readyGate delays the pod's readiness until after a cross-pod handoff is fully
 	// complete: the successor Envoy terminates the predecessor itself via
@@ -114,11 +143,12 @@ const readyGateBuffer = 3 * time.Second
 // New creates a Supervisor.
 func New(cfg Config, log logr.Logger) *Supervisor {
 	return &Supervisor{
-		cfg:         cfg,
-		log:         log.WithName("proxy-supervisor"),
-		children:    make(map[int]*exec.Cmd),
-		childExited: make(chan childExit, 8),
-		done:        make(chan struct{}),
+		cfg:           cfg,
+		log:           log.WithName("proxy-supervisor"),
+		children:      make(map[int]*exec.Cmd),
+		childExited:   make(chan childExit, 8),
+		done:          make(chan struct{}),
+		watchdogFired: make(chan error, 1),
 	}
 }
 
@@ -213,6 +243,14 @@ func (s *Supervisor) Run(ctx context.Context) error {
 				s.log.Error(err, "hot restart failed; keeping current epoch")
 			}
 
+		case err := <-s.watchdogFired:
+			// The newest Envoy is wedged (see watchLiveness): kill everything and
+			// exit non-zero. Kubernetes recreates the pod; the fresh supervisor
+			// re-probes the (now dead) predecessor and recovers at epoch 0.
+			s.log.Error(err, "liveness watchdog fired; terminating for container restart")
+			s.shutdown()
+			return err
+
 		case exit := <-s.childExited:
 			if exit.epoch == s.currentEpoch() {
 				if s.cfg.StateDir != "" && exit.err == nil {
@@ -256,6 +294,8 @@ func (s *Supervisor) hotRestart() error {
 
 	s.mu.Lock()
 	s.children[epoch] = cmd
+	s.epochLaunched = time.Now()
+	s.epochLive = false
 	s.mu.Unlock()
 
 	// The node epoch is published to the shared state file only once this Envoy is
@@ -342,6 +382,53 @@ func (s *Supervisor) currentEpoch() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.nextEpoch - 1
+}
+
+// epochProgress returns the newest epoch's launch time and whether it has been
+// confirmed LIVE at least once.
+func (s *Supervisor) epochProgress() (launched time.Time, live bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.epochLaunched, s.epochLive
+}
+
+// markEpochLive records that the newest epoch has been confirmed LIVE.
+func (s *Supervisor) markEpochLive() {
+	s.mu.Lock()
+	s.epochLive = true
+	s.mu.Unlock()
+}
+
+// childTracked reports whether the child for the given epoch is still tracked
+// (started and not yet reaped).
+func (s *Supervisor) childTracked(epoch int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.children[epoch]
+	return ok
+}
+
+func (s *Supervisor) handoffDeadline() time.Duration {
+	if s.cfg.HandoffDeadline > 0 {
+		return s.cfg.HandoffDeadline
+	}
+	return defaultHandoffDeadline
+}
+
+func (s *Supervisor) adminUnresponsiveDeadline() time.Duration {
+	if s.cfg.AdminUnresponsiveDeadline > 0 {
+		return s.cfg.AdminUnresponsiveDeadline
+	}
+	return defaultAdminUnresponsiveDeadline
+}
+
+// fireWatchdog delivers a fatal wedge diagnosis to Run (at most one is ever
+// consumed; extra fires are dropped).
+func (s *Supervisor) fireWatchdog(err error) {
+	select {
+	case s.watchdogFired <- err:
+	default:
+	}
 }
 
 // signalEpoch sends sig to the child for the given epoch, if still tracked.

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -70,6 +70,8 @@ spec:
             - "--state-dir=/run/aether/hotrestart"
             - "--ready-marker=/var/run/aether-proxy/ready"
             - "--admin-address=127.0.0.1:9901"
+            - "--handoff-deadline={{ .Values.proxy.hotRestart.handoffDeadline }}"
+            - "--admin-unresponsive-deadline={{ .Values.proxy.hotRestart.adminUnresponsiveDeadline }}"
             {{- end }}
             - "--envoy-arg=-l"
             - "--envoy-arg={{ .Values.proxy.logLevel }}"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -85,6 +85,14 @@ proxy:
     # (until its Envoy terminates the predecessor), so keep these modest.
     drainTime: 10s
     parentShutdownTime: 15s
+    # Watchdogs (Strategy B): a hot-restart epoch that never reaches LIVE within
+    # handoffDeadline of launch, or an admin endpoint unreachable for
+    # adminUnresponsiveDeadline after having been LIVE, means the successor's
+    # main thread is wedged in a blocking hot-restart RPC against a dead parent;
+    # the supervisor exits non-zero so the pod is recreated. 0 = built-in
+    # defaults (2m / 30s).
+    handoffDeadline: 0
+    adminUnresponsiveDeadline: 0
     # /dev/shm size for the hot-restart shared-memory segment (gauges/counters).
     # Strategy A only (emptyDir Memory); Strategy B uses shmHostPath instead.
     shmSizeLimit: 64Mi

--- a/cni/config/config.go
+++ b/cni/config/config.go
@@ -8,6 +8,8 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+	"time"
 
 	agentConstans "github.com/bpalermo/aether/agent/constants"
 	"github.com/containernetworking/cni/pkg/types"
@@ -32,8 +34,57 @@ type AetherConf struct {
 	// CRISocket is the path to the container runtime interface socket
 	CRISocket string `json:"cri_socket"`
 
+	// NetnsPinDisabled turns off netns pinning (on by default): Envoy dials
+	// local pods inside their netns by filepath, and a dial racing the
+	// runtime's netns removal segfaults Envoy (upstream bug; e2e findings
+	// 2026-06-10). CNI ADD bind-mounts the netns to an aether-owned path that
+	// stays valid until the agent has confirmed the pod's xDS resources are
+	// gone, so late dials fail gracefully instead of crashing the proxy.
+	NetnsPinDisabled bool `json:"netns_pin_disabled"`
+	// NetnsPinDir is where CNI ADD bind-mounts each pod's netns. Must be a
+	// host path visible to the aether-proxy container (which mounts /run/aether
+	// with HostToContainer propagation). Empty = /run/aether/netns.
+	NetnsPinDir string `json:"netns_pin_dir"`
+	// NetnsUnpinDelaySeconds is how long CNI DEL waits after the agent has
+	// deregistered the pod (and Envoy acked the listener removal) before
+	// unpinning the netns, covering Envoy's deferred cluster destruction and
+	// connection-pool drains that can still dial for a few seconds.
+	// 0 = 10s default; negative = no delay.
+	NetnsUnpinDelaySeconds int `json:"netns_unpin_delay_seconds"`
+
 	// RuntimeConfig holds runtime-provided configuration like pod annotations
 	RuntimeConfig *RuntimeConfig `json:"runtimeConfig,omitempty"`
+}
+
+// defaultNetnsPinDir lives under /run/aether, which the aether-proxy DaemonSet
+// already mounts with HostToContainer propagation, so pinned netns mounts made
+// by the (host-side) plugin become visible to Envoy without chart changes.
+const defaultNetnsPinDir = "/run/aether/netns"
+
+// defaultNetnsUnpinDelay covers the post-removal dial window observed on
+// talos-main (health checkers / connection pools dialing up to ~5-9s after the
+// listener and clusters were removed from the snapshot).
+const defaultNetnsUnpinDelay = 10 * time.Second
+
+// NetnsPinPath returns the pin target for a container (sandbox) ID.
+func (c AetherConf) NetnsPinPath(containerID string) string {
+	dir := c.NetnsPinDir
+	if dir == "" {
+		dir = defaultNetnsPinDir
+	}
+	return filepath.Join(dir, containerID)
+}
+
+// NetnsUnpinDelay returns the effective unpin delay.
+func (c AetherConf) NetnsUnpinDelay() time.Duration {
+	switch {
+	case c.NetnsUnpinDelaySeconds == 0:
+		return defaultNetnsUnpinDelay
+	case c.NetnsUnpinDelaySeconds < 0:
+		return 0
+	default:
+		return time.Duration(c.NetnsUnpinDelaySeconds) * time.Second
+	}
 }
 
 // RuntimeConfig holds container runtime-provided configuration passed to the CNI plugin.

--- a/cni/internal/plugin/BUILD.bazel
+++ b/cni/internal/plugin/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "plugin",
     srcs = [
         "client.go",
+        "netnspin.go",
         "plugin.go",
     ],
     importpath = "github.com/bpalermo/aether/cni/internal/plugin",
@@ -29,6 +30,7 @@ go_test(
     name = "plugin_test",
     srcs = [
         "client_test.go",
+        "netnspin_test.go",
         "plugin_test.go",
     ],
     embed = [":plugin"],

--- a/cni/internal/plugin/netnspin.go
+++ b/cni/internal/plugin/netnspin.go
@@ -1,0 +1,122 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"github.com/bpalermo/aether/cni/config"
+	"go.uber.org/zap"
+)
+
+// Netns pinning (e2e findings 2026-06-10, finding 1).
+//
+// The agent points Envoy at each local pod via the pod's netns *filepath*
+// (upstream source-address network_namespace_filepath). Envoy 1.38's error path
+// for a vanished netns returns a nullptr connection and the caller segfaults,
+// so any dial racing the runtime's netns teardown takes down the whole node
+// proxy — and a stale path left in agent storage makes the proxy unbootable
+// (cold-start health checkers dial immediately).
+//
+// CNI ADD therefore bind-mounts the runtime netns to an aether-owned pin path
+// and registers *that* path with the agent. The bind mount keeps the netns
+// alive (and the path open-able) independent of the runtime's teardown; CNI DEL
+// unpins only after the agent has deregistered the pod and Envoy acked the
+// config removal, plus a grace delay for deferred dials. A late dial against a
+// pinned-but-dead netns fails with a clean connection error instead of ENOENT.
+
+// pinNetns bind-mounts netns onto the pin path for containerID and returns the
+// pinned path. A pre-existing pin for the same container (retried ADD) is
+// replaced.
+func (p *AetherPlugin) pinNetns(conf config.AetherConf, netns, containerID string) (string, error) {
+	target := conf.NetnsPinPath(containerID)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return "", fmt.Errorf("creating netns pin dir: %w", err)
+	}
+
+	// Retried ADD: drop any previous pin before re-mounting.
+	_ = syscall.Unmount(target, 0)
+	_ = os.Remove(target)
+
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_RDONLY, 0o600)
+	if err != nil {
+		return "", fmt.Errorf("creating netns pin mount point: %w", err)
+	}
+	_ = f.Close()
+
+	if err := syscall.Mount(netns, target, "", syscall.MS_BIND, ""); err != nil {
+		_ = os.Remove(target)
+		return "", fmt.Errorf("bind-mounting netns %s to %s: %w", netns, target, err)
+	}
+	return target, nil
+}
+
+// unpinNetns removes the pin for containerID. A missing pin is not an error
+// (pinning may have failed at ADD, or a previous DEL already cleaned up). EBUSY
+// (a dial mid-setns) falls back to a lazy detach: the path disappears now and
+// the namespace is released when its last opener closes it.
+func (p *AetherPlugin) unpinNetns(conf config.AetherConf, containerID string) error {
+	target := conf.NetnsPinPath(containerID)
+	if _, err := os.Stat(target); os.IsNotExist(err) {
+		return nil
+	}
+	// Unmount errors (EINVAL: not a mount point because pin creation failed
+	// mid-way) are judged by the Remove that follows: a still-mounted target
+	// fails Remove with EBUSY, which is the real failure signal.
+	unmountErr := syscall.Unmount(target, 0)
+	if unmountErr != nil {
+		// EBUSY (a dial mid-setns): lazily detach so the path disappears now and
+		// the namespace is released when its last opener closes it.
+		if errors.Is(unmountErr, syscall.EBUSY) {
+			_ = syscall.Unmount(target, syscall.MNT_DETACH)
+		}
+	}
+	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("removing netns pin %s (unmount: %v): %w", target, unmountErr, err)
+	}
+	return nil
+}
+
+// gcAttachments is the CNI GC payload subset listing still-valid attachments.
+type gcAttachments struct {
+	ValidAttachments []struct {
+		ContainerID string `json:"containerID"`
+	} `json:"cni.dev/valid-attachments"`
+}
+
+// sweepNetnsPins unpins every entry in the pin dir whose container ID is not in
+// the valid set — orphans left by DELs that never completed (e.g. the agent was
+// down, so the pin was deliberately retained). Best-effort.
+func (p *AetherPlugin) sweepNetnsPins(conf config.AetherConf, stdinData []byte) {
+	var gc gcAttachments
+	if err := json.Unmarshal(stdinData, &gc); err != nil {
+		p.logger.Warn("netns pin sweep: failed to parse GC payload", zap.Error(err))
+		return
+	}
+	valid := make(map[string]struct{}, len(gc.ValidAttachments))
+	for _, a := range gc.ValidAttachments {
+		valid[a.ContainerID] = struct{}{}
+	}
+
+	dir := filepath.Dir(conf.NetnsPinPath("x"))
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			p.logger.Warn("netns pin sweep: failed to read pin dir", zap.String("dir", dir), zap.Error(err))
+		}
+		return
+	}
+	for _, e := range entries {
+		if _, ok := valid[e.Name()]; ok {
+			continue
+		}
+		if err := p.unpinNetns(conf, e.Name()); err != nil {
+			p.logger.Warn("netns pin sweep: failed to unpin orphan", zap.String("containerID", e.Name()), zap.Error(err))
+		} else {
+			p.logger.Info("netns pin sweep: unpinned orphan", zap.String("containerID", e.Name()))
+		}
+	}
+}

--- a/cni/internal/plugin/netnspin_test.go
+++ b/cni/internal/plugin/netnspin_test.go
@@ -1,0 +1,114 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/bpalermo/aether/cni/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func pinTestConf(t *testing.T) config.AetherConf {
+	t.Helper()
+	return config.AetherConf{NetnsPinDir: t.TempDir()}
+}
+
+func TestNetnsPinPathDefaults(t *testing.T) {
+	assert.Equal(t, "/run/aether/netns/abc", config.AetherConf{}.NetnsPinPath("abc"))
+	assert.Equal(t, "/custom/abc", config.AetherConf{NetnsPinDir: "/custom"}.NetnsPinPath("abc"))
+}
+
+func TestNetnsUnpinDelay(t *testing.T) {
+	assert.Equal(t, 10*time.Second, config.AetherConf{}.NetnsUnpinDelay())
+	assert.Equal(t, time.Duration(0), config.AetherConf{NetnsUnpinDelaySeconds: -1}.NetnsUnpinDelay())
+	assert.Equal(t, 3*time.Second, config.AetherConf{NetnsUnpinDelaySeconds: 3}.NetnsUnpinDelay())
+}
+
+// Unpinning a container that was never pinned (pin failed at ADD, or DEL
+// retried after cleanup) must succeed silently.
+func TestUnpinNetnsMissingIsNoop(t *testing.T) {
+	p := NewAetherPlugin(zap.NewNop())
+	require.NoError(t, p.unpinNetns(pinTestConf(t), "never-pinned"))
+}
+
+// A pin target that exists but is not a mount point (pin creation failed
+// mid-way) is removed without error.
+func TestUnpinNetnsPlainFile(t *testing.T) {
+	p := NewAetherPlugin(zap.NewNop())
+	conf := pinTestConf(t)
+	target := conf.NetnsPinPath("half-pinned")
+	require.NoError(t, os.WriteFile(target, nil, 0o600))
+
+	require.NoError(t, p.unpinNetns(conf, "half-pinned"))
+	_, err := os.Stat(target)
+	assert.True(t, os.IsNotExist(err))
+}
+
+// Without CAP_SYS_ADMIN the bind mount fails; pinNetns must surface the error
+// (CmdAdd then falls back to the runtime path) and leave no half-created pin.
+func TestPinNetnsWithoutPrivilegeFailsCleanly(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root; mount would succeed")
+	}
+	p := NewAetherPlugin(zap.NewNop())
+	conf := pinTestConf(t)
+	src := filepath.Join(t.TempDir(), "netns")
+	require.NoError(t, os.WriteFile(src, nil, 0o600))
+
+	_, err := p.pinNetns(conf, src, "cid-1")
+	require.Error(t, err)
+	_, statErr := os.Stat(conf.NetnsPinPath("cid-1"))
+	assert.True(t, os.IsNotExist(statErr), "failed pin must not leave a mount point behind")
+}
+
+// Root-only: full pin -> unpin round trip with a real bind mount.
+func TestPinUnpinNetnsRoundTrip(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("requires root for bind mounts")
+	}
+	p := NewAetherPlugin(zap.NewNop())
+	conf := pinTestConf(t)
+	src := filepath.Join(t.TempDir(), "netns")
+	require.NoError(t, os.WriteFile(src, []byte("ns"), 0o600))
+
+	pinned, err := p.pinNetns(conf, src, "cid-rt")
+	require.NoError(t, err)
+	assert.Equal(t, conf.NetnsPinPath("cid-rt"), pinned)
+	b, err := os.ReadFile(pinned)
+	require.NoError(t, err)
+	assert.Equal(t, "ns", string(b))
+
+	// Re-ADD replaces the existing pin.
+	_, err = p.pinNetns(conf, src, "cid-rt")
+	require.NoError(t, err)
+
+	require.NoError(t, p.unpinNetns(conf, "cid-rt"))
+	_, statErr := os.Stat(pinned)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+// The GC sweep unpins entries absent from the valid-attachments set and keeps
+// the rest.
+func TestSweepNetnsPins(t *testing.T) {
+	p := NewAetherPlugin(zap.NewNop())
+	conf := pinTestConf(t)
+	require.NoError(t, os.WriteFile(conf.NetnsPinPath("keep"), nil, 0o600))
+	require.NoError(t, os.WriteFile(conf.NetnsPinPath("orphan"), nil, 0o600))
+
+	p.sweepNetnsPins(conf, []byte(`{"cni.dev/valid-attachments":[{"containerID":"keep"}]}`))
+
+	_, err := os.Stat(conf.NetnsPinPath("keep"))
+	assert.NoError(t, err)
+	_, err = os.Stat(conf.NetnsPinPath("orphan"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+// A GC payload without attachments (or an unreadable pin dir) must not panic.
+func TestSweepNetnsPinsEmpty(t *testing.T) {
+	p := NewAetherPlugin(zap.NewNop())
+	p.sweepNetnsPins(config.AetherConf{NetnsPinDir: filepath.Join(t.TempDir(), "missing")}, []byte(`{}`))
+}

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	"github.com/bpalermo/aether/cni/config"
@@ -83,6 +84,19 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 
 	pidValue := p.resolvePID(args.Netns, netConf.CRISocket, args.ContainerID)
 	cniPod := newPodFromArgs(args, k8sArgs, podIPs, pidValue)
+
+	// Pin the netns to an aether-owned path and register that path instead of
+	// the runtime's, so Envoy's per-pod dials never race the runtime's netns
+	// teardown (see netnspin.go). Pin failure falls back to the runtime path:
+	// a working mesh with the old crash window beats a failed pod start.
+	if !netConf.NetnsPinDisabled {
+		if pinned, err := p.pinNetns(netConf, args.Netns, args.ContainerID); err != nil {
+			p.logger.Warn("failed to pin netns; falling back to runtime netns path",
+				zap.String("netns", args.Netns), zap.Error(err))
+		} else {
+			cniPod.NetworkNamespace = pinned
+		}
+	}
 
 	return p.sendAddPod(context.Background(), netConf, cniPod, prevResult)
 }
@@ -151,13 +165,38 @@ func (p *AetherPlugin) CmdDel(args *skel.CmdArgs) error {
 		zap.String("namespace", namespace),
 		zap.String("pod", podName))
 
-	return p.sendRemovePod(context.Background(), conf, podName, namespace, containerID)
+	if err := p.sendRemovePod(context.Background(), conf, podName, namespace, containerID); err != nil {
+		// Keep the netns pin: the agent has not confirmed the pod's xDS
+		// resources are gone, and unpinning now reintroduces the deleted-netns
+		// Envoy crash. The runtime retries DEL; CmdGC sweeps true orphans.
+		return err
+	}
+
+	if !conf.NetnsPinDisabled {
+		// The agent has deregistered the pod and waited for Envoy to ack the
+		// listener removal; hold the pin briefly for deferred cluster
+		// destruction / connection-pool dials, then release the netns.
+		time.Sleep(conf.NetnsUnpinDelay())
+		if err := p.unpinNetns(conf, args.ContainerID); err != nil {
+			p.logger.Warn("failed to unpin netns; orphan will be swept by GC",
+				zap.String("containerID", args.ContainerID), zap.Error(err))
+		}
+	}
+	return nil
 }
 
-// CmdGC handles the CNI GC (garbage collection) operation.
-// Currently a no-op; returns nil. Garbage collection is handled by the agent.
-func (p *AetherPlugin) CmdGC(_ *skel.CmdArgs) error {
+// CmdGC handles the CNI GC (garbage collection) operation: it unpins netns
+// pins whose container is no longer a valid attachment (orphans of failed
+// DELs). Registry/xDS garbage collection is handled by the agent.
+func (p *AetherPlugin) CmdGC(args *skel.CmdArgs) error {
 	p.logger.Debug("running CNI GC command")
+	conf, err := config.NewConf(args.StdinData)
+	if err != nil {
+		return fmt.Errorf("failed to parse config: %w", err)
+	}
+	if !conf.NetnsPinDisabled {
+		p.sweepNetnsPins(conf, args.StdinData)
+	}
 	return nil
 }
 
@@ -454,14 +493,29 @@ func (p *AetherPlugin) verifyPodRegistration(args *skel.CmdArgs, k8sArgs config.
 		}
 	}()
 
+	// The verification re-sends AddPod (idempotent by overwrite), so it must
+	// carry the same netns path ADD registered — the pinned one when present —
+	// or the check would silently replace the pinned path with the runtime's.
+	netns := args.Netns
+	if !conf.NetnsPinDisabled {
+		if pinned := conf.NetnsPinPath(args.ContainerID); fileExists(pinned) {
+			netns = pinned
+		}
+	}
+
 	pod := &cniv1.CNIPod{
 		ContainerId:      args.ContainerID,
 		Name:             string(k8sArgs.K8S_POD_NAME),
 		Namespace:        string(k8sArgs.K8S_POD_NAMESPACE),
-		NetworkNamespace: args.Netns,
+		NetworkNamespace: netns,
 	}
 
 	return client.VerifyPodRegistered(context.Background(), pod)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func ignorableNamespace(namespace string) bool {


### PR DESCRIPTION
## Summary

Fixes the two P1 findings from the 2026-06-10 long e2e on talos-main (multi-service traffic under proxy deployments + app pod drains):

**Finding 2 — wedged cross-pod hot restart** (`fa6a0e0`): Envoy's hot-restart RPCs are blocking `recvmsg` on a datagram socket with no timeout; a parent dying mid-RPC leaves the successor's main thread blocked forever (admin bound but not accepting, never LIVE, workers still serving) and the DaemonSet roll wedges. Two supervisor watchdogs now diagnose this and exit non-zero so the pod is recreated:
- handoff watchdog: epoch N>0 not LIVE within `--handoff-deadline` (default 2m) of launch
- admin watchdog: admin unreachable for `--admin-unresponsive-deadline` (default 30s) after having been LIVE

**Finding 1 — Envoy segfault dialing a deleted netns** (`6f0a809`): Envoy 1.38 null-derefs when an upstream dial hits a netns file that no longer exists (`dispatcher_impl.cc:184`, unfixed upstream). During the e2e this turned app rolls into node-wide proxy crashes, and a stale netns path in agent storage made proxies unbootable (crash loop on cold-start health checks). CNI ADD now bind-mounts the netns to `/run/aether/netns/<sandbox-id>` and registers that pinned path; DEL unpins only after the agent deregisters + Envoy acks removal + a 10s grace; GC sweeps orphans. Late dials now fail gracefully (ECONNREFUSED) instead of crashing the proxy.

## Validation

- New unit tests: watchdog firing pre-/post-LIVE (wedge repro with fake admin), pin/unpin lifecycle incl. failure fallback and GC sweep
- `bazel test //agent/... //cni/... //common/...` green
- Full e2e re-run on talos-main planned after this lands (artifacts of the failing run: `/tmp/aether-e2e-20260610/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)