### PR TITLE
fix(proxy): stats_matcher safe_regex is full-match — patterns silently excluded nothing

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -87,15 +87,20 @@ data:
             # Per-cluster active-HC verbose stats (attempt/success/failure
             # counters); membership_healthy/membership_total are not under
             # this subtree and remain readable. RE2 only — no lookahead.
+            # ⚠ StringMatcher.safe_regex is a FULL-STRING match (RE2
+            # FullMatch), not a search: every pattern must consume the whole
+            # stat name (trailing .*) or it silently excludes NOTHING — this
+            # exact pattern shipped without the trailing .* in #146-#155 and
+            # never matched.
             - safe_regex:
-                regex: "^cluster\\..*\\.health_check\\."
+                regex: "^cluster\\..*\\.health_check\\..*"
             # health_<pod> probe clusters never carry routed traffic, so their
             # upstream_*/lb_*/protocol subtrees are permanently zero (~100
             # dead stats per pod). The membership_* gauges the health_check
             # filter READS (2026-06-11 outage) do not match and remain.
             # Repro-validated against the deployed image: filter answers 200.
             - safe_regex:
-                regex: "^cluster\\.health_[^.]*\\.(upstream_|lb_|retry|external|circuit_breakers|http1|http2|max_host_weight|assignment|bind_|original_dst|default_total_match)"
+                regex: "^cluster\\.health_[^.]*\\.(upstream_|lb_|retry|external|circuit_breakers|http1|http2|max_host_weight|assignment|bind_|original_dst|default_total_match).*"
 
 {{- if .Values.proxy.overload.enabled }}
     # Graceful degradation BEFORE the container memory limit OOM-kills Envoy:


### PR DESCRIPTION
Found during the #155 post-deploy verification: probe clusters still carried ~115 stats each — the health_ trim wasn't working, and neither was the `health_check.` exclusion that's been in the bootstrap since #146.

## Root cause

`StringMatcher.safe_regex` is a **full-string match** (RE2 `FullMatch`), not a search. Both regex patterns matched only a prefix of the stat name → full match failed → **zero exclusions, silently, since they shipped**. The `prefix:`/`contains:` matchers use real prefix/substring semantics and did all the visible work, masking it.

## Proof (docker, deployed image digest)

| config | excluded-subtree stats on `health_x` |
|---|---|
| pattern without trailing `.*` (as shipped) | 70 |
| pattern with trailing `.*` | **0** |
| full corrected list | probe cluster down to **13 stats** (`membership_*` + `update_*`), health_check filter answers **200**, tag extraction coexists |

Also established: the matcher evaluates the **pre-extraction** name, so `aether.cluster`/`aether.pod` tags don't interfere with name-shaped exclusions.

## Change

Trailing `.*` on both `safe_regex` patterns + a loud comment documenting the full-match semantics (this is the second silent-footgun class in `stats_config` after #147's "stats are read, not just written").

Expected on deploy: ~100 stats/pod drop (the trim finally engaging), proxy total ~2679 → ~2350 at current pod counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)