### PR TITLE
fix(cni): detach netns unpin and widen the drain-tail margin to 60s

### DIFF
--- a/cni/cmd/cni/main.go
+++ b/cni/cmd/cni/main.go
@@ -26,6 +26,13 @@ func main() {
 
 	p := plugin.NewAetherPlugin(logger)
 
+	// Detached netns-unpin mode (spawned by CmdDel, not by the runtime): wait
+	// out the drain tail, then release the pin. See plugin.RunDetachedUnpin.
+	if len(os.Args) > 1 && os.Args[1] == plugin.NetnsUnpinSubcommand {
+		p.RunDetachedUnpin(os.Args[2:])
+		return
+	}
+
 	skel.PluginMainFuncs(skel.CNIFuncs{
 		Add:    p.CmdAdd,
 		Check:  p.CmdCheck,

--- a/cni/config/config.go
+++ b/cni/config/config.go
@@ -62,9 +62,11 @@ type AetherConf struct {
 const defaultNetnsPinDir = "/run/aether/netns"
 
 // defaultNetnsUnpinDelay covers the post-removal dial window observed on
-// talos-main (health checkers / connection pools dialing up to ~5-9s after the
-// listener and clusters were removed from the snapshot).
-const defaultNetnsUnpinDelay = 10 * time.Second
+// talos-main: health checkers / connection pools dialed up to ~13s after the
+// listener and clusters were removed from the snapshot under roll churn (one
+// such dial through an already-released pin segfaulted Envoy 1.38). The unpin
+// runs as a detached process, so a generous delay does not slow pod teardown.
+const defaultNetnsUnpinDelay = 60 * time.Second
 
 // NetnsPinPath returns the pin target for a container (sandbox) ID.
 func (c AetherConf) NetnsPinPath(containerID string) string {

--- a/cni/internal/plugin/netnspin.go
+++ b/cni/internal/plugin/netnspin.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/bpalermo/aether/cni/config"
 	"go.uber.org/zap"
@@ -59,7 +61,12 @@ func (p *AetherPlugin) pinNetns(conf config.AetherConf, netns, containerID strin
 // (a dial mid-setns) falls back to a lazy detach: the path disappears now and
 // the namespace is released when its last opener closes it.
 func (p *AetherPlugin) unpinNetns(conf config.AetherConf, containerID string) error {
-	target := conf.NetnsPinPath(containerID)
+	return p.unpinTarget(conf.NetnsPinPath(containerID))
+}
+
+// unpinTarget removes the pin at an explicit path (the detached unpinner gets
+// the resolved path on its argv rather than re-parsing CNI config).
+func (p *AetherPlugin) unpinTarget(target string) error {
 	if _, err := os.Stat(target); os.IsNotExist(err) {
 		return nil
 	}
@@ -78,6 +85,52 @@ func (p *AetherPlugin) unpinNetns(conf config.AetherConf, containerID string) er
 		return fmt.Errorf("removing netns pin %s (unmount: %v): %w", target, unmountErr, err)
 	}
 	return nil
+}
+
+// NetnsUnpinSubcommand is the hidden argv[1] under which the CNI binary
+// re-executes itself as a short-lived detached unpinner.
+const NetnsUnpinSubcommand = "netns-unpin"
+
+// spawnDetachedUnpin re-executes this binary as a detached (setsid) process
+// that sleeps delay and then unpins target. CNI DEL must return promptly (a
+// long in-process sleep delays pod teardown node-wide), but the pin must
+// outlive Envoy's drain tail — health checkers and pool drains were observed
+// dialing 10-13s after config removal under roll churn, and a dial through an
+// already-unpinned path is the nullptr segfault all over again.
+func (p *AetherPlugin) spawnDetachedUnpin(target string, delay time.Duration) error {
+	self, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolving self: %w", err)
+	}
+	cmd := exec.Command(self, NetnsUnpinSubcommand, target, delay.String())
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting detached unpinner: %w", err)
+	}
+	// Detach: the child outlives this CNI invocation; init reaps it.
+	return cmd.Process.Release()
+}
+
+// RunDetachedUnpin is the detached-unpinner entrypoint: argv = [target, delay].
+func (p *AetherPlugin) RunDetachedUnpin(args []string) {
+	if len(args) != 2 {
+		p.logger.Error("netns-unpin: expected <target> <delay>", zap.Strings("args", args))
+		return
+	}
+	target := args[0]
+	delay, err := time.ParseDuration(args[1])
+	if err != nil {
+		p.logger.Error("netns-unpin: bad delay", zap.String("delay", args[1]), zap.Error(err))
+		return
+	}
+	time.Sleep(delay)
+	if err := p.unpinTarget(target); err != nil {
+		p.logger.Warn("netns-unpin: failed; orphan will be swept by GC", zap.String("target", target), zap.Error(err))
+		return
+	}
+	p.logger.Info("netns-unpin: released", zap.String("target", target), zap.Duration("delay", delay))
 }
 
 // gcAttachments is the CNI GC payload subset listing still-valid attachments.

--- a/cni/internal/plugin/netnspin_test.go
+++ b/cni/internal/plugin/netnspin_test.go
@@ -23,7 +23,7 @@ func TestNetnsPinPathDefaults(t *testing.T) {
 }
 
 func TestNetnsUnpinDelay(t *testing.T) {
-	assert.Equal(t, 10*time.Second, config.AetherConf{}.NetnsUnpinDelay())
+	assert.Equal(t, 60*time.Second, config.AetherConf{}.NetnsUnpinDelay())
 	assert.Equal(t, time.Duration(0), config.AetherConf{NetnsUnpinDelaySeconds: -1}.NetnsUnpinDelay())
 	assert.Equal(t, 3*time.Second, config.AetherConf{NetnsUnpinDelaySeconds: 3}.NetnsUnpinDelay())
 }
@@ -111,4 +111,26 @@ func TestSweepNetnsPins(t *testing.T) {
 func TestSweepNetnsPinsEmpty(t *testing.T) {
 	p := NewAetherPlugin(zap.NewNop())
 	p.sweepNetnsPins(config.AetherConf{NetnsPinDir: filepath.Join(t.TempDir(), "missing")}, []byte(`{}`))
+}
+
+// TestUnpinDelayDefault pins the 60s drain-tail margin (observed late dials up
+// to ~13s post-removal; a dial through a released pin segfaults Envoy).
+func TestUnpinDelayDefault(t *testing.T) {
+	assert.Equal(t, 60*time.Second, config.AetherConf{}.NetnsUnpinDelay())
+}
+
+// TestRunDetachedUnpin: the detached entrypoint waits and releases the target;
+// bad argv is rejected without panicking.
+func TestRunDetachedUnpin(t *testing.T) {
+	p := NewAetherPlugin(zap.NewNop())
+	conf := pinTestConf(t)
+	target := conf.NetnsPinPath("det-1")
+	require.NoError(t, os.WriteFile(target, nil, 0o600))
+
+	p.RunDetachedUnpin([]string{target, "1ms"})
+	_, err := os.Stat(target)
+	assert.True(t, os.IsNotExist(err))
+
+	p.RunDetachedUnpin([]string{"only-one-arg"})
+	p.RunDetachedUnpin([]string{target, "not-a-duration"})
 }

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	"github.com/bpalermo/aether/cni/config"
@@ -174,11 +173,11 @@ func (p *AetherPlugin) CmdDel(args *skel.CmdArgs) error {
 
 	if !conf.NetnsPinDisabled {
 		// The agent has deregistered the pod and waited for Envoy to ack the
-		// listener removal; hold the pin briefly for deferred cluster
-		// destruction / connection-pool dials, then release the netns.
-		time.Sleep(conf.NetnsUnpinDelay())
-		if err := p.unpinNetns(conf, args.ContainerID); err != nil {
-			p.logger.Warn("failed to unpin netns; orphan will be swept by GC",
+		// listener removal; a detached unpinner holds the pin through Envoy's
+		// drain tail (health checkers and pool drains were observed dialing
+		// 10-13s after removal under churn) without delaying pod teardown.
+		if err := p.spawnDetachedUnpin(conf.NetnsPinPath(args.ContainerID), conf.NetnsUnpinDelay()); err != nil {
+			p.logger.Warn("failed to spawn netns unpinner; orphan will be swept by GC",
 				zap.String("containerID", args.ContainerID), zap.Error(err))
 		}
 	}


### PR DESCRIPTION
Validation on rev 54 caught a dial 13s post-removal segfaulting on a just-released pin (past the 10s in-process delay). The unpin is now a detached setsid re-exec with a 60s default — generous margin, no pod-teardown latency. Remaining true fix is the upstream Envoy nullptr patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)