### PR TITLE
feat(agent): retry endpoint-churn failures on client routes

### DIFF
--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/matching/common_inputs/transport_socket/v3:transport_socket",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/retry/host/previous_hosts/v3:previous_hosts",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_envoyproxy_go_control_plane_envoy//type/matcher/v3:matcher",
         "@com_github_envoyproxy_go_control_plane_envoy//type/v3:type",

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -2,14 +2,51 @@ package proxy
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/bpalermo/aether/agent/internal/xds/config"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	previoushostsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
 	// OutboundHTTPRouteName is the name of the outbound HTTP route configuration
 	OutboundHTTPRouteName = "out_http"
 )
+
+// outboundRetryPolicy returns the retry policy applied to every client-side
+// service route. It masks the sub-second windows inherent to endpoint churn —
+// a dial racing a pod that just received SIGTERM (connection refused before the
+// EDS removal propagates) or a 503 while a replacement endpoint finishes its
+// first health-check round — by retrying on a *different* host
+// (previous_hosts predicate).
+//
+// Only conditions that are safe for non-idempotent requests are retried:
+// connect-failure, refused-stream and reset-before-request all fail before the
+// request reaches an application, and 503 is the standard
+// "try-another-endpoint" drain signal (Envoy's no-healthy-upstream and
+// service overload both use it; applications returning 503 explicitly opt
+// into retry semantics).
+func outboundRetryPolicy() *routev3.RetryPolicy {
+	return &routev3.RetryPolicy{
+		RetryOn:              "connect-failure,refused-stream,reset-before-request,retriable-status-codes",
+		NumRetries:           wrapperspb.UInt32(2),
+		RetriableStatusCodes: []uint32{503},
+		RetryHostPredicate: []*routev3.RetryPolicy_RetryHostPredicate{{
+			Name: "envoy.retry_host_predicates.previous_hosts",
+			ConfigType: &routev3.RetryPolicy_RetryHostPredicate_TypedConfig{
+				TypedConfig: config.TypedConfig(&previoushostsv3.PreviousHostsPredicate{}),
+			},
+		}},
+		HostSelectionRetryMaxAttempts: 3,
+		RetryBackOff: &routev3.RetryPolicy_RetryBackOff{
+			BaseInterval: durationpb.New(25 * time.Millisecond),
+			MaxInterval:  durationpb.New(250 * time.Millisecond),
+		},
+	}
+}
 
 // BuildOutboundRouteConfiguration creates a route configuration for outbound traffic.
 // It includes the provided virtual hosts along with a catch-all virtual host that returns 404.
@@ -40,6 +77,7 @@ func BuildOutboundClusterVirtualHost(clusterName string) *routev3.VirtualHost {
 						ClusterSpecifier: &routev3.RouteAction_Cluster{
 							Cluster: clusterName,
 						},
+						RetryPolicy: outboundRetryPolicy(),
 					},
 				},
 			},

--- a/agent/internal/xds/proxy/route_test.go
+++ b/agent/internal/xds/proxy/route_test.go
@@ -74,3 +74,21 @@ func TestBuildOutboundClusterVirtualHost(t *testing.T) {
 		})
 	}
 }
+
+// TestOutboundRetryPolicy: every client-side service route retries endpoint-churn
+// failures (drain/warm-up windows) on a different host, with only
+// non-idempotent-safe conditions.
+func TestOutboundRetryPolicy(t *testing.T) {
+	for name, vh := range map[string]*routev3.VirtualHost{
+		"cluster vhost": BuildOutboundClusterVirtualHost("svc-1"),
+		"service vhost": NewServiceVirtualHost("svc-1"),
+	} {
+		rp := vh.GetRoutes()[0].GetRoute().GetRetryPolicy()
+		require.NotNil(t, rp, name)
+		assert.Equal(t, "connect-failure,refused-stream,reset-before-request,retriable-status-codes", rp.GetRetryOn(), name)
+		assert.Equal(t, []uint32{503}, rp.GetRetriableStatusCodes(), name)
+		assert.Equal(t, uint32(2), rp.GetNumRetries().GetValue(), name)
+		require.Len(t, rp.GetRetryHostPredicate(), 1, name)
+		assert.Equal(t, "envoy.retry_host_predicates.previous_hosts", rp.GetRetryHostPredicate()[0].GetName(), name)
+	}
+}

--- a/agent/internal/xds/proxy/vhost.go
+++ b/agent/internal/xds/proxy/vhost.go
@@ -22,6 +22,7 @@ func NewServiceVirtualHost(svcName string) *routev3.VirtualHost {
 						ClusterSpecifier: &routev3.RouteAction_Cluster{
 							Cluster: svcName,
 						},
+						RetryPolicy: outboundRetryPolicy(),
 					},
 				},
 			},


### PR DESCRIPTION
Step 1 of the residual-drain plan (after #113/#114 cut per-roll fails ~150 → ~90): mask the two remaining sub-second windows (SIGTERM race until EDS removal propagates; first-HC warm-up on replacement endpoints) with non-idempotent-safe retries on a different host. Validation: roll svc-1/2/3 under the standing harness, expect ~0 per-roll fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)