### PR TITLE
fix(agent): close upstream pools at drain-mark — eliminates the P2 app-drain gap

### DIFF
--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -64,9 +64,30 @@ func NewServiceCluster(serviceName string) *clusterv3.Cluster {
 			},
 		},
 		// Don't route to a newly discovered endpoint until its first readiness check
-		// passes, so traffic never lands on a not-yet-ready pod.
+		// passes, so traffic never lands on a not-yet-ready pod. Panic routing is
+		// disabled: with draining endpoints now reported UNHEALTHY (see
+		// endpointHealthStatus), a heavy simultaneous roll could cross Envoy's
+		// default 50% panic threshold and spray traffic at known-unhealthy hosts;
+		// deterministic exclusion + per-request retries + the registry's own
+		// health pipeline are the mesh's answer, not panic spraying.
 		CommonLbConfig: &clusterv3.Cluster_CommonLbConfig{
 			IgnoreNewHostsUntilFirstHc: true,
+			HealthyPanicThreshold:      &typev3.Percent{Value: 0},
+		},
+		// Close pool connections the moment an endpoint goes unhealthy (incl.
+		// the EDS drain mark above): the pools are idle then, and closing them
+		// pre-empts the app-exit GOAWAY race that strands claimed-but-unanswered
+		// streams. See endpointHealthStatus.
+		CloseConnectionsOnHostHealthFailure: true,
+		// Retry headroom: the default cluster max_retries circuit breaker (3
+		// concurrent) rejected retries during roll bursts (retry_overflow,
+		// instrumented 2026-06-11); pool-close at drain-mark briefly retries a
+		// burst of pre-request resets, which must never be sacrificed to the
+		// breaker.
+		CircuitBreakers: &clusterv3.CircuitBreakers{
+			Thresholds: []*clusterv3.CircuitBreakers_Thresholds{
+				{MaxRetries: wrapperspb.UInt32(16)},
+			},
 		},
 		// With active health checks configured, Envoy by default keeps an
 		// EDS-removed host in rotation until its health check fails — which would
@@ -178,9 +199,19 @@ func endpointHealthStatus(endpoint *registryv1.ServiceEndpoint) corev3.HealthSta
 	case registryv1.ServiceEndpoint_HEALTH_UNHEALTHY:
 		return corev3.HealthStatus_UNHEALTHY
 	case registryv1.ServiceEndpoint_HEALTH_DRAINING:
-		// Pod deletion requested: excluded from new selections, established
-		// connections drain gracefully.
-		return corev3.HealthStatus_DRAINING
+		// Pod deletion requested. UNHEALTHY — deliberately NOT Envoy's
+		// DRAINING: DRAINING excludes the host from new selections but keeps
+		// the established H2 pool connections open until the app's shutdown
+		// GOAWAY arrives, and streams the server had claimed but not yet
+		// answered at that instant fail non-retriably (the residual ~3-7
+		// fails per pod delete, P2; instrumented 2026-06-11: rx_reset=0,
+		// retry_success=retry_total — every failure was a stream the GOAWAY
+		// race left unretriable). UNHEALTHY combined with the cluster's
+		// close_connections_on_host_health_failure closes those pools at
+		// drain-mark time instead (~t0+0.8s), while the app is still healthy
+		// and the pools are idle; anything in flight resets pre-request and
+		// retries successfully onto a live endpoint.
+		return corev3.HealthStatus_UNHEALTHY
 	default:
 		return corev3.HealthStatus_HEALTHY
 	}

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -126,9 +126,31 @@ func TestServiceLocalityLbEndpointFromRegistryEndpoint_EDSMode(t *testing.T) {
 func TestEndpointHealthStatus(t *testing.T) {
 	assert.Equal(t, corev3.HealthStatus_UNHEALTHY,
 		endpointHealthStatus(&registryv1.ServiceEndpoint{Health: registryv1.ServiceEndpoint_HEALTH_UNHEALTHY}))
+	// DRAINING (deletion requested) maps to UNHEALTHY, not Envoy DRAINING:
+	// paired with close_connections_on_host_health_failure it closes the idle
+	// H2 pools at drain-mark time, pre-empting the app-exit GOAWAY race that
+	// strands claimed-but-unanswered streams (P2, instrumented 2026-06-11).
+	assert.Equal(t, corev3.HealthStatus_UNHEALTHY,
+		endpointHealthStatus(&registryv1.ServiceEndpoint{Health: registryv1.ServiceEndpoint_HEALTH_DRAINING}))
 	// Unspecified (older agents / fresh endpoints) and explicit healthy both route.
 	assert.Equal(t, corev3.HealthStatus_HEALTHY,
 		endpointHealthStatus(&registryv1.ServiceEndpoint{}))
 	assert.Equal(t, corev3.HealthStatus_HEALTHY,
 		endpointHealthStatus(&registryv1.ServiceEndpoint{Health: registryv1.ServiceEndpoint_HEALTH_HEALTHY}))
+}
+
+// TestServiceClusterDrainPoolClose pins the P2 drain-gap fix shape: pool
+// connections close on (EDS) health failure, panic routing is off, and the
+// retry circuit breaker has headroom for the drain-time reset burst.
+func TestServiceClusterDrainPoolClose(t *testing.T) {
+	c := NewServiceCluster("svc-x")
+	assert.True(t, c.GetCloseConnectionsOnHostHealthFailure(),
+		"pools must close at drain-mark, not at the app-exit GOAWAY race")
+	require.NotNil(t, c.GetCommonLbConfig().GetHealthyPanicThreshold())
+	assert.Zero(t, c.GetCommonLbConfig().GetHealthyPanicThreshold().GetValue(),
+		"panic spraying at known-unhealthy hosts is never the mesh behavior")
+	thresholds := c.GetCircuitBreakers().GetThresholds()
+	require.Len(t, thresholds, 1)
+	assert.Equal(t, uint32(16), thresholds[0].GetMaxRetries().GetValue(),
+		"drain-time reset bursts must not be sacrificed to the retry breaker")
 }


### PR DESCRIPTION
The last open mesh bug. Two instrumented svc-1 rolls (per-fail timestamps correlated against each old pod's `deletionTimestamp`, plus Envoy reset/retry stat deltas) pinned the residual ~3–7 fails per pod delete.

## What the data showed

- **The drain pipeline is fast and correct**: deletionTimestamp → EDS mark on every client in **<800ms**; **zero** fails in the propagation window and the preStop window.
- **100% of fails land at app exit** (+3–7s, the GOAWAY moment).
- `upstream_rq_rx_reset = 0` everywhere — the app never broke a response.
- `retry_success == retry_total` — every retry that could fire succeeded.
- The first pod deleted in each roll produced **zero** fails (its pools were fully idle at GOAWAY).

**Mechanism**: Envoy's `DRAINING` health excludes a host from new picks but deliberately keeps established H2 pool connections open. They idle through preStop and die at the app's shutdown GOAWAY — and streams the server had claimed but not yet answered at that instant fail **non-retriably** (`last_stream_id` race). Plus two `retry_overflow` rejections from the default 3-concurrent retry breaker.

## The fix

1. **Draining endpoints now report `UNHEALTHY`** (not `DRAINING`) + **`close_connections_on_host_health_failure: true`** on service clusters: pools close at drain-mark time (~t0+0.8s) while the app is healthy and the pools are idle; anything caught mid-transmit resets *pre-request* and retries successfully onto a live endpoint. Envoy's connection-level "drain gradually" semantics are redundant here — the mesh already does the gradual part at the EDS level with the app serving through preStop.
2. **`healthy_panic_threshold: 0`**: with drainers counting as unhealthy, a heavy simultaneous roll could cross the default 50% panic threshold and spray traffic at known-unhealthy hosts. Deterministic exclusion + per-request retries + the registry health pipeline are the mesh's answer (same call Istio makes).
3. **`max_retries` breaker 3 → 16**: the drain-time pool close produces a brief burst of pre-request resets; the default breaker rejected retries under exactly that burst (observed `retry_overflow`).

## Validation

- Unit: DRAINING→UNHEALTHY mapping + cluster shape pinned in tests; full suite 38/38.
- Post-deploy: re-run the instrumented single-svc roll — expect **0 fails** (the fix makes every pod look like the first-deleted pod, which already measured 0). 
- Bonus from instrumentation: **zero 404s under churn** — #142's retention guard confirmed holding in exactly the scenario it was built for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)