### PR TITLE
fix(agent): survive registry unavailability (startup, ADD, reconciliation)

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -4,25 +4,28 @@ import (
 	"context"
 	"time"
 
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/registry"
 )
 
-// Ghost-endpoint sweep (e2e finding, 2026-06-10).
-//
-// A registry endpoint whose deregistration was lost (agent down at CNI DEL,
-// node-level churn, registry outage mid-roll) is owned by nobody and lives
-// forever: nothing re-lists registry content against reality. Under active
-// health checking ghosts are merely noise (clients pin them at
-// failed_active_hc), but in EDS health-check mode a HEALTHY ghost would
-// receive traffic indefinitely — making this sweep a prerequisite for
-// delegated-liveness EDS mode.
+// Registry reconciliation (e2e findings, 2026-06-10).
 //
 // Each agent owns its node's slice of the registry: endpoints whose
-// KubernetesMetadata.NodeName matches this node. The sweep periodically lists
-// registry endpoints and deregisters any of this node's entries whose IP does
-// not belong to a live, locally stored pod. lifecycleMu serializes the sweep
-// against AddPod/RemovePod/liveness so a registering pod cannot be judged a
-// ghost mid-flight.
+// KubernetesMetadata.NodeName matches this node. The reconciler periodically
+// makes that slice equal to local pod storage, in both directions:
+//
+//   - Ghosts: an endpoint whose deregistration was lost (agent down at CNI
+//     DEL, node churn, registry outage mid-roll) is owned by nobody and lives
+//     forever. Under active health checking ghosts are merely noise (clients
+//     pin them at failed_active_hc), but in EDS health-check mode a HEALTHY
+//     ghost would receive traffic indefinitely.
+//   - Missing: a live local pod whose registration was lost (registry outage
+//     at CNI ADD — AddPod deliberately tolerates that — or registry data
+//     loss) would otherwise never receive traffic.
+//
+// lifecycleMu serializes the sweep against AddPod/RemovePod/liveness so a
+// registering pod cannot be judged a ghost mid-flight.
 
 const ghostSweepInterval = 60 * time.Second
 
@@ -41,8 +44,31 @@ func (s *CNIServer) runGhostSweepLoop(ctx context.Context) {
 	}
 }
 
-// sweepGhostEndpoints deregisters this node's registry endpoints that no live
-// local pod accounts for.
+// forgetLiveness queues a container ID for liveness-state reset (see
+// CNIServer.livenessForget).
+func (s *CNIServer) forgetLiveness(containerID string) {
+	s.livenessForgetMu.Lock()
+	defer s.livenessForgetMu.Unlock()
+	if s.livenessForget == nil {
+		s.livenessForget = map[string]struct{}{}
+	}
+	s.livenessForget[containerID] = struct{}{}
+}
+
+// drainLivenessForget removes queued container IDs from the liveness loop's
+// transition cache.
+func (s *CNIServer) drainLivenessForget(last map[string]registryv1.ServiceEndpoint_Health) {
+	s.livenessForgetMu.Lock()
+	defer s.livenessForgetMu.Unlock()
+	for id := range s.livenessForget {
+		delete(last, id)
+	}
+	s.livenessForget = nil
+}
+
+// sweepGhostEndpoints reconciles this node's registry endpoints with local pod
+// storage: deregisters entries no live local pod accounts for, and re-registers
+// live pods the registry is missing.
 func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	all, err := s.registry.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
 	if err != nil {
@@ -60,25 +86,27 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		s.log.V(1).Info("ghost sweep: failed to list local pods", "error", err)
 		return
 	}
-	// Live local IPs. Terminating pods are intentionally excluded: their
+	// Live local pods by IP. Terminating pods are intentionally excluded: their
 	// endpoints were already deregistered, so a ghost re-listing them would be
-	// equally stale.
-	live := make(map[string]struct{}, len(pods))
+	// equally stale (and they must not be re-registered as missing).
+	live := make(map[string]*cniv1.CNIPod, len(pods))
 	for _, p := range pods {
-		if p.GetTerminating() {
+		if p.GetTerminating() || isIgnorablePod(p) {
 			continue
 		}
 		for _, ip := range p.GetIps() {
-			live[ip] = struct{}{}
+			live[ip] = p
 		}
 	}
 
+	registered := make(map[string]struct{})
 	for service, endpoints := range all {
 		for _, ep := range endpoints {
 			if ep.GetKubernetesMetadata().GetNodeName() != s.nodeName {
 				continue // another agent's responsibility
 			}
 			if _, ok := live[ep.GetIp()]; ok {
+				registered[ep.GetIp()] = struct{}{}
 				continue
 			}
 			if err := s.registry.UnregisterEndpoint(ctx, service, ep.GetIp()); err != nil {
@@ -89,5 +117,31 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 			s.log.Info("ghost sweep: deregistered ghost endpoint",
 				"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
 		}
+	}
+
+	// Missing direction: live local pods absent from the registry (lost ADD
+	// registration, registry data loss). Register at the mode-default health
+	// (EDS mode: UNHEALTHY) and reset the liveness transition cache so the next
+	// healthy observation re-promotes.
+	for ip, pod := range live {
+		if _, ok := registered[ip]; ok {
+			continue
+		}
+		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, pod)
+		if err != nil {
+			s.log.V(1).Info("ghost sweep: failed to build endpoint for missing pod", "pod", pod.GetName(), "error", err)
+			continue
+		}
+		if endpoint.GetHealthCheckMode() == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS {
+			endpoint.Health = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
+		}
+		if err := s.registry.RegisterEndpoint(ctx, serviceName, protocol, endpoint); err != nil {
+			s.log.Error(err, "ghost sweep: failed to register missing endpoint",
+				"service", serviceName, "ip", ip, "pod", pod.GetName())
+			continue
+		}
+		s.forgetLiveness(pod.GetContainerId())
+		s.log.Info("ghost sweep: registered missing endpoint",
+			"service", serviceName, "ip", ip, "pod", pod.GetName())
 	}
 }

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -18,7 +18,8 @@ import (
 type sweepRegistry struct {
 	testRegistry
 	listing      map[string][]*registryv1.ServiceEndpoint
-	unregistered map[string][]string // service -> ips
+	unregistered map[string][]string                    // service -> ips
+	registered   map[string]*registryv1.ServiceEndpoint // service/ip -> endpoint
 }
 
 func (r *sweepRegistry) ListAllEndpoints(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
@@ -30,6 +31,14 @@ func (r *sweepRegistry) UnregisterEndpoint(_ context.Context, service, ip string
 		r.unregistered = map[string][]string{}
 	}
 	r.unregistered[service] = append(r.unregistered[service], ip)
+	return nil
+}
+
+func (r *sweepRegistry) RegisterEndpoint(_ context.Context, service string, _ registryv1.Service_Protocol, ep *registryv1.ServiceEndpoint) error {
+	if r.registered == nil {
+		r.registered = map[string]*registryv1.ServiceEndpoint{}
+	}
+	r.registered[service+"/"+ep.GetIp()] = ep
 	return nil
 }
 
@@ -77,4 +86,32 @@ func TestSweepGhostEndpoints(t *testing.T) {
 		"svc-a": {"10.0.0.9"},
 		"svc-b": {"10.0.0.2"},
 	}, reg.unregistered)
+	assert.Empty(t, reg.registered, "all live pods were present in the registry")
+}
+
+// TestSweepRegistersMissingEndpoint: a live local pod absent from the registry
+// (lost ADD registration, registry data loss) is re-registered at the
+// mode-default health (default EDS mode: UNHEALTHY, pending promotion) and its
+// liveness transition cache is invalidated.
+func TestSweepRegistersMissingEndpoint(t *testing.T) {
+	ctx := context.Background()
+
+	missing := validCNIPod("pod-missing", "default", "container-missing")
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-missing"), missing))
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "127.0.0.1:1")
+
+	s.sweepGhostEndpoints(ctx)
+
+	ep, ok := reg.registered["default/10.0.0.1"]
+	require.True(t, ok, "missing endpoint must be re-registered (service from SA, ip from pod)")
+	assert.Equal(t, registryv1.ServiceEndpoint_HEALTH_UNHEALTHY, ep.GetHealth(), "EDS-mode re-registration starts UNHEALTHY pending promotion")
+
+	// The liveness loop must treat the next observation as a transition.
+	last := map[string]registryv1.ServiceEndpoint_Health{"container-missing": registryv1.ServiceEndpoint_HEALTH_HEALTHY}
+	s.drainLivenessForget(last)
+	assert.NotContains(t, last, "container-missing")
 }

--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -39,6 +39,10 @@ func (s *CNIServer) runLivenessLoop(ctx context.Context) {
 // reconcileLiveness scrapes the proxy for per-pod app health and re-registers any
 // endpoint whose health changed since the last report.
 func (s *CNIServer) reconcileLiveness(ctx context.Context, last map[string]registryv1.ServiceEndpoint_Health) {
+	// Drop transition state the reconciler invalidated (re-registered endpoints
+	// sit at the mode-default health; the next observation must re-promote).
+	s.drainLivenessForget(last)
+
 	appHealth, err := s.envoyAdmin.AppClusterHealth(ctx)
 	if err != nil {
 		s.log.V(1).Info("liveness: failed to read app cluster health", "error", err)

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -70,8 +70,11 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		if fresh && sEndpoint.GetHealthCheckMode() == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS {
 			sEndpoint.Health = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
 		}
+		// Registry unavailability must not block pod creation node-wide (a
+		// failed ADD fails the sandbox): the pod is already stored, so the
+		// reconciliation sweep registers it as soon as the registry answers.
 		if err = s.registry.RegisterEndpoint(ctx, serviceName, protocol, sEndpoint); err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to register endpoint: %v", err)
+			log.Error(err, "failed to register endpoint; reconciliation sweep will retry", "service", serviceName)
 		}
 	}
 

--- a/agent/internal/cni/server/pod_test.go
+++ b/agent/internal/cni/server/pod_test.go
@@ -363,7 +363,10 @@ func TestAddPod(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid pod with registry failure returns error",
+			// Registry unavailability must not block pod creation node-wide:
+			// the pod is stored and the reconciliation sweep registers it once
+			// the registry answers.
+			name: "valid pod with registry failure still succeeds",
 			setupK8s: func() client.Client {
 				return fake.NewClientBuilder().WithObjects(validK8sPod("my-pod", "default")).Build()
 			},
@@ -376,8 +379,8 @@ func TestAddPod(t *testing.T) {
 			req: &cniv1.AddPodRequest{
 				Pod: validCNIPod("my-pod", "default", containerID),
 			},
-			want:    nil,
-			wantErr: true,
+			want:    &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_SUCCESS},
+			wantErr: false,
 		},
 		{
 			name: "valid pod with all dependencies succeeds",

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -53,6 +53,13 @@ type CNIServer struct {
 	// that nothing unregisters again.
 	lifecycleMu sync.Mutex
 
+	// livenessForget collects container IDs whose cached liveness state must be
+	// dropped (the reconciler re-registered their endpoint at the mode-default
+	// health, so the next observation must be treated as a transition).
+	// Consumed at the start of each liveness tick.
+	livenessForgetMu sync.Mutex
+	livenessForget   map[string]struct{}
+
 	snapshotCache *cache.SnapshotCache
 	spireBridge   *spire.Bridge
 	envoyAdmin    *admin.Client

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -5,6 +5,7 @@ package server
 
 import (
 	"context"
+	"time"
 
 	"github.com/bpalermo/aether/agent/constants"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
@@ -72,10 +73,39 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 		return err
 	}
 
+	// Registry unavailability must not prevent the agent from starting: a
+	// crash-looping agent takes down the node's CNI ADD/DEL and xDS entirely,
+	// turning a registrar blip into a node-wide outage (observed cascading
+	// failure on talos-main, 2026-06-10). Serve the local-only snapshot now and
+	// fill in registry-derived clusters/endpoints as soon as the registry
+	// answers; the registry refresher keeps it current afterwards.
 	if err := s.cache.LoadClustersFromRegistry(ctx, s.clusterName, s.nodeName, s.registry); err != nil {
-		s.log.Error(err, "failed to load clusters, endpoints and virtual hosts from registry")
-		return err
+		s.log.Error(err, "registry unavailable for initial snapshot; starting with local-only config and retrying in background")
+		go s.retryInitialRegistryLoad(ctx)
 	}
 
 	return nil
+}
+
+// retryInitialRegistryLoad retries the registry-derived snapshot load with
+// capped exponential backoff until it succeeds or ctx ends.
+func (s *AgentXdsServer) retryInitialRegistryLoad(ctx context.Context) {
+	const maxBackoff = 30 * time.Second
+	backoff := time.Second
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		if err := s.cache.LoadClustersFromRegistry(ctx, s.clusterName, s.nodeName, s.registry); err != nil {
+			s.log.V(1).Info("registry still unavailable; will retry", "backoff", backoff.String(), "error", err)
+			if backoff < maxBackoff {
+				backoff *= 2
+			}
+			continue
+		}
+		s.log.Info("registry recovered; snapshot now includes registry-derived config")
+		return
+	}
 }

--- a/agent/internal/xds/server/server_test.go
+++ b/agent/internal/xds/server/server_test.go
@@ -144,14 +144,17 @@ func TestAgentXdsServer_PreListen(t *testing.T) {
 			wantErr: errStorage,
 		},
 		{
-			name: "registry error returns error after storage succeeds",
+			// Registry unavailability must not prevent the agent from starting
+			// (a crash-looping agent takes down the node's CNI and xDS; the
+			// load is retried in the background): PreListen succeeds with the
+			// local-only snapshot.
+			name: "registry error starts local-only without error",
 			storageGetAll: func(_ context.Context) ([]*cniv1.CNIPod, error) {
 				return []*cniv1.CNIPod{}, nil
 			},
 			registryListAll: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 				return nil, errRegistry
 			},
-			wantErr: errRegistry,
 		},
 		{
 			name: "both succeed with empty data produces valid snapshot",


### PR DESCRIPTION
Resilience finding from the 2026-06-10 cascade: agents crash-looped on a registrar blip, taking down node CNI + xDS. PreListen now starts local-only with background retry; AddPod tolerates registration failure (pod stored, sweep reconciles); the ghost sweep is bidirectional (also re-registers missing live endpoints, with liveness-cache invalidation so promotion re-fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)