### PR TITLE
feat(proxy): OTel stats sink — push Envoy stats to the collector when telemetry is enabled

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -14,6 +14,22 @@ data:
           address: 127.0.0.1
           port_value: 9901
 
+{{- if .Values.telemetry.otlpEndpoint }}
+    # Push Envoy stats to the OTel collector over OTLP. Push-first like the
+    # rest of the mesh telemetry: the admin /stats endpoint renders on Envoy's
+    # MAIN thread (100-500ms at scale), so it must never be scraped — the sink
+    # serializes off the flush path instead. Stats stay bounded by the
+    # stats_config exclusions below.
+    stats_sinks:
+      - name: envoy.stat_sinks.open_telemetry
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig
+          grpc_service:
+            envoy_grpc:
+              cluster_name: otel_collector
+          prefix: envoy
+{{- end }}
+
     # Bound stats-memory growth (measured 2026-06-11: ~5.1k stats/proxy at
     # 7 pods + 8 services; per-pod clusters/listeners dominate). Nothing
     # scrapes the Envoy admin — delegated liveness rides the health-gateway
@@ -153,4 +169,24 @@ data:
                 initial_stream_window_size: 1048576    # 1 MiB
                 initial_connection_window_size: 1048576 # 1 MiB
                 max_concurrent_streams: 10
+{{- if .Values.telemetry.otlpEndpoint }}
+{{- $otlp := splitList ":" .Values.telemetry.otlpEndpoint }}
+      - name: otel_collector
+        type: STRICT_DNS
+        connect_timeout: 2s
+        load_assignment:
+          cluster_name: otel_collector
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: {{ index $otlp 0 }}
+                        port_value: {{ index $otlp 1 }}
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Completes the push-first telemetry story for the proxy: with `telemetry.otlpEndpoint` set, the bootstrap adds `envoy.stat_sinks.open_telemetry` + a static `otel_collector` cluster (STRICT_DNS, h2c). Without it the bootstrap is byte-identical to today.

Why a sink and not a scrape: admin `/stats` renders on Envoy's **main thread** (100–500ms at scale — measured during the cardinality audit), so Prometheus-style scraping is off the table; the OTel sink serializes on the stats flush path instead. Cardinality stays bounded by the existing `stats_config` exclusions (~2.7k stats/proxy).

Validation: chart lint/template tests pass; rendered bootstrap (with and without endpoint) `envoy --mode validate`d on the deployed image digest. E2e plan post-merge: deploy with `telemetry.otlpEndpoint` pointed at an in-cluster collector (debug/stdout exporter, no Prometheus) and confirm `envoy.*` metrics arrive alongside the control-plane (agent/registrar) OTel metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)