### PR TITLE
fix(agent): restore the default panic threshold — #143's panic-0 unmasked the Cloud Map registration race

### DIFF
--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -64,15 +64,18 @@ func NewServiceCluster(serviceName string) *clusterv3.Cluster {
 			},
 		},
 		// Don't route to a newly discovered endpoint until its first readiness check
-		// passes, so traffic never lands on a not-yet-ready pod. Panic routing is
-		// disabled: with draining endpoints now reported UNHEALTHY (see
-		// endpointHealthStatus), a heavy simultaneous roll could cross Envoy's
-		// default 50% panic threshold and spray traffic at known-unhealthy hosts;
-		// deterministic exclusion + per-request retries + the registry's own
-		// health pipeline are the mesh's answer, not panic spraying.
+		// passes, so traffic never lands on a not-yet-ready pod. Envoy's default
+		// 50% panic threshold is deliberately KEPT: panic spraying is the safety
+		// net for incorrect health bookkeeping, and the bookkeeping is not yet
+		// trustworthy during rolls — the Cloud Map async-registration race can
+		// leave brand-new (healthy, serving) pods unregistered for up to a sweep
+		// interval, so a roll can drive the *recorded* healthy fraction to zero
+		// while real capacity exists. Disabling panic (tried 2026-06-11) turned
+		// every roll into 300-500 hard no_healthy_upstream 503s. Revisit only
+		// after registration failures get fast retries instead of waiting for
+		// the 60s reconciliation sweep.
 		CommonLbConfig: &clusterv3.Cluster_CommonLbConfig{
 			IgnoreNewHostsUntilFirstHc: true,
-			HealthyPanicThreshold:      &typev3.Percent{Value: 0},
 		},
 		// Close pool connections the moment an endpoint goes unhealthy (incl.
 		// the EDS drain mark above): the pools are idle then, and closing them

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -146,9 +146,13 @@ func TestServiceClusterDrainPoolClose(t *testing.T) {
 	c := NewServiceCluster("svc-x")
 	assert.True(t, c.GetCloseConnectionsOnHostHealthFailure(),
 		"pools must close at drain-mark, not at the app-exit GOAWAY race")
-	require.NotNil(t, c.GetCommonLbConfig().GetHealthyPanicThreshold())
-	assert.Zero(t, c.GetCommonLbConfig().GetHealthyPanicThreshold().GetValue(),
-		"panic spraying at known-unhealthy hosts is never the mesh behavior")
+	// Default panic threshold deliberately kept (no override): the Cloud Map
+	// registration race can zero the RECORDED healthy fraction while real
+	// capacity exists; panic spraying is the safety net until registration
+	// failures get fast retries (panic 0 turned rolls into 300-500 hard 503s,
+	// e2e 2026-06-11).
+	assert.Nil(t, c.GetCommonLbConfig().GetHealthyPanicThreshold(),
+		"panic threshold must stay at Envoy's default")
 	thresholds := c.GetCircuitBreakers().GetThresholds()
 	require.Len(t, thresholds, 1)
 	assert.Equal(t, uint32(16), thresholds[0].GetMaxRetries().GetValue(),


### PR DESCRIPTION
**The rev-68 e2e went RED** — svc rolls cost 352/439 fails (vs 14–27 pre-#143), nearly all sustained `no_healthy_upstream` 503s in 30–70s windows. The #143 drain machinery itself is **working** (config confirmed on the wire; the GOAWAY-race `code=000` class shrank to ~6/pod; `retry_success == retries`, `retry_overflow: 0` on the 16-deep breaker; zero 404s everywhere).

## What actually broke

The **pre-existing Cloud Map async-registration race**: a brand-new (healthy, serving) pod's registration can fail (`failed to register endpoint; reconciliation sweep will retry`) and only the **60s sweep** retries it. During a roll, the *recorded* healthy fraction can hit zero while real capacity exists. Pre-#143, Envoy's default 50% **panic threshold was the accidental safety net** — it sprayed traffic across all known hosts (unregistered-but-serving newcomers were absent, but draining-yet-alive old pods caught it) and rolls stayed cheap. `healthy_panic_threshold: 0` removed the net and exposed the rot as hard no-route windows.

## This PR

Remove the `HealthyPanicThreshold: 0` override (back to Envoy's default 50%); keep the rest of #143 (drain-mark UNHEALTHY, `close_connections_on_host_health_failure`, `max_retries: 16`). The comment now documents why panic stays: it is the correct safety net for exactly this failure mode — *bookkeeping wrong, capacity real* — and must remain until the bookkeeping is trustworthy.

## Follow-up (the real fix, next PR)

Fast-retry failed endpoint registrations / health promotions in the agent (seconds with backoff, not the 60s sweep). Once the recorded healthy fraction stays truthful through rolls, panic never engages and the #143 target (0-fail rolls) becomes reachable — at that point panic-0 can be revisited with evidence.

Full suite 38/38. Post-deploy validation: repeat the svc-1 roll — expect back at/below the pre-#143 14–27 band (GOAWAY class now fixed, so likely ~6×4=24 worst case, plausibly under).

🤖 Generated with [Claude Code](https://claude.com/claude-code)