### PR TITLE
fix(registrar): force-resync slow watchers instead of silently dropping events

### DIFF
--- a/registrar/internal/server/BUILD.bazel
+++ b/registrar/internal/server/BUILD.bazel
@@ -22,6 +22,8 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@io_opentelemetry_go_otel_metric//:metric",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -15,7 +15,10 @@ const (
 
 // Broadcaster fans out endpoint events to all connected agent watch streams.
 // Each watcher is identified by a string key (typically node name) and receives
-// events on a buffered channel. Events are dropped for slow consumers.
+// events on a buffered channel. A watcher too slow to keep up is forcibly
+// resynced: its channel is closed, ending its WatchEndpoints stream, and the
+// agent's reconnect receives a full snapshot — it must never silently miss an
+// event and serve stale endpoints until something else triggers a resync.
 type Broadcaster struct {
 	mu       sync.RWMutex
 	watchers map[string]chan *registrarv1.WatchEndpointsResponse
@@ -74,23 +77,53 @@ func (b *Broadcaster) Unsubscribe(id string, ch <-chan *registrarv1.WatchEndpoin
 	b.log.V(1).Info("watcher unsubscribed", "id", id)
 }
 
-// Broadcast sends events to all watchers. Events are sent non-blocking;
-// if a watcher's channel is full the event is dropped for that watcher.
+// Broadcast sends events to all watchers. Events are sent non-blocking; a
+// watcher whose channel is full has already missed an event, so it is forced
+// to resync: its channel is closed, which ends its WatchEndpoints stream, and
+// the agent reconnects to receive a fresh full snapshot. The alternative —
+// silently dropping the event — leaves the agent serving stale endpoints with
+// nothing to correct it until its next reconnect for unrelated reasons.
 func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
+	// Collect overflowed watchers under the read lock; closing them requires
+	// the write lock, taken afterwards to avoid lock-upgrade deadlocks.
+	type droppedWatcher struct {
+		id string
+		ch chan *registrarv1.WatchEndpointsResponse
+	}
+	var dropped []droppedWatcher
 
+	b.mu.RLock()
 	for _, event := range events {
 		for id, ch := range b.watchers {
 			select {
 			case ch <- event:
 				b.metrics.eventBroadcast(context.Background(), event.GetType().String())
 			default:
-				// A dropped event means this watcher's view silently diverges
-				// until it reconnects — the counter is the staleness alarm.
+				// This watcher's view has diverged — schedule a force-resync.
+				// The counter is the staleness alarm.
 				b.metrics.eventDropped(context.Background(), event.GetType().String())
-				b.log.V(1).Info("dropped event for slow watcher", "id", id, "eventType", event.GetType())
+				b.log.Info("event overflowed slow watcher; forcing resync",
+					"id", id, "eventType", event.GetType())
+				dropped = append(dropped, droppedWatcher{id: id, ch: ch})
 			}
+		}
+	}
+	b.mu.RUnlock()
+
+	if len(dropped) == 0 {
+		return
+	}
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for _, d := range dropped {
+		// Re-check identity: the watcher may have reconnected (replacing its
+		// channel) or unsubscribed between the locks; later events in this batch
+		// may also have queued the same channel more than once.
+		if current, ok := b.watchers[d.id]; ok && current == d.ch {
+			close(current)
+			delete(b.watchers, d.id)
+			b.metrics.watcherUnsubscribed(context.Background())
 		}
 	}
 }

--- a/registrar/internal/server/broadcaster_test.go
+++ b/registrar/internal/server/broadcaster_test.go
@@ -264,12 +264,12 @@ func TestBroadcaster_Broadcast_EmptyEventList(t *testing.T) {
 	assert.Equal(t, 1, b.WatcherCount())
 }
 
-// TestBroadcaster_Broadcast_DropsEventsForSlowConsumer verifies that Broadcast
-// does not block and drops events when a watcher's channel is full.
-//
-// Broadcast uses a non-blocking select internally, so it must return immediately
-// even when the watcher channel is at capacity.
-func TestBroadcaster_Broadcast_DropsEventsForSlowConsumer(t *testing.T) {
+// TestBroadcaster_Broadcast_ForcesResyncOnSlowConsumer verifies that Broadcast
+// does not block when a watcher's channel is full, and that the overflowed
+// watcher is force-resynced: removed from the broadcaster with its channel
+// closed, so its WatchEndpoints stream ends and the agent reconnects for a
+// full snapshot instead of silently missing the event.
+func TestBroadcaster_Broadcast_ForcesResyncOnSlowConsumer(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
 	ch := b.Subscribe("slow-node")
 
@@ -284,17 +284,54 @@ func TestBroadcaster_Broadcast_DropsEventsForSlowConsumer(t *testing.T) {
 	}
 	require.Equal(t, defaultChannelBuffer, len(ch), "channel must be full before overflow test")
 
-	// Broadcasting onto a full channel must be a non-blocking no-op (the event is
-	// dropped via the default branch in Broadcast). Verify this by checking that
-	// the channel length is unchanged after the extra call.
+	// Overflow by several events in one batch: the channel must be closed
+	// exactly once (no panic) and the watcher removed.
 	overflowEvent := &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
 		ServiceName: "svc-overflow",
 	}
-	b.Broadcast([]*registrarv1.WatchEndpointsResponse{overflowEvent})
+	b.Broadcast([]*registrarv1.WatchEndpointsResponse{overflowEvent, overflowEvent})
 
-	// Channel must still hold exactly defaultChannelBuffer events; overflow dropped.
-	assert.Equal(t, defaultChannelBuffer, len(ch))
+	assert.Equal(t, 0, b.WatcherCount(), "overflowed watcher must be removed")
+
+	// The buffered events remain readable, then the channel reports closed.
+	for i := 0; i < defaultChannelBuffer; i++ {
+		_, ok := <-ch
+		require.True(t, ok, "buffered event %d must still be readable", i)
+	}
+	_, ok := <-ch
+	assert.False(t, ok, "channel must be closed after the buffer drains")
+
+	// The stream handler's deferred Unsubscribe must be a stale no-op.
+	b.Unsubscribe("slow-node", ch)
+	assert.Equal(t, 0, b.WatcherCount())
+}
+
+// TestBroadcaster_Broadcast_ResyncedWatcherCanResubscribe verifies the
+// force-resync recovery path: the agent reconnects under the same watcher ID
+// and receives events normally.
+func TestBroadcaster_Broadcast_ResyncedWatcherCanResubscribe(t *testing.T) {
+	b := NewBroadcaster(logr.Discard(), nil)
+	b.Subscribe("slow-node")
+
+	event := &registrarv1.WatchEndpointsResponse{
+		Type: registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+	}
+	for i := 0; i < defaultChannelBuffer+1; i++ {
+		b.Broadcast([]*registrarv1.WatchEndpointsResponse{event})
+	}
+	require.Equal(t, 0, b.WatcherCount(), "watcher must be force-resynced")
+
+	ch2 := b.Subscribe("slow-node")
+	b.Broadcast([]*registrarv1.WatchEndpointsResponse{event})
+	require.Equal(t, 1, b.WatcherCount())
+	select {
+	case got, ok := <-ch2:
+		require.True(t, ok)
+		assert.Equal(t, event.GetType(), got.GetType())
+	default:
+		t.Fatal("resubscribed watcher did not receive the event")
+	}
 }
 
 // TestBroadcaster_WatcherCount verifies WatcherCount through subscribe/unsubscribe

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -11,6 +11,8 @@ import (
 	"github.com/bpalermo/aether/registry"
 	"github.com/go-logr/logr"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // RegistrarServer implements the RegistrarServiceServer gRPC interface.
@@ -149,7 +151,14 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 			return stream.Context().Err()
 		case event, ok := <-ch:
 			if !ok {
-				return nil
+				// Channel closed: either the broadcaster force-resynced this
+				// slow watcher after an overflow, or a reconnect replaced the
+				// subscription. Either way the client must NOT resume from its
+				// last seen version — events within a batch share one version,
+				// so a mid-batch overflow can leave the client's lastVersion
+				// equal to the current version while it still missed events.
+				// DataLoss tells the client to clear its resume token.
+				return status.Error(codes.DataLoss, "watch stream overflowed; reconnect for a full snapshot")
 			}
 			if err := stream.Send(event); err != nil {
 				return fmt.Errorf("failed to send event: %w", err)

--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -16,7 +16,9 @@ go_library(
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_metric//:metric",
         "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//credentials/insecure",
+        "@org_golang_google_grpc//status",
     ],
 )
 
@@ -35,5 +37,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",
         "@io_opentelemetry_go_otel_sdk_metric//metricdata",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -17,7 +17,9 @@ import (
 	"github.com/go-logr/logr"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -280,6 +282,15 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 	for {
 		event, err := stream.Recv()
 		if err != nil {
+			// DataLoss means the registrar force-resynced this watcher (its
+			// event buffer overflowed). Resuming from lastVersion could skip
+			// the missed events — batches share a version, so lastVersion may
+			// match the current version while events were still dropped. Clear
+			// the resume token so the reconnect receives a full snapshot.
+			if status.Code(err) == codes.DataLoss {
+				r.log.Info("registrar forced a resync; requesting full snapshot on reconnect")
+				return ""
+			}
 			if err != io.EOF && ctx.Err() == nil {
 				r.log.Error(err, "watch stream disconnected")
 			}

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -2,6 +2,7 @@ package registrar
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	registrarv1 "github.com/bpalermo/aether/api/aether/registrar/v1"
@@ -9,6 +10,8 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func newTestRegistry() *RegistrarRegistry {
@@ -427,4 +430,74 @@ func TestSignalChange_Coalesces(t *testing.T) {
 		t.Fatal("expected change signals to coalesce into one")
 	default:
 	}
+}
+
+// fakeWatchStream feeds canned events to processStream, then returns err.
+// Only Recv is used by processStream; the embedded nil interface panics on
+// anything else, which would indicate a test assumption broke.
+type fakeWatchStream struct {
+	registrarv1.RegistrarService_WatchEndpointsClient
+	events []*registrarv1.WatchEndpointsResponse
+	err    error
+}
+
+func (f *fakeWatchStream) Recv() (*registrarv1.WatchEndpointsResponse, error) {
+	if len(f.events) > 0 {
+		e := f.events[0]
+		f.events = f.events[1:]
+		return e, nil
+	}
+	return nil, f.err
+}
+
+func TestProcessStream_TracksLastVersion(t *testing.T) {
+	r := newTestRegistry()
+	stream := &fakeWatchStream{
+		events: []*registrarv1.WatchEndpointsResponse{
+			{
+				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+				ServiceName: "svc-a",
+				Endpoint:    makeEndpoint("10.0.0.1", 8080),
+				Version:     "7",
+			},
+		},
+		err: io.EOF,
+	}
+
+	got := r.processStream(context.Background(), stream, "5")
+	assert.Equal(t, "7", got, "lastVersion must advance to the newest event version")
+}
+
+// TestProcessStream_DataLossClearsResumeToken verifies the force-resync
+// contract: when the registrar ends the stream with DataLoss (event buffer
+// overflowed), the client must NOT resume from its last seen version —
+// events within a batch share one version, so lastVersion can equal the
+// registrar's current version while events were still missed. Clearing the
+// token makes the reconnect fetch a full snapshot.
+func TestProcessStream_DataLossClearsResumeToken(t *testing.T) {
+	r := newTestRegistry()
+	stream := &fakeWatchStream{
+		events: []*registrarv1.WatchEndpointsResponse{
+			{
+				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+				ServiceName: "svc-a",
+				Endpoint:    makeEndpoint("10.0.0.1", 8080),
+				Version:     "7",
+			},
+		},
+		err: status.Error(codes.DataLoss, "watch stream overflowed; reconnect for a full snapshot"),
+	}
+
+	got := r.processStream(context.Background(), stream, "5")
+	assert.Equal(t, "", got, "DataLoss must clear the resume token to force a full snapshot")
+}
+
+func TestProcessStream_OtherErrorsKeepResumeToken(t *testing.T) {
+	r := newTestRegistry()
+	stream := &fakeWatchStream{
+		err: status.Error(codes.Unavailable, "connection reset"),
+	}
+
+	got := r.processStream(context.Background(), stream, "5")
+	assert.Equal(t, "5", got, "transient errors must keep the resume token")
 }


### PR DESCRIPTION
PR 3 of the observability plan (stacked on #123). Fixes the known missed-update path the new `aether.registrar.broadcast.dropped_events` counter instruments.

## Problem

`Broadcaster.Broadcast` non-blockingly dropped events for watchers whose 256-event channel was full. That agent's endpoint view silently diverged — nothing corrected it until an unrelated reconnect or a ghost-sweep pass.

## Fix

1. **Broadcast**: an overflowed watcher is removed and its channel closed. Drops are collected under the existing `RLock`; close+delete happens after under the write lock with an identity re-check, so a concurrent reconnect/unsubscribe is never clobbered and a multi-event batch closes once.
2. **WatchEndpoints**: the `!ok` channel path now returns `codes.DataLoss` instead of `nil`.
3. **Agent client**: `processStream` clears its resume token on `DataLoss` (keeps it on transient errors), so the reconnect requests a full snapshot.

## Why the explicit DataLoss signal

Events in a batch share one snapshot version. A watcher that received part of a batch and overflowed mid-batch can hold `lastVersion == currentVersion` — version-based resume would skip the missed events even after a reconnect. The error code is the only reliable "your view is torn, resync" channel.

## Testing

- Overflow closes channel exactly once (multi-overflow batch), buffered events stay readable, watcher removed, stale `Unsubscribe` no-op, resubscribe works.
- `processStream`: DataLoss → token cleared; Unavailable → token kept; happy path advances version.
- `bazel test //...` green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)