### PR TITLE
fix(agent): bound idle connections and per-connection buffers

### DIFF
--- a/agent/internal/xds/config/BUILD.bazel
+++ b/agent/internal/xds/config/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/upstreams/http/v3:http",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
 

--- a/agent/internal/xds/config/http.go
+++ b/agent/internal/xds/config/http.go
@@ -1,14 +1,32 @@
 package config
 
 import (
+	"time"
+
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
+
+// UpstreamIdleTimeout bounds how long an idle upstream connection (and its
+// pool) survives. Service clusters use connection_pool_per_downstream_connection
+// for per-source mTLS, so when a downstream connection closes its dedicated
+// pool is orphaned — it can never be selected again, and the only thing that
+// reclaims its upstream connection is this idle timeout. Envoy's default is
+// 1 HOUR: under non-keepalive downstream traffic that plateaus at
+// rate×3600 leaked mTLS connections per proxy (observed: ~41k active upstream
+// conns and 3.2 GiB heap within minutes on talos-main). 30s caps the orphan
+// window; for live downstream connections an idle upstream is simply
+// re-established on the next request.
+const UpstreamIdleTimeout = 30 * time.Second
 
 // Http1ProtocolOptions creates HTTP/1.1 protocol options for upstream clusters.
 // This is used to configure Envoy to communicate with services that only support HTTP/1.1.
 func Http1ProtocolOptions() *httpv3.HttpProtocolOptions {
 	return &httpv3.HttpProtocolOptions{
+		CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
+			IdleTimeout: durationpb.New(UpstreamIdleTimeout),
+		},
 		UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{
 			ExplicitHttpConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_HttpProtocolOptions{
@@ -23,6 +41,9 @@ func Http1ProtocolOptions() *httpv3.HttpProtocolOptions {
 // This is used to configure Envoy to communicate with services that support HTTP/2.
 func Http2ProtocolOptions() *httpv3.HttpProtocolOptions {
 	return &httpv3.HttpProtocolOptions{
+		CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
+			IdleTimeout: durationpb.New(UpstreamIdleTimeout),
+		},
 		UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{
 			ExplicitHttpConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig{
 				ProtocolConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{

--- a/agent/internal/xds/config/http_test.go
+++ b/agent/internal/xds/config/http_test.go
@@ -73,3 +73,23 @@ func TestHttp2ProtocolOptions(t *testing.T) {
 		})
 	}
 }
+
+// TestUpstreamIdleTimeoutSet verifies both protocol-options helpers carry the
+// 30s idle timeout. Service clusters pool per downstream connection for
+// per-source mTLS; an orphaned pool's upstream connection is reclaimed ONLY by
+// this timeout (Envoy default 1h leaked ~41k mTLS conns / 3.2 GiB per proxy
+// under non-keepalive downstream traffic on talos-main, 2026-06-11).
+func TestUpstreamIdleTimeoutSet(t *testing.T) {
+	for name, opts := range map[string]*httpv3.HttpProtocolOptions{
+		"http1": Http1ProtocolOptions(),
+		"http2": Http2ProtocolOptions(),
+	} {
+		idle := opts.GetCommonHttpProtocolOptions().GetIdleTimeout()
+		if idle == nil {
+			t.Fatalf("%s: idle timeout must be set (orphaned per-downstream pools leak without it)", name)
+		}
+		if idle.AsDuration() != UpstreamIdleTimeout {
+			t.Fatalf("%s: idle timeout = %v, want %v", name, idle.AsDuration(), UpstreamIdleTimeout)
+		}
+	}
+}

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -77,7 +77,8 @@ func AppPortFromPod(cniPod *cniv1.CNIPod) uint16 {
 // is assumed to speak HTTP/1.1, so no explicit HTTP/2 protocol options are set.
 func NewAppCluster(name, netns string, port uint16) *clusterv3.Cluster {
 	return &clusterv3.Cluster{
-		Name: name,
+		Name:                          name,
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		ClusterDiscoveryType: &clusterv3.Cluster_Type{
 			Type: clusterv3.Cluster_STATIC,
 		},

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -27,6 +27,7 @@ func NewServiceCluster(serviceName string) *clusterv3.Cluster {
 	return &clusterv3.Cluster{
 		Name:                                  serviceName,
 		ConnectTimeout:                        durationpb.New(2 * time.Second),
+		PerConnectionBufferLimitBytes:         wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		ConnectionPoolPerDownstreamConnection: true,
 		ClusterDiscoveryType: &clusterv3.Cluster_Type{
 			Type: clusterv3.Cluster_EDS,

--- a/agent/internal/xds/proxy/healthgateway.go
+++ b/agent/internal/xds/proxy/healthgateway.go
@@ -82,7 +82,8 @@ func BuildHealthGatewayListener(socketPath string, probeClusters []string) *list
 	}
 
 	return &listenerv3.Listener{
-		Name: HealthGatewayListenerName,
+		Name:                          HealthGatewayListenerName,
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		Address: &corev3.Address{
 			Address: &corev3.Address_Pipe{
 				Pipe: &corev3.Pipe{Path: socketPath},

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -60,7 +60,8 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.L
 	validationContextName := fmt.Sprintf("spiffe://%s", trustDomain)
 
 	return &listenerv3.Listener{
-		Name: InboundListenerName(cniPod),
+		Name:                          InboundListenerName(cniPod),
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		Address: &corev3.Address{
 			Address: &corev3.Address_SocketAddress{
 				SocketAddress: &corev3.SocketAddress{

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -8,6 +8,7 @@ import (
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -16,6 +17,14 @@ const (
 	// defaultHTTPOutboundPort is the port for outbound HTTP listeners. Shared
 	// with the CNI plugin, which probes it in-netns for data-plane readiness.
 	defaultHTTPOutboundPort = constants.ProxyOutboundPort
+	// perConnectionBufferLimitBytes caps read/write buffering per connection on
+	// every generated listener and cluster (Envoy edge-hardening guidance: 32
+	// KiB). Envoy's default is 1 MiB per connection per direction — with the
+	// node proxy's per-pod listeners and per-source upstream pools carrying
+	// thousands of connections, that default turns connection-count incidents
+	// into memory incidents. Flow control (watermarks) handles larger payloads;
+	// this does not cap request/response sizes.
+	perConnectionBufferLimitBytes = 32 * 1024
 )
 
 // OutboundListenerName returns the name of the per-pod outbound HTTP listener,
@@ -85,8 +94,9 @@ func generateOutboundHTTPListener(cniPod *cniv1.CNIPod) (*listenerv3.Listener, e
 				},
 			},
 		},
-		StatPrefix:       fmt.Sprintf("out_http_%s", cniPod.GetName()),
-		TrafficDirection: corev3.TrafficDirection_OUTBOUND,
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		StatPrefix:                    fmt.Sprintf("out_http_%s", cniPod.GetName()),
+		TrafficDirection:              corev3.TrafficDirection_OUTBOUND,
 		FilterChains: []*listenerv3.FilterChain{
 			buildDefaultOutboundHTTPFilterChain(cniPod.GetName()),
 		},

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -127,3 +127,24 @@ func TestGenerateOutboundHTTPListener(t *testing.T) {
 		})
 	}
 }
+
+// TestPerConnectionBufferLimits verifies every generated listener and cluster
+// caps per-connection buffering at 32 KiB (Envoy default is 1 MiB/connection/
+// direction, which turns connection-count incidents into memory incidents on
+// a node proxy carrying thousands of connections).
+func TestPerConnectionBufferLimits(t *testing.T) {
+	pod := &cniv1.CNIPod{
+		Name:             "buf-pod",
+		NetworkNamespace: "/var/run/netns/buf",
+	}
+	inbound, outbound, appCluster, healthCluster, err := GenerateListenersFromRegistryPod(pod, "aether.internal")
+	require.NoError(t, err)
+
+	want := uint32(perConnectionBufferLimitBytes)
+	assert.Equal(t, want, inbound.GetPerConnectionBufferLimitBytes().GetValue(), "inbound listener")
+	assert.Equal(t, want, outbound.GetPerConnectionBufferLimitBytes().GetValue(), "outbound listener")
+	assert.Equal(t, want, appCluster.GetPerConnectionBufferLimitBytes().GetValue(), "app cluster")
+	assert.Equal(t, want, healthCluster.GetPerConnectionBufferLimitBytes().GetValue(), "health cluster")
+	assert.Equal(t, want, NewServiceCluster("svc-x").GetPerConnectionBufferLimitBytes().GetValue(), "service cluster")
+	assert.Equal(t, want, BuildHealthGatewayListener("/run/aether/health.sock", nil).GetPerConnectionBufferLimitBytes().GetValue(), "health gateway")
+}

--- a/agent/internal/xds/proxy/networkfilter.go
+++ b/agent/internal/xds/proxy/networkfilter.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"time"
+
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -9,6 +11,7 @@ import (
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	set_filter_state_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/set_filter_state/v3"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 const (
@@ -52,6 +55,15 @@ func buildSetFilterState(objectKey string, inlineStringFormatString string) *lis
 	return networkFilter("envoy.filters.network.set_filter_state", filter)
 }
 
+// downstreamIdleTimeout bounds idle downstream connections on the per-pod HCMs
+// (inbound mesh mTLS conns from peer proxies, and app→proxy conns on the
+// outbound listener). It is the server-side backstop to the upstream
+// config.UpstreamIdleTimeout: peers reclaim their idle conns at 30s, so this
+// only catches clients that don't (Envoy's default is 1 hour, which let a
+// peer's leaked upstream conns pin ~7k inbound conns per listener). Kept well
+// above the upstream timeout so the client side always disconnects first.
+const downstreamIdleTimeout = 5 * time.Minute
+
 // buildHTTPConnectionManager creates an HTTP connection manager for processing HTTP traffic.
 // It includes a router HTTP filter and uses the provided route configuration.
 // If routeConfig is nil, routes will be retrieved via RDS.
@@ -59,6 +71,9 @@ func buildHTTPConnectionManager(name string, routeConfig *routev3.RouteConfigura
 	return &http_connection_managerv3.HttpConnectionManager{
 		StatPrefix: name,
 		CodecType:  http_connection_managerv3.HttpConnectionManager_AUTO,
+		CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
+			IdleTimeout: durationpb.New(downstreamIdleTimeout),
+		},
 		HttpFilters: []*http_connection_managerv3.HttpFilter{
 			routerHttpFilter(),
 		},

--- a/agent/internal/xds/proxy/networkfilter_test.go
+++ b/agent/internal/xds/proxy/networkfilter_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"testing"
 
+	"github.com/bpalermo/aether/agent/internal/xds/config"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/assert"
@@ -74,4 +75,16 @@ func TestBuildSetFilterState(t *testing.T) {
 	require.NotNil(t, filter)
 	assert.Equal(t, "envoy.filters.network.set_filter_state", filter.GetName())
 	assert.NotNil(t, filter.GetTypedConfig())
+}
+
+// TestHCMDownstreamIdleTimeout verifies the shared HCM builder sets the
+// downstream idle timeout backstop (Envoy default is 1h, which let a peer's
+// leaked upstream connections pin thousands of inbound connections).
+func TestHCMDownstreamIdleTimeout(t *testing.T) {
+	hcm := buildHTTPConnectionManager("test", nil)
+	idle := hcm.GetCommonHttpProtocolOptions().GetIdleTimeout()
+	require.NotNil(t, idle, "downstream idle timeout must be set")
+	assert.Equal(t, downstreamIdleTimeout, idle.AsDuration())
+	assert.Greater(t, downstreamIdleTimeout, config.UpstreamIdleTimeout,
+		"downstream timeout must exceed upstream so the client side disconnects first")
 }


### PR DESCRIPTION
## The leak (measured live on talos-main, post-#135)

#135 silenced the CDS churn, but proxy RSS kept growing ~80–100 Mi/min on nodes with loadgen traffic. Envoy `/memory` on the worker-02 proxy showed **3.2 GiB of live heap** (allocated ≈ heap_size, so real objects, not fragmentation) with only 5,216 stats. `/stats` found the objects:

```
cluster.svc-1.upstream_cx_active: 13900
cluster.svc-2.upstream_cx_active: 13882
cluster.svc-3.upstream_cx_active: 13873        ← ~41k live upstream mTLS conns
http.loadgen-….downstream_cx_total: 20099
http.loadgen-….downstream_cx_active: 1         ← downstream conns close fine
http.inbound_svc-….downstream_cx_active: ~7400 ← peers' leaked upstreams, mirrored
```

## Root cause

Service clusters use `connection_pool_per_downstream_connection: true` (required: a source pod's mTLS connection must never be reused for another source). Every non-keepalive downstream connection therefore creates a dedicated pool + fresh upstream mTLS H2 connection. When the downstream closes, the orphaned pool can never be selected again — and the only mechanism that reclaims its upstream connection is the common HTTP **idle timeout, which Envoy defaults to 1 hour**. Under burst traffic that plateaus at rate×3600 leaked connections per proxy (≈75 KiB each), far past 4-core node capacity. The resulting saturation is what cascaded into kubelet flaps, agent informer-desync liveness kills (13×) and proxy admin-watchdog kills (14×) — previously attributed entirely to the #135 churn.

## Changes

1. **Upstream 30s idle timeout** (`config.UpstreamIdleTimeout`) on the HTTP/1+HTTP/2 protocol options used by service clusters — orphaned pools reclaimed in seconds; a live downstream just re-establishes an idle upstream on its next request. Active HC connections probe every 5s and never idle out.
2. **Downstream 5m backstop** on the shared per-pod HCM builder (inbound mesh conns + app-side outbound conns), kept well above the upstream timeout so the client side always disconnects first.
3. **`per_connection_buffer_limit_bytes: 32 KiB`** (Envoy edge-hardening guidance) on every generated listener and cluster — the 1 MiB/connection/direction default turns connection-count incidents into memory incidents; flow control handles larger payloads, request/response sizes are not capped.

## Testing

- `TestUpstreamIdleTimeoutSet`, `TestHCMDownstreamIdleTimeout` (incl. downstream > upstream ordering), `TestPerConnectionBufferLimits` (all six generated resource kinds)
- Full suite `bazel test //...`: 38/38 pass

Post-deploy validation: `upstream_cx_active` plateaus at ~rate×30 (~1.5k at current load) instead of climbing; proxy RSS flat over hours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)