### PR TITLE
chore(registrar,registry): post-cloudmap cleanup — honor AWS_REGION; drop stale comments

### DIFF
--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -33,8 +33,7 @@ registryBackend: kubernetes
 
 # AWS configuration for the dynamodb registry backend.
 aws:
-  # Region for AWS SDK clients. NOTE: the registrar binary currently forces
-  # us-east-1 internally; this is wired for forward-compat and clarity.
+  # Region for AWS SDK clients (exported as AWS_REGION).
   region: us-east-1
   # Name of an existing Secret holding AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY.
   # Empty = inject nothing (rely on IRSA / instance role / ambient credentials).

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -158,9 +158,15 @@ func setupRegistry(ctx context.Context, m ctrl.Manager) (registry.Registry, erro
 			ClusterName: cfg.ClusterName,
 		})
 	case "dynamodb":
-		awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion("us-east-1"))
+		// Region comes from the standard AWS chain (AWS_REGION env — set by the
+		// chart's aws.region value — shared config, IMDS), falling back to
+		// us-east-1 so bare runs keep the historical default.
+		awsCfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		}
+		if awsCfg.Region == "" {
+			awsCfg.Region = "us-east-1"
 		}
 		reg = registry.NewDynamoDBRegistry(l, awsCfg)
 	case "etcd":

--- a/registry/internal/ddb/dynamodb_test.go
+++ b/registry/internal/ddb/dynamodb_test.go
@@ -162,7 +162,7 @@ func TestDynamoDBRegistry_RegisterEndpoint(t *testing.T) {
 	assert.Equal(t, ep.Metadata["version"], endpoints[0].Metadata["version"])
 	assert.Equal(t, ep.ContainerMetadata.ContainerId, endpoints[0].ContainerMetadata.ContainerId)
 	assert.Equal(t, ep.KubernetesMetadata.Namespace, endpoints[0].KubernetesMetadata.Namespace)
-	// Feature parity with cloudmap: health round-trip.
+	// Health round-trip parity across registry backends.
 	assert.Equal(t, ep.Health, endpoints[0].Health)
 }
 

--- a/registry/internal/etcd/etcd_test.go
+++ b/registry/internal/etcd/etcd_test.go
@@ -150,7 +150,7 @@ func TestEtcdRegistry_RegisterEndpoint(t *testing.T) {
 	assert.Equal(t, ep.Metadata["version"], endpoints[0].Metadata["version"])
 	assert.Equal(t, ep.ContainerMetadata.ContainerId, endpoints[0].ContainerMetadata.ContainerId)
 	assert.Equal(t, ep.KubernetesMetadata.Namespace, endpoints[0].KubernetesMetadata.Namespace)
-	// Feature parity with cloudmap: health round-trip.
+	// Health round-trip parity across registry backends.
 	assert.Equal(t, ep.Health, endpoints[0].Health)
 }
 

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -248,7 +248,7 @@ func TestListEndpoints(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:        "pod readiness is derived (parity with cloudmap)",
+			name:        "pod readiness is derived (parity with other backends)",
 			clusterName: "test-cluster",
 			objects: []any{
 				func() *corev1.Pod {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -47,8 +47,7 @@ type ChangeNotifier interface {
 // reads are served from an asynchronously populated cache (the registrar
 // watch client). WaitReady blocks until the cache holds a complete snapshot
 // or ctx ends; callers bound it with a timeout and may proceed with degraded
-// reads on expiry. Synchronous backends (DynamoDB, etcd, Cloud Map direct)
-// do not implement it.
+// reads on expiry. Synchronous backends (DynamoDB, etcd) do not implement it.
 type ReadyWaiter interface {
 	WaitReady(ctx context.Context) error
 }


### PR DESCRIPTION
Follow-up to #150, from the post-removal audit:

1. **`aws.region` is now honored.** The dynamodb case hardcoded `config.WithRegion("us-east-1")`, overriding the `AWS_REGION` env the chart already exports from `values.aws.region`. Region now resolves through the standard AWS chain with a us-east-1 fallback for bare runs (preserves historical default; chart-deployed behavior unchanged since the chart default is also us-east-1).
2. **Stale Cloud Map references removed**: `ReadyWaiter` doc comment ("Cloud Map direct") and three "parity with cloudmap" test comments.

No behavior change for current deployments. Registrar/registry/chart tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)