### PR TITLE
fix(registry): propagate Cloud Map health-update failures; cluster-scope the sweep

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -110,8 +110,12 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	registered := make(map[string]struct{})
 	for service, endpoints := range all {
 		for _, ep := range endpoints {
-			if ep.GetKubernetesMetadata().GetNodeName() != s.nodeName {
-				continue // another agent's responsibility
+			// Own only this cluster's slice of this node's endpoints: registrars
+			// run per cluster against a shared mesh registry, and node names are
+			// NOT unique across clusters — matching on NodeName alone could
+			// deregister another cluster's endpoints.
+			if ep.GetClusterName() != s.clusterName || ep.GetKubernetesMetadata().GetNodeName() != s.nodeName {
+				continue // another agent's (or cluster's) responsibility
 			}
 			if _, ok := live[ep.GetIp()]; ok {
 				registered[ep.GetIp()] = struct{}{}

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -44,7 +44,8 @@ func (r *sweepRegistry) RegisterEndpoint(_ context.Context, service string, _ re
 
 func sweepEndpoint(ip, node, pod string) *registryv1.ServiceEndpoint {
 	return &registryv1.ServiceEndpoint{
-		Ip: ip,
+		Ip:          ip,
+		ClusterName: "test-cluster",
 		KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
 			Namespace: "default",
 			PodName:   pod,
@@ -73,6 +74,14 @@ func TestSweepGhostEndpoints(t *testing.T) {
 			sweepEndpoint("10.0.0.1", "test-node", "pod-live"),   // live -> keep
 			sweepEndpoint("10.0.0.9", "test-node", "pod-ghost"),  // ghost -> deregister
 			sweepEndpoint("10.0.0.3", "other-node", "pod-other"), // other node -> ignore
+			func() *registryv1.ServiceEndpoint {
+				// Same node name, different cluster: registrars share the mesh
+				// registry across clusters and node names are not unique — this
+				// is another cluster's endpoint, never ours to sweep.
+				ep := sweepEndpoint("10.0.0.4", "test-node", "pod-foreign")
+				ep.ClusterName = "other-cluster"
+				return ep
+			}(),
 		},
 		"svc-b": {
 			// Terminating pod's endpoint: marked DRAINING by the termination

--- a/registry/internal/cloudmap/cloudmap.go
+++ b/registry/internal/cloudmap/cloudmap.go
@@ -128,14 +128,22 @@ func (r *CloudMapRegistry) RegisterEndpoint(ctx context.Context, serviceName str
 	// Health lives in Cloud Map's native per-instance status, not an attribute.
 	// AWS_INIT_HEALTH_STATUS only applies to brand-new instances, so an update
 	// is required for re-registrations (liveness transitions, draining marks).
-	// Best-effort: services created before custom health checks reject this
-	// until they are re-created (see resolveOrCreateServiceID).
+	//
+	// The failure MUST propagate: RegisterInstance is asynchronous, so this
+	// update races a brand-new instance's visibility (InstanceNotFound) — if
+	// the failure were tolerated, the caller would consider the health
+	// recorded and never retry, leaving the durable Cloud Map status stale
+	// (observed on talos-main: every re-registered instance stuck UNHEALTHY,
+	// a mesh-wide outage on the next registrar resync). Returning the error
+	// lets the agent liveness loop retry on its next tick, converging as soon
+	// as the registration operation completes.
 	if _, healthErr := r.client.UpdateInstanceCustomHealthStatus(ctx, &servicediscovery.UpdateInstanceCustomHealthStatusInput{
 		ServiceId:  aws.String(svcID),
 		InstanceId: aws.String(instID),
 		Status:     customHealthStatus(endpoint.GetHealth()),
 	}); healthErr != nil {
-		r.log.Error(healthErr, "failed to update instance health status", "service", serviceName, "ip", ip)
+		r.log.Error(healthErr, "failed to update instance health status; caller retries", "service", serviceName, "ip", ip)
+		return fmt.Errorf("failed to update health status for IP %s: %w", ip, healthErr)
 	}
 
 	// Evict endpoint cache for this service (all protocols)


### PR DESCRIPTION
Two fixes from the #119 rollout: (1) the async-RegisterInstance vs UpdateInstanceCustomHealthStatus race left instances durably UNHEALTHY when tolerated — now propagates so liveness retries to convergence (live issue on talos-main right now, masked by the registrar cache); (2) multi-cluster correctness: the sweep now requires ClusterName to match, since node names aren't unique across clusters sharing one mesh registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)