### PR TITLE
fix(agent,registrar): close the agent-roll 404 gaps

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 
 import (
 	"sync"
+	"time"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -52,6 +53,9 @@ type SnapshotCache struct {
 
 	clusterMu sync.RWMutex
 	clusters  map[string]clusterEntry // keyed by cluster name
+	// serviceRetentionGrace overrides defaultServiceRetentionGrace when > 0
+	// (test hook; see clusterEntry.absentSince).
+	serviceRetentionGrace time.Duration
 
 	secretMu sync.RWMutex
 	secrets  map[string]*tlsv3.Secret // keyed by secret name (SPIFFE ID or trust domain)
@@ -106,6 +110,13 @@ type clusterEntry struct {
 	loadAssignment *endpointv3.ClusterLoadAssignment
 	endpoints      map[string]*endpointv3.LocalityLbEndpoints // keyed by IP, for granular add/remove
 	vhost          *routev3.VirtualHost
+	// absentSince is non-zero while the service is missing from the registry
+	// listing. Such entries are retained (with empty endpoints) for
+	// serviceRetentionGrace before being pruned: during pod churn a service
+	// can transiently lose ALL endpoints, and dropping its vhost turns
+	// in-flight client traffic into 404s (route table miss) instead of the
+	// honest, retriable 503 of an empty cluster (rev-66 roll, 2026-06-11).
+	absentSince time.Time
 }
 
 // NewSnapshotCache creates and returns a new SnapshotCache for the given node.

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
@@ -157,9 +158,14 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 	c.log.V(1).Info("found service endpoints in registry", "count", len(serviceEndpoints))
 
 	c.clusterMu.Lock()
-	// Rebuild the cluster set from scratch so this method is idempotent and safe
-	// to call repeatedly (on registry changes, not just at startup): services and
-	// endpoints that disappeared from the registry are pruned rather than retained.
+	// Rebuild the cluster set so this method is idempotent and safe to call
+	// repeatedly (on registry changes, not just at startup). Services that
+	// disappeared from the listing are NOT dropped immediately: pod churn can
+	// transiently empty a service's endpoint set, and removing its vhost
+	// turns live client traffic into 404s (route-table miss) instead of the
+	// honest, retriable 503 of an empty cluster. Absent services are retained
+	// with empty endpoints for serviceRetentionGrace, then pruned.
+	prev := c.clusters
 	c.clusters = make(map[string]clusterEntry, len(serviceEndpoints))
 	for serviceName, endpoints := range serviceEndpoints {
 		// The outbound service cluster speaks per-source mTLS HTTP/2 to each
@@ -187,11 +193,43 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 		}
 	}
 
+	// Retain recently disappeared services with an empty endpoint set.
+	now := time.Now()
+	for name, entry := range prev {
+		if _, present := c.clusters[name]; present {
+			continue
+		}
+		if entry.absentSince.IsZero() {
+			entry.absentSince = now
+			entry.loadAssignment = proxy.NewClusterLoadAssignment(name)
+			entry.endpoints = map[string]*endpointv3.LocalityLbEndpoints{}
+			c.log.Info("service disappeared from registry; retaining empty cluster/vhost for grace period",
+				"service", name, "grace", c.retentionGrace().String())
+		} else if now.Sub(entry.absentSince) > c.retentionGrace() {
+			c.log.Info("service absent past grace period; pruning", "service", name)
+			continue
+		}
+		c.clusters[name] = entry
+	}
+
 	c.clusterMu.Unlock()
 
 	c.log.V(1).Info("loaded clusters from registry", "count", len(c.clusters))
 
 	return c.generateClusterSnapshot(ctx)
+}
+
+// defaultServiceRetentionGrace is how long a service that vanished from the
+// registry listing keeps its (empty) cluster and vhost before being pruned.
+// Sized to outlast a rolling-restart churn window (~40s observed) with margin.
+const defaultServiceRetentionGrace = 90 * time.Second
+
+// retentionGrace returns the configured service retention grace (test hook).
+func (c *SnapshotCache) retentionGrace() time.Duration {
+	if c.serviceRetentionGrace > 0 {
+		return c.serviceRetentionGrace
+	}
+	return defaultServiceRetentionGrace
 }
 
 // generateClusterSnapshot regenerates the node snapshot after a cluster,

--- a/agent/internal/xds/cache/cluster_test.go
+++ b/agent/internal/xds/cache/cluster_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -492,6 +493,7 @@ func TestLoadClustersFromRegistry_EndpointsReachable(t *testing.T) {
 // pruned from the cache rather than retained.
 func TestLoadClustersFromRegistry_RebuildPrunesStale(t *testing.T) {
 	c := newTestCache("node-1")
+	c.serviceRetentionGrace = 50 * time.Millisecond
 	data := map[string][]*registryv1.ServiceEndpoint{
 		"keep":   {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
 		"remove": {makeEndpoint("10.0.0.2", "cluster-1", "node-2", 8080)},
@@ -506,14 +508,23 @@ func TestLoadClustersFromRegistry_RebuildPrunesStale(t *testing.T) {
 	require.NotNil(t, c.Endpoints("keep"))
 	require.NotNil(t, c.Endpoints("remove"))
 
-	// The registry now reports only "keep"; a reload must drop "remove".
+	// The registry now reports only "keep". "remove" is RETAINED with empty
+	// endpoints during the retention grace (dropping the vhost mid-churn 404s
+	// live traffic — rev-66), and pruned once the grace elapses.
 	data = map[string][]*registryv1.ServiceEndpoint{
 		"keep": {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
 
 	assert.NotNil(t, c.Endpoints("keep"))
-	assert.Nil(t, c.Endpoints("remove"), "stale cluster should be pruned on reload")
+	if assert.NotNil(t, c.Endpoints("remove"), "disappeared cluster is retained during the grace") {
+		cla := c.Endpoints("remove")[0].(*endpointv3.ClusterLoadAssignment)
+		assert.Empty(t, cla.GetEndpoints(), "retained cluster serves no endpoints")
+	}
+
+	time.Sleep(60 * time.Millisecond) // c.serviceRetentionGrace is 50ms in this test
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	assert.Nil(t, c.Endpoints("remove"), "stale cluster is pruned after the retention grace")
 }
 
 // TestLoadClustersFromRegistry_VirtualHostsPopulated verifies that after loading, VirtualHosts()
@@ -659,4 +670,55 @@ func TestSnapshotCache_VirtualHosts_ThreadSafety(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		<-done
 	}
+}
+
+// TestLoadClustersFromRegistry_RetainsDisappearedServices is the regression
+// test for the rev-66 404 gap (Gap 1): a service whose endpoints all vanish
+// mid-churn must keep its cluster and vhost (with empty endpoints) for the
+// retention grace, so clients get a retriable 503 instead of a route-table
+// 404; after the grace it is pruned.
+func TestLoadClustersFromRegistry_RetainsDisappearedServices(t *testing.T) {
+	c := newTestCache("node-1")
+	c.serviceRetentionGrace = 50 * time.Millisecond
+
+	full := map[string][]*registryv1.ServiceEndpoint{
+		"svc-a": {{Ip: "10.0.0.1"}},
+		"svc-b": {{Ip: "10.0.0.2"}},
+	}
+	partial := map[string][]*registryv1.ServiceEndpoint{
+		"svc-a": {{Ip: "10.0.0.1"}},
+	}
+	data := full
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return data, nil
+		},
+	}
+
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	require.Contains(t, c.clusters, "svc-b")
+
+	// svc-b vanishes from the listing: retained with empty endpoints + vhost.
+	data = partial
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	entry, ok := c.clusters["svc-b"]
+	require.True(t, ok, "disappeared service must be retained during grace")
+	assert.False(t, entry.absentSince.IsZero(), "absence must be stamped")
+	assert.Empty(t, entry.endpoints, "retained service must have empty endpoints")
+	assert.Empty(t, entry.loadAssignment.GetEndpoints(), "retained CLA must be empty")
+	assert.NotNil(t, entry.vhost, "vhost must survive (404 prevention)")
+
+	// Reappearance clears the absence mark and restores endpoints.
+	data = full
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	entry = c.clusters["svc-b"]
+	assert.True(t, entry.absentSince.IsZero(), "reappeared service must be unmarked")
+	assert.Len(t, entry.endpoints, 1)
+
+	// Absent past the grace: pruned.
+	data = partial
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	time.Sleep(80 * time.Millisecond)
+	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
+	assert.NotContains(t, c.clusters, "svc-b", "service absent past grace must be pruned")
 }

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -76,6 +76,21 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 		return err
 	}
 
+	// Wait (bounded) for the registry watch cache to hold a complete snapshot
+	// before deriving the initial config from it: a fresh agent that builds its
+	// snapshot from an empty/partial cache opens the xDS socket serving a
+	// route config with missing vhosts, and the reconnecting Envoy 404s live
+	// traffic until the next refresh (rev-66 agent roll, 2026-06-11). On
+	// timeout we proceed — the fallback below still serves local-only config
+	// rather than crash-looping the node.
+	if rw, ok := s.registry.(registry.ReadyWaiter); ok {
+		waitCtx, cancel := context.WithTimeout(ctx, registryReadyTimeout)
+		if err := rw.WaitReady(waitCtx); err != nil {
+			s.log.Info("registry watch cache not complete in time; proceeding (RPC fallback / background retry will fill in)", "timeout", registryReadyTimeout.String(), "error", err.Error())
+		}
+		cancel()
+	}
+
 	// Registry unavailability must not prevent the agent from starting: a
 	// crash-looping agent takes down the node's CNI ADD/DEL and xDS entirely,
 	// turning a registrar blip into a node-wide outage (observed cascading
@@ -89,6 +104,12 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 
 	return nil
 }
+
+// registryReadyTimeout bounds how long PreListen waits for the registry watch
+// cache to hold a complete snapshot. Generous enough to cover a registrar
+// restart finishing its first external-registry sync (~3-5s observed), small
+// enough that a genuinely unavailable registrar cannot stall agent startup.
+const registryReadyTimeout = 15 * time.Second
 
 // retryInitialRegistryLoad retries the registry-derived snapshot load with
 // capped exponential backoff until it succeeds or ctx ends.

--- a/api/aether/registrar/v1/registrar.proto
+++ b/api/aether/registrar/v1/registrar.proto
@@ -49,6 +49,11 @@ message WatchEndpointsResponse {
     EVENT_TYPE_ENDPOINT_ADDED = 2;
     EVENT_TYPE_ENDPOINT_REMOVED = 3;
     EVENT_TYPE_ENDPOINT_UPDATED = 4;
+    // Sent by the server once the initial full snapshot has been fully
+    // streamed (or immediately when the client was already up-to-date).
+    // Carries the snapshot version; has no service_name/endpoint. Clients use
+    // it to know their cache is complete before deriving config from it.
+    EVENT_TYPE_SNAPSHOT_COMPLETE = 5;
   }
 
   EventType type = 1;

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -131,6 +131,9 @@ func runRegistrar(ctx context.Context) (retErr error) {
 	}
 
 	grpcSrv := server.NewRegistrarServer(reg, snapshot, broadcaster, cfg.GRPCAddress, l, serverMetrics, grpcOpts...)
+	// Snapshot-serving RPCs block until the syncer's first cycle so a freshly
+	// rolled registrar never serves an empty/partial world view to agents.
+	grpcSrv.GateOnSync(syncer.Synced())
 	if err = m.Add(grpcSrv); err != nil {
 		return fmt.Errorf("failed to add gRPC server: %w", err)
 	}

--- a/registrar/internal/server/BUILD.bazel
+++ b/registrar/internal/server/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     srcs = [
         "broadcaster_test.go",
         "metrics_test.go",
+        "server_test.go",
         "snapshot_test.go",
         "sync_test.go",
     ],
@@ -45,5 +46,6 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",
         "@io_opentelemetry_go_otel_sdk_metric//metricdata",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -27,8 +27,32 @@ type RegistrarServer struct {
 	log         logr.Logger
 	metrics     *Metrics
 
+	// synced, when set (GateOnSync), gates snapshot-serving RPCs until the
+	// syncer's first cycle completes: a freshly restarted registrar must not
+	// serve an empty/partial world view — agents derive route configs from it
+	// and 404 live traffic (rev-66 co-roll, 2026-06-11).
+	synced <-chan struct{}
+
 	// Embed xds.Server for gRPC lifecycle management.
 	xds.Server
+}
+
+// GateOnSync makes snapshot-serving RPCs (WatchEndpoints, ListAllEndpoints)
+// block until ch is closed (the syncer's first completed cycle). Nil leaves
+// the RPCs ungated.
+func (s *RegistrarServer) GateOnSync(ch <-chan struct{}) { s.synced = ch }
+
+// awaitSynced blocks until the sync gate opens or ctx ends.
+func (s *RegistrarServer) awaitSynced(ctx context.Context) error {
+	if s.synced == nil {
+		return nil
+	}
+	select {
+	case <-s.synced:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // NewRegistrarServer creates a RegistrarServer and registers it on the gRPC server.
@@ -131,6 +155,11 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 	watcherID := fmt.Sprintf("%s/%s", req.GetClusterName(), req.GetNodeName())
 	s.log.V(1).Info("WatchEndpoints", "watcher", watcherID, "lastVersion", req.GetLastVersion())
 
+	// Never serve a snapshot before the first sync has populated it.
+	if err := s.awaitSynced(stream.Context()); err != nil {
+		return err
+	}
+
 	// Send current snapshot unless the client is already up-to-date.
 	events, currentVersion := s.snapshot.FullSnapshotEvents()
 	if req.GetLastVersion() != currentVersion {
@@ -139,6 +168,14 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 				return fmt.Errorf("failed to send snapshot event: %w", err)
 			}
 		}
+	}
+	// Mark the snapshot boundary so the client knows its cache is complete
+	// (sent even when the snapshot was skipped: the client is current).
+	if err := stream.Send(&registrarv1.WatchEndpointsResponse{
+		Type:    registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE,
+		Version: currentVersion,
+	}); err != nil {
+		return fmt.Errorf("failed to send snapshot-complete event: %w", err)
 	}
 
 	// Subscribe and stream incremental events.
@@ -168,8 +205,14 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 }
 
 // ListAllEndpoints returns all endpoints from the local snapshot.
-func (s *RegistrarServer) ListAllEndpoints(_ context.Context, req *registrarv1.ListAllEndpointsRequest) (*registrarv1.ListAllEndpointsResponse, error) {
+func (s *RegistrarServer) ListAllEndpoints(ctx context.Context, req *registrarv1.ListAllEndpointsRequest) (*registrarv1.ListAllEndpointsResponse, error) {
 	s.log.V(1).Info("ListAllEndpoints", "protocol", req.GetProtocol())
+
+	// Never serve a snapshot before the first sync has populated it (agents
+	// fall back to this RPC at startup when their watch cache is empty).
+	if err := s.awaitSynced(ctx); err != nil {
+		return nil, err
+	}
 
 	endpoints, version := s.snapshot.GetAllWithVersion(req.GetProtocol())
 

--- a/registrar/internal/server/server_test.go
+++ b/registrar/internal/server/server_test.go
@@ -1,0 +1,108 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	registrarv1 "github.com/bpalermo/aether/api/aether/registrar/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// fakeWatchServerStream captures events sent by WatchEndpoints. Only Send and
+// Context are used; the embedded nil interface panics on anything else.
+type fakeWatchServerStream struct {
+	grpc.ServerStream
+	ctx  context.Context
+	sent []*registrarv1.WatchEndpointsResponse
+}
+
+func (f *fakeWatchServerStream) Send(e *registrarv1.WatchEndpointsResponse) error {
+	f.sent = append(f.sent, e)
+	return nil
+}
+func (f *fakeWatchServerStream) Context() context.Context { return f.ctx }
+
+func newGateTestServer(t *testing.T) *RegistrarServer {
+	t.Helper()
+	snap := NewSnapshot()
+	snap.Apply([]*registrarv1.WatchEndpointsResponse{{
+		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+		ServiceName: "svc-a",
+		Protocol:    registryv1.Service_PROTOCOL_HTTP,
+		Endpoint:    &registryv1.ServiceEndpoint{Ip: "10.0.0.1"},
+	}})
+	return NewRegistrarServer(nil, snap, NewBroadcaster(logr.Discard(), nil), "127.0.0.1:0", logr.Discard(), nil)
+}
+
+// TestWatchEndpointsSendsSnapshotComplete verifies the snapshot boundary
+// marker (Gap 2 of the rev-66 404 fix): after the initial FULL_SNAPSHOT
+// events, the server sends SNAPSHOT_COMPLETE with the snapshot version so
+// clients know their cache holds a complete world view.
+func TestWatchEndpointsSendsSnapshotComplete(t *testing.T) {
+	s := newGateTestServer(t)
+	synced := make(chan struct{})
+	close(synced)
+	s.GateOnSync(synced)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &fakeWatchServerStream{ctx: ctx}
+	done := make(chan error, 1)
+	go func() { done <- s.WatchEndpoints(&registrarv1.WatchEndpointsRequest{}, stream) }()
+
+	require.Eventually(t, func() bool { return len(stream.sent) >= 2 },
+		5*time.Second, 10*time.Millisecond, "snapshot + marker never sent")
+	cancel()
+	<-done
+
+	last := stream.sent[len(stream.sent)-1]
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, last.GetType())
+	assert.NotEmpty(t, last.GetVersion(), "marker must carry the snapshot version")
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT, stream.sent[0].GetType())
+}
+
+// TestWatchEndpointsGatedOnFirstSync verifies a freshly started registrar
+// does not serve a snapshot before its first external-registry sync (the
+// co-roll amplifier of the rev-66 404 gap): the RPC blocks until the gate
+// opens, then serves.
+func TestWatchEndpointsGatedOnFirstSync(t *testing.T) {
+	s := newGateTestServer(t)
+	synced := make(chan struct{})
+	s.GateOnSync(synced)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stream := &fakeWatchServerStream{ctx: ctx}
+	done := make(chan error, 1)
+	go func() { done <- s.WatchEndpoints(&registrarv1.WatchEndpointsRequest{}, stream) }()
+
+	time.Sleep(100 * time.Millisecond)
+	assert.Empty(t, stream.sent, "nothing may be served before the first sync")
+
+	close(synced) // first sync completes
+	require.Eventually(t, func() bool { return len(stream.sent) >= 2 },
+		5*time.Second, 10*time.Millisecond, "snapshot not served after gate opened")
+	cancel()
+	<-done
+}
+
+// TestListAllEndpointsGatedOnFirstSync verifies the agent's startup RPC
+// fallback is gated the same way.
+func TestListAllEndpointsGatedOnFirstSync(t *testing.T) {
+	s := newGateTestServer(t)
+	synced := make(chan struct{})
+	s.GateOnSync(synced)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err := s.ListAllEndpoints(ctx, &registrarv1.ListAllEndpointsRequest{Protocol: registryv1.Service_PROTOCOL_HTTP})
+	require.Error(t, err, "must block (and here time out) before the first sync")
+
+	close(synced)
+	resp, err := s.ListAllEndpoints(context.Background(), &registrarv1.ListAllEndpointsRequest{Protocol: registryv1.Service_PROTOCOL_HTTP})
+	require.NoError(t, err)
+	assert.Len(t, resp.GetServices(), 1)
+}

--- a/registrar/internal/server/sync.go
+++ b/registrar/internal/server/sync.go
@@ -28,6 +28,11 @@ type Syncer struct {
 	log          logr.Logger
 	metrics      *Metrics
 	firstSync    bool
+	// synced is closed after the first successful sync cycle; RPCs that serve
+	// snapshot state gate on it so a freshly restarted registrar never serves
+	// an empty/partial view of the world (agents deriving route configs from
+	// such a view 404 live traffic — observed on the rev-66 co-roll).
+	synced chan struct{}
 }
 
 // NewSyncer creates a Syncer that polls the external registry at the given
@@ -41,8 +46,13 @@ func NewSyncer(reg registry.Registry, snapshot *Snapshot, broadcaster *Broadcast
 		log:          log.WithName("syncer"),
 		metrics:      metrics,
 		firstSync:    true,
+		synced:       make(chan struct{}),
 	}
 }
+
+// Synced returns a channel that is closed once the first sync cycle has
+// completed and the snapshot reflects the external registry.
+func (s *Syncer) Synced() <-chan struct{} { return s.synced }
 
 // Start runs the sync loop until the context is cancelled.
 func (s *Syncer) Start(ctx context.Context) error {
@@ -110,6 +120,7 @@ func (s *Syncer) sync(ctx context.Context) {
 	if s.firstSync {
 		s.log.Info("initial sync complete", "version", version, "endpoints", countEndpoints(newState))
 		s.firstSync = false
+		close(s.synced)
 	} else if len(events) > 0 {
 		s.log.V(1).Info("sync detected changes", "version", version, "events", len(events))
 	}

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -65,6 +65,13 @@ type RegistrarRegistry struct {
 	// burst of watch events collapses into a single pending signal.
 	notify chan struct{}
 
+	// ready is closed when the first SNAPSHOT_COMPLETE event arrives — the
+	// local cache then holds a complete world view. Consumers deriving config
+	// from the cache (the agent's initial snapshot) wait on it so they never
+	// publish from an empty/partial cache (rev-66 404 gap).
+	ready     chan struct{}
+	readyOnce sync.Once
+
 	cancel context.CancelFunc
 }
 
@@ -83,6 +90,7 @@ func NewRegistrarRegistry(log logr.Logger, cfg Config) *RegistrarRegistry {
 		metrics: metrics,
 		cache:   make(map[string][]*registryv1.ServiceEndpoint),
 		notify:  make(chan struct{}, 1),
+		ready:   make(chan struct{}),
 	}
 }
 
@@ -93,6 +101,19 @@ func NewRegistrarRegistry(log logr.Logger, cfg Config) *RegistrarRegistry {
 // registry.ChangeNotifier capability.
 func (r *RegistrarRegistry) Changes() <-chan struct{} {
 	return r.notify
+}
+
+// WaitReady blocks until the watch cache holds a complete snapshot (the first
+// SNAPSHOT_COMPLETE event) or ctx ends. It satisfies the registry.ReadyWaiter
+// capability; callers bound it with a context timeout and may proceed with
+// degraded (RPC-fallback) reads on expiry.
+func (r *RegistrarRegistry) WaitReady(ctx context.Context) error {
+	select {
+	case <-r.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // signalChange performs a non-blocking send on the notify channel, coalescing
@@ -305,6 +326,11 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 			snapshotCleared = true
 		}
 
+		if event.GetType() == registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE {
+			// The cache now holds a complete world view.
+			r.readyOnce.Do(func() { close(r.ready) })
+		}
+
 		r.applyEvent(event)
 
 		if event.GetVersion() != "" {
@@ -332,6 +358,10 @@ func (r *RegistrarRegistry) applyEvent(event *registrarv1.WatchEndpointsResponse
 
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED:
 		r.removeLocked(svcName, ep.GetIp())
+
+	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE:
+		// Marker only; no cache mutation. The change signal below still fires
+		// so consumers re-derive from the now-complete cache.
 	}
 
 	// Wake consumers (e.g. the agent xDS cache) so they re-read the registry and

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	registrarv1 "github.com/bpalermo/aether/api/aether/registrar/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
@@ -500,4 +501,46 @@ func TestProcessStream_OtherErrorsKeepResumeToken(t *testing.T) {
 
 	got := r.processStream(context.Background(), stream, "5")
 	assert.Equal(t, "5", got, "transient errors must keep the resume token")
+}
+
+// TestSnapshotCompleteClosesReady verifies WaitReady unblocks once
+// processStream sees the SNAPSHOT_COMPLETE marker (Gap 2 of the rev-66 404
+// fix): consumers deriving config from the watch cache wait until it holds a
+// complete world view, the marker advances the resume token, and it mutates
+// no cache state.
+func TestSnapshotCompleteClosesReady(t *testing.T) {
+	r := newTestRegistry()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	require.Error(t, r.WaitReady(ctx), "WaitReady must block before SNAPSHOT_COMPLETE")
+	cancel()
+
+	stream := &fakeWatchStream{
+		events: []*registrarv1.WatchEndpointsResponse{
+			{
+				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT,
+				ServiceName: "svc-a",
+				Endpoint:    makeEndpoint("10.0.0.1", 8080),
+				Version:     "7",
+			},
+			{
+				Type:    registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE,
+				Version: "7",
+			},
+			// A second marker (reconnect) must be harmless.
+			{
+				Type:    registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE,
+				Version: "8",
+			},
+		},
+		err: io.EOF,
+	}
+
+	got := r.processStream(context.Background(), stream, "")
+	assert.Equal(t, "8", got, "marker version must advance the resume token")
+	require.NoError(t, r.WaitReady(context.Background()), "ready must be closed after the marker")
+
+	eps, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	assert.Len(t, eps, 1, "marker must not mutate the cache")
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -42,3 +42,13 @@ type ChangeNotifier interface {
 	// endpoints changes.
 	Changes() <-chan struct{}
 }
+
+// ReadyWaiter is an optional capability for Registry implementations whose
+// reads are served from an asynchronously populated cache (the registrar
+// watch client). WaitReady blocks until the cache holds a complete snapshot
+// or ctx ends; callers bound it with a timeout and may proceed with degraded
+// reads on expiry. Synchronous backends (DynamoDB, etcd, Cloud Map direct)
+// do not implement it.
+type ReadyWaiter interface {
+	WaitReady(ctx context.Context) error
+}


### PR DESCRIPTION
Fixes the ~3.8k-failure 404 window from the rev-66 roll. Root-cause investigation reconstructed a per-second timeline; two gaps share one flaw — **config derived from whatever the registry returns at a single instant** — plus a co-roll amplifier.

> **Mechanism correction (post-review, verified from registrar logs):** the original Gap 1 attribution ("helm termination wave unregistered endpoints") was imprecise — the helm upgrade only rolled `aether-system`, and there are **zero UnregisterEndpoint RPCs in the 13:13–13:15 window**. What actually emptied services was **partial world views**: the co-rolled registrar restarted with an empty snapshot, agents reconnected/fell back to it mid-warm and faithfully replaced good 8-service caches with partial ones (the `RegisterEndpoint` storm at 13:13:54+ is the agents' ghost-sweep re-registering *real, running* pods the partial view said didn't exist). That mechanism is killed by layer 3 below. The retention grace (layer 0) remains essential for the *legitimate* transient-emptying path: deletionTimestamp early-dereg during fast svc rolls can briefly drive a real service to 0 registered endpoints.

## Gap 1 — vhost loss on healthy nodes (~36s, the bulk of the damage)

Services that transiently vanish from the registry listing dropped out of `LoadClustersFromRegistry`'s wholesale rebuild → live proxies received route configs with 2 of 8 vhosts → 404s. A route-table miss is a lie: the service exists.

**Fix**: disappeared services are retained with their cluster + vhost and an **empty endpoint set** for a 90s grace (outlasting observed churn), then pruned. During the grace clients get the honest, **retriable** no-healthy-upstream 503 and recover the instant endpoints reappear. (Deliberately chose retention over the investigated count-based hold-down: a count heuristic both masks real deletions and misses same-count swaps.)

## Gap 2 — fresh agent serving vhosts=0 (~170ms, guaranteed hit)

`RegistrarRegistry.Initialize` starts its watch loop async and returns; `PreListen` derived the initial snapshot from an empty cache and opened the xDS socket — the reconnecting Envoy landed exactly in that window.

**Fix, three layers**:
1. **Protocol**: new `EVENT_TYPE_SNAPSHOT_COMPLETE` marks the end of the initial snapshot stream (sent even when the client is up-to-date). Backward-compatible: old clients no-op on unknown event types.
2. **Client**: `WaitReady` (`registry.ReadyWaiter` capability) blocks until the first marker; `PreListen` waits up to 15s before deriving the initial snapshot, then proceeds degraded (the existing local-only fallback and background retry are untouched — a dead registrar still cannot crash-loop the node).
3. **Registrar**: snapshot-serving RPCs (`WatchEndpoints`, `ListAllEndpoints`) gate on the syncer's **first completed cycle**. This kills the actual rev-66 mechanism — without it, a freshly rolled registrar serves a complete-but-**empty/partial** snapshot to every reconnecting agent while still warming from Cloud Map, and the marker alone would bless garbage.

## Testing

- `TestLoadClustersFromRegistry_RetainsDisappearedServices`: retain-empty → reappear-restore → prune-after-grace; existing prune test updated to the graced semantics.
- `TestSnapshotCompleteClosesReady`: through `processStream` — marker closes ready, advances the resume token, mutates nothing, idempotent on reconnect markers.
- `TestWatchEndpointsSendsSnapshotComplete`, `TestWatchEndpointsGatedOnFirstSync`, `TestListAllEndpointsGatedOnFirstSync`.
- Full suite 38/38.

**Post-deploy validation**: repeat the full-chart co-roll; expect the 404 class gone (fails back to the ~7–14 connection-churn baseline, any residue 503/000-shaped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)