### PR TITLE
fix(proxy): never exclude cluster.health_ stats — membership gauges are read by the health_check filter

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -17,16 +17,24 @@ data:
     # Bound stats-memory growth (measured 2026-06-11: ~5.1k stats/proxy at
     # 7 pods + 8 services; per-pod clusters/listeners dominate). Nothing
     # scrapes the Envoy admin — delegated liveness rides the health-gateway
-    # listener and the supervisor only polls /server_info — so the excluded
-    # subtrees have zero operational value. Excluded stats are null (not
-    # rendered, not allocated, increments are no-ops).
+    # listener and the supervisor only polls /server_info. Excluded stats
+    # are null (not rendered, not allocated, increments AND READS are
+    # no-ops).
     #
-    # NOTE: excluding cluster.health_* also nulls the probe clusters'
-    # upstream_cx_total, which Envoy's HC interval selection consults
-    # (".used()" is permanently false) — those clusters then ALWAYS run on
-    # the no-traffic HC cadence. Safe only because the agent pins
-    # no_traffic_interval == interval on probe clusters; do not remove that
-    # pin while this exclusion exists.
+    # ⚠ Excluded stats are not write-only: Envoy internals READ stats too.
+    # NEVER exclude cluster.health_* — the health_check filter evaluates
+    # cluster_min_healthy_percentages by reading the cluster's
+    # membership_healthy/membership_total GAUGES; excluding them nulls both
+    # to 0, the gateway and every inbound readiness path answer 503, the
+    # liveness loop demotes every endpoint, and with panic routing at 0 the
+    # whole mesh goes dark (2026-06-11 20:03-20:14Z outage, rev 70; repro'd
+    # in isolation against the same image). cluster.app_* carries no
+    # min-healthy reference (verified: only health_<pod> clusters appear in
+    # ClusterMinHealthyPercentages) and stays excluded.
+    #
+    # NOTE: probe clusters never carry routed traffic, so Envoy's HC
+    # interval selection sees them as no-traffic regardless; the agent pins
+    # no_traffic_interval == interval on them (cluster.go) — keep that pin.
     stats_config:
       # No scraper exists; skip default tag extraction (saves per-stat tag
       # structs and admin /stats render time, which runs on the main thread).
@@ -34,14 +42,14 @@ data:
       stats_matcher:
         exclusion_list:
           patterns:
-            # Per-pod delivery + health-probe clusters: O(pods) x ~230 stats.
+            # Per-pod delivery clusters: O(pods) x ~115 stats. Do NOT add
+            # cluster.health_ here — see the outage note above.
             - prefix: "cluster.app_"
-            - prefix: "cluster.health_"
             # Certificate expiration gauges: SPIRE owns rotation/expiry.
             - contains: "ssl.certificate."
-            # Per-cluster active-HC verbose stats on the remaining (service)
-            # clusters; membership_healthy/membership_total are not under
-            # this subtree and remain. RE2 only — no lookahead.
+            # Per-cluster active-HC verbose stats (attempt/success/failure
+            # counters); membership_healthy/membership_total are not under
+            # this subtree and remain readable. RE2 only — no lookahead.
             - safe_regex:
                 regex: "^cluster\\..*\\.health_check\\."
 


### PR DESCRIPTION
## Incident: rev 70 mesh outage, 2026-06-11 20:03–20:14Z (~11 min, ~100k failed requests)

#146's `stats_config` excluded `cluster.health_*`. That was wrong in a way `envoy --mode validate` cannot catch: **excluded stats are not write-only — Envoy internals read stats too.** The `health_check` filter evaluates `cluster_min_healthy_percentages` by reading the probe cluster's `membership_healthy`/`membership_total` **gauges**; with them nulled to 0/0:

1. health gateway → 503 for every pod → liveness loop demoted every endpoint to UNHEALTHY
2. inbound readiness paths → 503 → every client-side active HC failed
3. panic routing at 0 (deliberate, #143) → nothing routable → mesh-wide 503

**Mitigation:** `helm rollback aether-agent 69` at 20:13:40Z; recovery confirmed (0 fails across all loadgens within ~90s).

## Root-cause proof (isolated, same image digest)

Minimal config: one `health_x` cluster + health_check filter with `cluster_min_healthy_percentages: {health_x: 100}`:

| stats_config | /healthz |
|---|---|
| none | **200** |
| `prefix: cluster.health_` excluded | **503** |
| this PR's exclusion list | **200** |

## Change

- Drop the `cluster.health_` prefix exclusion; keep `cluster.app_` (verified only `health_<pod>` clusters appear in `ClusterMinHealthyPercentages`), `ssl.certificate.`, and the `health_check.` counter subtree (membership gauges are not under it).
- Rewrite the bootstrap comments: outage note + NEVER-exclude warning, and keep the `no_traffic_interval` pin note (still required — probe clusters are genuinely no-traffic).

Cost: stats land ~2534/proxy instead of 2419 (+115 = one health cluster block per pod) — still −51% vs the original ~5.1k.

Chart tests pass; rendered bootstrap re-validated with `envoy --mode validate` on the deployed image digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)