### PR TITLE
feat(registry): DRAINING endpoint health + Cloud Map native health status

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -86,12 +86,20 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		s.log.V(1).Info("ghost sweep: failed to list local pods", "error", err)
 		return
 	}
-	// Live local pods by IP. Terminating pods are intentionally excluded: their
-	// endpoints were already deregistered, so a ghost re-listing them would be
-	// equally stale (and they must not be re-registered as missing).
+	// Live local pods by IP. Terminating pods are tracked separately: their
+	// endpoints are deliberately still registered (marked DRAINING by the
+	// termination watch, removed at CNI DEL) — they are neither ghosts to
+	// deregister nor missing entries to re-register.
 	live := make(map[string]*cniv1.CNIPod, len(pods))
+	terminating := make(map[string]struct{})
 	for _, p := range pods {
-		if p.GetTerminating() || isIgnorablePod(p) {
+		if isIgnorablePod(p) {
+			continue
+		}
+		if p.GetTerminating() {
+			for _, ip := range p.GetIps() {
+				terminating[ip] = struct{}{}
+			}
 			continue
 		}
 		for _, ip := range p.GetIps() {
@@ -108,6 +116,9 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 			if _, ok := live[ep.GetIp()]; ok {
 				registered[ep.GetIp()] = struct{}{}
 				continue
+			}
+			if _, ok := terminating[ep.GetIp()]; ok {
+				continue // draining; CNI DEL owns the final removal
 			}
 			if err := s.registry.UnregisterEndpoint(ctx, service, ep.GetIp()); err != nil {
 				s.log.Error(err, "ghost sweep: failed to deregister ghost endpoint",

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -75,7 +75,9 @@ func TestSweepGhostEndpoints(t *testing.T) {
 			sweepEndpoint("10.0.0.3", "other-node", "pod-other"), // other node -> ignore
 		},
 		"svc-b": {
-			sweepEndpoint("10.0.0.2", "test-node", "pod-term"), // terminating ghost -> deregister
+			// Terminating pod's endpoint: marked DRAINING by the termination
+			// watch and removed at CNI DEL — the sweep must leave it alone.
+			sweepEndpoint("10.0.0.2", "test-node", "pod-term"),
 		},
 	}}
 	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "127.0.0.1:1")
@@ -84,7 +86,6 @@ func TestSweepGhostEndpoints(t *testing.T) {
 
 	assert.Equal(t, map[string][]string{
 		"svc-a": {"10.0.0.9"},
-		"svc-b": {"10.0.0.2"},
 	}, reg.unregistered)
 	assert.Empty(t, reg.registered, "all live pods were present in the registry")
 }

--- a/agent/internal/cni/server/termination.go
+++ b/agent/internal/cni/server/termination.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/types"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/registry"
 	corev1 "k8s.io/api/core/v1"
 	toolscache "k8s.io/client-go/tools/cache"
@@ -102,23 +103,35 @@ func (s *CNIServer) handlePodTerminating(ctx context.Context, pod *corev1.Pod) {
 		return // already removed by CNI DEL, or another event won the race
 	}
 
-	// Mark first: even if the unregister below fails transiently, the liveness
-	// loop must stop refreshing this endpoint (CNI DEL retries the unregister).
+	// Mark first: even if the registry update below fails transiently, the
+	// liveness loop must stop refreshing this endpoint (CNI DEL still removes
+	// it at teardown).
 	cur.Terminating = true
 	if err := s.storage.AddResource(ctx, types.ContainerID(cur.GetContainerId()), cur); err != nil {
 		log.Error(err, "termination: failed to persist terminating flag")
 	}
 
-	serviceName, ips, err := registry.ExtractCNIPodInformation(cur)
+	// Mark the endpoint DRAINING rather than removing it: Envoy excludes
+	// DRAINING hosts from new selections but lets established connections
+	// finish through the grace period — less connection-pool churn than
+	// outright removal. CNI DEL performs the final removal.
+	serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, cur)
 	if err != nil {
-		log.Error(err, "termination: failed to extract endpoint info")
+		log.Error(err, "termination: failed to build endpoint")
 		return
 	}
-	if err := s.registry.UnregisterEndpoints(ctx, serviceName, ips); err != nil {
-		log.Error(err, "termination: early deregistration failed; CNI DEL will retry")
+	endpoint.Health = registryv1.ServiceEndpoint_HEALTH_DRAINING
+	if err := s.registry.RegisterEndpoint(ctx, serviceName, protocol, endpoint); err != nil {
+		log.Error(err, "termination: failed to mark endpoint draining; falling back to deregistration")
+		// Removal is strictly safer than leaving the endpoint selectable.
+		if _, ips, exErr := registry.ExtractCNIPodInformation(cur); exErr == nil {
+			if unregErr := s.registry.UnregisterEndpoints(ctx, serviceName, ips); unregErr != nil {
+				log.Error(unregErr, "termination: fallback deregistration also failed; CNI DEL will retry")
+			}
+		}
 		return
 	}
-	log.Info("pod terminating: endpoint deregistered ahead of shutdown", "service", serviceName)
+	log.Info("pod terminating: endpoint marked draining ahead of shutdown", "service", serviceName)
 }
 
 // findStoredPod scans local storage for the CNIPod with the given name and

--- a/agent/internal/cni/server/termination_test.go
+++ b/agent/internal/cni/server/termination_test.go
@@ -22,6 +22,7 @@ type unregisterRecordingRegistry struct {
 	testRegistry
 	unregistered int
 	registered   int
+	lastHealth   registryv1.ServiceEndpoint_Health
 }
 
 func (r *unregisterRecordingRegistry) UnregisterEndpoints(_ context.Context, _ string, _ []string) error {
@@ -29,9 +30,10 @@ func (r *unregisterRecordingRegistry) UnregisterEndpoints(_ context.Context, _ s
 	return r.unregisterEndpointsErr
 }
 
-func (r *unregisterRecordingRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, _ *registryv1.ServiceEndpoint) error {
+func (r *unregisterRecordingRegistry) RegisterEndpoint(_ context.Context, _ string, _ registryv1.Service_Protocol, ep *registryv1.ServiceEndpoint) error {
 	r.registered++
-	return nil
+	r.lastHealth = ep.GetHealth()
+	return r.registerEndpointErr
 }
 
 // terminatingK8sPod returns a corev1.Pod on the given node with
@@ -49,8 +51,9 @@ func terminatingK8sPod(name, namespace, node string) *corev1.Pod {
 }
 
 // TestHandlePodTerminating covers the early-drain path: a deletion-requested
-// pod is deregistered exactly once, persisted as terminating, and repeat events
-// (informer resync, force-delete after the transition) are no-ops.
+// pod is marked DRAINING in the registry exactly once, persisted as
+// terminating, and repeat events (informer resync, force-delete after the
+// transition) are no-ops.
 func TestHandlePodTerminating(t *testing.T) {
 	ctx := context.Background()
 	pod := validCNIPod("pod-a", "default", "container-a")
@@ -62,14 +65,33 @@ func TestHandlePodTerminating(t *testing.T) {
 
 	s.handlePodTerminating(ctx, terminatingK8sPod("pod-a", "default", "test-node"))
 
-	assert.Equal(t, 1, reg.unregistered, "endpoint must be deregistered")
+	assert.Equal(t, 1, reg.registered, "endpoint must be re-registered as draining")
+	assert.Equal(t, registryv1.ServiceEndpoint_HEALTH_DRAINING, reg.lastHealth)
+	assert.Zero(t, reg.unregistered, "draining replaces removal; CNI DEL removes later")
 	stored, err := store.GetResource(ctx, types.ContainerID("container-a"))
 	require.NoError(t, err)
 	assert.True(t, stored.GetTerminating(), "terminating flag must be persisted")
 
 	// Second event (resync / DELETE after the transition): idempotent.
 	s.handlePodTerminating(ctx, terminatingK8sPod("pod-a", "default", "test-node"))
-	assert.Equal(t, 1, reg.unregistered, "repeat events must not deregister again")
+	assert.Equal(t, 1, reg.registered, "repeat events must not re-mark again")
+}
+
+// TestHandlePodTerminatingFallsBackToRemoval: if the DRAINING mark cannot be
+// written, removal is the safe fallback (never leave the endpoint selectable).
+func TestHandlePodTerminatingFallsBackToRemoval(t *testing.T) {
+	ctx := context.Background()
+	pod := validCNIPod("pod-a", "default", "container-a")
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-a"), pod))
+	reg := &unregisterRecordingRegistry{}
+	reg.registerEndpointErr = assert.AnError
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "127.0.0.1:1")
+
+	s.handlePodTerminating(ctx, terminatingK8sPod("pod-a", "default", "test-node"))
+
+	assert.Equal(t, 1, reg.unregistered, "failed draining mark must fall back to deregistration")
 }
 
 // TestHandlePodTerminatingScope: pods on other nodes or unknown to local
@@ -84,23 +106,24 @@ func TestHandlePodTerminatingScope(t *testing.T) {
 	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "127.0.0.1:1")
 
 	s.handlePodTerminating(ctx, terminatingK8sPod("pod-a", "default", "other-node"))
-	assert.Zero(t, reg.unregistered, "another node's pod must be ignored")
+	assert.Zero(t, reg.registered+reg.unregistered, "another node's pod must be ignored")
 
 	s.handlePodTerminating(ctx, terminatingK8sPod("pod-unknown", "default", "test-node"))
-	assert.Zero(t, reg.unregistered, "a pod absent from local storage must be ignored")
+	assert.Zero(t, reg.registered+reg.unregistered, "a pod absent from local storage must be ignored")
 }
 
-// TestHandlePodTerminatingMarksEvenWhenUnregisterFails: the terminating flag is
-// persisted before the registry call, so a transient unregister failure cannot
+// TestHandlePodTerminatingMarksEvenWhenRegistryFails: the terminating flag is
+// persisted before any registry call, so transient registry failures cannot
 // leave the liveness loop free to resurrect the endpoint (CNI DEL retries the
-// unregister later).
-func TestHandlePodTerminatingMarksEvenWhenUnregisterFails(t *testing.T) {
+// removal later).
+func TestHandlePodTerminatingMarksEvenWhenRegistryFails(t *testing.T) {
 	ctx := context.Background()
 	pod := validCNIPod("pod-a", "default", "container-a")
 
 	store := storage.NewMockStorage[*cniv1.CNIPod]()
 	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-a"), pod))
 	reg := &unregisterRecordingRegistry{}
+	reg.registerEndpointErr = assert.AnError
 	reg.unregisterEndpointsErr = assert.AnError
 	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "127.0.0.1:1")
 
@@ -108,7 +131,7 @@ func TestHandlePodTerminatingMarksEvenWhenUnregisterFails(t *testing.T) {
 
 	stored, err := store.GetResource(ctx, types.ContainerID("container-a"))
 	require.NoError(t, err)
-	assert.True(t, stored.GetTerminating(), "flag must be set even when unregister fails")
+	assert.True(t, stored.GetTerminating(), "flag must be set even when the registry is unavailable")
 }
 
 // TestReconcileLivenessSkipsTerminatingPod: the liveness loop must never

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -162,8 +162,14 @@ func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceE
 // the Envoy EDS health status. Unknown/unspecified defaults to HEALTHY so older
 // agents and freshly registered endpoints route until proven unhealthy.
 func endpointHealthStatus(endpoint *registryv1.ServiceEndpoint) corev3.HealthStatus {
-	if endpoint.GetHealth() == registryv1.ServiceEndpoint_HEALTH_UNHEALTHY {
+	switch endpoint.GetHealth() {
+	case registryv1.ServiceEndpoint_HEALTH_UNHEALTHY:
 		return corev3.HealthStatus_UNHEALTHY
+	case registryv1.ServiceEndpoint_HEALTH_DRAINING:
+		// Pod deletion requested: excluded from new selections, established
+		// connections drain gracefully.
+		return corev3.HealthStatus_DRAINING
+	default:
+		return corev3.HealthStatus_HEALTHY
 	}
-	return corev3.HealthStatus_HEALTHY
 }

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -51,6 +51,12 @@ message ServiceEndpoint {
     HEALTH_UNSPECIFIED = 0;
     HEALTH_HEALTHY = 1;
     HEALTH_UNHEALTHY = 2;
+    // HEALTH_DRAINING marks an endpoint whose pod's deletion has been
+    // requested: clients must stop selecting it for new requests (Envoy EDS
+    // DRAINING) while established connections finish through the pod's
+    // termination grace period. Set by the agent's termination watch; the
+    // endpoint is removed entirely at CNI DEL.
+    HEALTH_DRAINING = 3;
   }
 
   Health health = 9;

--- a/registry/internal/cloudmap/attrs.go
+++ b/registry/internal/cloudmap/attrs.go
@@ -26,12 +26,20 @@ const (
 	attrK8sNamespace    = "AETHER_K8S_NAMESPACE"
 	attrK8sPod          = "AETHER_K8S_POD"
 	attrK8sNode         = "AETHER_K8S_NODE"
-	attrHealth          = "AETHER_HEALTH"
 	attrHealthCheckMode = "AETHER_HEALTH_CHECK_MODE"
-	attrContainerID     = "AETHER_CONTAINER_ID"
-	attrNetworkNS       = "AETHER_NETWORK_NS"
-	attrMetadata        = "AETHER_METADATA"
-	attrController      = "AETHER_CONTROLLER"
+	// attrDraining refines Cloud Map's binary instance health: a draining
+	// endpoint is natively UNHEALTHY (excluded from selection) and this marker
+	// upgrades it to EDS DRAINING (established connections finish gracefully).
+	// The health verdict itself lives in Cloud Map's native per-instance
+	// status, never in an attribute.
+	attrDraining = "AETHER_DRAINING"
+	// attrInitHealth is Cloud Map's reserved attribute seeding a brand-new
+	// instance's custom health status at registration.
+	attrInitHealth  = "AWS_INIT_HEALTH_STATUS"
+	attrContainerID = "AETHER_CONTAINER_ID"
+	attrNetworkNS   = "AETHER_NETWORK_NS"
+	attrMetadata    = "AETHER_METADATA"
+	attrController  = "AETHER_CONTROLLER"
 
 	// controllerName identifies instances managed by Aether.
 	controllerName = "aether"
@@ -90,9 +98,12 @@ func marshalAttrs(protocol registryv1.Service_Protocol, ep *registryv1.ServiceEn
 		}
 	}
 
-	// Only persist an explicit health verdict; absence means "unknown" (healthy).
-	if h := ep.GetHealth(); h != registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED {
-		attrs[attrHealth] = h.String()
+	// Health is native: seed new instances via AWS_INIT_HEALTH_STATUS (updates
+	// go through UpdateInstanceCustomHealthStatus). DRAINING maps to natively
+	// UNHEALTHY plus the draining marker.
+	attrs[attrInitHealth] = string(initHealthStatus(ep.GetHealth()))
+	if ep.GetHealth() == registryv1.ServiceEndpoint_HEALTH_DRAINING {
+		attrs[attrDraining] = "true"
 	}
 
 	// Only persist an explicit mode; absence means the default (active).
@@ -152,10 +163,6 @@ func unmarshalEndpoint(attrs map[string]string) (*registryv1.ServiceEndpoint, er
 		}
 	}
 
-	if h, ok := registryv1.ServiceEndpoint_Health_value[attrs[attrHealth]]; ok {
-		ep.Health = registryv1.ServiceEndpoint_Health(h)
-	}
-
 	if m, ok := registryv1.ServiceEndpoint_HealthCheckMode_value[attrs[attrHealthCheckMode]]; ok {
 		ep.HealthCheckMode = registryv1.ServiceEndpoint_HealthCheckMode(m)
 	}
@@ -163,9 +170,41 @@ func unmarshalEndpoint(attrs map[string]string) (*registryv1.ServiceEndpoint, er
 	return ep, nil
 }
 
-// unmarshalEndpointFromSummary converts an HttpInstanceSummary into a ServiceEndpoint.
+// unmarshalEndpointFromSummary converts an HttpInstanceSummary into a
+// ServiceEndpoint. Health comes from Cloud Map's native per-instance status
+// (set via custom health checks), refined to DRAINING by the draining marker;
+// an unknown status maps to UNSPECIFIED (treated healthy, matching older
+// instances).
 func unmarshalEndpointFromSummary(summary types.HttpInstanceSummary) (*registryv1.ServiceEndpoint, error) {
-	return unmarshalEndpoint(summary.Attributes)
+	ep, err := unmarshalEndpoint(summary.Attributes)
+	if err != nil {
+		return nil, err
+	}
+	switch summary.HealthStatus {
+	case types.HealthStatusHealthy:
+		ep.Health = registryv1.ServiceEndpoint_HEALTH_HEALTHY
+	case types.HealthStatusUnhealthy:
+		ep.Health = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
+		if summary.Attributes[attrDraining] == "true" {
+			ep.Health = registryv1.ServiceEndpoint_HEALTH_DRAINING
+		}
+	default:
+		ep.Health = registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED
+	}
+	return ep, nil
+}
+
+// initHealthStatus maps a registry health to the AWS_INIT_HEALTH_STATUS seed.
+func initHealthStatus(h registryv1.ServiceEndpoint_Health) types.CustomHealthStatus {
+	if h == registryv1.ServiceEndpoint_HEALTH_UNHEALTHY || h == registryv1.ServiceEndpoint_HEALTH_DRAINING {
+		return types.CustomHealthStatusUnhealthy
+	}
+	return types.CustomHealthStatusHealthy
+}
+
+// customHealthStatus maps a registry health to the native custom health update.
+func customHealthStatus(h registryv1.ServiceEndpoint_Health) types.CustomHealthStatus {
+	return initHealthStatus(h)
 }
 
 // protocolFromAttrs extracts the protocol from instance attributes.

--- a/registry/internal/cloudmap/attrs_test.go
+++ b/registry/internal/cloudmap/attrs_test.go
@@ -39,6 +39,13 @@ func fullEndpoint() *registryv1.ServiceEndpoint {
 	}
 }
 
+// healthStripped returns the endpoint as it comes back from an attribute-only
+// unmarshal: health is carried natively, not in attributes.
+func healthStripped(ep *registryv1.ServiceEndpoint) *registryv1.ServiceEndpoint {
+	ep.Health = registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED
+	return ep
+}
+
 func TestMarshalAttrsUnmarshalEndpointRoundTrip(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -49,14 +56,19 @@ func TestMarshalAttrsUnmarshalEndpointRoundTrip(t *testing.T) {
 		expected *registryv1.ServiceEndpoint
 	}{
 		{
+			// Health deliberately does NOT round-trip through attributes: it
+			// lives in Cloud Map's native per-instance status (see
+			// unmarshalEndpointFromSummary / TestSummaryHealthMapping).
 			name:     "full endpoint with HTTP protocol",
 			protocol: registryv1.Service_PROTOCOL_HTTP,
 			endpoint: fullEndpoint(),
+			expected: healthStripped(fullEndpoint()),
 		},
 		{
 			name:     "full endpoint with unspecified protocol",
 			protocol: registryv1.Service_PROTOCOL_UNSPECIFIED,
 			endpoint: fullEndpoint(),
+			expected: healthStripped(fullEndpoint()),
 		},
 		{
 			name:     "minimal endpoint — only required fields",
@@ -555,4 +567,43 @@ func TestInstanceIDFormat(t *testing.T) {
 	// Verify the ID uses the expected "clusterName/ip" separator format.
 	got := instanceID("prod-cluster", "192.168.0.5")
 	assert.Equal(t, fmt.Sprintf("%s/%s", "prod-cluster", "192.168.0.5"), got)
+}
+
+// TestSummaryHealthMapping: native Cloud Map instance health maps onto the
+// registry health, with the draining marker refining UNHEALTHY to DRAINING.
+func TestSummaryHealthMapping(t *testing.T) {
+	for name, tc := range map[string]struct {
+		status   types.HealthStatus
+		draining bool
+		want     registryv1.ServiceEndpoint_Health
+	}{
+		"healthy":            {types.HealthStatusHealthy, false, registryv1.ServiceEndpoint_HEALTH_HEALTHY},
+		"unhealthy":          {types.HealthStatusUnhealthy, false, registryv1.ServiceEndpoint_HEALTH_UNHEALTHY},
+		"draining":           {types.HealthStatusUnhealthy, true, registryv1.ServiceEndpoint_HEALTH_DRAINING},
+		"unknown -> default": {types.HealthStatusUnknown, false, registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ep := fullEndpoint()
+			ep.Health = registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED
+			if tc.draining {
+				ep.Health = registryv1.ServiceEndpoint_HEALTH_DRAINING // sets the marker on marshal
+			}
+			attrs := marshalAttrs(registryv1.Service_PROTOCOL_HTTP, ep)
+			got, err := unmarshalEndpointFromSummary(types.HttpInstanceSummary{
+				Attributes:   attrs,
+				HealthStatus: tc.status,
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got.GetHealth())
+		})
+	}
+}
+
+// TestInitHealthStatus: registry health seeds Cloud Map custom health; both
+// UNHEALTHY and DRAINING gate natively as UNHEALTHY.
+func TestInitHealthStatus(t *testing.T) {
+	assert.Equal(t, types.CustomHealthStatusHealthy, initHealthStatus(registryv1.ServiceEndpoint_HEALTH_UNSPECIFIED))
+	assert.Equal(t, types.CustomHealthStatusHealthy, initHealthStatus(registryv1.ServiceEndpoint_HEALTH_HEALTHY))
+	assert.Equal(t, types.CustomHealthStatusUnhealthy, initHealthStatus(registryv1.ServiceEndpoint_HEALTH_UNHEALTHY))
+	assert.Equal(t, types.CustomHealthStatusUnhealthy, initHealthStatus(registryv1.ServiceEndpoint_HEALTH_DRAINING))
 }

--- a/registry/internal/cloudmap/client.go
+++ b/registry/internal/cloudmap/client.go
@@ -15,4 +15,5 @@ type Client interface {
 	RegisterInstance(ctx context.Context, params *servicediscovery.RegisterInstanceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.RegisterInstanceOutput, error)
 	DeregisterInstance(ctx context.Context, params *servicediscovery.DeregisterInstanceInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DeregisterInstanceOutput, error)
 	DiscoverInstances(ctx context.Context, params *servicediscovery.DiscoverInstancesInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.DiscoverInstancesOutput, error)
+	UpdateInstanceCustomHealthStatus(ctx context.Context, params *servicediscovery.UpdateInstanceCustomHealthStatusInput, optFns ...func(*servicediscovery.Options)) (*servicediscovery.UpdateInstanceCustomHealthStatusOutput, error)
 }

--- a/registry/internal/cloudmap/cloudmap.go
+++ b/registry/internal/cloudmap/cloudmap.go
@@ -125,6 +125,19 @@ func (r *CloudMapRegistry) RegisterEndpoint(ctx context.Context, serviceName str
 		return fmt.Errorf("failed to register instance for IP %s: %w", ip, err)
 	}
 
+	// Health lives in Cloud Map's native per-instance status, not an attribute.
+	// AWS_INIT_HEALTH_STATUS only applies to brand-new instances, so an update
+	// is required for re-registrations (liveness transitions, draining marks).
+	// Best-effort: services created before custom health checks reject this
+	// until they are re-created (see resolveOrCreateServiceID).
+	if _, healthErr := r.client.UpdateInstanceCustomHealthStatus(ctx, &servicediscovery.UpdateInstanceCustomHealthStatusInput{
+		ServiceId:  aws.String(svcID),
+		InstanceId: aws.String(instID),
+		Status:     customHealthStatus(endpoint.GetHealth()),
+	}); healthErr != nil {
+		r.log.Error(healthErr, "failed to update instance health status", "service", serviceName, "ip", ip)
+	}
+
 	// Evict endpoint cache for this service (all protocols)
 	r.evictEndpointCache(serviceName)
 
@@ -302,6 +315,12 @@ func (r *CloudMapRegistry) resolveOrCreateServiceID(ctx context.Context, service
 	out, err := r.client.CreateService(ctx, &servicediscovery.CreateServiceInput{
 		Name:        aws.String(serviceName),
 		NamespaceId: aws.String(r.namespaceID),
+		// Custom health checks let endpoint health live in Cloud Map's native
+		// per-instance health status (UpdateInstanceCustomHealthStatus) instead
+		// of an Aether attribute. Immutable after creation: services created
+		// without it must be deleted and re-created (the agents' reconciliation
+		// sweep re-registers all live endpoints automatically).
+		HealthCheckCustomConfig: &types.HealthCheckCustomConfig{},
 	})
 	if err != nil {
 		return "", fmt.Errorf("failed to create service %q: %w", serviceName, err)

--- a/registry/internal/cloudmap/fake_client_test.go
+++ b/registry/internal/cloudmap/fake_client_test.go
@@ -22,6 +22,8 @@ type fakeClient struct {
 	services map[string]map[string]string
 	// instances maps serviceID -> (instanceID -> attributes)
 	instances map[string]map[string]map[string]string
+	// health maps serviceID -> (instanceID -> custom health status)
+	health map[string]map[string]types.HealthStatus
 	// serviceNameByID maps serviceID -> serviceName (reverse lookup)
 	serviceNameByID map[string]string
 	// namespaceIDByServiceID maps serviceID -> namespaceID
@@ -35,6 +37,7 @@ func newFakeClient() *fakeClient {
 		namespaces:             make(map[string]string),
 		services:               make(map[string]map[string]string),
 		instances:              make(map[string]map[string]map[string]string),
+		health:                 make(map[string]map[string]types.HealthStatus),
 		serviceNameByID:        make(map[string]string),
 		namespaceIDByServiceID: make(map[string]string),
 	}
@@ -146,6 +149,20 @@ func (f *fakeClient) RegisterInstance(_ context.Context, input *servicediscovery
 		return nil, fmt.Errorf("service %s not found", svcID)
 	}
 
+	// AWS_INIT_HEALTH_STATUS seeds custom health for brand-new instances only
+	// (matching Cloud Map: re-registrations keep the current health).
+	if _, exists := svcInstances[instID]; !exists {
+		if f.health[svcID] == nil {
+			f.health[svcID] = make(map[string]types.HealthStatus)
+		}
+		switch input.Attributes["AWS_INIT_HEALTH_STATUS"] {
+		case "UNHEALTHY":
+			f.health[svcID][instID] = types.HealthStatusUnhealthy
+		default:
+			f.health[svcID][instID] = types.HealthStatusHealthy
+		}
+	}
+
 	// Copy attributes (upsert semantics)
 	attrs := make(map[string]string, len(input.Attributes))
 	for k, v := range input.Attributes {
@@ -154,6 +171,26 @@ func (f *fakeClient) RegisterInstance(_ context.Context, input *servicediscovery
 	svcInstances[instID] = attrs
 
 	return &servicediscovery.RegisterInstanceOutput{}, nil
+}
+
+func (f *fakeClient) UpdateInstanceCustomHealthStatus(_ context.Context, input *servicediscovery.UpdateInstanceCustomHealthStatusInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.UpdateInstanceCustomHealthStatusOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	svcID := aws.ToString(input.ServiceId)
+	instID := aws.ToString(input.InstanceId)
+	if _, ok := f.instances[svcID][instID]; !ok {
+		return nil, fmt.Errorf("instance %s not found in service %s", instID, svcID)
+	}
+	if f.health[svcID] == nil {
+		f.health[svcID] = make(map[string]types.HealthStatus)
+	}
+	if input.Status == types.CustomHealthStatusUnhealthy {
+		f.health[svcID][instID] = types.HealthStatusUnhealthy
+	} else {
+		f.health[svcID][instID] = types.HealthStatusHealthy
+	}
+	return &servicediscovery.UpdateInstanceCustomHealthStatusOutput{}, nil
 }
 
 func (f *fakeClient) DeregisterInstance(_ context.Context, input *servicediscovery.DeregisterInstanceInput, _ ...func(*servicediscovery.Options)) (*servicediscovery.DeregisterInstanceOutput, error) {
@@ -197,8 +234,9 @@ func (f *fakeClient) DiscoverInstances(_ context.Context, input *servicediscover
 			continue
 		}
 		results = append(results, types.HttpInstanceSummary{
-			InstanceId: aws.String(instID),
-			Attributes: copyAttrs(attrs),
+			InstanceId:   aws.String(instID),
+			Attributes:   copyAttrs(attrs),
+			HealthStatus: f.health[svcID][instID],
 		})
 	}
 


### PR DESCRIPTION
Phase (b) of the drain plan. **Stacked on #118** (shares the reconciliation-sweep code — this diff includes #118's commit until it merges, then rebases clean).

- Termination watch marks endpoints `HEALTH_DRAINING` (EDS DRAINING: excluded from selection, established conns finish) instead of removing; removal fallback if the mark fails; CNI DEL still does final removal; sweep leaves terminating endpoints alone.
- Cloud Map health moves to **native custom health status** (HealthCheckCustomConfig + AWS_INIT_HEALTH_STATUS + UpdateInstanceCustomHealthStatus; reads from DiscoverInstances HealthStatus) per design directive — health is never attribute-borne; AETHER_DRAINING is a metadata marker refining native-UNHEALTHY to EDS DRAINING.
- **Migration**: custom health config is immutable; delete existing Cloud Map services once after deploy — the agents' reconciliation sweep re-registers all live endpoints into re-created services automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)