### PR TITLE
feat(proxy): overload manager with health-gateway bypass

### DIFF
--- a/agent/internal/xds/proxy/healthgateway.go
+++ b/agent/internal/xds/proxy/healthgateway.go
@@ -84,6 +84,18 @@ func BuildHealthGatewayListener(socketPath string, probeClusters []string) *list
 	return &listenerv3.Listener{
 		Name:                          HealthGatewayListenerName,
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		// Exempt from overload-manager actions (stop_accepting_requests etc.):
+		// the gateway answers the agent's delegated-liveness probes, whose job is
+		// to report APP truth, not proxy state. Without the bypass, an overloaded
+		// proxy would 503 liveness probes, the agent would mark every local pod
+		// unhealthy, and the registry would flap cluster-wide on transient
+		// overload. Shedding away from an overloaded node happens through the
+		// data-plane listeners instead: 503'd new streams are retried by client
+		// routes on a different endpoint, and active-mode client health checks
+		// fail against the inbound listener. The gateway is a node-local UDS
+		// with a handful of agent connections — bypassing it frees no
+		// meaningful memory.
+		BypassOverloadManager: true,
 		Address: &corev3.Address{
 			Address: &corev3.Address_Pipe{
 				Pipe: &corev3.Pipe{Path: socketPath},

--- a/agent/internal/xds/proxy/healthgateway_test.go
+++ b/agent/internal/xds/proxy/healthgateway_test.go
@@ -65,3 +65,11 @@ func TestBuildHealthGatewayListener_Empty(t *testing.T) {
 	require.Len(t, hcm.GetHttpFilters(), 1)
 	assert.Equal(t, httpRouterFilterName, hcm.GetHttpFilters()[0].GetName())
 }
+
+// TestHealthGatewayBypassesOverloadManager verifies the gateway is exempt from
+// overload actions: liveness must report app truth, not proxy state, or an
+// overloaded proxy would flap every local pod's registry health cluster-wide.
+func TestHealthGatewayBypassesOverloadManager(t *testing.T) {
+	l := BuildHealthGatewayListener("/run/aether/health.sock", []string{"health_a"})
+	assert.True(t, l.GetBypassOverloadManager(), "health gateway must bypass overload manager actions")
+}

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -14,6 +14,57 @@ data:
           address: 127.0.0.1
           port_value: 9901
 
+{{- if .Values.proxy.overload.enabled }}
+    # Graceful degradation BEFORE the container memory limit OOM-kills Envoy:
+    # shed the cheapest state first (free heap, then idle downstream
+    # connections), then stop accepting new work. stop_accepting_requests
+    # 503s new streams, which the mesh's client retry policy retries on a
+    # DIFFERENT endpoint — an overloaded node sheds load to other replicas.
+    # The agent-generated health-gateway listener sets
+    # bypass_overload_manager so delegated liveness keeps reporting APP
+    # truth (not proxy state) and the registry never flaps on transient
+    # overload.
+    overload_manager:
+      refresh_interval: 0.25s
+      resource_monitors:
+        - name: "envoy.resource_monitors.fixed_heap"
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+            max_heap_size_bytes: {{ int64 .Values.proxy.overload.maxHeapSizeBytes }}
+      actions:
+        - name: "envoy.overload_actions.shrink_heap"
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              threshold:
+                value: 0.80
+        - name: "envoy.overload_actions.disable_http_keepalive"
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              threshold:
+                value: 0.90
+        - name: "envoy.overload_actions.reduce_timeouts"
+          typed_config:
+            "@type": type.googleapis.com/envoy.config.overload.v3.ScaleTimersOverloadActionConfig
+            timer_scale_factors:
+              - timer: HTTP_DOWNSTREAM_CONNECTION_IDLE
+                min_timeout: 2s
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              scaled:
+                scaling_threshold: 0.85
+                saturation_threshold: 0.95
+        - name: "envoy.overload_actions.stop_accepting_requests"
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              threshold:
+                value: 0.95
+        - name: "envoy.overload_actions.stop_accepting_connections"
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              threshold:
+                value: 0.98
+{{- end }}
+
     dynamic_resources:
       ads_config:
         api_type: DELTA_GRPC

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -27,19 +27,28 @@ data:
     overload_manager:
       refresh_interval: 0.25s
       resource_monitors:
-        - name: "envoy.resource_monitors.fixed_heap"
+        # cgroup_memory measures the container's ACTUAL memory usage against
+        # its ACTUAL cgroup limit (memory.current / memory.max, cgroup v2) —
+        # unlike a heap monitor it sees everything the OOM killer sees
+        # (tcmalloc heap, the supervisor process, kernel socket buffers), so
+        # the thresholds are against the real kill line with no heap-to-RSS
+        # ratio guesswork. Validated at runtime against the pinned Envoy
+        # image (pressure tracks the docker --memory limit; failed_updates 0).
+        - name: "envoy.resource_monitors.cgroup_memory"
           typed_config:
-            "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
-            max_heap_size_bytes: {{ int64 .Values.proxy.overload.maxHeapSizeBytes }}
+            "@type": type.googleapis.com/envoy.extensions.resource_monitors.cgroup_memory.v3.CgroupMemoryConfig
+            {{- if .Values.proxy.overload.maxMemoryBytes }}
+            max_memory_bytes: {{ int64 .Values.proxy.overload.maxMemoryBytes }}
+            {{- end }}
       actions:
         - name: "envoy.overload_actions.shrink_heap"
           triggers:
-            - name: "envoy.resource_monitors.fixed_heap"
+            - name: "envoy.resource_monitors.cgroup_memory"
               threshold:
                 value: 0.80
         - name: "envoy.overload_actions.disable_http_keepalive"
           triggers:
-            - name: "envoy.resource_monitors.fixed_heap"
+            - name: "envoy.resource_monitors.cgroup_memory"
               threshold:
                 value: 0.90
         - name: "envoy.overload_actions.reduce_timeouts"
@@ -49,18 +58,18 @@ data:
               - timer: HTTP_DOWNSTREAM_CONNECTION_IDLE
                 min_timeout: 2s
           triggers:
-            - name: "envoy.resource_monitors.fixed_heap"
+            - name: "envoy.resource_monitors.cgroup_memory"
               scaled:
                 scaling_threshold: 0.85
                 saturation_threshold: 0.95
         - name: "envoy.overload_actions.stop_accepting_requests"
           triggers:
-            - name: "envoy.resource_monitors.fixed_heap"
+            - name: "envoy.resource_monitors.cgroup_memory"
               threshold:
                 value: 0.95
         - name: "envoy.overload_actions.stop_accepting_connections"
           triggers:
-            - name: "envoy.resource_monitors.fixed_heap"
+            - name: "envoy.resource_monitors.cgroup_memory"
               threshold:
                 value: 0.98
 {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -135,11 +135,12 @@ proxy:
   # state heap sits far below the first (0.80) rung.
   overload:
     enabled: true
-    # Heap budget for the fixed_heap monitor. Keep at ~75% of
-    # resources.limits.memory: Envoy's heap excludes stats memory, code and
-    # the hot-restart /dev/shm segment, all of which also count against the
-    # container limit. Bump BOTH together.
-    maxHeapSizeBytes: 805306368 # 768Mi = 75% of 1Gi
+    # Optional upper bound for the cgroup_memory monitor; when unset (0) the
+    # container's own cgroup limit (resources.limits.memory) is the
+    # denominator, so the thresholds track the real OOM kill line and nothing
+    # needs bumping in lockstep. Set only to engage the ladder below the
+    # cgroup limit (e.g. canary-tightening).
+    maxMemoryBytes: 0
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
 # The chart never bakes credentials into the image. By default it references an

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -128,6 +128,18 @@ proxy:
       memory: 1Gi
     limits:
       memory: 1Gi
+  # Envoy overload manager: a graceful-degradation ladder (shrink heap ->
+  # close idle/keepalive downstream connections -> scale idle timeouts down
+  # -> 503 new requests -> stop accepting connections) that engages well
+  # before the memory limit's OOM kill. Inert in normal operation: steady-
+  # state heap sits far below the first (0.80) rung.
+  overload:
+    enabled: true
+    # Heap budget for the fixed_heap monitor. Keep at ~75% of
+    # resources.limits.memory: Envoy's heap excludes stats memory, code and
+    # the hot-restart /dev/shm segment, all of which also count against the
+    # container limit. Bump BOTH together.
+    maxHeapSizeBytes: 805306368 # 768Mi = 75% of 1Gi
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
 # The chart never bakes credentials into the image. By default it references an


### PR DESCRIPTION
Third layer of the memory-incident defense: **prevention** (#135/#136) → **containment** (#137's 1Gi limit) → **graceful degradation** (this PR). Today, hitting the limit means a kernel OOM SIGKILL — abrupt epoch loss and a node blip. This engages a shedding ladder well before that.

## Monitor: `cgroup_memory` (updated from `fixed_heap` after review discussion)

The monitor reads `memory.current / memory.max` from the container's own cgroup (v2 — talos), so pressure is measured against the **real kill line**: it sees everything the OOM killer sees (tcmalloc heap, the supervisor process sharing the container, kernel socket buffers — which are charged to the cgroup and correlate with exactly the overload scenario). No heap-to-RSS ratio guesswork, no values knob to bump in lockstep with the memory limit; optional `proxy.overload.maxMemoryBytes` only to engage the ladder below the cgroup limit.

Empirically verified against the pinned Envoy image (1.38 digest): listed in the binary's compiled-in resource monitors, `--mode validate` OK on the rendered bootstrap, and a live run under `docker --memory=256m` reports `cgroup_memory.pressure` tracking the limit with `failed_updates: 0`.

## The ladder

| Pressure | Action | Fit |
|---|---|---|
| 0.80 | `shrink_heap` | release tcmalloc pages |
| 0.90 | `disable_http_keepalive` | sheds idle downstream conns → their per-downstream upstream pools idle out via #136's 30s timeout — **the exact resource class that blew up** |
| 0.85→0.95 | `reduce_timeouts` (HTTP downstream idle scaled toward 2s) | the dynamic version of #136's static timeouts |
| 0.95 | `stop_accepting_requests` | 503s new streams, which client routes retry **on a different endpoint** — the overloaded node sheds load to other replicas |
| 0.98 | `stop_accepting_connections` | last resort before OOM |

## Health-gateway `bypass_overload_manager`

Delegated liveness must report **app truth, not proxy state**. Without the bypass, an overloaded proxy 503s the agent's liveness probes → the agent marks every local pod unhealthy → registry health flaps **cluster-wide** on transient overload, plus a slow re-promotion round on recovery. Shedding belongs to the data-plane listeners (503+retry, client active HC against the inbound listener), not the liveness channel. The gateway is a node-local UDS with a handful of agent connections, so the exemption frees no meaningful memory.

Trade accepted: under *prolonged* overload, eds-mode endpoints stay in rotation and each request pays one failed attempt + retry, instead of leaving rotation entirely — strictly better than health-flapping the registry on brief overload.

## Notes

- Inert in normal operation: post-#136 steady-state RSS (~70–150Mi measured in the latest e2e) sits far below the 0.80 rung of 1Gi.
- Supervisor unaffected: admin runs on the main thread outside overload actions, so `/server_info` watchdogs keep working.
- CPU overload deliberately out of scope: `CONTAINER` mode needs a cpu quota (we intentionally set none — throttling a data plane is worse), `HOST` mode would shed on co-tenant noise.

## Testing

- `TestHealthGatewayBypassesOverloadManager`; chart lint + template tests; full suite 38/38.
- Rendered bootstrap validated against the pinned image digest (`configuration OK`) + live cgroup-pressure smoke test.
- Post-deploy validation: `overload.envoy.resource_monitors.cgroup_memory.pressure` reflects RSS/1Gi, `failed_updates` 0, all `overload_actions.*.active` 0 in steady state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)