### PR TITLE
fix(supervisor): hold readiness while serving as hot-restart parent

### DIFF
--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -171,6 +171,7 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 	defer t.Stop()
 	ready := false
 	everLive := false
+	holding := false
 	var unreachableSince time.Time
 	for {
 		select {
@@ -188,6 +189,7 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			}
 			if live {
 				everLive = true
+				holding = false
 				if launched, wasLive := s.epochProgress(); !wasLive {
 					// First LIVE confirmation for this epoch: the handoff (or
 					// initial start, epoch 0) completed.
@@ -206,9 +208,27 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 				}
 				continue
 			}
-			if ready {
+			// Hold readiness while this supervisor's Envoy is still the serving
+			// hot-restart parent: admin reachable but answering at another (or
+			// not-yet-LIVE) epoch with our newest child alive is the normal
+			// mid-handoff state — a surging successor pod attaching to us, or our
+			// own in-pod restart still initializing. Dropping Ready here lets the
+			// DaemonSet (maxUnavailable=0 counts only Ready pods) delete this pod
+			// immediately, and the kubelet's grace-period SIGKILL then cuts the
+			// parent from under the successor's hot-restart protocol — observed as
+			// errno-111 aborts and node data-plane gaps when a proxy roll
+			// coincided with pod churn (e2e 2026-06-11). The wedge watchdogs below
+			// still run: a successor stuck pre-LIVE or an unreachable admin ends
+			// the hold via container restart, and the child exiting ends it here.
+			hold := ready && reachable && s.childTracked(epoch)
+			if hold && !holding {
+				holding = true
+				s.log.Info("holding readiness: serving as hot-restart parent mid-handoff", "epoch", epoch)
+			}
+			if ready && !hold {
 				s.clearReady()
 				ready = false
+				holding = false
 				s.metrics.readyTransition(false)
 				s.log.Info("pod not ready: envoy not live at newest epoch", "epoch", epoch)
 			}

--- a/agent/internal/proxy/hotrestart/coordination_test.go
+++ b/agent/internal/proxy/hotrestart/coordination_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -136,6 +137,80 @@ func TestReadyMarker(t *testing.T) {
 	s.clearReady()
 	_, err = os.Stat(s.cfg.ReadyMarkerPath)
 	assert.True(t, os.IsNotExist(err))
+}
+
+// TestReadinessHeldWhileServingParentMidHandoff reproduces the 2026-06-11 e2e
+// finding: a surging successor pod binds the shared admin socket and answers at
+// its (not yet LIVE) epoch, which previously made the old pod's supervisor drop
+// the ready marker immediately — the DaemonSet (maxUnavailable=0 counts only
+// Ready pods) then deleted the old pod mid-handoff and the kubelet's grace
+// SIGKILL cut the hot-restart parent from under the successor (errno-111
+// abort). While this supervisor's newest child is alive and admin is reachable,
+// readiness must be HELD; it clears once the child exits (protocol terminate).
+func TestReadinessHeldWhileServingParentMidHandoff(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available in this sandbox")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "envoy.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("v0\n"), 0o644))
+	recordPath := filepath.Join(t.TempDir(), "epochs.txt")
+	marker := filepath.Join(t.TempDir(), "ready")
+
+	// Mutable admin: starts LIVE at this supervisor's epoch 0, then flips to a
+	// successor answering INITIALIZING at epoch 1.
+	var adminResp atomic.Value
+	adminResp.Store(`{"state":"LIVE","command_line_options":{"restart_epoch":0}}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprint(w, adminResp.Load().(string))
+	}))
+	defer srv.Close()
+
+	s := New(Config{
+		EnvoyPath:          stubEnvoy(t, recordPath),
+		ConfigPath:         configPath,
+		DrainTime:          time.Second,
+		ParentShutdownTime: time.Second,
+		StateDir:           t.TempDir(),
+		ReadyMarkerPath:    marker,
+		AdminAddress:       srv.Listener.Addr().String(),
+	}, logr.Discard(), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-runErr:
+		case <-time.After(10 * time.Second):
+			t.Error("Run did not return after cancel")
+		}
+	})
+
+	// Phase A: LIVE at our epoch -> Ready.
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, 10*time.Second, 50*time.Millisecond, "pod never became ready")
+
+	// Phase B: a successor binds admin, not yet LIVE. Readiness must be held
+	// while our child (the successor's hot-restart parent) is alive.
+	adminResp.Store(`{"state":"INITIALIZING","command_line_options":{"restart_epoch":1}}`)
+	assert.Never(t, func() bool {
+		_, err := os.Stat(marker)
+		return os.IsNotExist(err)
+	}, 3*readyPollInterval+500*time.Millisecond, 100*time.Millisecond,
+		"ready marker dropped mid-handoff while still the serving parent")
+
+	// Phase C: the successor's protocol terminates our child (clean exit) ->
+	// nothing left serving here -> readiness clears.
+	s.signalEpoch(0, syscall.SIGTERM)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return os.IsNotExist(err)
+	}, 10*time.Second, 100*time.Millisecond, "ready marker must clear once the child exits")
 }
 
 // TestHandoffWatchdogFiresWhenSuccessorNeverLive reproduces the 2026-06-10 e2e

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -36,9 +36,12 @@ spec:
       {{- if and .Values.proxy.hotRestart.enabled .Values.proxy.hotRestart.crossPod }}
       # The deleted (old) pod must keep its Envoy alive as the successor's
       # hot-restart parent until the successor's protocol terminates it — the
-      # successor's timers start only after its xDS-gated init. Give the
-      # supervisor room to wait; the kubelet's SIGKILL here is the hard stop.
-      terminationGracePeriodSeconds: 60
+      # successor's timers start only after its xDS-gated init, which pod churn
+      # can stretch past a minute (e2e 2026-06-11: a 60s grace SIGKILLed the
+      # parent mid-protocol on 3/5 nodes when a proxy roll coincided with
+      # churn). Give the supervisor generous room to wait; the kubelet's
+      # SIGKILL here is the hard stop.
+      terminationGracePeriodSeconds: 180
       {{- end }}
       {{- if .Values.proxy.hotRestart.enabled }}
       initContainers:


### PR DESCRIPTION
Fixes the Phase-5 finding from the 2026-06-11 e2e (proxy roll **concurrent** with pod churn → errno-111 aborts and ~30-50s data-plane gaps on 3/5 nodes).

## Failure chain

1. Surging successor attaches at epoch N+1; the churn stretches its xDS-gated init past 60s.
2. The old pod's supervisor **dropped its ready marker** the moment the successor bound the shared admin socket and answered at its not-yet-LIVE epoch (`watchLiveness`'s "not LIVE at my epoch" branch).
3. NotReady pods don't count against `maxUnavailable=0` → the DaemonSet **deleted the old pod immediately**, not waiting for the successor.
4. `terminationGracePeriodSeconds: 60` expired before successor-LIVE + parent-shutdown(15s) → kubelet SIGKILLed the parent Envoy mid-protocol.
5. Successor `sendmsg()` → ECONNREFUSED → Envoy aborts by design → epoch-0 recovery (correct, but the node gap is the cost).

#112 fixed the supervisor's *reaction* to predecessor deletion; this fixes the premature-NotReady *trigger* upstream of it. Proxy-only rolls never tripped it (~20-40s init + 15s fits in 60s grace) — Phase 4 of the same e2e was 0-failure hitless.

## Fix

- **Hold the ready marker** while this supervisor's newest child is alive and admin is reachable — covers both the surging-successor attach and our own in-pod restart window (which previously also flapped NotReady on every config-change restart). Old pod stays Ready until the *successor pod* is Ready → `maxUnavailable=0` sequences the roll correctly → deletion lands after the handoff.
- The hold is bounded: handoff watchdog (successor stuck pre-LIVE), admin watchdog (admin unreachable), and child exit all end it.
- Belt-and-braces: chart `terminationGracePeriodSeconds` 60 → 180 for deletion-mid-handoff cases that remain.

## Testing

- New `TestReadinessHeldWhileServingParentMidHandoff`: LIVE→Ready, successor binds admin pre-LIVE → marker **held** across poll intervals, child protocol-terminated → marker clears.
- Existing watchdog regression tests unchanged and passing; `bazel test //agent/...` 13/13, lint clean.
- After merge: full multi-service/multi-roll e2e re-run on talos-main, including the concurrent proxy-roll+churn phase that exposed this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)