### PR TITLE
feat(registrar): wire --etcd-endpoints through the chart

### DIFF
--- a/charts/registrar/templates/deployment.yaml
+++ b/charts/registrar/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
             {{- if eq .Values.registryBackend "cloudmap" }}
             - "--cloudmap-namespace={{ .Values.cloudMap.namespace }}"
             {{- end }}
+            {{- if eq .Values.registryBackend "etcd" }}
+            - "--etcd-endpoints={{ join "," .Values.etcd.endpoints }}"
+            {{- end }}
             - "--grpc-address=:{{ .Values.service.targetPort }}"
             - "--spire-enabled={{ .Values.spire.enabled }}"
             {{- if .Values.spire.enabled }}

--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -45,6 +45,12 @@ cloudMap:
   # Cloud Map HTTP namespace name (`--cloudmap-namespace`).
   namespace: aether
 
+# etcd settings (used when registryBackend == etcd).
+etcd:
+  # etcd client endpoints (`--etcd-endpoints`), e.g.
+  # ["http://etcd.aether-etcd.svc.cluster.local:2379"].
+  endpoints: []
+
 # Enable verbose logging (`--debug`).
 debug: true
 


### PR DESCRIPTION
The registrar binary accepts `--etcd-endpoints` but the chart had no way to pass it, making `registryBackend=etcd` undeployable via helm. Adds `values.etcd.endpoints` (list), joined into the flag only when the backend is etcd.

Needed for the etcd-vs-dynamodb backend comparison e2e on talos-main. Chart lint/template tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)