### PR TITLE
feat(agent): delegated-liveness (EDS) health mode by default + ghost sweep

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "server",
     srcs = [
         "config.go",
+        "ghostsweep.go",
         "liveness.go",
         "pod.go",
         "resubscribe.go",
@@ -42,6 +43,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "ghostsweep_test.go",
         "liveness_test.go",
         "pod_test.go",
         "resubscribe_test.go",

--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -1,0 +1,93 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+)
+
+// Ghost-endpoint sweep (e2e finding, 2026-06-10).
+//
+// A registry endpoint whose deregistration was lost (agent down at CNI DEL,
+// node-level churn, registry outage mid-roll) is owned by nobody and lives
+// forever: nothing re-lists registry content against reality. Under active
+// health checking ghosts are merely noise (clients pin them at
+// failed_active_hc), but in EDS health-check mode a HEALTHY ghost would
+// receive traffic indefinitely — making this sweep a prerequisite for
+// delegated-liveness EDS mode.
+//
+// Each agent owns its node's slice of the registry: endpoints whose
+// KubernetesMetadata.NodeName matches this node. The sweep periodically lists
+// registry endpoints and deregisters any of this node's entries whose IP does
+// not belong to a live, locally stored pod. lifecycleMu serializes the sweep
+// against AddPod/RemovePod/liveness so a registering pod cannot be judged a
+// ghost mid-flight.
+
+const ghostSweepInterval = 60 * time.Second
+
+// runGhostSweepLoop periodically reconciles this node's registry endpoints
+// against local pod storage. It returns when ctx is cancelled.
+func (s *CNIServer) runGhostSweepLoop(ctx context.Context) {
+	ticker := time.NewTicker(ghostSweepInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sweepGhostEndpoints(ctx)
+		}
+	}
+}
+
+// sweepGhostEndpoints deregisters this node's registry endpoints that no live
+// local pod accounts for.
+func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
+	all, err := s.registry.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	if err != nil {
+		s.log.V(1).Info("ghost sweep: failed to list registry endpoints", "error", err)
+		return
+	}
+
+	// Serialize against pod lifecycle so an in-flight AddPod (stored after the
+	// registry write) or RemovePod cannot race the liveness judgment.
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	pods, err := s.storage.GetAll(ctx)
+	if err != nil {
+		s.log.V(1).Info("ghost sweep: failed to list local pods", "error", err)
+		return
+	}
+	// Live local IPs. Terminating pods are intentionally excluded: their
+	// endpoints were already deregistered, so a ghost re-listing them would be
+	// equally stale.
+	live := make(map[string]struct{}, len(pods))
+	for _, p := range pods {
+		if p.GetTerminating() {
+			continue
+		}
+		for _, ip := range p.GetIps() {
+			live[ip] = struct{}{}
+		}
+	}
+
+	for service, endpoints := range all {
+		for _, ep := range endpoints {
+			if ep.GetKubernetesMetadata().GetNodeName() != s.nodeName {
+				continue // another agent's responsibility
+			}
+			if _, ok := live[ep.GetIp()]; ok {
+				continue
+			}
+			if err := s.registry.UnregisterEndpoint(ctx, service, ep.GetIp()); err != nil {
+				s.log.Error(err, "ghost sweep: failed to deregister ghost endpoint",
+					"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
+				continue
+			}
+			s.log.Info("ghost sweep: deregistered ghost endpoint",
+				"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
+		}
+	}
+}

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/storage"
+	"github.com/bpalermo/aether/agent/types"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sweepRegistry serves a fixed endpoint listing and records UnregisterEndpoint calls.
+type sweepRegistry struct {
+	testRegistry
+	listing      map[string][]*registryv1.ServiceEndpoint
+	unregistered map[string][]string // service -> ips
+}
+
+func (r *sweepRegistry) ListAllEndpoints(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	return r.listing, nil
+}
+
+func (r *sweepRegistry) UnregisterEndpoint(_ context.Context, service, ip string) error {
+	if r.unregistered == nil {
+		r.unregistered = map[string][]string{}
+	}
+	r.unregistered[service] = append(r.unregistered[service], ip)
+	return nil
+}
+
+func sweepEndpoint(ip, node, pod string) *registryv1.ServiceEndpoint {
+	return &registryv1.ServiceEndpoint{
+		Ip: ip,
+		KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+			Namespace: "default",
+			PodName:   pod,
+			NodeName:  node,
+		},
+	}
+}
+
+// TestSweepGhostEndpoints: only this node's endpoints without a live local pod
+// are deregistered — live pods, other nodes' endpoints, and terminating pods'
+// (already deregistered) entries are handled correctly.
+func TestSweepGhostEndpoints(t *testing.T) {
+	ctx := context.Background()
+
+	live := validCNIPod("pod-live", "default", "container-live") // Ips: 10.0.0.1
+	terminating := validCNIPod("pod-term", "default", "container-term")
+	terminating.Ips = []string{"10.0.0.2"}
+	terminating.Terminating = true
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-live"), live))
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-term"), terminating))
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{
+		"svc-a": {
+			sweepEndpoint("10.0.0.1", "test-node", "pod-live"),   // live -> keep
+			sweepEndpoint("10.0.0.9", "test-node", "pod-ghost"),  // ghost -> deregister
+			sweepEndpoint("10.0.0.3", "other-node", "pod-other"), // other node -> ignore
+		},
+		"svc-b": {
+			sweepEndpoint("10.0.0.2", "test-node", "pod-term"), // terminating ghost -> deregister
+		},
+	}}
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "127.0.0.1:1")
+
+	s.sweepGhostEndpoints(ctx)
+
+	assert.Equal(t, map[string][]string{
+		"svc-a": {"10.0.0.9"},
+		"svc-b": {"10.0.0.2"},
+	}, reg.unregistered)
+}

--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -65,12 +65,18 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, last map[string]regis
 			want = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
 		}
 
-		// Absent prior state is treated as healthy (the registration default), so
-		// only a real transition triggers a re-register.
+		// Absent prior state is seeded with the endpoint's registration health so
+		// only a real transition triggers a re-register: EDS-mode endpoints are
+		// registered UNHEALTHY (gated until this proxy vets the app — the first
+		// healthy observation here is the promotion), active-mode endpoints
+		// register HEALTHY.
 		key := pod.GetContainerId()
 		prev, ok := last[key]
 		if !ok {
 			prev = registryv1.ServiceEndpoint_HEALTH_HEALTHY
+			if registry.HealthCheckModeFromAnnotations(pod.GetAnnotations()) == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS {
+				prev = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
+			}
 		}
 		if prev == want {
 			continue

--- a/agent/internal/cni/server/liveness_test.go
+++ b/agent/internal/cni/server/liveness_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/bpalermo/aether/agent/types"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,6 +45,10 @@ func fakeClustersAdmin(t *testing.T, probeCluster string) *httptest.Server {
 // registry permanently.
 func TestReconcileLivenessSkipsRemovedPod(t *testing.T) {
 	pod := validCNIPod("pod-a", "default", "container-a")
+	// Pin active mode: in (default) EDS mode the registration health is already
+	// UNHEALTHY, so a failing health check at first observation is not a
+	// transition (covered by TestReconcileLivenessEDSPromotion).
+	pod.Annotations[constants.AnnotationEndpointHealthCheckMode] = constants.HealthCheckModeActive
 
 	srv := fakeClustersAdmin(t, "health_pod-a")
 	defer srv.Close()
@@ -79,4 +84,38 @@ func TestReconcileLivenessSkipsRemovedPod(t *testing.T) {
 		assert.Equal(t, 1, reg.registered, "healthy->unhealthy transition must re-register")
 		assert.Equal(t, registryv1.ServiceEndpoint_HEALTH_UNHEALTHY, last[pod.GetContainerId()])
 	})
+}
+
+// healthyClustersAdmin serves an Envoy /clusters dump where the given
+// health-probe cluster passes its active health check.
+func healthyClustersAdmin(t *testing.T, probeCluster string) *httptest.Server {
+	t.Helper()
+	body := `{"cluster_statuses":[{"name":"` + probeCluster + `","host_statuses":[{"health_status":{}}]}]}`
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestReconcileLivenessEDSPromotion: a (default) EDS-mode endpoint registers
+// UNHEALTHY; the first healthy observation by the node-local proxy must promote
+// it (re-register HEALTHY) — the absent-state seed has to match the
+// registration health, or the promotion never fires.
+func TestReconcileLivenessEDSPromotion(t *testing.T) {
+	pod := validCNIPod("pod-a", "default", "container-a")
+
+	srv := healthyClustersAdmin(t, "health_pod-a")
+	defer srv.Close()
+
+	store := storage.NewMockStorageWithGetAll[*cniv1.CNIPod](func(_ context.Context) ([]*cniv1.CNIPod, error) {
+		return []*cniv1.CNIPod{pod}, nil
+	})
+	require.NoError(t, store.AddResource(context.Background(), types.ContainerID(pod.GetContainerId()), pod))
+	reg := &recordingRegistry{}
+	srvr := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), srv.Listener.Addr().String())
+
+	last := make(map[string]registryv1.ServiceEndpoint_Health)
+	srvr.reconcileLiveness(context.Background(), last)
+
+	assert.Equal(t, 1, reg.registered, "first healthy observation must promote the EDS-mode endpoint")
+	assert.Equal(t, registryv1.ServiceEndpoint_HEALTH_HEALTHY, last[pod.GetContainerId()])
 }

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/agent/types"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/registry"
 	"google.golang.org/grpc/codes"
@@ -42,8 +43,11 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		return &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_SUCCESS}, nil
 	}
 
-	// Store in the local storage
+	// Store in the local storage. Whether this container was already known
+	// distinguishes a fresh CNI ADD from an idempotent re-add (CNI CHECK).
 	containerdID := types.ContainerID(cniPod.GetContainerId())
+	_, getErr := s.storage.GetResource(ctx, containerdID)
+	fresh := getErr != nil
 	log.Info("adding pod to storage", "containerID", containerdID)
 	if err := s.storage.AddResource(ctx, containerdID, cniPod); err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to add pod to storage: %v", err)
@@ -57,6 +61,14 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, cniPod)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to build endpoint: %v", err)
+		}
+		// Delegated liveness (EDS mode): a brand-new endpoint enters the registry
+		// UNHEALTHY — clients must not route to it until this node's proxy has
+		// seen the app pass its health check, at which point the liveness loop
+		// promotes it. A re-add of a known pod keeps the registration default
+		// (HEALTHY) so a CHECK can't yank a serving endpoint out of rotation.
+		if fresh && sEndpoint.GetHealthCheckMode() == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS {
+			sEndpoint.Health = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
 		}
 		if err = s.registry.RegisterEndpoint(ctx, serviceName, protocol, sEndpoint); err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to register endpoint: %v", err)

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -127,6 +127,11 @@ func (s *CNIServer) PreListen(ctx context.Context) error {
 	// (deletionTimestamp), instead of waiting for CNI DEL after the containers
 	// are already dead.
 	go s.runTerminationWatch(ctx, s.informers)
+
+	// Ghost reconciliation: deregister this node's registry endpoints that no
+	// live local pod accounts for (lost CNI DELs, node churn). Prerequisite for
+	// EDS health-check mode, where a HEALTHY ghost would receive traffic forever.
+	go s.runGhostSweepLoop(ctx)
 	return nil
 }
 

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -20,10 +20,12 @@ const (
 	AnnotationEndpointHealthPath = annotationAetherEndpointPrefix + "health-path"
 
 	// AnnotationEndpointHealthCheckMode is the pod annotation key selecting how
-	// client proxies determine this endpoint's health. Unset or "active" (default)
-	// makes each client actively health-check the endpoint's mesh readiness path;
-	// "eds" makes clients rely on the EDS health status pushed by the node-local
-	// agent (delegated liveness) instead of probing the endpoint.
+	// client proxies determine this endpoint's health. Unset or "eds" (default)
+	// makes clients rely on the EDS health status pushed by the node-local agent
+	// (delegated liveness): the endpoint registers UNHEALTHY, is promoted once
+	// the local proxy sees the app pass its health check, and enters every
+	// client pre-warmed (no per-client first-HC round). "active" opts the pod
+	// back into per-client active health checking of its mesh readiness path.
 	AnnotationEndpointHealthCheckMode = annotationAetherEndpointPrefix + "health-check-mode"
 	// HealthCheckModeActive / HealthCheckModeEDS are the accepted annotation values.
 	HealthCheckModeActive = "active"

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -37,7 +37,7 @@ func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegio
 		Port:            uint32(port),
 		Weight:          weight,
 		Metadata:        getEndpointMetadataFromAnnotations(cniPod.GetAnnotations()),
-		HealthCheckMode: healthCheckModeFromAnnotations(cniPod.GetAnnotations()),
+		HealthCheckMode: HealthCheckModeFromAnnotations(cniPod.GetAnnotations()),
 		ContainerMetadata: &registryv1.ServiceEndpoint_ContainerMetadata{
 			ContainerId:      cniPod.GetContainerId(),
 			NetworkNamespace: cniPod.GetNetworkNamespace(),
@@ -106,18 +106,18 @@ func getWeightFromAnnotations(annotations map[string]string) (uint32, error) {
 	return uint32(weight), nil
 }
 
-// healthCheckModeFromAnnotations maps the endpoint.aether.io/health-check-mode
-// annotation to the ServiceEndpoint health-check mode. "eds" yields EDS; "active"
-// yields ACTIVE; unset yields UNSPECIFIED, which consumers treat as active (the
-// default).
-func healthCheckModeFromAnnotations(annotations map[string]string) registryv1.ServiceEndpoint_HealthCheckMode {
+// HealthCheckModeFromAnnotations maps the endpoint.aether.io/health-check-mode
+// annotation to the ServiceEndpoint health-check mode. "active" yields ACTIVE;
+// "eds" or unset yields EDS — delegated liveness is the default: the node-local
+// agent vets each endpoint once and publishes its health over EDS, so new
+// endpoints enter every client pre-warmed (no per-client first-HC round) and a
+// per-pod annotation opts back into per-client active checking.
+func HealthCheckModeFromAnnotations(annotations map[string]string) registryv1.ServiceEndpoint_HealthCheckMode {
 	switch annotations[constants.AnnotationEndpointHealthCheckMode] {
-	case constants.HealthCheckModeEDS:
-		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS
 	case constants.HealthCheckModeActive:
 		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_ACTIVE
 	default:
-		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_UNSPECIFIED
+		return registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS
 	}
 }
 


### PR DESCRIPTION
Phase (c) of the drain plan (finding 4, warm-up gap). EDS mode canary-validated on talos-main today (svc-3). Includes the prerequisite ghost-endpoint sweep (two real ghosts found in Cloud Map after today's incident windows — fatal in EDS mode, where no active HC would ever evict them). k8s registry backend keeps its own defaulting (separate backend, untouched). Validation after merge: full drain roll comparison with #115 retries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)