### PR TITLE
feat(supervisor): pre-validate changed bootstrap on-node before hot restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,3 +79,12 @@ load-all: load-agent-image load-cni-install-image load-registrar-image
 
 .PHONY: push-all
 push-all: push-agent-image push-cni-install-image push-registrar-image
+
+# Publish everything in the order that works: image manifests FIRST, then the
+# charts (chart-only push targets). The combined `:*.push` targets race the
+# chart's digest reference against the image manifest upload and fail with
+# `Tag ... not found` (observed repeatedly); pushing images first avoids it.
+.PHONY: publish
+publish: push-all
+	@bazel run //charts/agent:agent.push_registry --stamp
+	@bazel run //charts/registrar:registrar.push_registry --stamp

--- a/agent/internal/proxy/hotrestart/metrics.go
+++ b/agent/internal/proxy/hotrestart/metrics.go
@@ -43,6 +43,7 @@ type SupervisorMetrics struct {
 	wedges              metric.Int64Counter
 	restartTriggers     metric.Int64Counter
 	childExits          metric.Int64Counter
+	configRejections    metric.Int64Counter
 	predecessorDetected metric.Int64Gauge
 	drainDuration       metric.Float64Histogram
 	readyTransitions    metric.Int64Counter
@@ -74,6 +75,10 @@ func NewSupervisorMetrics(meter metric.Meter) (*SupervisorMetrics, error) {
 	if m.childExits, err = meter.Int64Counter("aether.supervisor.child_exits",
 		metric.WithDescription("Supervised Envoy process exits, by kind")); err != nil {
 		return nil, fmt.Errorf("child exits: %w", err)
+	}
+	if m.configRejections, err = meter.Int64Counter("aether.supervisor.config_validation_failures",
+		metric.WithDescription("Changed bootstrap configs rejected by node-local envoy --mode validate before hot restart (each one is a prevented outage; the current epoch keeps serving)")); err != nil {
+		return nil, fmt.Errorf("config validation failures: %w", err)
 	}
 	if m.predecessorDetected, err = meter.Int64Gauge("aether.supervisor.predecessor_detected",
 		metric.WithDescription("1 if a live predecessor was found at startup (cross-pod hot restart), 0 for a fresh epoch-0 start")); err != nil {
@@ -126,6 +131,13 @@ func (m *SupervisorMetrics) childExited(kind string) {
 		return
 	}
 	m.childExits.Add(context.Background(), 1, metric.WithAttributes(attrExitKind.String(kind)))
+}
+
+func (m *SupervisorMetrics) configValidationFailed() {
+	if m == nil {
+		return
+	}
+	m.configRejections.Add(context.Background(), 1)
 }
 
 func (m *SupervisorMetrics) predecessorFound(found bool) {

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -289,6 +289,23 @@ func (s *Supervisor) Run(ctx context.Context) error {
 				arm("deferred_not_live")
 				continue
 			}
+			// Pre-validate the changed bootstrap ON THIS NODE before forking
+			// the new epoch. Every supervisor sees a ConfigMap change at the
+			// same time (fsnotify), so a config that fails at runtime takes
+			// down every node's data plane simultaneously, bypassing all
+			// rollout safety — observed 2026-06-11 (rev 64): a resource
+			// monitor that validated fine in docker was fatal in the
+			// privileged pod environment, and the fleet-wide in-place hot
+			// restart turned it into a 13-minute cluster outage. envoy
+			// --mode validate executes bootstrap initialization in the same
+			// environment as the real fork, so it catches exactly that
+			// class. On failure: keep the current epoch serving, count it,
+			// and wait for the next config change.
+			if err := s.validateConfig(ctx); err != nil {
+				s.metrics.configValidationFailed()
+				s.log.Error(err, "changed bootstrap config failed node-local validation; KEEPING current epoch (hot restart skipped)")
+				continue
+			}
 			s.log.Info("performing hot restart")
 			if err := s.hotRestart(); err != nil {
 				s.log.Error(err, "hot restart failed; keeping current epoch")
@@ -439,6 +456,33 @@ func (s *Supervisor) watchConfig(ctx context.Context, trigger chan<- struct{}) {
 			s.log.Error(err, "config watch error")
 		}
 	}
+}
+
+// configValidateTimeout bounds the node-local `envoy --mode validate` run. A
+// hung validation must not wedge the trigger loop; validation of this
+// bootstrap takes well under a second normally.
+const configValidateTimeout = 30 * time.Second
+
+// validateConfig runs `envoy --mode validate` against the (changed) bootstrap
+// in the exact environment the real fork would use — same binary, same
+// container, same cgroup/namespace context — so environment-dependent
+// bootstrap failures (the class that docker-side validation cannot catch)
+// are detected before the serving epoch is put at risk. ExtraArgs are passed
+// through because the config may reference --service-cluster/--service-node.
+func (s *Supervisor) validateConfig(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, configValidateTimeout)
+	defer cancel()
+
+	args := append([]string{"--mode", "validate", "-c", s.cfg.ConfigPath}, s.cfg.ExtraArgs...)
+	out, err := exec.CommandContext(ctx, s.cfg.EnvoyPath, args...).CombinedOutput()
+	if err != nil {
+		tail := out
+		if len(tail) > 2048 {
+			tail = tail[len(tail)-2048:]
+		}
+		return fmt.Errorf("envoy --mode validate: %w; output tail: %s", err, string(tail))
+	}
+	return nil
 }
 
 // buildEnvoyCmd constructs the Envoy invocation for a given restart epoch.

--- a/agent/internal/proxy/hotrestart/supervisor_test.go
+++ b/agent/internal/proxy/hotrestart/supervisor_test.go
@@ -46,13 +46,16 @@ func TestBuildEnvoyCmd(t *testing.T) {
 func stubEnvoy(t *testing.T, recordPath string) string {
 	t.Helper()
 	script := "#!/bin/sh\n" +
-		"epoch=\"\"\n" +
+		"epoch=\"\"; mode=\"\"\n" +
 		"while [ $# -gt 0 ]; do\n" +
 		"  case \"$1\" in\n" +
+		"    --mode) mode=\"$2\"; shift 2;;\n" +
 		"    --restart-epoch) epoch=\"$2\"; shift 2;;\n" +
 		"    *) shift;;\n" +
 		"  esac\n" +
 		"done\n" +
+		"# config pre-validation invocations succeed immediately\n" +
+		"[ \"$mode\" = \"validate\" ] && exit 0\n" +
 		"echo \"$epoch\" >> \"" + recordPath + "\"\n" +
 		"trap 'exit 0' TERM INT\n" +
 		"while true; do sleep 0.05; done\n"
@@ -272,5 +275,90 @@ func TestBindCollisionRetriedInProcess(t *testing.T) {
 		assert.NoError(t, err, "Run must return nil on context cancel")
 	case <-time.After(10 * time.Second):
 		t.Fatal("supervisor did not return after context cancel")
+	}
+}
+
+// validatingStubEnvoy behaves like stubEnvoy but also implements
+// `--mode validate`: it exits 1 if the config file contains "poison",
+// 0 otherwise (mirroring envoy's bootstrap-init validation).
+func validatingStubEnvoy(t *testing.T, recordPath string) string {
+	t.Helper()
+	script := "#!/bin/sh\n" +
+		"mode=\"\"; epoch=\"\"; cfg=\"\"\n" +
+		"while [ $# -gt 0 ]; do\n" +
+		"  case \"$1\" in\n" +
+		"    --mode) mode=\"$2\"; shift 2;;\n" +
+		"    -c) cfg=\"$2\"; shift 2;;\n" +
+		"    --restart-epoch) epoch=\"$2\"; shift 2;;\n" +
+		"    *) shift;;\n" +
+		"  esac\n" +
+		"done\n" +
+		"if [ \"$mode\" = \"validate\" ]; then\n" +
+		"  grep -q poison \"$cfg\" && { echo 'config poison detected' >&2; exit 1; }\n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"echo \"$epoch\" >> \"" + recordPath + "\"\n" +
+		"trap 'exit 0' TERM INT\n" +
+		"while true; do sleep 0.05; done\n"
+
+	path := filepath.Join(t.TempDir(), "stub-envoy-validate.sh")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+// TestPoisonedConfigDoesNotHotRestart is the regression test for the rev-64
+// outage (2026-06-11): a bootstrap config that fails node-local validation
+// must NOT be hot-restarted into — the current epoch keeps serving — and a
+// subsequent good config must restart normally.
+func TestPoisonedConfigDoesNotHotRestart(t *testing.T) {
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available in this sandbox")
+	}
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "envoy.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("v0\n"), 0o644))
+	recordPath := filepath.Join(t.TempDir(), "epochs.txt")
+
+	s := New(Config{
+		EnvoyPath:          validatingStubEnvoy(t, recordPath),
+		ConfigPath:         configPath,
+		DrainTime:          1 * time.Second,
+		ParentShutdownTime: 1 * time.Second,
+		WatchConfig:        true,
+	}, logr.Discard(), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	runErr := make(chan error, 1)
+	go func() { runErr <- s.Run(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return len(recordedEpochs(t, recordPath)) >= 1
+	}, 5*time.Second, 50*time.Millisecond, "epoch 0 never started")
+
+	// Poisoned config: watcher fires, validation rejects, NO epoch 1.
+	require.NoError(t, os.WriteFile(configPath, []byte("v1 poison\n"), 0o644))
+	time.Sleep(2 * time.Second) // debounce (500ms) + headroom for a wrong restart to appear
+	assert.Len(t, recordedEpochs(t, recordPath), 1, "poisoned config must not be hot-restarted into")
+	select {
+	case err := <-runErr:
+		t.Fatalf("supervisor exited on poisoned config: %v", err)
+	default:
+	}
+
+	// Good config afterwards: validated, epoch 1 spawns.
+	require.NoError(t, os.WriteFile(configPath, []byte("v2 fixed\n"), 0o644))
+	require.Eventually(t, func() bool {
+		epochs := recordedEpochs(t, recordPath)
+		return len(epochs) == 2 && epochs[1] == "1"
+	}, 5*time.Second, 50*time.Millisecond, "good config after a rejected one did not hot restart")
+
+	cancel()
+	select {
+	case err := <-runErr:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("supervisor did not return after cancel")
 	}
 }


### PR DESCRIPTION
The config-poison guard — the systemic fix for the rev-64 outage class.

## Problem

Every supervisor sees a ConfigMap change at the same time (fsnotify) and hot-restarts in place, so a bootstrap that fails at runtime takes down **every node's data plane simultaneously**, bypassing all rollout safety. Observed 2026-06-11 (rev 64): a resource monitor that validated fine under docker was fatal in the privileged pod environment — one bad ConfigMap, 13-minute cluster-wide outage.

## Fix

Before forking the new epoch on a config-change/SIGHUP trigger, the supervisor runs `envoy --mode validate -c <config> <extra-args>` **on the node** — same binary, same container, same cgroup/namespace environment as the real fork, which is exactly the context external validation cannot reproduce. On failure:

- the current epoch **keeps serving** (no restart),
- the rejection is logged with the validator's output tail,
- `aether.supervisor.config_validation_failures` increments — each one is a prevented outage.

Bounded by a 30s timeout. Initial start is not gated (no old config to protect; Envoy's own crash is the signal there). The next config change re-triggers normally.

## Testing

- `TestPoisonedConfigDoesNotHotRestart`: stub envoy implements `--mode validate` (rejects configs containing "poison") — poisoned change forks no epoch and the supervisor keeps running; a subsequent good config hot-restarts normally.
- Existing stub taught validate-mode; full suite 38/38.

## Also included

`make publish`: image manifests first, then chart-only pushes — the combined `:*.push` targets race the chart's digest reference against the image upload (`Tag … not found`, hit on the last two releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)