### PR TITLE
fix(agent): honor EDS host removal immediately on service clusters

### DIFF
--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -67,6 +67,12 @@ func NewServiceCluster(serviceName string) *clusterv3.Cluster {
 		CommonLbConfig: &clusterv3.Cluster_CommonLbConfig{
 			IgnoreNewHostsUntilFirstHc: true,
 		},
+		// With active health checks configured, Envoy by default keeps an
+		// EDS-removed host in rotation until its health check fails — which would
+		// defeat the early termination drain (the agent deregisters an endpoint
+		// the moment its pod's deletion is requested, precisely so clients stop
+		// picking it before the app dies). Honor EDS removals immediately.
+		IgnoreHealthOnHostRemoval: true,
 	}
 }
 

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -30,6 +30,7 @@ func TestNewServiceCluster(t *testing.T) {
 	require.Len(t, c.GetHealthChecks(), 1)
 	assert.Equal(t, MeshReadyPath, c.GetHealthChecks()[0].GetHttpHealthCheck().GetPath())
 	assert.True(t, c.GetCommonLbConfig().GetIgnoreNewHostsUntilFirstHc(), "don't route to a pod until its first readiness check passes")
+	assert.True(t, c.GetIgnoreHealthOnHostRemoval(), "EDS removals (early termination drain) must take effect immediately, not after an HC failure")
 }
 
 func TestInjectUpstreamMTLS(t *testing.T) {


### PR DESCRIPTION
Completes #113's drain path: with active HCs, Envoy keeps an EDS-removed host until its HC fails — `ignore_health_on_host_removal: true` makes the early deregistration effective within one EDS push instead of one HC round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)