### PR TITLE
fix(agent): omit transport-socket matcher when no local workloads exist

### DIFF
--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -81,8 +81,19 @@ func NewServiceCluster(serviceName string) *clusterv3.Cluster {
 // that pod's client certificate (on-no-match presents the node identity). The
 // matches reference each local workload's SVID over SDS. This is applied at snapshot
 // time because it depends on the current set of local workloads.
+//
+// With no local workload mappings the matcher is omitted entirely — an empty
+// exact_match_map NACKs the whole CDS push — and the node identity is presented
+// directly (what on_no_match would have done for every connection). No
+// transport_socket_matches are set in that branch: without the matcher Envoy
+// falls back to legacy metadata matching, where an empty match criteria set
+// would select the first entry for every endpoint.
 func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]string, spiffeIDs []string, nodeSpiffeID, validationContextName string) {
 	matcher := UpstreamTransportSocketMatcher(netnsToSpiffeID)
+	if matcher == nil {
+		cluster.TransportSocket = UpstreamTransportSocket(nodeSpiffeID, validationContextName)
+		return
+	}
 	matcher.OnNoMatch = transportSocketNameOnMatch(nodeSpiffeID)
 
 	cluster.TransportSocketMatcher = matcher

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -52,6 +52,34 @@ func TestInjectUpstreamMTLS(t *testing.T) {
 	}
 	assert.True(t, names[ids[0]] && names[ids[1]] && names[node], "matches for both pods and the node")
 	require.NotNil(t, c.GetTransportSocketMatcher().GetOnNoMatch(), "on-no-match present")
+	assert.GreaterOrEqual(t, len(c.GetTransportSocketMatcher().GetMatcherTree().GetExactMatchMap().GetMap()), 1,
+		"exact_match_map must never be empty (proto validation rejects it)")
+}
+
+// TestInjectUpstreamMTLS_NoLocalWorkloads: an empty netns→SPIFFE-ID map must
+// not produce a matcher — an empty exact_match_map fails Envoy's proto
+// validation and NACKs the whole CDS push (observed on agents starting before
+// any local workload mapping exists, and permanent on nodes with no managed
+// pods). The node identity is presented directly instead, and no legacy
+// transport_socket_matches are set (without the matcher, an empty match
+// criteria set would select the first entry for every endpoint).
+func TestInjectUpstreamMTLS_NoLocalWorkloads(t *testing.T) {
+	node := "spiffe://example.org/ns/aether-system/sa/aether-agent"
+
+	for name, netnsToID := range map[string]map[string]string{
+		"nil map":              nil,
+		"empty map":            {},
+		"only invalid entries": {"": "spiffe://example.org/x", "/ns/a": ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := NewServiceCluster("svc-a")
+			InjectUpstreamMTLS(c, netnsToID, nil, node, "spiffe://example.org")
+
+			assert.Nil(t, c.GetTransportSocketMatcher(), "no matcher without local workloads")
+			assert.Empty(t, c.GetTransportSocketMatches(), "no legacy matches without the matcher")
+			require.NotNil(t, c.GetTransportSocket(), "node identity presented directly")
+		})
+	}
 }
 
 func TestServiceLocalityLbEndpointFromRegistryEndpoint(t *testing.T) {

--- a/agent/internal/xds/proxy/transportsocketmatch.go
+++ b/agent/internal/xds/proxy/transportsocketmatch.go
@@ -49,6 +49,13 @@ func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName st
 // each local pod's network namespace to a TransportSocketNameAction naming that
 // pod's SPIFFE ID — the match name used by UpstreamTransportSocketMatches — so
 // the upstream connection presents the originating pod's certificate.
+//
+// Returns nil when no valid netns→SPIFFE-ID entries exist: an empty
+// exact_match_map fails proto validation (`MatchMapValidationError.Map: value
+// must contain at least 1 pair(s)`), making Envoy NACK the entire CDS push —
+// observed on agents starting before any local workload mapping exists, and
+// permanent on nodes with zero managed pods (e2e 2026-06-10). Callers fall
+// back to a plain transport socket.
 func UpstreamTransportSocketMatcher(netnsToSpiffeID map[string]string) *matcherv3.Matcher {
 	m := make(map[string]*matcherv3.Matcher_OnMatch, len(netnsToSpiffeID))
 	for netns, id := range netnsToSpiffeID {
@@ -56,6 +63,9 @@ func UpstreamTransportSocketMatcher(netnsToSpiffeID map[string]string) *matcherv
 			continue
 		}
 		m[netns] = transportSocketNameOnMatch(id)
+	}
+	if len(m) == 0 {
+		return nil
 	}
 
 	return &matcherv3.Matcher{


### PR DESCRIPTION
First catch by the `aether.agent.xds.nacks` metric (#129), during the #130 e2e on talos-main.

## The bug

`InjectUpstreamMTLS` always built the per-source transport-socket matcher, even with zero local netns→SPIFFE-ID mappings. An empty `exact_match_map` fails Envoy's proto validation:

```
MatchMapValidationError.Map: value must contain at least 1 pair(s)
```

…and a NACK rejects the **entire CDS push** — all service clusters. Observed transiently on an agent that started before any local workload mapping existed (self-healed on the next pod event), but on a node with **zero managed pods** this is permanent: service clusters can never be programmed there.

## The fix

With no mappings, every connection would take the `on_no_match` path anyway — so skip the matcher and present the node identity directly via a plain `transport_socket`. Deliberately no `transport_socket_matches` in that branch: without the new-style matcher Envoy falls back to legacy metadata matching, where an empty match criteria set selects the first entry for every endpoint.

## Testing

- `TestInjectUpstreamMTLS_NoLocalWorkloads` (nil / empty / only-invalid-entries) + a never-empty-map guard on the populated path; `bazel test //agent/...` 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)