### PR TITLE
feat(agent): persist pod UID; storage/informer divergence gauge; storage ADR

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "liveness_test.go",
         "metrics_test.go",
         "pod_test.go",
+        "poduid_test.go",
         "resubscribe_test.go",
         "server_integration_test.go",
         "termination_test.go",

--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -6,10 +6,12 @@ import (
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/common/telemetry"
 	"github.com/bpalermo/aether/registry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Registry reconciliation (e2e findings, 2026-06-10).
@@ -127,6 +129,20 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		}
 	}
 
+	// Divergence signal: count the node's mesh-managed pods per the informer
+	// and record it next to the storage count. Persistent skew between the two
+	// gauges surfaces a storage/informer inconsistency (e.g. a stranded storage
+	// file after a lost CNI DEL) without waiting for it to become a ghost.
+	// Best-effort: the sweep's correctness never depends on the informer.
+	if s.k8sClient != nil {
+		var podList corev1.PodList
+		if listErr := s.k8sClient.List(ctx, &podList); listErr == nil {
+			s.metrics.recordInformerPods(ctx, countManagedPods(podList.Items))
+		} else {
+			s.log.V(1).Info("ghost sweep: failed to list informer pods", "error", listErr)
+		}
+	}
+
 	registered := make(map[string]struct{})
 	for service, endpoints := range all {
 		for _, ep := range endpoints {
@@ -181,4 +197,27 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		s.log.Info("ghost sweep: registered missing endpoint",
 			"service", serviceName, "ip", ip, "pod", pod.GetName())
 	}
+}
+
+// countManagedPods counts pods the mesh would manage — the informer-side
+// equivalent of isIgnorablePod over local storage: not in an ignored
+// namespace, carrying the managed label, and holding an IP. Terminating pods
+// count (their storage entries persist until CNI DEL), so the count is
+// directly comparable to aether.agent.storage.pods.
+func countManagedPods(pods []corev1.Pod) int {
+	n := 0
+	for i := range pods {
+		pod := &pods[i]
+		if constants.IsIgnoredNamespace(pod.Namespace) {
+			continue
+		}
+		if pod.Labels[constants.LabelAetherManaged] != "true" {
+			continue
+		}
+		if pod.Status.PodIP == "" {
+			continue
+		}
+		n++
+	}
+	return n
 }

--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -28,6 +28,7 @@ type cniMetrics struct {
 	missingRegistered metric.Int64Counter
 	sweepErrors       metric.Int64Counter
 	storagePods       metric.Int64Gauge
+	informerPods      metric.Int64Gauge
 	healthTransitions metric.Int64Counter
 }
 
@@ -52,6 +53,10 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 		metric.WithDescription("Pods currently tracked in the agent's local file storage")); err != nil {
 		return nil, fmt.Errorf("storage pods: %w", err)
 	}
+	if m.informerPods, err = meter.Int64Gauge("aether.agent.informer.pods",
+		metric.WithDescription("Mesh-managed pods on this node per the API-server informer (compare with aether.agent.storage.pods for skew)")); err != nil {
+		return nil, fmt.Errorf("informer pods: %w", err)
+	}
 	if m.healthTransitions, err = meter.Int64Counter("aether.agent.liveness.health_transitions",
 		metric.WithDescription("Endpoint health transitions reflected into the registry by the liveness loop")); err != nil {
 		return nil, fmt.Errorf("health transitions: %w", err)
@@ -75,6 +80,13 @@ func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingR
 		m.missingRegistered.Add(ctx, int64(missingRegistered))
 	}
 	m.storagePods.Record(ctx, int64(storedPods))
+}
+
+func (m *cniMetrics) recordInformerPods(ctx context.Context, n int) {
+	if m == nil {
+		return
+	}
+	m.informerPods.Record(ctx, int64(n))
 }
 
 func (m *cniMetrics) healthTransition(ctx context.Context, from, to string) {

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -239,6 +239,9 @@ func (s *CNIServer) enhanceCNIPod(ctx context.Context, cniPod *cniv1.CNIPod) (_ 
 	cniPod.Annotations = k8sPod.Annotations
 	cniPod.Labels = k8sPod.Labels
 	cniPod.ServiceAccount = k8sPod.Spec.ServiceAccountName
+	// Persisted so an agent restart can rebuild SPIRE selectors (k8s:pod-uid)
+	// from storage alone, without an API-server round trip per pod.
+	cniPod.KubernetesUid = string(k8sPod.UID)
 	// A pod whose deletion has already been requested must never (re-)enter the
 	// registry: CNI CHECK re-sends AddPod for existing pods, which would
 	// otherwise clear the terminating flag and resurrect the endpoint mid-drain.

--- a/agent/internal/cni/server/poduid_test.go
+++ b/agent/internal/cni/server/poduid_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/storage"
+	"github.com/bpalermo/aether/agent/types"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	"github.com/bpalermo/aether/common/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestStorage_KubernetesUIDRoundTrip verifies the persisted UID survives the
+// storage write/read cycle the agent relies on across restarts.
+func TestStorage_KubernetesUIDRoundTrip(t *testing.T) {
+	s := storage.NewCachedLocalStorage[*cniv1.CNIPod](t.TempDir(), func() *cniv1.CNIPod { return &cniv1.CNIPod{} })
+	if err := s.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	pod := &cniv1.CNIPod{
+		Name:             "web-1",
+		Namespace:        "default",
+		NetworkNamespace: "/var/run/netns/x",
+		ContainerId:      "cid-1",
+		KubernetesUid:    "8f7c2e1a-1234-4d4e-9f00-abcdefabcdef",
+	}
+	if err := s.AddResource(context.Background(), types.ContainerID(pod.GetContainerId()), pod); err != nil {
+		t.Fatalf("AddResource() error = %v", err)
+	}
+
+	got, err := s.GetResource(context.Background(), types.ContainerID(pod.GetContainerId()))
+	if err != nil {
+		t.Fatalf("GetResource() error = %v", err)
+	}
+	if got.GetKubernetesUid() != pod.GetKubernetesUid() {
+		t.Errorf("KubernetesUid = %q, want %q", got.GetKubernetesUid(), pod.GetKubernetesUid())
+	}
+}
+
+// TestStorage_PreUIDFileLoadsWithEmptyUID verifies backward compatibility: a
+// pod file written before kubernetes_uid existed loads with an empty UID, the
+// signal for the resubscribe path to fall back to an API-server fetch.
+func TestStorage_PreUIDFileLoadsWithEmptyUID(t *testing.T) {
+	dir := t.TempDir()
+	// JSON written by a pre-UID agent: no kubernetesUid key.
+	legacy := `{"name":"web-1","namespace":"default","networkNamespace":"/var/run/netns/x","containerId":"cid-legacy"}`
+	if err := os.WriteFile(filepath.Join(dir, "cid-legacy.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatalf("writing legacy file: %v", err)
+	}
+
+	s := storage.NewCachedLocalStorage[*cniv1.CNIPod](dir, func() *cniv1.CNIPod { return &cniv1.CNIPod{} })
+	if err := s.Initialize(context.Background()); err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+
+	got, err := s.GetResource(context.Background(), types.ContainerID("cid-legacy"))
+	if err != nil {
+		t.Fatalf("GetResource() error = %v", err)
+	}
+	if got.GetKubernetesUid() != "" {
+		t.Errorf("KubernetesUid = %q, want empty for pre-UID file", got.GetKubernetesUid())
+	}
+	if got.GetName() != "web-1" {
+		t.Errorf("Name = %q, want web-1", got.GetName())
+	}
+}
+
+func TestCountManagedPods(t *testing.T) {
+	mkPod := func(ns string, managed bool, ip string) corev1.Pod {
+		labels := map[string]string{}
+		if managed {
+			labels[constants.LabelAetherManaged] = "true"
+		}
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Labels: labels},
+			Status:     corev1.PodStatus{PodIP: ip},
+		}
+	}
+
+	pods := []corev1.Pod{
+		mkPod("default", true, "10.0.0.1"),     // counted
+		mkPod("default", true, "10.0.0.2"),     // counted
+		mkPod("default", true, ""),             // no IP yet: not counted
+		mkPod("default", false, "10.0.0.3"),    // unmanaged: not counted
+		mkPod("kube-system", true, "10.0.0.4"), // ignored namespace: not counted
+	}
+
+	if got := countManagedPods(pods); got != 2 {
+		t.Errorf("countManagedPods() = %d, want 2", got)
+	}
+}

--- a/agent/internal/cni/server/resubscribe.go
+++ b/agent/internal/cni/server/resubscribe.go
@@ -17,12 +17,12 @@ import (
 // breaks ("Secret is not supplied by SDS") until the pods are recreated.
 //
 // It waits for the SPIRE bridge to connect (SubscribePod no-ops before then),
-// then re-subscribes every managed stored pod, re-fetching the pod UID from the
-// API server (the UID is needed for the SPIRE k8s:pod-uid selector and is not
-// persisted in storage). Idempotent: SubscribePod no-ops for an
-// already-subscribed network namespace, so racing a concurrent CNI ADD is safe.
-// Pods deleted while the agent was down fail the UID lookup and are skipped;
-// their CNI DEL cleans them up.
+// then re-subscribes every managed stored pod using the persisted Kubernetes
+// UID (needed for the SPIRE k8s:pod-uid selector). Pods stored before the UID
+// was persisted fall back to an API-server fetch; in that path, pods deleted
+// while the agent was down fail the lookup and are skipped (their CNI DEL
+// cleans them up). Idempotent: SubscribePod no-ops for an already-subscribed
+// network namespace, so racing a concurrent CNI ADD is safe.
 func (s *CNIServer) runResubscribeStoredPods(ctx context.Context) {
 	if s.spireBridge == nil {
 		return
@@ -47,14 +47,21 @@ func (s *CNIServer) runResubscribeStoredPods(ctx context.Context) {
 		}
 		log := s.log.WithValues("pod", pod.GetName(), "namespace", pod.GetNamespace())
 
-		var k8sPod corev1.Pod
-		if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: pod.GetNamespace(), Name: pod.GetName()}, &k8sPod); err != nil {
-			log.V(1).Info("resubscribe: pod not found in API server; skipping", "error", err)
-			continue
+		uid := pod.GetKubernetesUid()
+		if uid == "" {
+			// Pod stored before the UID was persisted: fall back to the API
+			// server. This path disappears once every stored pod has cycled.
+			var k8sPod corev1.Pod
+			if err := s.k8sClient.Get(ctx, client.ObjectKey{Namespace: pod.GetNamespace(), Name: pod.GetName()}, &k8sPod); err != nil {
+				log.V(1).Info("resubscribe: no stored UID and pod not found in API server; skipping", "error", err)
+				continue
+			}
+			uid = string(k8sPod.UID)
+			log.V(1).Info("resubscribe: no stored UID; fetched from API server")
 		}
 
 		spiffeID := proxy.SpiffeIDFromPod(pod, s.trustDomain)
-		selectors := spire.PodSelectors(pod.GetNamespace(), pod.GetServiceAccount(), pod.GetName(), string(k8sPod.UID))
+		selectors := spire.PodSelectors(pod.GetNamespace(), pod.GetServiceAccount(), pod.GetName(), uid)
 		if err := s.spireBridge.SubscribePod(pod.GetNetworkNamespace(), spiffeID, selectors); err != nil {
 			log.Error(err, "resubscribe: failed to subscribe SVID", "spiffeID", spiffeID)
 			continue

--- a/api/aether/cni/v1/cni.proto
+++ b/api/aether/cni/v1/cni.proto
@@ -42,4 +42,11 @@ message CNIPod {
   // liveness loop must never re-register it. Local xDS resources stay until the
   // CNI DEL performs final teardown.
   bool terminating = 10;
+
+  // kubernetes_uid is the pod's Kubernetes UID, captured by the agent from the
+  // API server at CNI ADD (not set by the CNI plugin binary). Persisting it
+  // lets an agent restart rebuild SPIRE workload selectors (k8s:pod-uid) from
+  // local storage alone, without re-querying the API server. Empty for pods
+  // stored before this field existed; readers must fall back to an API fetch.
+  string kubernetes_uid = 11;
 }

--- a/docs/proposals/003_agent-storage-vs-api-server.md
+++ b/docs/proposals/003_agent-storage-vs-api-server.md
@@ -1,0 +1,63 @@
+# 003: Agent pod storage — local files vs querying the API server
+
+**Status:** Accepted (2026-06-10)
+
+## Question
+
+The agent keeps a per-pod JSON file (`{containerID}.json` under
+`/var/lib/aether/registry`, protojson-encoded `CNIPod`) written at CNI ADD and
+deleted at CNI DEL, with an in-memory cache loaded at startup. The agent also
+has a node-scoped Pod informer (field selector `spec.nodeName`). Should the
+file-based storage be replaced by reading pod state directly from the API
+server?
+
+## Decision
+
+**Keep file-based storage as the source of truth.** Close two gaps instead:
+persist the pod's Kubernetes UID, and export storage/informer divergence
+metrics.
+
+## Rationale
+
+1. **The storage holds data the API server does not have.** The pinned network
+   namespace path, sandbox container ID, and CNI-time PID come from the CNI
+   invocation (kubelet → CNI args). They drive xDS listener generation and
+   SPIRE workload subscriptions. There is no API-server substitute for the
+   netns path — losing it means losing the pod's data-plane wiring.
+
+2. **Restart safety.** On agent restart, `LoadListenersFromStorage` rebuilds
+   the full xDS snapshot *before* the xDS server accepts Envoy connections.
+   The informer cache starts empty and needs an API round trip to sync;
+   making the initial snapshot depend on it would couple data-plane recovery
+   to API-server availability — precisely wrong during control-plane outages
+   or node drains, when the mesh must keep serving from local state.
+
+3. **The hybrid is already correctly layered.** API-derived fields (labels,
+   annotations, service account, `terminating`) are fetched once at CNI ADD
+   (`enhanceCNIPod`) and snapshotted into storage — the contract at admission
+   time. The informer supplies the one *live* signal that matters afterwards:
+   `deletionTimestamp` for the early-drain termination watch. Storage = state
+   at admission; informer = change notification. Migrating reads to the
+   informer would buy nothing (the fields are immutable in practice for mesh
+   purposes) and cost restart independence.
+
+4. **Two real gaps, both cheap (fixed alongside this ADR):**
+   - The pod **UID was not persisted**, so `runResubscribeStoredPods` had to
+     re-query the API server per pod at startup to rebuild SPIRE
+     `k8s:pod-uid` selectors — the agent's only hard startup API dependency.
+     `CNIPod.kubernetes_uid` now removes it (with an API fallback for
+     pre-upgrade files).
+   - **Divergence was invisible**: skew between storage, the informer, and
+     the registry only surfaced when the ghost sweep silently fixed it. The
+     `aether.agent.storage.pods` vs `aether.agent.informer.pods` gauges and
+     the `aether.agent.ghost_sweep.*` counters make it observable.
+
+## Consequences
+
+- Agent restart is fully independent of the API server for data-plane
+  recovery (xDS rebuild and SPIRE resubscription both run from storage).
+- Storage/informer skew is an alertable signal instead of an inferred one:
+  `abs(aether_agent_storage_pods - aether_agent_informer_pods) > 0` sustained
+  across sweep intervals warrants investigation.
+- The CNI ADD path keeps its single API-server read (`enhanceCNIPod`); no new
+  API load is introduced (the divergence count reads the informer cache).


### PR DESCRIPTION
PR 5 (final) of the observability plan (stacked on #125). Implements the storage-vs-API-server assessment outcome.

## Assessment (docs/proposals/003)

**Keep file-based pod storage as the source of truth; do not migrate to API-server reads.**

1. Storage holds data the API server doesn't have: pinned netns path, container ID, CNI-time PID — the pod's data-plane wiring.
2. Restart safety: the xDS snapshot is rebuilt from storage *before* Envoy connects; depending on informer sync would couple data-plane recovery to API-server availability.
3. The hybrid is already correctly layered: storage = state at admission (`enhanceCNIPod` snapshot), informer = live change signal (termination watch).

## The two gaps it closes

- **Pod UID now persisted** (`CNIPod.kubernetes_uid`, additive field): `runResubscribeStoredPods` rebuilds SPIRE `k8s:pod-uid` selectors from storage instead of one API fetch per pod at startup — the agent's last hard startup API dependency. Fallback to API fetch only for pre-upgrade files (empty UID).
- **Divergence now observable**: the ghost sweep records `aether.agent.informer.pods` (mesh-managed pods per the node-scoped informer, same filter semantics as storage) next to `aether.agent.storage.pods`. Sustained `abs(storage - informer) > 0` is the alert; previously this skew was only visible when the sweep silently fixed it.

## Testing

- UID round-trip through real storage; backward-compat: legacy JSON without the field loads with empty UID (the fallback trigger).
- `countManagedPods` filter semantics (ignored namespace / unmanaged / no-IP).
- Nil-client guard keeps the sweep informer-independent. `bazel test //...` 38/38, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)