### PR TITLE
fix(agent): re-subscribe SPIRE streams with backoff instead of failing

### DIFF
--- a/agent/internal/spire/BUILD.bazel
+++ b/agent/internal/spire/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "bridge.go",
         "client.go",
         "converter.go",
+        "metrics.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/spire",
     visibility = ["//agent:__subpackages__"],
@@ -17,6 +18,9 @@ go_library(
         "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/agent/delegatedidentity/v1:delegatedidentity",
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/types",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_metric//:metric",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials/insecure",
     ],
@@ -25,12 +29,14 @@ go_library(
 go_test(
     name = "spire_test",
     srcs = [
+        "bridge_reconnect_test.go",
         "bridge_test.go",
         "converter_test.go",
         "node_svid_test.go",
     ],
     embed = [":spire"],
     deps = [
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_go_logr_logr//:logr",
         "@com_github_spiffe_go_spiffe_v2//spiffeid",
         "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
@@ -38,5 +44,6 @@ go_test(
         "@com_github_spiffe_spire_api_sdk//proto/spire/api/types",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -25,11 +26,23 @@ import (
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
 	apitypes "github.com/spiffe/spire-api-sdk/proto/spire/api/types"
+	"go.opentelemetry.io/otel"
 )
 
 // nodeSVIDRefreshInterval is how often the bridge re-reads its node SVID from
 // the Workload API source to pick up rotations and push the refreshed secret.
 const nodeSVIDRefreshInterval = 30 * time.Second
+
+// Backoff policy for re-establishing delegated-identity subscription streams
+// after a disconnect (e.g. a SPIRE agent restart). Matches the registrar
+// watch-stream policy. The backoff resets only once a response is received on
+// the new stream, so a stream that connects and immediately closes keeps
+// backing off rather than hot-looping.
+const (
+	initialStreamBackoff = 1 * time.Second
+	maxStreamBackoff     = 30 * time.Second
+	streamJitterFraction = 0.2
+)
 
 // SecretStore is the interface for pushing secrets into the xDS snapshot cache.
 type SecretStore interface {
@@ -59,6 +72,12 @@ type Bridge struct {
 	client     *Client
 	store      SecretStore
 	log        logr.Logger
+	metrics    *bridgeMetrics
+
+	// Stream re-subscribe backoff bounds; set to the package constants in
+	// NewBridge, overridable in tests.
+	backoffInitial time.Duration
+	backoffMax     time.Duration
 
 	// nodeSource provides the agent's own SVID (the node identity). When set,
 	// the bridge serves it as an SDS secret named by its SPIFFE ID and refreshes
@@ -96,14 +115,24 @@ type podSubscription struct {
 // API SVID source used to serve the node identity; it may be nil to disable
 // node-SVID serving.
 func NewBridge(socketPath string, store SecretStore, nodeSource X509SVIDSource, log logr.Logger) *Bridge {
+	// Instruments ride the global MeterProvider (no-op unless --otel-enabled);
+	// a registration failure only disables instrumentation, never the bridge.
+	metrics, err := newBridgeMetrics(otel.Meter(meterName))
+	if err != nil {
+		log.Error(err, "failed to create SPIRE bridge metrics; continuing without instrumentation")
+	}
+
 	return &Bridge{
-		socketPath:    socketPath,
-		store:         store,
-		nodeSource:    nodeSource,
-		log:           log.WithName("spire-bridge"),
-		secrets:       make(map[string]*tlsv3.Secret),
-		subscriptions: make(map[string]podSubscription),
-		started:       make(chan struct{}),
+		socketPath:     socketPath,
+		store:          store,
+		nodeSource:     nodeSource,
+		log:            log.WithName("spire-bridge"),
+		metrics:        metrics,
+		backoffInitial: initialStreamBackoff,
+		backoffMax:     maxStreamBackoff,
+		secrets:        make(map[string]*tlsv3.Secret),
+		subscriptions:  make(map[string]podSubscription),
+		started:        make(chan struct{}),
 	}
 }
 
@@ -144,13 +173,6 @@ func (b *Bridge) Start(ctx context.Context) error {
 	b.log.Info("connected to SPIRE agent", "socket", b.socketPath)
 	close(b.started)
 
-	bundleCh, err := client.SubscribeBundles(ctx)
-	if err != nil {
-		return fmt.Errorf("subscribing to bundles: %w", err)
-	}
-
-	b.log.Info("subscribed to X.509 bundles")
-
 	// Serve the agent's own node SVID (for node-originated upstream mTLS and the
 	// node-health listener) and keep it refreshed on rotation.
 	if b.nodeSource != nil {
@@ -160,19 +182,83 @@ func (b *Bridge) Start(ctx context.Context) error {
 		go b.runNodeSVIDRefresh(ctx)
 	}
 
+	// Maintain the bundle subscription for the bridge's lifetime, re-subscribing
+	// with backoff when the stream ends (e.g. the SPIRE agent restarts) instead
+	// of failing the runnable — which would take down the whole agent for a
+	// transient disconnect. SPIRE sends the full bundle set as the first response
+	// on every new stream, so a plain re-subscribe fully resynchronizes; the
+	// cached bundle secrets keep serving while disconnected.
+	backoff := b.backoffInitial
+	first := true
 	for {
-		select {
-		case <-ctx.Done():
-			b.log.Info("shutting down SPIRE bridge")
-			return nil
-		case resp, ok := <-bundleCh:
-			if !ok {
-				return fmt.Errorf("bundle subscription stream closed unexpectedly")
+		bundleCh, subErr := client.SubscribeBundles(ctx)
+		if subErr != nil {
+			if ctx.Err() != nil {
+				b.log.Info("shutting down SPIRE bridge")
+				return nil
 			}
-			if err := b.handleBundleUpdate(ctx, resp); err != nil {
-				b.log.Error(err, "handling bundle update")
+			b.metrics.streamFailed(ctx, streamBundle)
+			wait := jitteredBackoff(backoff)
+			b.log.Error(subErr, "subscribing to X.509 bundles failed; retrying", "backoff", wait)
+			if !sleepCtx(ctx, wait) {
+				b.log.Info("shutting down SPIRE bridge")
+				return nil
+			}
+			backoff = min(backoff*2, b.backoffMax)
+			first = false
+			continue
+		}
+		if first {
+			b.log.Info("subscribed to X.509 bundles")
+			first = false
+		} else {
+			b.metrics.streamReconnected(ctx, streamBundle)
+			b.log.Info("re-subscribed to X.509 bundles")
+		}
+
+	receive:
+		for {
+			select {
+			case <-ctx.Done():
+				b.log.Info("shutting down SPIRE bridge")
+				return nil
+			case resp, ok := <-bundleCh:
+				if !ok {
+					break receive
+				}
+				// Receiving proves the stream is healthy; reset the backoff.
+				backoff = b.backoffInitial
+				if err := b.handleBundleUpdate(ctx, resp); err != nil {
+					b.log.Error(err, "handling bundle update")
+				}
 			}
 		}
+
+		b.metrics.streamFailed(ctx, streamBundle)
+		wait := jitteredBackoff(backoff)
+		b.log.Info("bundle subscription stream closed; re-subscribing", "backoff", wait)
+		if !sleepCtx(ctx, wait) {
+			b.log.Info("shutting down SPIRE bridge")
+			return nil
+		}
+		backoff = min(backoff*2, b.backoffMax)
+	}
+}
+
+// jitteredBackoff returns d plus up to streamJitterFraction of random jitter,
+// de-synchronizing re-subscribe attempts across streams and agents.
+func jitteredBackoff(d time.Duration) time.Duration {
+	return d + time.Duration(float64(d)*streamJitterFraction*rand.Float64())
+}
+
+// sleepCtx waits for d or until ctx is done; it reports whether the full wait
+// elapsed (false means ctx was cancelled).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
 	}
 }
 
@@ -237,22 +323,54 @@ func (b *Bridge) SubscribePod(netns, spiffeID string, selectors []*apitypes.Sele
 	b.log.Info("subscribed to SVIDs", "spiffeID", spiffeID)
 
 	go func() {
+		ch := svidCh
+		backoff := b.backoffInitial
 		for {
-			select {
-			case <-subCtx.Done():
-				return
-			case resp, ok := <-svidCh:
-				if !ok {
-					b.log.Info("SVID subscription stream closed", "spiffeID", spiffeID)
+		receive:
+			for {
+				select {
+				case <-subCtx.Done():
+					return
+				case resp, ok := <-ch:
+					if !ok {
+						break receive
+					}
+					// Receiving proves the stream is healthy; reset the backoff.
+					backoff = b.backoffInitial
+					// Use subCtx (tied to the bridge/subscription lifetime), not the
+					// caller's request context: SubscribePod is called synchronously
+					// from CmdAdd, whose context is cancelled as soon as it returns —
+					// pushing the SVID into the snapshot must outlive that request.
+					if handleErr := b.handleSVIDUpdate(subCtx, resp); handleErr != nil {
+						b.log.Error(handleErr, "handling SVID update", "spiffeID", spiffeID)
+					}
+				}
+			}
+
+			// The stream ended while the pod is still subscribed (e.g. the SPIRE
+			// agent restarted): re-subscribe with backoff so rotations keep
+			// flowing — exiting here would silently freeze this pod's SVID until
+			// it expired. The cached SVID keeps serving meanwhile, and the first
+			// response on the new stream is the current SVID set, so a plain
+			// re-subscribe fully resynchronizes.
+			b.metrics.streamFailed(subCtx, streamSVID)
+			for {
+				wait := jitteredBackoff(backoff)
+				b.log.Info("SVID subscription stream closed; re-subscribing", "spiffeID", spiffeID, "backoff", wait)
+				if !sleepCtx(subCtx, wait) {
 					return
 				}
-				// Use subCtx (tied to the bridge/subscription lifetime), not the
-				// caller's request context: SubscribePod is called synchronously
-				// from CmdAdd, whose context is cancelled as soon as it returns —
-				// pushing the SVID into the snapshot must outlive that request.
-				if handleErr := b.handleSVIDUpdate(subCtx, resp); handleErr != nil {
-					b.log.Error(handleErr, "handling SVID update", "spiffeID", spiffeID)
+				backoff = min(backoff*2, b.backoffMax)
+				newCh, subErr := b.client.SubscribeSVIDsBySelectors(subCtx, selectors)
+				if subErr != nil {
+					b.metrics.streamFailed(subCtx, streamSVID)
+					b.log.Error(subErr, "re-subscribing to SVIDs failed; retrying", "spiffeID", spiffeID)
+					continue
 				}
+				ch = newCh
+				b.metrics.streamReconnected(subCtx, streamSVID)
+				b.log.Info("re-subscribed to SVIDs", "spiffeID", spiffeID)
+				break
 			}
 		}
 	}()

--- a/agent/internal/spire/bridge_reconnect_test.go
+++ b/agent/internal/spire/bridge_reconnect_test.go
@@ -1,0 +1,174 @@
+package spire
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/go-logr/logr"
+	delegatedidentityv1 "github.com/spiffe/spire-api-sdk/proto/spire/api/agent/delegatedidentity/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// fakeDelegatedIdentity is a SPIRE delegated-identity server whose first
+// subscription stream of each kind sends one empty response and then ends,
+// simulating a SPIRE agent restart. Subsequent streams stay open until the
+// test ends so the bridge can settle in a healthy reconnected state.
+type fakeDelegatedIdentity struct {
+	delegatedidentityv1.UnimplementedDelegatedIdentityServer
+
+	mu         sync.Mutex
+	bundleSubs int
+	svidSubs   int
+}
+
+// counts returns the number of bundle and SVID subscriptions seen so far.
+func (f *fakeDelegatedIdentity) counts() (bundle, svid int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.bundleSubs, f.svidSubs
+}
+
+func (f *fakeDelegatedIdentity) SubscribeToX509Bundles(_ *delegatedidentityv1.SubscribeToX509BundlesRequest, stream grpc.ServerStreamingServer[delegatedidentityv1.SubscribeToX509BundlesResponse]) error {
+	f.mu.Lock()
+	f.bundleSubs++
+	n := f.bundleSubs
+	f.mu.Unlock()
+
+	if err := stream.Send(&delegatedidentityv1.SubscribeToX509BundlesResponse{}); err != nil {
+		return err
+	}
+	if n == 1 {
+		return nil // simulated SPIRE agent restart: stream ends after one update
+	}
+	<-stream.Context().Done()
+	return nil
+}
+
+func (f *fakeDelegatedIdentity) SubscribeToX509SVIDs(_ *delegatedidentityv1.SubscribeToX509SVIDsRequest, stream grpc.ServerStreamingServer[delegatedidentityv1.SubscribeToX509SVIDsResponse]) error {
+	f.mu.Lock()
+	f.svidSubs++
+	n := f.svidSubs
+	f.mu.Unlock()
+
+	if err := stream.Send(&delegatedidentityv1.SubscribeToX509SVIDsResponse{}); err != nil {
+		return err
+	}
+	if n == 1 {
+		return nil // simulated SPIRE agent restart: stream ends after one update
+	}
+	<-stream.Context().Done()
+	return nil
+}
+
+// nopStore is a SecretStore that accepts and discards all pushes.
+type nopStore struct{}
+
+func (nopStore) SetSecrets(context.Context, []*tlsv3.Secret) error { return nil }
+
+// startFakeSpire serves a fakeDelegatedIdentity on a temporary UDS and returns
+// it with the socket path. It uses os.MkdirTemp under /tmp to keep the path
+// within the ~108-byte UDS limit (Bazel sandbox paths can exceed it).
+func startFakeSpire(t *testing.T) (*fakeDelegatedIdentity, string) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "spire")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "agent.sock")
+
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	fake := &fakeDelegatedIdentity{}
+	srv := grpc.NewServer()
+	delegatedidentityv1.RegisterDelegatedIdentityServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return fake, sock
+}
+
+// newReconnectTestBridge creates a bridge against the fake SPIRE socket with
+// backoff shortened so reconnects happen within the test budget.
+func newReconnectTestBridge(sock string) *Bridge {
+	b := NewBridge(sock, nopStore{}, nil, logr.Discard())
+	b.backoffInitial = 10 * time.Millisecond
+	b.backoffMax = 50 * time.Millisecond
+	return b
+}
+
+// TestBundleStreamReconnects verifies that a bundle subscription stream ending
+// (e.g. a SPIRE agent restart) does not fail the bridge runnable — which would
+// take down the whole agent — but is re-subscribed with backoff.
+func TestBundleStreamReconnects(t *testing.T) {
+	fake, sock := startFakeSpire(t)
+	b := newReconnectTestBridge(sock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- b.Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		bundle, _ := fake.counts()
+		return bundle >= 2
+	}, 10*time.Second, 10*time.Millisecond, "bridge must re-subscribe to bundles after the stream ends")
+
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned instead of retrying the bundle stream: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "Start must return nil on context cancellation")
+	case <-time.After(10 * time.Second):
+		t.Fatal("Start did not return after cancellation")
+	}
+}
+
+// TestSVIDStreamResubscribes verifies that a pod's SVID stream ending is
+// re-subscribed instead of silently freezing the pod's SVID until expiry, and
+// that the subscription stays tracked so UnsubscribePod still works.
+func TestSVIDStreamResubscribes(t *testing.T) {
+	fake, sock := startFakeSpire(t)
+	b := newReconnectTestBridge(sock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Start(ctx) }()
+
+	select {
+	case <-b.Started():
+	case <-time.After(10 * time.Second):
+		t.Fatal("bridge did not start")
+	}
+
+	const netns = "/proc/42/ns/net"
+	require.NoError(t, b.SubscribePod(netns, "spiffe://example.org/sa", PodSelectors("ns", "sa", "pod", "uid")))
+
+	require.Eventually(t, func() bool {
+		_, svid := fake.counts()
+		return svid >= 2
+	}, 10*time.Second, 10*time.Millisecond, "bridge must re-subscribe to SVIDs after the stream ends")
+
+	b.subsMu.Lock()
+	_, exists := b.subscriptions[netns]
+	b.subsMu.Unlock()
+	require.True(t, exists, "subscription must remain tracked across reconnects")
+
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned unexpectedly: %v", err)
+	default:
+	}
+}

--- a/agent/internal/spire/metrics.go
+++ b/agent/internal/spire/metrics.go
@@ -1,0 +1,66 @@
+package spire
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// meterName identifies this instrumentation scope in metric backends.
+const meterName = "aether/agent-spire-bridge"
+
+// attrStream labels which delegated-identity stream an event belongs to.
+// Bounded cardinality: bundle or svid.
+const attrStream = attribute.Key("aether.spire.stream")
+
+const (
+	streamBundle = "bundle"
+	streamSVID   = "svid"
+)
+
+// bridgeMetrics holds the subscription-stream instruments. All methods are
+// nil-receiver-safe so the bridge runs unchanged when telemetry is disabled.
+//
+// A flapping SPIRE agent used to surface only as an unexplained aether-agent
+// restart (a bundle stream ending was fatal) or as a pod whose SVID silently
+// stopped rotating; these counters make stream churn visible now that the
+// bridge re-subscribes in place.
+type bridgeMetrics struct {
+	failures   metric.Int64Counter
+	reconnects metric.Int64Counter
+}
+
+// newBridgeMetrics registers the subscription-stream instruments on the given meter.
+func newBridgeMetrics(meter metric.Meter) (*bridgeMetrics, error) {
+	m := &bridgeMetrics{}
+	var err error
+
+	if m.failures, err = meter.Int64Counter("aether.agent.spire.stream_failures",
+		metric.WithDescription("SPIRE delegated-identity streams that ended unexpectedly or failed to re-subscribe, by stream kind (bundle/svid)")); err != nil {
+		return nil, fmt.Errorf("stream failures: %w", err)
+	}
+	if m.reconnects, err = meter.Int64Counter("aether.agent.spire.stream_reconnects",
+		metric.WithDescription("SPIRE delegated-identity streams re-established after a failure, by stream kind (bundle/svid)")); err != nil {
+		return nil, fmt.Errorf("stream reconnects: %w", err)
+	}
+
+	return m, nil
+}
+
+// streamFailed records one unexpected stream end or failed re-subscribe attempt.
+func (m *bridgeMetrics) streamFailed(ctx context.Context, stream string) {
+	if m == nil {
+		return
+	}
+	m.failures.Add(ctx, 1, metric.WithAttributes(attrStream.String(stream)))
+}
+
+// streamReconnected records one stream re-established after a failure.
+func (m *bridgeMetrics) streamReconnected(ctx context.Context, stream string) {
+	if m == nil {
+		return
+	}
+	m.reconnects.Add(ctx, 1, metric.WithAttributes(attrStream.String(stream)))
+}


### PR DESCRIPTION
## Problem

A SPIRE agent restart closes the delegated-identity subscription streams, with two failure modes in the bridge:

- **Bundle stream** (`bridge.go`): the closed channel made `Bridge.Start` return an error, failing the controller-runtime runnable and **restarting the entire agent**. Observed once in the 2026-06-11 e2e run (`bundle subscription stream closed unexpectedly`).
- **Per-pod SVID streams**: a closed stream exited its goroutine **silently and permanently**, leaving the stale `subscriptions` entry behind (blocking re-subscribe for the same netns) and freezing that pod's SVID until expiry — a delayed, hard-to-diagnose mTLS outage.

## Fix

- Both stream kinds are now maintained with a jittered exponential-backoff reconnect loop (1s → 30s, ×2, 20% jitter — same policy as the registrar watch stream). Backoff resets only once a response is received on the new stream, so a connect-then-instant-close flap cannot hot-loop.
- Cached secrets keep serving while disconnected; SPIRE sends the full current state as the first response on every new stream, so a plain re-subscribe fully resynchronizes — no reconciliation needed.
- The SVID re-subscribe happens inside the existing per-pod goroutine, so the subscription entry and its cancel func stay valid for `UnsubscribePod`.
- New counters by stream kind (`bundle`/`svid`) so a flapping SPIRE agent shows up in dashboards rather than as mystery restarts:
  - `aether.agent.spire.stream_failures` — unexpected stream ends + failed re-subscribe attempts
  - `aether.agent.spire.stream_reconnects` — streams re-established after a failure

## Testing

New `bridge_reconnect_test.go` with a fake `DelegatedIdentityServer` over a real UDS whose first stream of each kind sends one response then ends (simulated SPIRE agent restart):

- `TestBundleStreamReconnects` — `Start` does not return, re-subscribes, and still exits nil on context cancellation
- `TestSVIDStreamResubscribes` — the pod stream re-subscribes and stays tracked in `subscriptions`

Backoff bounds are bridge fields (set from the constants in `NewBridge`) so tests shorten them to 10ms.

Full suite: `bazel test //...` 38/38 pass; `--config=lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)