### PR TITLE
feat(proxy): stats cardinality round 2 — collapse per-pod stat names, label by tag

### DIFF
--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -117,6 +117,12 @@ func NewAppCluster(name, netns string, port uint16) *clusterv3.Cluster {
 				NetworkNamespaceFilepath: netns,
 			},
 		},
+		// Collapse every per-pod app cluster into one cluster.app.* stats block
+		// (cardinality round 2): the Envoy->app loopback hop gets node-aggregate
+		// visibility (connect failures, rq totals) at O(1) instead of either
+		// O(pods) stats or a blanket exclusion. Nothing reads app cluster stats
+		// per-cluster (verified: no ClusterMinHealthyPercentages references).
+		AltStatName: "app",
 	}
 }
 
@@ -134,6 +140,12 @@ func HealthProbeClusterName(cniPod *cniv1.CNIPod) string {
 // app_<pod> at startup and whenever the probe fails.
 func NewAppHealthProbeCluster(name, netns string, port uint16, healthPath string) *clusterv3.Cluster {
 	c := NewAppCluster(name, netns, port)
+	// MUST stay per-pod (clear the inherited collapse): the health_check
+	// filter answers per-pod readiness by reading THIS cluster's
+	// membership_healthy/membership_total gauges (see the 2026-06-11 stats
+	// outage). A shared alt_stat_name would merge every pod's membership into
+	// one gauge and one unhealthy pod would fail every pod's readiness.
+	c.AltStatName = ""
 	c.HealthChecks = []*corev3.HealthCheck{
 		{
 			Timeout:            durationpb.New(1 * time.Second),

--- a/agent/internal/xds/proxy/filterchain.go
+++ b/agent/internal/xds/proxy/filterchain.go
@@ -10,9 +10,11 @@ import (
 
 // buildDefaultOutboundHTTPFilterChain creates a filter chain for outbound HTTP traffic.
 // It uses RDS (Route Discovery Service) to dynamically fetch routes and includes
-// network namespace filter state.
+// network namespace filter state. The chain NAME stays per-pod; the HCM stat
+// prefix is shared across pods (cardinality round 2) — per-pod egress
+// attribution rides tags and cluster stats, not HCM stat names.
 func buildDefaultOutboundHTTPFilterChain(name string) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager(name, nil)
+	hcm := buildHTTPConnectionManager("outbound_http", nil)
 
 	// Readiness probe target: answered on worker threads ahead of the router, so
 	// the CNI plugin's in-netns probe never depends on routes or upstreams.

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -74,11 +74,12 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.L
 				},
 			},
 		},
-		// Shared across all pods (cardinality round 2): per-pod inbound traffic
-		// visibility lives in client-side service-cluster stats and the per-pod
-		// health_ membership gauges; the listener/HCM stat families aggregate
-		// node-wide. Listener NAME stays per-pod — only stats collapse.
-		StatPrefix:       "inbound",
+		// Per-pod listener stats are kept deliberately (downstream_cx_* per pod
+		// is the connection-leak debugging signal — see the 2026-06-11 cx-leak).
+		// The "inbound_<pod>" shape is what the aether.pod stats_tag extracts, so
+		// exports collapse to listener.inbound.* labeled by pod while the stats
+		// stay per-pod. HCM stats (5x larger) aggregate node-wide instead.
+		StatPrefix:       fmt.Sprintf("inbound_%s", cniPod.GetName()),
 		TrafficDirection: corev3.TrafficDirection_INBOUND,
 		ListenerFilters:  buildInboundListenerFilters(),
 		FilterChains: []*listenerv3.FilterChain{

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -74,7 +74,11 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.L
 				},
 			},
 		},
-		StatPrefix:       fmt.Sprintf("in_%s", cniPod.GetName()),
+		// Shared across all pods (cardinality round 2): per-pod inbound traffic
+		// visibility lives in client-side service-cluster stats and the per-pod
+		// health_ membership gauges; the listener/HCM stat families aggregate
+		// node-wide. Listener NAME stays per-pod — only stats collapse.
+		StatPrefix:       "inbound",
 		TrafficDirection: corev3.TrafficDirection_INBOUND,
 		ListenerFilters:  buildInboundListenerFilters(),
 		FilterChains: []*listenerv3.FilterChain{
@@ -87,7 +91,7 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.L
 // inbound listener: it routes all requests to the pod's application cluster and sets
 // XFCC from the verified peer certificate's URI SAN (the caller's SVID).
 func buildInboundFilterChain(cniPod *cniv1.CNIPod, tlsCertificateSecretName, validationContextName string) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager(InboundListenerName(cniPod), buildInboundRouteConfiguration(AppClusterName(cniPod)))
+	hcm := buildHTTPConnectionManager("inbound", buildInboundRouteConfiguration(AppClusterName(cniPod)))
 	// Liveness/readiness are answered locally before the router; everything else
 	// passes through to the pod's application.
 	hcm.HttpFilters = []*http_connection_managerv3.HttpFilter{

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -95,12 +95,10 @@ func generateOutboundHTTPListener(cniPod *cniv1.CNIPod) (*listenerv3.Listener, e
 			},
 		},
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
-		// Shared across all pods: per-pod listener stats cost ~40/pod for data
-		// available elsewhere; per-pod attribution rides tags/cluster stats, not
-		// listener stat names (cardinality round 2). The listener NAME stays
-		// per-pod — only stats collapse.
-		StatPrefix:                    "out_http",
-		TrafficDirection:              corev3.TrafficDirection_OUTBOUND,
+		// Per-pod listener stats kept (see ingress.go); "out_http_<pod>" is the
+		// shape the aether.pod stats_tag extracts.
+		StatPrefix:       fmt.Sprintf("out_http_%s", cniPod.GetName()),
+		TrafficDirection: corev3.TrafficDirection_OUTBOUND,
 		FilterChains: []*listenerv3.FilterChain{
 			buildDefaultOutboundHTTPFilterChain(cniPod.GetName()),
 		},

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -95,7 +95,11 @@ func generateOutboundHTTPListener(cniPod *cniv1.CNIPod) (*listenerv3.Listener, e
 			},
 		},
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
-		StatPrefix:                    fmt.Sprintf("out_http_%s", cniPod.GetName()),
+		// Shared across all pods: per-pod listener stats cost ~40/pod for data
+		// available elsewhere; per-pod attribution rides tags/cluster stats, not
+		// listener stat names (cardinality round 2). The listener NAME stays
+		// per-pod — only stats collapse.
+		StatPrefix:                    "out_http",
 		TrafficDirection:              corev3.TrafficDirection_OUTBOUND,
 		FilterChains: []*listenerv3.FilterChain{
 			buildDefaultOutboundHTTPFilterChain(cniPod.GetName()),

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -58,6 +58,10 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 			require.NotNil(t, healthCluster)
 			assert.Equal(t, HealthProbeClusterName(tt.cniPod), healthCluster.GetName())
 			require.Len(t, healthCluster.GetHealthChecks(), 1, "probe cluster carries the HC")
+			assert.Equal(t, "app", appCluster.GetAltStatName(),
+				"app clusters collapse into one cluster.app.* stats block (cardinality round 2)")
+			assert.Empty(t, healthCluster.GetAltStatName(),
+				"health probe cluster stats MUST stay per-pod: the health_check filter reads THIS cluster's membership gauges (2026-06-11 outage) — a shared alt_stat_name merges every pod's membership")
 			hc := healthCluster.GetHealthChecks()[0]
 			assert.Equal(t, hc.GetInterval().AsDuration(), hc.GetNoTrafficInterval().AsDuration(),
 				"probe cluster never carries routed traffic; the no-traffic interval (default 60s) would govern every check after the first")
@@ -84,7 +88,7 @@ func TestGenerateOutboundHTTPListener(t *testing.T) {
 				Name:             "test-pod",
 				NetworkNamespace: "/var/run/netns/test",
 			},
-			expectedStatPrefix:       "out_http_test-pod",
+			expectedStatPrefix:       "out_http",
 			expectedNetworkNamespace: "/var/run/netns/test",
 			expectedError:            false,
 		},

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -88,7 +88,7 @@ func TestGenerateOutboundHTTPListener(t *testing.T) {
 				Name:             "test-pod",
 				NetworkNamespace: "/var/run/netns/test",
 			},
-			expectedStatPrefix:       "out_http",
+			expectedStatPrefix:       "out_http_test-pod",
 			expectedNetworkNamespace: "/var/run/netns/test",
 			expectedError:            false,
 		},

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -28,6 +28,11 @@ data:
             envoy_grpc:
               cluster_name: otel_collector
           prefix: envoy
+          # Export the tag-extracted name with tags as OTLP attributes: one
+          # metric family per stat, labeled by aether.cluster (see stats_tags)
+          # instead of a name per cluster.
+          emit_tags_as_attributes: true
+          use_tag_extracted_name: true
 {{- end }}
 
     # Bound stats-memory growth (measured 2026-06-11: ~5.1k stats/proxy at
@@ -52,15 +57,23 @@ data:
     # interval selection sees them as no-traffic regardless; the agent pins
     # no_traffic_interval == interval on them (cluster.go) — keep that pin.
     stats_config:
-      # No scraper exists; skip default tag extraction (saves per-stat tag
-      # structs and admin /stats render time, which runs on the main thread).
+      # Default tag extraction stays off; the single custom tag below lifts
+      # the cluster name out of cluster.* stat names so the OTel sink exports
+      # one metric family per stat with the cluster as an attribute
+      # (use_tag_extracted_name + emit_tags_as_attributes on the sink). For
+      # health_<pod> probe clusters that attribute IS the pod identity.
       use_all_default_tags: false
+      stats_tags:
+        - tag_name: aether.cluster
+          regex: "^cluster\\.(([^.]+))\\."
       stats_matcher:
         exclusion_list:
           patterns:
-            # Per-pod delivery clusters: O(pods) x ~115 stats. Do NOT add
-            # cluster.health_ here — see the outage note above.
-            - prefix: "cluster.app_"
+            # NOTE: per-pod app_ delivery clusters are no longer excluded —
+            # they collapse into one cluster.app.* block via alt_stat_name
+            # (agent cluster.go), trading the exclusion for O(1) aggregate
+            # visibility of the Envoy->app loopback hop.
+            #
             # Certificate expiration gauges: SPIRE owns rotation/expiry.
             - contains: "ssl.certificate."
             # Per-cluster active-HC verbose stats (attempt/success/failure
@@ -68,6 +81,13 @@ data:
             # this subtree and remain readable. RE2 only — no lookahead.
             - safe_regex:
                 regex: "^cluster\\..*\\.health_check\\."
+            # health_<pod> probe clusters never carry routed traffic, so their
+            # upstream_*/lb_*/protocol subtrees are permanently zero (~100
+            # dead stats per pod). The membership_* gauges the health_check
+            # filter READS (2026-06-11 outage) do not match and remain.
+            # Repro-validated against the deployed image: filter answers 200.
+            - safe_regex:
+                regex: "^cluster\\.health_[^.]*\\.(upstream_|lb_|retry|external|circuit_breakers|http1|http2|max_host_weight|assignment|bind_|original_dst|default_total_match)"
 
 {{- if .Values.proxy.overload.enabled }}
     # Graceful degradation BEFORE the container memory limit OOM-kills Envoy:

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -63,9 +63,17 @@ data:
       # (use_tag_extracted_name + emit_tags_as_attributes on the sink). For
       # health_<pod> probe clusters that attribute IS the pod identity.
       use_all_default_tags: false
+      # Envoy tag semantics: the FIRST capture group is removed from the stat
+      # name; the tag value is the SECOND group. Groups must include trailing
+      # separators or the collapsed name keeps a double dot.
       stats_tags:
         - tag_name: aether.cluster
-          regex: "^cluster\\.(([^.]+))\\."
+          regex: "^cluster\\.(([^.]+)\\.)"
+        # Per-pod listener stats stay allocated (cx-leak debugging needs
+        # downstream_cx_* per pod); this lifts the pod into a tag so exports
+        # collapse to listener.{inbound,out_http}.* labeled by aether.pod.
+        - tag_name: aether.pod
+          regex: "^listener\\.(?:inbound|out_http)(_([^.]+))\\."
       stats_matcher:
         exclusion_list:
           patterns:


### PR DESCRIPTION
Follows the per-pod listener/cluster discussion: stats are allocated per full name, so `stat_prefix`/`alt_stat_name` collapse is the memory lever, and tag extraction is the labeling lever. Applied per family, with one deliberate exception (amended in `504cc53`):

| family | move | per-pod cost |
|---|---|---|
| inbound/outbound **HCMs** | shared `stat_prefix` (`inbound`, `outbound_http`) — stats aggregate node-wide | ~172 → 0 |
| inbound/outbound **listeners** | **kept per-pod** (`inbound_<pod>`, `out_http_<pod>`): per-pod `downstream_cx_*` is the connection-leak debugging signal (#136 diagnosis pattern). The `aether.pod` stats_tag lifts the pod into an attribute, so exports still collapse to `listener.{inbound,out_http}.*{aether.pod=…}` | ~82 (kept, labeled) |
| `app_<pod>` clusters | `alt_stat_name: "app"`, round-1 exclusion **removed** — regains O(1) node-aggregate visibility of the Envoy→app hop | per-pod 0 (~115/node total) |
| `health_<pod>` clusters | **kept per-pod** (membership gauges are read per-cluster by the health_check filter — collapsing merges every pod's membership: one unhealthy pod would 503 every pod's readiness). Dead traffic subtrees excluded instead (probe clusters never carry routed traffic → `upstream_*`/`lb_*`/… are permanently zero) | ~116 → ~16 |
| export shape | `stats_tags` extracts `aether.cluster` + `aether.pod`; sink gains `use_tag_extracted_name` + `emit_tags_as_attributes` → one metric family per stat, cluster/pod as attribute | — |

**Net: ~370 → ~98 stats per pod marginal (16 health membership + 82 listener); pod-term at the 250-pod design point: ~92k → ~24.5k.** (The earlier ~16/pod / ~5k figures predate keeping the listener stats; the extra ~82/pod is the explicit price of pod-level connection debugging.)

Pod identity answer: there is no automatic pod label — the pod name only ever appears because our own prefixes/cluster names carry it. After this PR it survives exactly where it's meaningful, as attributes: `aether.cluster` on `health_<pod>` membership gauges (per-pod health) and `aether.pod` on listener stats (per-pod connections), while traffic families aggregate.

Safety, post-#147 discipline:
- health_check filter behavior repro-validated against the deployed image digest with the new exclusions (answers 200; membership gauges intact)
- both tag extractions verified empirically on the deployed image (prometheus render: `envoy_listener_inbound_downstream_cx_destroy{aether_pod="pod-x7abc"}`, clean cluster names — incl. the first-commit double-dot regex bug fix: Envoy removes the FIRST capture group from the name, so the group must include the trailing separator)
- regression tests: `app` alt_stat_name present, health cluster alt_stat_name **must be empty** (with the outage rationale in the assertion message)
- rendered bootstrap `envoy --mode validate`d with and without `otlpEndpoint`
- 37/37 test targets pass

E2e plan post-merge: deploy, then verify via the stdout collector — `envoy.http.inbound.*`/`envoy.cluster.app.*` collapsed, `membership_healthy{aether.cluster=health_<pod>}` and `listener.inbound.*{aether.pod=…}` labeled, before/after stats count per proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)