### PR TITLE
fix(agent,registry): ghost sweep diffs against authoritative listing, not the watch cache

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -100,7 +100,21 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		telemetry.EndSpan(span, retErr)
 	}()
 
-	all, err := s.registry.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	// The sweep decides what to (de)register, so it must diff against the
+	// AUTHORITATIVE registry state, never the watch-fed cache: a fresh or
+	// failed-over registrar with an empty snapshot emits no events, the cache
+	// keeps the stale pre-loss world, and a cache-based diff concludes nothing
+	// is missing — exactly defeating the reconnect re-assert this sweep
+	// implements (observed 2026-06-11: a registry-backend switch left the
+	// registry empty while every agent no-op'd; only an agent restart healed
+	// it).
+	var all map[string][]*registryv1.ServiceEndpoint
+	var err error
+	if al, ok := s.registry.(registry.AuthoritativeLister); ok {
+		all, err = al.ListAllEndpointsAuthoritative(ctx, registryv1.Service_PROTOCOL_HTTP)
+	} else {
+		all, err = s.registry.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	}
 	if err != nil {
 		s.log.V(1).Info("ghost sweep: failed to list registry endpoints", "error", err)
 		retErr = err

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -128,3 +128,45 @@ func TestSweepRegistersMissingEndpoint(t *testing.T) {
 	assert.NotContains(t, state.last, "container-missing")
 	assert.NotContains(t, state.sawHealthy, "container-missing", "forget must clear warm-up memory too")
 }
+
+// authoritativeSweepRegistry simulates the post-backend-switch trap: the
+// watch-fed cache (ListAllEndpoints) still holds the stale pre-switch world,
+// while the authoritative listing (the registrar's actual snapshot) is empty.
+type authoritativeSweepRegistry struct {
+	sweepRegistry
+	authoritative map[string][]*registryv1.ServiceEndpoint
+}
+
+func (r *authoritativeSweepRegistry) ListAllEndpointsAuthoritative(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	return r.authoritative, nil
+}
+
+// TestSweepPrefersAuthoritativeListing: when the registry exposes an
+// authoritative listing, the sweep must diff against it — not the watch cache.
+// A fresh/failed-over registrar with an empty snapshot emits no events, so the
+// cache remains a stale superset claiming every pod is registered; diffing
+// against it silently skips the re-assert (observed 2026-06-11: a backend
+// switch left the registry empty until the agents were restarted).
+func TestSweepPrefersAuthoritativeListing(t *testing.T) {
+	ctx := context.Background()
+
+	pod := validCNIPod("pod-stale", "default", "container-stale")
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-stale"), pod))
+
+	reg := &authoritativeSweepRegistry{
+		// Cache claims the pod is registered (stale superset)...
+		sweepRegistry: sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{
+			"default": {sweepEndpoint("10.0.0.1", "test-node", "pod-stale")},
+		}},
+		// ...but the registrar's real snapshot is empty.
+		authoritative: map[string][]*registryv1.ServiceEndpoint{},
+	}
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", logr.Discard()), "")
+
+	s.sweepGhostEndpoints(ctx)
+
+	_, ok := reg.registered["default/10.0.0.1"]
+	require.True(t, ok, "sweep must re-register from the authoritative (empty) listing, not the stale cache")
+}

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -248,6 +248,15 @@ func (r *RegistrarRegistry) ListAllEndpoints(ctx context.Context, protocol regis
 	return r.listAllEndpointsFromServer(ctx, protocol)
 }
 
+// ListAllEndpointsAuthoritative lists endpoints via the ListAllEndpoints RPC,
+// bypassing the watch-fed cache. It satisfies the registry.AuthoritativeLister
+// capability: the cache can be a stale superset of a fresh registrar's
+// snapshot (an empty snapshot emits no FULL_SNAPSHOT events, so the cache is
+// never cleared), and reconciliation diffing against it would silently no-op.
+func (r *RegistrarRegistry) ListAllEndpointsAuthoritative(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	return r.listAllEndpointsFromServer(ctx, protocol)
+}
+
 func (r *RegistrarRegistry) listEndpointsFromServer(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
 	resp, err := r.client.ListAllEndpoints(ctx, &registrarv1.ListAllEndpointsRequest{
 		Protocol: protocol,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -61,3 +61,16 @@ type ReadyWaiter interface {
 type ReconnectNotifier interface {
 	Reconnects() <-chan struct{}
 }
+
+// AuthoritativeLister is an optional capability for Registry implementations
+// whose ListAllEndpoints may serve from a local watch-fed cache. It lists from
+// the authoritative source (an RPC to the registrar, the external registry),
+// bypassing any cache. Reconciliation that decides what to (de)register must
+// use this when present: a watch cache can be a stale superset of a fresh or
+// failed-over registrar's snapshot — an empty snapshot emits no events, so the
+// cache keeps the old world and a cache-based diff concludes nothing is
+// missing (2026-06-11: backend switch left the registry empty while every
+// agent's re-assert no-op'd against its own stale cache).
+type AuthoritativeLister interface {
+	ListAllEndpointsAuthoritative(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error)
+}


### PR DESCRIPTION
## The bug (found by the backend-comparison e2e, 2026-06-11)

The reconnect re-assert (#145) runs the ghost sweep, which lists registry endpoints through the registrar client — **served from the watch-fed local cache**. On reconnect to a fresh/failed-over registrar whose snapshot is *empty*, zero `FULL_SNAPSHOT` events arrive, so the client cache is never cleared (`processStream` only clears on a FULL_SNAPSHOT event). The cache remains a stale superset claiming every pod is registered → the diff sees nothing missing → **re-assert silently no-ops**, defeating exactly the state-loss repair it was built for.

In vivo: switching the registrar's backend (cloudmap → dynamodb) left the new registry at `services: 0` for minutes while every agent served stale EDS — a latent mesh outage armed for the next agent restart. Only `kubectl rollout restart ds/aether-agent` (fresh cache = server truth) healed it.

## Fix

- `registry.AuthoritativeLister` capability: list from the authoritative source, bypassing any cache.
- Registrar client implements it via the existing `ListAllEndpoints` RPC (one call per sweep per node, served from the registrar's in-memory snapshot).
- Ghost sweep prefers it when present; non-caching backends are unaffected.

Considered and rejected: unconditionally re-registering all local pods on reconnect — registrations start at mode-default health (EDS-mode = UNHEALTHY), so benign reconnects would demote healthy serving pods fleet-wide until the next liveness promotion. The authoritative diff re-registers only what's actually missing.

## Validation

- New regression test reproduces the stale-superset trap (cache full, authoritative empty → must re-register).
- All 38 test targets pass.
- In-vivo validation planned: the upcoming dynamodb backend switch on talos-main will run **without** the agent-restart workaround — self-healing repopulation proves the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)