### PR TITLE
feat(agent): metrics for xDS ACK-tracking error paths

### DIFF
--- a/agent/internal/xds/ack/BUILD.bazel
+++ b/agent/internal/xds/ack/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "ack",
-    srcs = ["tracker.go"],
+    srcs = [
+        "metrics.go",
+        "tracker.go",
+    ],
     importpath = "github.com/bpalermo/aether/agent/internal/xds/ack",
     visibility = ["//agent:__subpackages__"],
     deps = [
@@ -11,12 +14,18 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
         "@com_github_envoyproxy_go_control_plane_envoy//service/discovery/v3:discovery",
         "@com_github_go_logr_logr//:logr",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_metric//:metric",
     ],
 )
 
 go_test(
     name = "ack_test",
-    srcs = ["tracker_test.go"],
+    srcs = [
+        "metrics_test.go",
+        "tracker_test.go",
+    ],
     embed = [":ack"],
     deps = [
         "@com_github_envoyproxy_go_control_plane//pkg/resource/v3:resource",
@@ -24,6 +33,9 @@ go_test(
         "@com_github_go_logr_logr//:logr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk_metric//metricdata",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
     ],

--- a/agent/internal/xds/ack/metrics.go
+++ b/agent/internal/xds/ack/metrics.go
@@ -1,0 +1,68 @@
+package ack
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// meterName identifies this instrumentation scope in metric backends.
+const meterName = "aether/agent-xds-ack"
+
+// Attribute keys. Bounded cardinality: xDS type URLs (a handful), wait kind
+// (present/absent) and failure reason (nack/timeout).
+const (
+	attrTypeURL = attribute.Key("aether.xds.type_url")
+	attrWait    = attribute.Key("aether.xds.wait")
+	attrReason  = attribute.Key("aether.xds.reason")
+)
+
+// trackerMetrics holds the ACK-tracking instruments. All methods are
+// nil-receiver-safe so the tracker runs unchanged when telemetry is disabled.
+//
+// Every NACK is Envoy refusing config this agent generated (bad config, failed
+// netns bind) and every wait failure is a pod lifecycle step that could not
+// confirm delivery — both were previously only V(1) log lines.
+type trackerMetrics struct {
+	nacks        metric.Int64Counter
+	waitFailures metric.Int64Counter
+}
+
+// newTrackerMetrics registers the ACK-tracking instruments on the given meter.
+func newTrackerMetrics(meter metric.Meter) (*trackerMetrics, error) {
+	m := &trackerMetrics{}
+	var err error
+
+	if m.nacks, err = meter.Int64Counter("aether.agent.xds.nacks",
+		metric.WithDescription("Delta-xDS responses Envoy rejected (NACK with error detail), by resource type URL")); err != nil {
+		return nil, fmt.Errorf("nacks: %w", err)
+	}
+	if m.waitFailures, err = meter.Int64Counter("aether.agent.xds.ack_wait_failures",
+		metric.WithDescription("ACK waits that failed, by wait kind (present/absent) and reason (nack/timeout)")); err != nil {
+		return nil, fmt.Errorf("ack wait failures: %w", err)
+	}
+
+	return m, nil
+}
+
+// nacked records one rejected delta response.
+func (m *trackerMetrics) nacked(ctx context.Context, typeURL string) {
+	if m == nil {
+		return
+	}
+	m.nacks.Add(ctx, 1, metric.WithAttributes(attrTypeURL.String(typeURL)))
+}
+
+// waitFailed records one failed ACK wait.
+func (m *trackerMetrics) waitFailed(ctx context.Context, wantPresent bool, reason string) {
+	if m == nil {
+		return
+	}
+	wait := "absent"
+	if wantPresent {
+		wait = "present"
+	}
+	m.waitFailures.Add(ctx, 1, metric.WithAttributes(attrWait.String(wait), attrReason.String(reason)))
+}

--- a/agent/internal/xds/ack/metrics_test.go
+++ b/agent/internal/xds/ack/metrics_test.go
@@ -1,0 +1,109 @@
+package ack
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// newTestTracker builds a Tracker whose instruments record into a manual
+// reader, bypassing the global MeterProvider.
+func newTestTracker(t *testing.T) (*Tracker, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := newTrackerMetrics(provider.Meter("test"))
+	require.NoError(t, err)
+
+	tr := NewTracker(logr.Discard())
+	tr.metrics = metrics
+	return tr, reader
+}
+
+// counterValue returns the summed value of the named counter, and whether it
+// was found, optionally requiring an attribute value to be present on the
+// data point.
+func counterValue(t *testing.T, reader *sdkmetric.ManualReader, name, attrKey, attrVal string) (int64, bool) {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "metric %s is not an int64 sum", name)
+			var total int64
+			found := false
+			for _, dp := range sum.DataPoints {
+				if attrKey != "" {
+					if v, has := dp.Attributes.Value(attribute.Key(attrKey)); !has || v.AsString() != attrVal {
+						continue
+					}
+				}
+				total += dp.Value
+				found = true
+			}
+			return total, found
+		}
+	}
+	return 0, false
+}
+
+func TestMetrics_Nack(t *testing.T) {
+	tr, reader := newTestTracker(t)
+	sendDelta(tr, 1, "n1", []string{testListener}, nil)
+	ackDelta(tr, 1, "n1", "bad config")
+
+	v, ok := counterValue(t, reader, "aether.agent.xds.nacks", "aether.xds.type_url", resourcev3.ListenerType)
+	require.True(t, ok, "nack counter not recorded")
+	assert.Equal(t, int64(1), v)
+}
+
+func TestMetrics_WaitFailures(t *testing.T) {
+	t.Run("timeout", func(t *testing.T) {
+		tr, reader := newTestTracker(t)
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		require.Error(t, tr.WaitListenerPresent(ctx, testListener))
+
+		v, ok := counterValue(t, reader, "aether.agent.xds.ack_wait_failures", "aether.xds.reason", "timeout")
+		require.True(t, ok, "wait failure counter not recorded")
+		assert.Equal(t, int64(1), v)
+	})
+
+	t.Run("nack", func(t *testing.T) {
+		tr, reader := newTestTracker(t)
+		sendDelta(tr, 1, "n1", []string{testListener}, nil)
+		ackDelta(tr, 1, "n1", "cannot bind")
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		require.Error(t, tr.WaitListenerPresent(ctx, testListener))
+
+		v, ok := counterValue(t, reader, "aether.agent.xds.ack_wait_failures", "aether.xds.reason", "nack")
+		require.True(t, ok, "wait failure counter not recorded")
+		assert.Equal(t, int64(1), v)
+	})
+}
+
+func TestMetrics_NilSafe(t *testing.T) {
+	tr := NewTracker(logr.Discard())
+	tr.metrics = nil
+
+	sendDelta(tr, 1, "n1", []string{testListener}, nil)
+	ackDelta(tr, 1, "n1", "bad config")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.Error(t, tr.WaitListenerAbsent(ctx, testListener))
+}

--- a/agent/internal/xds/ack/tracker.go
+++ b/agent/internal/xds/ack/tracker.go
@@ -19,6 +19,7 @@ import (
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel"
 )
 
 // resourceState is the last word Envoy gave about one resource.
@@ -49,7 +50,8 @@ type inflightResponse struct {
 // Tracker observes the delta-xDS streams via server callbacks and lets callers
 // wait until Envoy has acknowledged the presence or removal of a named resource.
 type Tracker struct {
-	log logr.Logger
+	log     logr.Logger
+	metrics *trackerMetrics // nil disables instrumentation
 
 	mu       sync.Mutex
 	state    map[string]resourceState // keyed by typeURL + "/" + name
@@ -60,8 +62,16 @@ type Tracker struct {
 
 // NewTracker creates an empty Tracker.
 func NewTracker(log logr.Logger) *Tracker {
+	log = log.WithName("xds-ack")
+	// Instruments ride the global MeterProvider (no-op unless --otel-enabled);
+	// a registration failure only disables instrumentation, never the tracker.
+	metrics, err := newTrackerMetrics(otel.Meter(meterName))
+	if err != nil {
+		log.Error(err, "failed to create xds ack metrics; continuing without instrumentation")
+	}
 	return &Tracker{
-		log:      log.WithName("xds-ack"),
+		log:      log,
+		metrics:  metrics,
 		state:    make(map[string]resourceState),
 		inflight: make(map[inflightKey]inflightResponse),
 		changed:  make(chan struct{}),
@@ -107,6 +117,7 @@ func (t *Tracker) wait(ctx context.Context, typeURL, name string, wantPresent bo
 		t.mu.Unlock()
 
 		if st.nackErr != nil {
+			t.metrics.waitFailed(ctx, wantPresent, "nack")
 			return fmt.Errorf("envoy rejected config for %s: %w", name, st.nackErr)
 		}
 		if st.present == wantPresent {
@@ -115,6 +126,7 @@ func (t *Tracker) wait(ctx context.Context, typeURL, name string, wantPresent bo
 
 		select {
 		case <-ctx.Done():
+			t.metrics.waitFailed(ctx, wantPresent, "timeout")
 			if wantPresent {
 				return fmt.Errorf("timed out waiting for envoy to ack %s", name)
 			}
@@ -183,6 +195,7 @@ func (t *Tracker) onDeltaRequest(streamID int64, req *discoveryv3.DeltaDiscovery
 	t.mu.Unlock()
 
 	if detail := req.GetErrorDetail(); detail != nil {
+		t.metrics.nacked(context.Background(), entry.typeURL)
 		t.log.Info("envoy NACKed delta response",
 			"typeURL", entry.typeURL, "added", entry.added, "removed", entry.removed, "error", detail.GetMessage())
 	}


### PR DESCRIPTION
Follow-up to #128: surface the xDS callback failures that were previously only V(1) log lines.

## Metrics

| Metric | Attributes | Fires when |
|---|---|---|
| `aether.agent.xds.nacks` | `aether.xds.type_url` | Envoy NACKs a delta response — it refused config this agent generated (bad config, failed netns socket bind) |
| `aether.agent.xds.ack_wait_failures` | `aether.xds.wait` (present/absent), `aether.xds.reason` (nack/timeout) | A pod lifecycle ACK wait could not confirm config delivery |

## Notes

- Same conventions as the other agent instruments: registered on the global MeterProvider (no-op unless `--otel-enabled`), nil-receiver-safe so a registration failure only disables instrumentation, bounded attribute cardinality.
- The NACK counter increments in the callback itself, so it fires even when no lifecycle wait is in flight (e.g. a NACK against a snapshot refresh).

## Testing

- ManualReader-based unit tests for both counters (timeout + nack reasons, type_url attribution) and the nil-metrics path; `bazel test //agent/...` 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)