### PR TITLE
feat(supervisor): hot-restart lifecycle metrics with crash-forensics flush

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,6 +90,7 @@ use_repo(
     "com_github_moby_spdystream",
     "com_github_mxk_go_flowrate",
     "com_github_pquerna_protoc_gen_dynamo",
+    "com_github_prometheus_client_golang",
     "com_github_spf13_cobra",
     "com_github_spiffe_go_spiffe_v2",
     "com_github_spiffe_spire_api_sdk",

--- a/agent/internal/cmd/supervisor.go
+++ b/agent/internal/cmd/supervisor.go
@@ -16,6 +16,8 @@ import (
 // subcommand. SPIKE: see docs/proposals/001_proxy-hot-restart.md.
 var (
 	supervisorCfg            hotrestart.Config
+	supervisorTelemetryCfg   hotrestart.TelemetryConfig
+	supervisorMetricsEnabled bool
 	supervisorDebug          bool
 	supervisorInstallPath    string
 	supervisorReadinessCheck bool
@@ -44,7 +46,31 @@ var proxySupervisorCmd = &cobra.Command{
 			return nil
 		}
 		log := manager.SetupLogging(supervisorDebug, cmd.Name())
-		return hotrestart.New(supervisorCfg, log).Run(cmd.Context())
+
+		// Metrics are the supervisor's crash forensics: the wedge watchdog exits
+		// the process non-zero, so the deferred Shutdown flush is what gets the
+		// wedge counter out before the pod is recreated. Telemetry failures are
+		// never fatal — the supervisor's job is keeping Envoy alive.
+		var metrics *hotrestart.SupervisorMetrics
+		if supervisorMetricsEnabled {
+			supervisorTelemetryCfg.ServiceVersion = Version
+			telemetry, telErr := hotrestart.NewTelemetry(cmd.Context(), supervisorTelemetryCfg, log)
+			if telErr != nil {
+				log.Error(telErr, "failed to set up supervisor telemetry; continuing without metrics")
+			} else {
+				defer func() {
+					if shutdownErr := telemetry.Shutdown(); shutdownErr != nil {
+						log.V(1).Error(shutdownErr, "failed to flush supervisor metrics")
+					}
+				}()
+				go telemetry.Serve(cmd.Context())
+				if metrics, telErr = hotrestart.NewSupervisorMetrics(telemetry.Meter()); telErr != nil {
+					log.Error(telErr, "failed to create supervisor metrics; continuing without metrics")
+				}
+			}
+		}
+
+		return hotrestart.New(supervisorCfg, log, metrics).Run(cmd.Context())
 	},
 }
 
@@ -92,6 +118,9 @@ func init() {
 	f.BoolVar(&supervisorReadinessCheck, "readiness-check", false, "Exit 0 iff the --ready-marker file exists (exec readiness probe mode)")
 	f.DurationVar(&supervisorCfg.HandoffDeadline, "handoff-deadline", 0, "Watchdog: max time a hot-restart epoch may stay not-LIVE after launch before the supervisor exits non-zero (0 = 2m default)")
 	f.DurationVar(&supervisorCfg.AdminUnresponsiveDeadline, "admin-unresponsive-deadline", 0, "Watchdog: max time the Envoy admin may be unreachable (once previously LIVE) before the supervisor exits non-zero (0 = 30s default)")
+	f.BoolVar(&supervisorMetricsEnabled, "metrics-enabled", true, "Enable supervisor hot-restart lifecycle metrics")
+	f.StringVar(&supervisorTelemetryCfg.BindAddress, "metrics-bind-address", ":9902", "Prometheus /metrics address; the supervisor shares the host netns, so a surge predecessor holding the port is retried, not fatal")
+	f.StringVar(&supervisorTelemetryCfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP gRPC collector endpoint for metrics push (e.g. collector:4317); empty disables OTLP export")
 
 	rootCmd.AddCommand(proxySupervisorCmd)
 }

--- a/agent/internal/proxy/hotrestart/BUILD.bazel
+++ b/agent/internal/proxy/hotrestart/BUILD.bazel
@@ -4,13 +4,24 @@ go_library(
     name = "hotrestart",
     srcs = [
         "coordination.go",
+        "metrics.go",
         "supervisor.go",
+        "telemetry.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/proxy/hotrestart",
     visibility = ["//agent:__subpackages__"],
     deps = [
         "@com_github_fsnotify_fsnotify//:fsnotify",
         "@com_github_go_logr_logr//:logr",
+        "@com_github_prometheus_client_golang//prometheus",
+        "@com_github_prometheus_client_golang//prometheus/promhttp",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//semconv/v1.30.0:v1_30_0",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlpmetric_otlpmetricgrpc//:otlpmetricgrpc",
+        "@io_opentelemetry_go_otel_exporters_prometheus//:prometheus",
+        "@io_opentelemetry_go_otel_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk//resource",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
     ],
 )
 
@@ -18,6 +29,7 @@ go_test(
     name = "hotrestart_test",
     srcs = [
         "coordination_test.go",
+        "metrics_test.go",
         "supervisor_test.go",
     ],
     embed = [":hotrestart"],
@@ -25,5 +37,7 @@ go_test(
         "@com_github_go_logr_logr//:logr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk_metric//metricdata",
     ],
 )

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -60,12 +60,14 @@ func (s *Supervisor) initStartEpoch(ctx context.Context) {
 		epoch, hb, ok := s.readState()
 		if !ok || time.Since(hb) >= predecessorStale {
 			s.log.Info("no live predecessor; starting fresh at epoch 0", "statePresent", ok)
+			s.metrics.predecessorFound(false)
 			return
 		}
 		if s.adminLiveAtEpoch(ctx, epoch) {
 			s.mu.Lock()
 			s.nextEpoch = epoch + 1
 			s.mu.Unlock()
+			s.metrics.predecessorFound(true)
 			s.log.Info("live predecessor confirmed; starting cross-pod hot restart",
 				"predecessorEpoch", epoch, "startEpoch", epoch+1, "heartbeatAge", time.Since(hb).Round(time.Millisecond).String())
 			return
@@ -186,6 +188,11 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			}
 			if live {
 				everLive = true
+				if launched, wasLive := s.epochProgress(); !wasLive {
+					// First LIVE confirmation for this epoch: the handoff (or
+					// initial start, epoch 0) completed.
+					s.metrics.handoffCompleted(time.Since(launched).Seconds())
+				}
 				s.markEpochLive()
 				s.writeState(epoch) // LIVE-gated heartbeat
 				// Hold readiness until the cross-pod handoff is fully complete (the
@@ -194,6 +201,7 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 				if !ready && !time.Now().Before(s.readyGate) {
 					s.setReady()
 					ready = true
+					s.metrics.readyTransition(true)
 					s.log.Info("pod ready: envoy live at newest epoch", "epoch", epoch)
 				}
 				continue
@@ -201,17 +209,20 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			if ready {
 				s.clearReady()
 				ready = false
+				s.metrics.readyTransition(false)
 				s.log.Info("pod not ready: envoy not live at newest epoch", "epoch", epoch)
 			}
 
 			launched, wasLive := s.epochProgress()
 			if epoch > 0 && !wasLive && s.childTracked(epoch) && time.Since(launched) > s.handoffDeadline() {
+				s.metrics.wedged(wedgeHandoffTimeout)
 				s.fireWatchdog(fmt.Errorf(
 					"hot-restart handoff watchdog: epoch %d not LIVE within %s of launch (parent likely died mid-handoff)",
 					epoch, s.handoffDeadline()))
 				return
 			}
 			if everLive && !reachable && s.childTracked(epoch) && time.Since(unreachableSince) > s.adminUnresponsiveDeadline() {
+				s.metrics.wedged(wedgeAdminUnresponsive)
 				s.fireWatchdog(fmt.Errorf(
 					"admin watchdog: envoy admin %s unresponsive for %s with child alive at epoch %d",
 					s.cfg.AdminAddress, s.adminUnresponsiveDeadline(), epoch))

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -18,7 +18,7 @@ import (
 
 func newCoordSupervisor(t *testing.T) *Supervisor {
 	t.Helper()
-	return New(Config{StateDir: t.TempDir()}, logr.Discard())
+	return New(Config{StateDir: t.TempDir()}, logr.Discard(), nil)
 }
 
 // fakeAdmin starts an Envoy-admin stub that reports the given state and restart
@@ -119,7 +119,7 @@ func TestInitStartEpoch(t *testing.T) {
 		assert.Equal(t, 0, s.nextEpoch)
 	})
 	t.Run("disabled (no StateDir) -> epoch 0", func(t *testing.T) {
-		s := New(Config{}, logr.Discard())
+		s := New(Config{}, logr.Discard(), nil)
 		s.initStartEpoch(ctx)
 		assert.Equal(t, 0, s.nextEpoch)
 	})
@@ -127,7 +127,7 @@ func TestInitStartEpoch(t *testing.T) {
 
 func TestReadyMarker(t *testing.T) {
 	dir := t.TempDir()
-	s := New(Config{ReadyMarkerPath: filepath.Join(dir, "ready")}, logr.Discard())
+	s := New(Config{ReadyMarkerPath: filepath.Join(dir, "ready")}, logr.Discard(), nil)
 	_, err := os.Stat(s.cfg.ReadyMarkerPath)
 	require.True(t, os.IsNotExist(err))
 	s.setReady()
@@ -165,7 +165,7 @@ func TestHandoffWatchdogFiresWhenSuccessorNeverLive(t *testing.T) {
 		// selects epoch 1 — which then never reaches LIVE (the wedge).
 		AdminAddress:    fakeAdmin(t, "LIVE", 0),
 		HandoffDeadline: 1 * time.Second,
-	}, logr.Discard())
+	}, logr.Discard(), nil)
 	writeRawState(t, s, 0, 0)
 
 	runErr := make(chan error, 1)
@@ -212,7 +212,7 @@ func TestAdminWatchdogFiresWhenAdminUnreachableAfterLive(t *testing.T) {
 		ReadyMarkerPath:           marker,
 		AdminAddress:              srv.Listener.Addr().String(),
 		AdminUnresponsiveDeadline: 1 * time.Second,
-	}, logr.Discard())
+	}, logr.Discard(), nil)
 
 	runErr := make(chan error, 1)
 	go func() { runErr <- s.Run(context.Background()) }()

--- a/agent/internal/proxy/hotrestart/metrics.go
+++ b/agent/internal/proxy/hotrestart/metrics.go
@@ -1,0 +1,153 @@
+package hotrestart
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// Wedge / trigger / exit attribute keys. All values are from small fixed sets.
+const (
+	attrWedgeReason   = attribute.Key("aether.supervisor.wedge.reason")
+	attrTriggerReason = attribute.Key("aether.supervisor.trigger")
+	attrExitKind      = attribute.Key("aether.supervisor.exit_kind")
+	attrReady         = attribute.Key("aether.supervisor.ready")
+)
+
+// Wedge reasons (watchdog diagnoses).
+const (
+	wedgeHandoffTimeout    = "handoff_timeout"
+	wedgeAdminUnresponsive = "admin_unresponsive"
+)
+
+// Child exit kinds.
+const (
+	exitDrained             = "drained"              // older epoch finished draining after a hot restart
+	exitUnexpected          = "unexpected"           // newest epoch died — pod restart follows
+	exitSuccessorTerminated = "successor_terminated" // cross-pod handoff: successor's parent-shutdown protocol
+)
+
+// SupervisorMetrics holds the hot-restart lifecycle instruments. All methods
+// are nil-receiver-safe so the supervisor runs unchanged without telemetry.
+//
+// These exist for post-mortems of wedged or crashed proxy pods: the epoch
+// gauge and handoff histogram show how far a handoff got and how long it
+// took, the wedge counter says why the watchdog killed the pod, and the
+// child-exit counter distinguishes expected drains from crashes.
+type SupervisorMetrics struct {
+	epoch               metric.Int64Gauge
+	handoffDuration     metric.Float64Histogram
+	wedges              metric.Int64Counter
+	restartTriggers     metric.Int64Counter
+	childExits          metric.Int64Counter
+	predecessorDetected metric.Int64Gauge
+	drainDuration       metric.Float64Histogram
+	readyTransitions    metric.Int64Counter
+}
+
+// NewSupervisorMetrics registers the supervisor instruments on the given meter.
+func NewSupervisorMetrics(meter metric.Meter) (*SupervisorMetrics, error) {
+	m := &SupervisorMetrics{}
+	var err error
+
+	if m.epoch, err = meter.Int64Gauge("aether.supervisor.epoch",
+		metric.WithDescription("Newest Envoy restart epoch launched by this supervisor")); err != nil {
+		return nil, fmt.Errorf("epoch: %w", err)
+	}
+	if m.handoffDuration, err = meter.Float64Histogram("aether.supervisor.handoff.duration",
+		metric.WithDescription("Time from forking an Envoy epoch to the admin confirming it LIVE"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(1, 5, 10, 30, 60, 120, 300)); err != nil {
+		return nil, fmt.Errorf("handoff duration: %w", err)
+	}
+	if m.wedges, err = meter.Int64Counter("aether.supervisor.wedges",
+		metric.WithDescription("Watchdog wedge diagnoses (each one terminates the pod), by reason")); err != nil {
+		return nil, fmt.Errorf("wedges: %w", err)
+	}
+	if m.restartTriggers, err = meter.Int64Counter("aether.supervisor.restart_triggers",
+		metric.WithDescription("Hot-restart trigger arms, by source (debounce may coalesce several into one restart)")); err != nil {
+		return nil, fmt.Errorf("restart triggers: %w", err)
+	}
+	if m.childExits, err = meter.Int64Counter("aether.supervisor.child_exits",
+		metric.WithDescription("Supervised Envoy process exits, by kind")); err != nil {
+		return nil, fmt.Errorf("child exits: %w", err)
+	}
+	if m.predecessorDetected, err = meter.Int64Gauge("aether.supervisor.predecessor_detected",
+		metric.WithDescription("1 if a live predecessor was found at startup (cross-pod hot restart), 0 for a fresh epoch-0 start")); err != nil {
+		return nil, fmt.Errorf("predecessor detected: %w", err)
+	}
+	if m.drainDuration, err = meter.Float64Histogram("aether.supervisor.drain.duration",
+		metric.WithDescription("Time from shutdown SIGTERM to the last supervised Envoy exiting"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(1, 5, 10, 30, 60, 120)); err != nil {
+		return nil, fmt.Errorf("drain duration: %w", err)
+	}
+	if m.readyTransitions, err = meter.Int64Counter("aether.supervisor.ready_transitions",
+		metric.WithDescription("Readiness marker transitions, by new state")); err != nil {
+		return nil, fmt.Errorf("ready transitions: %w", err)
+	}
+
+	return m, nil
+}
+
+func (m *SupervisorMetrics) epochStarted(epoch int) {
+	if m == nil {
+		return
+	}
+	m.epoch.Record(context.Background(), int64(epoch))
+}
+
+func (m *SupervisorMetrics) handoffCompleted(seconds float64) {
+	if m == nil {
+		return
+	}
+	m.handoffDuration.Record(context.Background(), seconds)
+}
+
+func (m *SupervisorMetrics) wedged(reason string) {
+	if m == nil {
+		return
+	}
+	m.wedges.Add(context.Background(), 1, metric.WithAttributes(attrWedgeReason.String(reason)))
+}
+
+func (m *SupervisorMetrics) restartTriggered(trigger string) {
+	if m == nil {
+		return
+	}
+	m.restartTriggers.Add(context.Background(), 1, metric.WithAttributes(attrTriggerReason.String(trigger)))
+}
+
+func (m *SupervisorMetrics) childExited(kind string) {
+	if m == nil {
+		return
+	}
+	m.childExits.Add(context.Background(), 1, metric.WithAttributes(attrExitKind.String(kind)))
+}
+
+func (m *SupervisorMetrics) predecessorFound(found bool) {
+	if m == nil {
+		return
+	}
+	v := int64(0)
+	if found {
+		v = 1
+	}
+	m.predecessorDetected.Record(context.Background(), v)
+}
+
+func (m *SupervisorMetrics) drainCompleted(seconds float64) {
+	if m == nil {
+		return
+	}
+	m.drainDuration.Record(context.Background(), seconds)
+}
+
+func (m *SupervisorMetrics) readyTransition(ready bool) {
+	if m == nil {
+		return
+	}
+	m.readyTransitions.Add(context.Background(), 1, metric.WithAttributes(attrReady.Bool(ready)))
+}

--- a/agent/internal/proxy/hotrestart/metrics_test.go
+++ b/agent/internal/proxy/hotrestart/metrics_test.go
@@ -1,0 +1,152 @@
+package hotrestart
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newTestSupervisorMetrics(t *testing.T) (*SupervisorMetrics, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	m, err := NewSupervisorMetrics(provider.Meter("test"))
+	if err != nil {
+		t.Fatalf("NewSupervisorMetrics() error = %v", err)
+	}
+	return m, reader
+}
+
+// metricValue returns the summed counter value or last gauge value for the
+// named metric, and whether it was found.
+func metricValue(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64, bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect() error = %v", err)
+	}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			switch data := m.Data.(type) {
+			case metricdata.Sum[int64]:
+				var total int64
+				for _, dp := range data.DataPoints {
+					total += dp.Value
+				}
+				return total, true
+			case metricdata.Gauge[int64]:
+				if len(data.DataPoints) == 0 {
+					return 0, false
+				}
+				return data.DataPoints[len(data.DataPoints)-1].Value, true
+			case metricdata.Histogram[float64]:
+				var count int64
+				for _, dp := range data.DataPoints {
+					count += int64(dp.Count)
+				}
+				return count, true
+			default:
+				t.Fatalf("metric %s has unexpected data type %T", name, m.Data)
+			}
+		}
+	}
+	return 0, false
+}
+
+func TestSupervisorMetrics_NilReceiverSafe(t *testing.T) {
+	var m *SupervisorMetrics
+	m.epochStarted(1)
+	m.handoffCompleted(2.5)
+	m.wedged(wedgeHandoffTimeout)
+	m.restartTriggered("sighup")
+	m.childExited(exitDrained)
+	m.predecessorFound(true)
+	m.drainCompleted(1.0)
+	m.readyTransition(true)
+}
+
+func TestSupervisorMetrics_Recording(t *testing.T) {
+	m, reader := newTestSupervisorMetrics(t)
+
+	m.epochStarted(0)
+	m.epochStarted(1)
+	m.handoffCompleted(3.2)
+	m.wedged(wedgeAdminUnresponsive)
+	m.restartTriggered("config_change")
+	m.restartTriggered("sighup")
+	m.childExited(exitDrained)
+	m.predecessorFound(true)
+	m.drainCompleted(12.0)
+	m.readyTransition(true)
+	m.readyTransition(false)
+
+	want := map[string]int64{
+		"aether.supervisor.epoch":                1, // gauge: last value
+		"aether.supervisor.handoff.duration":     1, // histogram: sample count
+		"aether.supervisor.wedges":               1,
+		"aether.supervisor.restart_triggers":     2,
+		"aether.supervisor.child_exits":          1,
+		"aether.supervisor.predecessor_detected": 1,
+		"aether.supervisor.drain.duration":       1,
+		"aether.supervisor.ready_transitions":    2,
+	}
+	for name, wantV := range want {
+		got, found := metricValue(t, reader, name)
+		if !found {
+			t.Errorf("metric %s not recorded", name)
+			continue
+		}
+		if got != wantV {
+			t.Errorf("%s = %d, want %d", name, got, wantV)
+		}
+	}
+}
+
+// TestSupervisor_HotRestartRecordsEpoch verifies the epoch gauge tracks the
+// newest launched epoch through the real hotRestart path.
+func TestSupervisor_HotRestartRecordsEpoch(t *testing.T) {
+	m, reader := newTestSupervisorMetrics(t)
+	s := New(Config{
+		EnvoyPath:  "/bin/true", // exits immediately; only the fork matters here
+		ConfigPath: "/dev/null",
+	}, logr.Discard(), m)
+
+	if err := s.hotRestart(); err != nil {
+		t.Fatalf("hotRestart() error = %v", err)
+	}
+	defer s.shutdown()
+
+	if got, _ := metricValue(t, reader, "aether.supervisor.epoch"); got != 0 {
+		t.Errorf("epoch after first start = %d, want 0", got)
+	}
+
+	if err := s.hotRestart(); err != nil {
+		t.Fatalf("hotRestart() error = %v", err)
+	}
+	if got, _ := metricValue(t, reader, "aether.supervisor.epoch"); got != 1 {
+		t.Errorf("epoch after hot restart = %d, want 1", got)
+	}
+}
+
+func TestTelemetry_MeterAndShutdown(t *testing.T) {
+	tel, err := NewTelemetry(context.Background(), TelemetryConfig{
+		ServiceVersion: "test",
+		// no BindAddress: Serve is a no-op; no OTLP: Prometheus reader only
+	}, logr.Discard())
+	if err != nil {
+		t.Fatalf("NewTelemetry() error = %v", err)
+	}
+
+	if _, err := NewSupervisorMetrics(tel.Meter()); err != nil {
+		t.Fatalf("NewSupervisorMetrics() on telemetry meter error = %v", err)
+	}
+	if err := tel.Shutdown(); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+}

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -109,8 +109,9 @@ type childExit struct {
 
 // Supervisor owns the Envoy process lifecycle and performs hot restarts.
 type Supervisor struct {
-	cfg Config
-	log logr.Logger
+	cfg     Config
+	log     logr.Logger
+	metrics *SupervisorMetrics // nil disables instrumentation
 
 	mu        sync.Mutex
 	children  map[int]*exec.Cmd // keyed by restart epoch
@@ -140,11 +141,12 @@ type Supervisor struct {
 // successor's readiness, to ensure the predecessor is fully gone first.
 const readyGateBuffer = 3 * time.Second
 
-// New creates a Supervisor.
-func New(cfg Config, log logr.Logger) *Supervisor {
+// New creates a Supervisor. metrics may be nil to disable instrumentation.
+func New(cfg Config, log logr.Logger, metrics *SupervisorMetrics) *Supervisor {
 	return &Supervisor{
 		cfg:           cfg,
 		log:           log.WithName("proxy-supervisor"),
+		metrics:       metrics,
 		children:      make(map[int]*exec.Cmd),
 		childExited:   make(chan childExit, 8),
 		done:          make(chan struct{}),
@@ -189,6 +191,7 @@ func (s *Supervisor) Run(ctx context.Context) error {
 
 	arm := func(reason string) {
 		s.log.V(1).Info("hot restart armed", "reason", reason, "debounce", debounceDelay)
+		s.metrics.restartTriggered(reason)
 		debounce.Reset(debounceDelay)
 		debounceC = debounce.C
 	}
@@ -217,13 +220,13 @@ func (s *Supervisor) Run(ctx context.Context) error {
 		case sig := <-sigCh:
 			switch sig {
 			case syscall.SIGHUP:
-				arm("SIGHUP")
+				arm("sighup")
 			case syscall.SIGUSR1:
 				s.forwardToCurrent(syscall.SIGUSR1)
 			}
 
 		case <-trigger:
-			arm("config change")
+			arm("config_change")
 
 		case <-debounceC:
 			debounceC = nil
@@ -235,7 +238,7 @@ func (s *Supervisor) Run(ctx context.Context) error {
 			// admin address is configured.
 			if s.cfg.AdminAddress != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
 				s.log.V(1).Info("current epoch not yet live; deferring hot restart", "epoch", s.currentEpoch())
-				arm("deferred: current epoch not live")
+				arm("deferred_not_live")
 				continue
 			}
 			s.log.Info("performing hot restart")
@@ -254,6 +257,7 @@ func (s *Supervisor) Run(ctx context.Context) error {
 		case exit := <-s.childExited:
 			if exit.epoch == s.currentEpoch() {
 				if s.cfg.StateDir != "" && exit.err == nil {
+					s.metrics.childExited(exitSuccessorTerminated)
 					// Clean exit (status 0) of our newest epoch in cross-pod mode:
 					// that's the successor's hot-restart parent-shutdown protocol
 					// terminating us (a crash would be non-zero/signaled). The signal
@@ -268,11 +272,13 @@ func (s *Supervisor) Run(ctx context.Context) error {
 				}
 				// The newest epoch died unexpectedly: nothing left serving traffic.
 				// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).
+				s.metrics.childExited(exitUnexpected)
 				s.reap(exit.epoch)
 				s.shutdown()
 				return fmt.Errorf("envoy epoch %d exited unexpectedly: %w", exit.epoch, exit.err)
 			}
 			// An older epoch finished draining after a hot restart: expected. Reap it.
+			s.metrics.childExited(exitDrained)
 			s.reap(exit.epoch)
 		}
 	}
@@ -297,6 +303,7 @@ func (s *Supervisor) hotRestart() error {
 	s.epochLaunched = time.Now()
 	s.epochLive = false
 	s.mu.Unlock()
+	s.metrics.epochStarted(epoch)
 
 	// The node epoch is published to the shared state file only once this Envoy is
 	// confirmed LIVE (by watchLiveness), never at launch — so a failed handoff does
@@ -494,6 +501,8 @@ func (s *Supervisor) shutdown() {
 	if len(pending) == 0 {
 		return
 	}
+	start := time.Now()
+	defer func() { s.metrics.drainCompleted(time.Since(start).Seconds()) }()
 
 	deadline := time.NewTimer(s.cfg.DrainTime + shutdownGrace)
 	defer deadline.Stop()

--- a/agent/internal/proxy/hotrestart/supervisor_test.go
+++ b/agent/internal/proxy/hotrestart/supervisor_test.go
@@ -21,7 +21,7 @@ func TestBuildEnvoyCmd(t *testing.T) {
 		DrainTime:          45 * time.Second,
 		ParentShutdownTime: 60 * time.Second,
 		ExtraArgs:          []string{"-l", "info", "--service-cluster", "aether-proxy"},
-	}, logr.Discard())
+	}, logr.Discard(), nil)
 
 	cmd := s.buildEnvoyCmd(3)
 
@@ -96,7 +96,7 @@ func TestSupervisorConfigChangeTriggersHotRestart(t *testing.T) {
 		DrainTime:          1 * time.Second,
 		ParentShutdownTime: 1 * time.Second,
 		WatchConfig:        true,
-	}, logr.Discard())
+	}, logr.Discard(), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runErr := make(chan error, 1)
@@ -146,7 +146,7 @@ func TestHotRestartDeferredWhileEpochNotLive(t *testing.T) {
 		WatchConfig:        true,
 		// Admin reports the current epoch as still initializing.
 		AdminAddress: fakeAdmin(t, "PRE_INITIALIZING", 0),
-	}, logr.Discard())
+	}, logr.Discard(), nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/agent/internal/proxy/hotrestart/telemetry.go
+++ b/agent/internal/proxy/hotrestart/telemetry.go
@@ -1,0 +1,154 @@
+package hotrestart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	otelprom "go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+)
+
+const (
+	// telemetryServiceName identifies the supervisor in metric backends.
+	telemetryServiceName = "aether-proxy-supervisor"
+	// bindRetryInterval is how often a failed metrics listen is retried. The
+	// supervisor shares the host network namespace, so during a surge upgrade
+	// the predecessor pod still holds the metrics port; the successor must keep
+	// retrying until the predecessor exits rather than treating the collision
+	// as fatal.
+	bindRetryInterval = 15 * time.Second
+	// telemetryShutdownTimeout bounds the final flush. The supervisor exits
+	// non-zero on a wedge — the flush must reliably get the wedge counter out
+	// before the process dies, but must never stall the restart.
+	telemetryShutdownTimeout = 5 * time.Second
+	// otlpTimeout bounds each OTLP export.
+	otlpTimeout = 10 * time.Second
+)
+
+// TelemetryConfig configures the supervisor's metrics outlet.
+type TelemetryConfig struct {
+	// BindAddress is the Prometheus scrape endpoint (host:port). The supervisor
+	// is not under the controller-runtime manager, so it serves its own /metrics.
+	BindAddress string
+	// OTLPEndpoint optionally adds OTLP gRPC push export (e.g. "collector:4317").
+	OTLPEndpoint string
+	// ServiceVersion is the build version recorded on the OTel resource.
+	ServiceVersion string
+}
+
+// Telemetry is the supervisor's standalone metrics pipeline: an OTel
+// MeterProvider with a Prometheus exporter on a private registry (the
+// supervisor must not share the agent's controller-runtime registry — it is a
+// separate process) plus an optional OTLP push reader.
+type Telemetry struct {
+	provider *sdkmetric.MeterProvider
+	registry *prometheus.Registry
+	cfg      TelemetryConfig
+	log      logr.Logger
+}
+
+// NewTelemetry builds the supervisor metrics pipeline. It does not start the
+// HTTP endpoint; call Serve for that.
+func NewTelemetry(ctx context.Context, cfg TelemetryConfig, log logr.Logger) (*Telemetry, error) {
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(telemetryServiceName),
+			semconv.ServiceVersion(cfg.ServiceVersion),
+		),
+		resource.WithFromEnv(),
+		resource.WithTelemetrySDK(),
+		resource.WithProcess(),
+		resource.WithHost(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create resource: %w", err)
+	}
+
+	registry := prometheus.NewRegistry()
+	promExporter, err := otelprom.New(otelprom.WithRegisterer(registry))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create prometheus exporter: %w", err)
+	}
+
+	opts := []sdkmetric.Option{
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(promExporter),
+	}
+	if cfg.OTLPEndpoint != "" {
+		grpcExporter, grpcErr := otlpmetricgrpc.New(ctx,
+			otlpmetricgrpc.WithEndpoint(cfg.OTLPEndpoint),
+			otlpmetricgrpc.WithInsecure(),
+			otlpmetricgrpc.WithTimeout(otlpTimeout),
+		)
+		if grpcErr != nil {
+			return nil, fmt.Errorf("failed to create OTLP gRPC exporter: %w", grpcErr)
+		}
+		opts = append(opts, sdkmetric.WithReader(sdkmetric.NewPeriodicReader(grpcExporter)))
+	}
+
+	return &Telemetry{
+		provider: sdkmetric.NewMeterProvider(opts...),
+		registry: registry,
+		cfg:      cfg,
+		log:      log.WithName("supervisor-telemetry"),
+	}, nil
+}
+
+// Meter returns the meter to register supervisor instruments on.
+func (t *Telemetry) Meter() metric.Meter {
+	return t.provider.Meter("aether/proxy-supervisor")
+}
+
+// Serve runs the Prometheus /metrics endpoint until ctx is canceled. A bind
+// failure is retried, not fatal: during a surge upgrade the predecessor pod
+// (same host netns) still owns the port, and the successor inherits it once
+// the predecessor exits. Metrics export over OTLP is unaffected either way.
+func (t *Telemetry) Serve(ctx context.Context) {
+	if t.cfg.BindAddress == "" {
+		return
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(t.registry, promhttp.HandlerOpts{}))
+
+	for {
+		srv := &http.Server{Addr: t.cfg.BindAddress, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+		go func() {
+			<-ctx.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutdownCtx)
+		}()
+
+		err := srv.ListenAndServe()
+		if ctx.Err() != nil || errors.Is(err, http.ErrServerClosed) {
+			return
+		}
+		t.log.Info("metrics endpoint unavailable; retrying (predecessor pod may still hold the port)",
+			"address", t.cfg.BindAddress, "retryIn", bindRetryInterval, "error", err.Error())
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(bindRetryInterval):
+		}
+	}
+}
+
+// Shutdown flushes and stops the provider. Called on every supervisor exit
+// path — including the wedge watchdog's fatal exit, where the final flush is
+// the crash forensics.
+func (t *Telemetry) Shutdown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), telemetryShutdownTimeout)
+	defer cancel()
+	return t.provider.Shutdown(ctx)
+}

--- a/go.mod
+++ b/go.mod
@@ -95,7 +95,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
+	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect


### PR DESCRIPTION
PR 4 of the observability plan (stacked on #124). Targets the hot-restart debugging pain point directly.

## What

The `proxy-supervisor` runs outside the controller-runtime manager and had logs only. This adds a standalone metrics pipeline plus instruments at every lifecycle transition.

### Instruments (`aether.supervisor.*`)

| Metric | Records |
|---|---|
| `epoch` (gauge) | newest launched restart epoch |
| `handoff.duration` (histogram, 1s–300s buckets) | fork → admin-confirmed LIVE |
| `wedges{reason}` | watchdog diagnoses: `handoff_timeout`, `admin_unresponsive` |
| `restart_triggers{trigger}` | `sighup`, `config_change`, `deferred_not_live` |
| `child_exits{kind}` | `drained`, `unexpected`, `successor_terminated` |
| `predecessor_detected` (0/1) | cross-pod start decision in `initStartEpoch` |
| `drain.duration` | shutdown SIGTERM → last child exit |
| `ready_transitions{ready}` | readiness marker flips |

### Design decisions

- **Own outlet**: private Prometheus registry on `:9902` (`--metrics-enabled` default true, `--metrics-bind-address`) + optional OTLP push (`--otlp-endpoint`). Not the agent's registry — separate process.
- **Host-netns surge safety**: during a surge upgrade two supervisors coexist in the host netns; a bind collision on the metrics port is retried every 15s, never fatal. The successor inherits the port when the predecessor exits.
- **Crash-forensics flush**: the wedge watchdog exits the process non-zero — the cmd layer defers a 5s-bounded `Shutdown()` flush on every exit path so the wedge counter reaches the backend before the pod is recreated.
- **No tracing for the supervisor** (per plan): post-mortem of a dead pod needs reliably-exported counters + the epoch state file, not spans that may never flush.

## Testing

ManualReader unit tests for all instruments (incl. nil-receiver safety), epoch-gauge tracking through the real `hotRestart()` fork path, telemetry construct/shutdown. `bazel test //...` 38/38, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)