### PR TITLE
fix(proxy): overload manager back to fixed_heap; default memory limit 512Mi

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -27,28 +27,34 @@ data:
     overload_manager:
       refresh_interval: 0.25s
       resource_monitors:
-        # cgroup_memory measures the container's ACTUAL memory usage against
-        # its ACTUAL cgroup limit (memory.current / memory.max, cgroup v2) —
-        # unlike a heap monitor it sees everything the OOM killer sees
-        # (tcmalloc heap, the supervisor process, kernel socket buffers), so
-        # the thresholds are against the real kill line with no heap-to-RSS
-        # ratio guesswork. Validated at runtime against the pinned Envoy
-        # image (pressure tracks the docker --memory limit; failed_updates 0).
-        - name: "envoy.resource_monitors.cgroup_memory"
+        # fixed_heap (tcmalloc-internal), NOT cgroup_memory. cgroup_memory
+        # reads /sys/fs/cgroup/memory.{current,max}, which works in docker
+        # (private cgroup namespace: the container sees its own leaf cgroup)
+        # but NOT in this DaemonSet: the proxy is a privileged pod, which
+        # gets the HOST cgroup namespace — /sys/fs/cgroup is the host root
+        # cgroup, where memory.max does not exist. Envoy then aborts at
+        # bootstrap with "No supported cgroup memory implementation found",
+        # and the config-watching supervisors hot-restarted every node into
+        # the poisoned config simultaneously (cluster-wide data-plane outage,
+        # 2026-06-11 ~12:50Z, rev 64). Do not reintroduce cgroup_memory
+        # unless the proxy stops being privileged or gains a private
+        # cgroupns. Keep maxHeapSizeBytes at ~75% of
+        # proxy.resources.limits.memory: the heap excludes the supervisor
+        # process, kernel socket buffers and thread stacks, and the top rung
+        # must engage below the real OOM line.
+        - name: "envoy.resource_monitors.fixed_heap"
           typed_config:
-            "@type": type.googleapis.com/envoy.extensions.resource_monitors.cgroup_memory.v3.CgroupMemoryConfig
-            {{- if .Values.proxy.overload.maxMemoryBytes }}
-            max_memory_bytes: {{ int64 .Values.proxy.overload.maxMemoryBytes }}
-            {{- end }}
+            "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+            max_heap_size_bytes: {{ int64 .Values.proxy.overload.maxHeapSizeBytes }}
       actions:
         - name: "envoy.overload_actions.shrink_heap"
           triggers:
-            - name: "envoy.resource_monitors.cgroup_memory"
+            - name: "envoy.resource_monitors.fixed_heap"
               threshold:
                 value: 0.80
         - name: "envoy.overload_actions.disable_http_keepalive"
           triggers:
-            - name: "envoy.resource_monitors.cgroup_memory"
+            - name: "envoy.resource_monitors.fixed_heap"
               threshold:
                 value: 0.90
         - name: "envoy.overload_actions.reduce_timeouts"
@@ -58,18 +64,18 @@ data:
               - timer: HTTP_DOWNSTREAM_CONNECTION_IDLE
                 min_timeout: 2s
           triggers:
-            - name: "envoy.resource_monitors.cgroup_memory"
+            - name: "envoy.resource_monitors.fixed_heap"
               scaled:
                 scaling_threshold: 0.85
                 saturation_threshold: 0.95
         - name: "envoy.overload_actions.stop_accepting_requests"
           triggers:
-            - name: "envoy.resource_monitors.cgroup_memory"
+            - name: "envoy.resource_monitors.fixed_heap"
               threshold:
                 value: 0.95
         - name: "envoy.overload_actions.stop_accepting_connections"
           triggers:
-            - name: "envoy.resource_monitors.cgroup_memory"
+            - name: "envoy.resource_monitors.fixed_heap"
               threshold:
                 value: 0.98
 {{- end }}

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -125,9 +125,9 @@ proxy:
   resources:
     requests:
       cpu: 500m
-      memory: 1Gi
+      memory: 512Mi
     limits:
-      memory: 1Gi
+      memory: 512Mi
   # Envoy overload manager: a graceful-degradation ladder (shrink heap ->
   # close idle/keepalive downstream connections -> scale idle timeouts down
   # -> 503 new requests -> stop accepting connections) that engages well
@@ -141,7 +141,7 @@ proxy:
     # ladder's top rung must engage below the real OOM line. (cgroup_memory
     # would avoid this coupling but is unusable in the privileged proxy pod
     # — host cgroup namespace; see the bootstrap ConfigMap comment.)
-    maxHeapSizeBytes: 805306368 # 768Mi = 75% of 1Gi
+    maxHeapSizeBytes: 402653184 # 384Mi = 75% of 512Mi
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
 # The chart never bakes credentials into the image. By default it references an

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -135,12 +135,13 @@ proxy:
   # state heap sits far below the first (0.80) rung.
   overload:
     enabled: true
-    # Optional upper bound for the cgroup_memory monitor; when unset (0) the
-    # container's own cgroup limit (resources.limits.memory) is the
-    # denominator, so the thresholds track the real OOM kill line and nothing
-    # needs bumping in lockstep. Set only to engage the ladder below the
-    # cgroup limit (e.g. canary-tightening).
-    maxMemoryBytes: 0
+    # Heap budget for the fixed_heap monitor. Keep at ~75% of
+    # resources.limits.memory (bump BOTH together): heap excludes the
+    # supervisor process, kernel socket buffers and thread stacks, and the
+    # ladder's top rung must engage below the real OOM line. (cgroup_memory
+    # would avoid this coupling but is unusable in the privileged proxy pod
+    # — host cgroup namespace; see the bootstrap ConfigMap comment.)
+    maxHeapSizeBytes: 805306368 # 768Mi = 75% of 1Gi
 
 # AWS credentials consumed by the agent (DynamoDB / Cloud Map registry backends).
 # The chart never bakes credentials into the image. By default it references an


### PR DESCRIPTION
## Incident

Deploying #138 (rev 64, ~12:50Z) took the **entire data plane down for ~13 minutes**: every proxy aborted at bootstrap with `No supported cgroup memory implementation found` and crash-looped. Recovered at rev 65 by disabling the overload manager via values (`--set proxy.overload.enabled=false` — ConfigMap-only, picked up on the next crash retry).

## Root cause (config bug)

`cgroup_memory` reads `/sys/fs/cgroup/memory.{current,max}`. Under **docker** — where the pre-merge validation ran — containers get a **private cgroup namespace**, so the path is the container's own leaf cgroup and the monitor works. The aether-proxy DaemonSet is a **privileged** pod, which gets the **host cgroup namespace**: `/sys/fs/cgroup` is the host *root* cgroup, which has no `memory.max`. Envoy treats the failed probe as fatal at bootstrap. The docker validation was a false positive about the runtime environment, not the config.

## Root cause (blast radius — the more important lesson)

The outage was **cluster-wide instead of canaried**: supervisors watch the bootstrap config (fsnotify) and hot-restarted **every node simultaneously** into the poisoned ConfigMap, bypassing the DaemonSet rollout safety entirely. Old pods didn't survive to keep serving — their own in-place hot restarts crashed them.

**Planned follow-up hardening (separate PR)**: the supervisor pre-validates a changed bootstrap with `envoy --mode validate` *on the node* before forking the new epoch, and keeps the old config serving (+ logs/metric) on failure. Node-local validation **would have caught this** — the same probe fails in the same environment — converting a cluster-wide outage into a no-op with alarms.

## This PR

- Monitor back to `fixed_heap` (tcmalloc-internal — no cgroup access, environment-independent validation); ConfigMap comment documents exactly why `cgroup_memory` must not be reintroduced while the proxy is privileged (revisit if the proxy drops `privileged` or gains a private cgroupns).
- **Default proxy memory limit lowered 1Gi → 512Mi** (request == limit, Guaranteed): steady-state RSS is 67–148Mi post-#136, so 512Mi keeps ~3.5× headroom, halves the node reservation, and engages the overload ladder earlier on a real leak. Heap budget scales with it: `maxHeapSizeBytes` 384Mi = 75% of the limit (top rung 0.98×384 ≈ 376Mi + non-heap extras stays under the cgroup kill line).
- Ladder, thresholds, and the health-gateway `bypass_overload_manager` unchanged.
- Rendered bootstrap re-validated against the pinned image (`configuration OK`); chart tests pass.

Cluster is currently at rev 65 (#138 chart, overload disabled). Merging this re-enables the overload manager safely on the next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)