### PR TITLE
feat(registrar): demand-scoped watch with per-service fan-out (004 Phase 2)

### DIFF
--- a/agent/internal/xds/server/refresh.go
+++ b/agent/internal/xds/server/refresh.go
@@ -42,6 +42,23 @@ type RegistryRefresher struct {
 	refreshErrors metric.Int64Counter
 }
 
+// AssertWatchFilter pushes the cache's current dependency set to the registry
+// as the watch service filter (registry.WatchScoper capability), so the
+// registrar fans out endpoint changes for this node's dependencies only.
+// No-op for registries without watch scoping or when the filter is unchanged.
+func AssertWatchFilter(c *cache.SnapshotCache, reg registry.Registry) {
+	scoper, ok := reg.(registry.WatchScoper)
+	if !ok {
+		return
+	}
+	deps := c.DependencySet()
+	services := make([]string, 0, len(deps))
+	for svc := range deps {
+		services = append(services, svc)
+	}
+	scoper.SetServiceFilter(services)
+}
+
 // NewRegistryRefresher creates a RegistryRefresher.
 func NewRegistryRefresher(clusterName, nodeName string, snapshotCache *cache.SnapshotCache, reg registry.Registry, log logr.Logger) *RegistryRefresher {
 	r := &RegistryRefresher{
@@ -123,6 +140,11 @@ func (r *RegistryRefresher) Start(ctx context.Context) error {
 			// recomputed even though the registry contents are unchanged.
 			arm()
 		case <-timer.C:
+			// Re-assert the watch filter from the current dependency set
+			// before reloading: a grown set must reach the registrar so the
+			// watch cache receives the newly in-scope services (no-op when
+			// unchanged; the resulting watch events trigger the next reload).
+			AssertWatchFilter(r.cache, r.registry)
 			if err := r.cache.LoadClustersFromRegistry(ctx, r.clusterName, r.nodeName, r.registry); err != nil {
 				r.log.Error(err, "failed to refresh clusters from registry")
 				if r.refreshErrors != nil {

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -76,6 +76,11 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 		return err
 	}
 
+	// The dependency set is now known (local pods loaded): scope the registry
+	// watch to it before waiting on the watch cache, so the snapshot the
+	// registrar streams is the filtered one (demand-scoped distribution).
+	AssertWatchFilter(s.cache, s.registry)
+
 	// Wait (bounded) for the registry watch cache to hold a complete snapshot
 	// before deriving the initial config from it: a fresh agent that builds its
 	// snapshot from an empty/partial cache opens the xDS socket serving a

--- a/api/aether/registrar/v1/registrar.proto
+++ b/api/aether/registrar/v1/registrar.proto
@@ -40,6 +40,19 @@ message WatchEndpointsRequest {
   string cluster_name = 1;
   string node_name = 2;
   string last_version = 3;
+  // When set, the watch is scoped to filter.services: the initial snapshot
+  // and incremental events are limited to those services (demand-scoped
+  // distribution -- fan-out per endpoint change scales with the service's
+  // consumer count, not the node count). An explicitly set but empty filter
+  // watches nothing (a node with no mesh pods). Unset = full watch.
+  // Agents re-assert their filter on every reconnect; the registrar never
+  // serves less than asked.
+  ServiceFilter filter = 4;
+}
+
+// ServiceFilter scopes a watch to a set of service names.
+message ServiceFilter {
+  repeated string services = 1;
 }
 
 message WatchEndpointsResponse {

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -13,53 +13,81 @@ const (
 	defaultChannelBuffer = 256
 )
 
-// Broadcaster fans out endpoint events to all connected agent watch streams.
-// Each watcher is identified by a string key (typically node name) and receives
-// events on a buffered channel. A watcher too slow to keep up is forcibly
-// resynced: its channel is closed, ending its WatchEndpoints stream, and the
-// agent's reconnect receives a full snapshot — it must never silently miss an
-// event and serve stale endpoints until something else triggers a resync.
+// watcher is one subscribed agent watch stream: its event channel plus the
+// service filter the stream asked for (nil = full watch).
+type watcher struct {
+	ch chan *registrarv1.WatchEndpointsResponse
+	// services is the watch filter; nil means full watch (every service).
+	// A non-nil empty set watches nothing.
+	services map[string]struct{}
+}
+
+// Broadcaster fans out endpoint events to connected agent watch streams.
+// Each watcher is identified by a string key (typically cluster/node) and
+// receives events on a buffered channel. Watchers carrying a service filter
+// are indexed by service, so an endpoint change fans out to that service's
+// consumers only (demand-scoped distribution) instead of every node.
+// A watcher too slow to keep up is forcibly resynced: its channel is closed,
+// ending its WatchEndpoints stream, and the agent's reconnect receives a
+// fresh (filtered) snapshot — it must never silently miss an event and serve
+// stale endpoints until something else triggers a resync.
 type Broadcaster struct {
 	mu       sync.RWMutex
-	watchers map[string]chan *registrarv1.WatchEndpointsResponse
-	log      logr.Logger
-	metrics  *Metrics
+	watchers map[string]*watcher
+	// byService indexes filtered watchers by service name for O(consumers)
+	// fan-out; fullWatchers holds the watchers with no filter.
+	byService    map[string]map[string]*watcher
+	fullWatchers map[string]*watcher
+	log          logr.Logger
+	metrics      *Metrics
 }
 
 // NewBroadcaster creates a Broadcaster. metrics may be nil to disable
 // instrumentation.
 func NewBroadcaster(log logr.Logger, metrics *Metrics) *Broadcaster {
 	return &Broadcaster{
-		watchers: make(map[string]chan *registrarv1.WatchEndpointsResponse),
-		log:      log.WithName("broadcaster"),
-		metrics:  metrics,
+		watchers:     make(map[string]*watcher),
+		byService:    make(map[string]map[string]*watcher),
+		fullWatchers: make(map[string]*watcher),
+		log:          log.WithName("broadcaster"),
+		metrics:      metrics,
 	}
 }
 
-// Subscribe registers a new watcher and returns a channel that will receive
+// Subscribe registers a new watcher scoped to the given services (nil =
+// full watch; empty = watch nothing) and returns a channel that will receive
 // endpoint events. The caller must call Unsubscribe when done.
-func (b *Broadcaster) Subscribe(id string) <-chan *registrarv1.WatchEndpointsResponse {
+func (b *Broadcaster) Subscribe(id string, services []string) <-chan *registrarv1.WatchEndpointsResponse {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	// Close any existing channel for this ID (reconnection scenario).
 	existing, replaced := b.watchers[id]
 	if replaced {
-		close(existing)
+		b.removeFromIndexLocked(id, existing)
+		close(existing.ch)
 	}
 
-	ch := make(chan *registrarv1.WatchEndpointsResponse, defaultChannelBuffer)
-	b.watchers[id] = ch
+	w := &watcher{ch: make(chan *registrarv1.WatchEndpointsResponse, defaultChannelBuffer)}
+	if services != nil {
+		w.services = make(map[string]struct{}, len(services))
+		for _, s := range services {
+			w.services[s] = struct{}{}
+		}
+	}
+	b.watchers[id] = w
+	b.addToIndexLocked(id, w)
 	if !replaced {
 		// A reconnect replaces the channel but keeps the watcher count.
 		b.metrics.watcherSubscribed(context.Background())
 	}
-	b.log.V(1).Info("watcher subscribed", "id", id)
-	return ch
+	b.metrics.filteredWatchers(context.Background(), b.filteredCountLocked())
+	b.log.V(1).Info("watcher subscribed", "id", id, "filtered", w.services != nil, "services", len(services))
+	return w.ch
 }
 
-// Unsubscribe removes a watcher and closes its channel. The channel returned by
-// the matching Subscribe call must be passed so that a stale caller (whose
+// Unsubscribe removes a watcher and closes its channel. The channel returned
+// by the matching Subscribe call must be passed so that a stale caller (whose
 // subscription was already replaced by a reconnect with the same id) does not
 // close or delete the newer subscription's channel.
 func (b *Broadcaster) Unsubscribe(id string, ch <-chan *registrarv1.WatchEndpointsResponse) {
@@ -67,20 +95,63 @@ func (b *Broadcaster) Unsubscribe(id string, ch <-chan *registrarv1.WatchEndpoin
 	defer b.mu.Unlock()
 
 	existing, exists := b.watchers[id]
-	if !exists || (<-chan *registrarv1.WatchEndpointsResponse)(existing) != ch {
+	if !exists || (<-chan *registrarv1.WatchEndpointsResponse)(existing.ch) != ch {
 		return
 	}
 
-	close(existing)
+	b.removeFromIndexLocked(id, existing)
+	close(existing.ch)
 	delete(b.watchers, id)
 	b.metrics.watcherUnsubscribed(context.Background())
+	b.metrics.filteredWatchers(context.Background(), b.filteredCountLocked())
 	b.log.V(1).Info("watcher unsubscribed", "id", id)
 }
 
-// Broadcast sends events to all watchers. Events are sent non-blocking; a
+// addToIndexLocked inserts the watcher into the fan-out index. Caller must
+// hold mu.
+func (b *Broadcaster) addToIndexLocked(id string, w *watcher) {
+	if w.services == nil {
+		b.fullWatchers[id] = w
+		return
+	}
+	for svc := range w.services {
+		m, ok := b.byService[svc]
+		if !ok {
+			m = make(map[string]*watcher)
+			b.byService[svc] = m
+		}
+		m[id] = w
+	}
+}
+
+// removeFromIndexLocked removes the watcher from the fan-out index. Caller
+// must hold mu.
+func (b *Broadcaster) removeFromIndexLocked(id string, w *watcher) {
+	if w.services == nil {
+		delete(b.fullWatchers, id)
+		return
+	}
+	for svc := range w.services {
+		if m, ok := b.byService[svc]; ok {
+			delete(m, id)
+			if len(m) == 0 {
+				delete(b.byService, svc)
+			}
+		}
+	}
+}
+
+// filteredCountLocked returns the number of watchers carrying a service
+// filter. Caller must hold mu.
+func (b *Broadcaster) filteredCountLocked() int {
+	return len(b.watchers) - len(b.fullWatchers)
+}
+
+// Broadcast sends each event to the watchers subscribed to its service (the
+// service's consumers plus full watchers). Events are sent non-blocking; a
 // watcher whose channel is full has already missed an event, so it is forced
 // to resync: its channel is closed, which ends its WatchEndpoints stream, and
-// the agent reconnects to receive a fresh full snapshot. The alternative —
+// the agent reconnects to receive a fresh filtered snapshot. The alternative —
 // silently dropping the event — leaves the agent serving stale endpoints with
 // nothing to correct it until its next reconnect for unrelated reasons.
 func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
@@ -88,24 +159,31 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 	// the write lock, taken afterwards to avoid lock-upgrade deadlocks.
 	type droppedWatcher struct {
 		id string
-		ch chan *registrarv1.WatchEndpointsResponse
+		w  *watcher
 	}
 	var dropped []droppedWatcher
 
+	send := func(id string, w *watcher, event *registrarv1.WatchEndpointsResponse) {
+		select {
+		case w.ch <- event:
+			b.metrics.eventBroadcast(context.Background(), event.GetType().String())
+		default:
+			// This watcher's view has diverged — schedule a force-resync.
+			// The counter is the staleness alarm.
+			b.metrics.eventDropped(context.Background(), event.GetType().String())
+			b.log.Info("event overflowed slow watcher; forcing resync",
+				"id", id, "eventType", event.GetType())
+			dropped = append(dropped, droppedWatcher{id: id, w: w})
+		}
+	}
+
 	b.mu.RLock()
 	for _, event := range events {
-		for id, ch := range b.watchers {
-			select {
-			case ch <- event:
-				b.metrics.eventBroadcast(context.Background(), event.GetType().String())
-			default:
-				// This watcher's view has diverged — schedule a force-resync.
-				// The counter is the staleness alarm.
-				b.metrics.eventDropped(context.Background(), event.GetType().String())
-				b.log.Info("event overflowed slow watcher; forcing resync",
-					"id", id, "eventType", event.GetType())
-				dropped = append(dropped, droppedWatcher{id: id, ch: ch})
-			}
+		for id, w := range b.byService[event.GetServiceName()] {
+			send(id, w, event)
+		}
+		for id, w := range b.fullWatchers {
+			send(id, w, event)
 		}
 	}
 	b.mu.RUnlock()
@@ -120,12 +198,14 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 		// Re-check identity: the watcher may have reconnected (replacing its
 		// channel) or unsubscribed between the locks; later events in this batch
 		// may also have queued the same channel more than once.
-		if current, ok := b.watchers[d.id]; ok && current == d.ch {
-			close(current)
+		if current, ok := b.watchers[d.id]; ok && current == d.w {
+			b.removeFromIndexLocked(d.id, current)
+			close(current.ch)
 			delete(b.watchers, d.id)
 			b.metrics.watcherUnsubscribed(context.Background())
 		}
 	}
+	b.metrics.filteredWatchers(context.Background(), b.filteredCountLocked())
 }
 
 // WatcherCount returns the number of currently subscribed watchers.

--- a/registrar/internal/server/broadcaster_test.go
+++ b/registrar/internal/server/broadcaster_test.go
@@ -44,7 +44,7 @@ func TestBroadcaster_Subscribe(t *testing.T) {
 			b := NewBroadcaster(logr.Discard(), nil)
 
 			for _, id := range tt.ids {
-				ch := b.Subscribe(id)
+				ch := b.Subscribe(id, nil)
 				require.NotNil(t, ch)
 			}
 
@@ -58,12 +58,12 @@ func TestBroadcaster_Subscribe(t *testing.T) {
 func TestBroadcaster_Subscribe_SameID(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
 
-	ch1 := b.Subscribe("node-1")
+	ch1 := b.Subscribe("node-1", nil)
 	require.NotNil(t, ch1)
 	assert.Equal(t, 1, b.WatcherCount())
 
 	// Re-subscribing with the same ID should close the old channel.
-	ch2 := b.Subscribe("node-1")
+	ch2 := b.Subscribe("node-1", nil)
 	require.NotNil(t, ch2)
 
 	// The watcher count must stay at one (replacement, not addition).
@@ -106,7 +106,7 @@ func TestBroadcaster_Unsubscribe(t *testing.T) {
 
 			var targetCh <-chan *registrarv1.WatchEndpointsResponse
 			for _, id := range tt.subscribeIDs {
-				ch := b.Subscribe(id)
+				ch := b.Subscribe(id, nil)
 				if id == tt.unsubscribeID {
 					targetCh = ch
 				}
@@ -128,7 +128,7 @@ func TestBroadcaster_Unsubscribe(t *testing.T) {
 // ID is a no-op and does not panic or alter the watcher count.
 func TestBroadcaster_Unsubscribe_UnknownID(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
-	b.Subscribe("node-1")
+	b.Subscribe("node-1", nil)
 
 	// Must not panic.
 	b.Unsubscribe("does-not-exist", nil)
@@ -154,8 +154,8 @@ func TestBroadcaster_Unsubscribe_EmptyBroadcaster(t *testing.T) {
 func TestBroadcaster_Unsubscribe_StaleChannel(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
 
-	ch1 := b.Subscribe("node-1") // first connection; channel closed by re-Subscribe below
-	ch2 := b.Subscribe("node-1") // reconnect with the same id replaces ch1
+	ch1 := b.Subscribe("node-1", nil) // first connection; channel closed by re-Subscribe below
+	ch2 := b.Subscribe("node-1", nil) // reconnect with the same id replaces ch1
 
 	// The stale caller unsubscribing with its old channel must be a no-op: ch2 is
 	// still the live subscription and must remain registered.
@@ -220,7 +220,7 @@ func TestBroadcaster_Broadcast_DeliveredToAll(t *testing.T) {
 
 			channels := make(map[string]<-chan *registrarv1.WatchEndpointsResponse, len(tt.watcherIDs))
 			for _, id := range tt.watcherIDs {
-				channels[id] = b.Subscribe(id)
+				channels[id] = b.Subscribe(id, nil)
 			}
 
 			b.Broadcast(tt.events)
@@ -256,7 +256,7 @@ func TestBroadcaster_Broadcast_NoWatchers(t *testing.T) {
 // event slice is a no-op and does not panic.
 func TestBroadcaster_Broadcast_EmptyEventList(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
-	b.Subscribe("node-1")
+	b.Subscribe("node-1", nil)
 
 	// Must not panic.
 	b.Broadcast([]*registrarv1.WatchEndpointsResponse{})
@@ -271,7 +271,7 @@ func TestBroadcaster_Broadcast_EmptyEventList(t *testing.T) {
 // full snapshot instead of silently missing the event.
 func TestBroadcaster_Broadcast_ForcesResyncOnSlowConsumer(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
-	ch := b.Subscribe("slow-node")
+	ch := b.Subscribe("slow-node", nil)
 
 	// Fill the watcher's channel to capacity by broadcasting one event at a time.
 	// No goroutine drains the channel so after defaultChannelBuffer calls it is full.
@@ -312,7 +312,7 @@ func TestBroadcaster_Broadcast_ForcesResyncOnSlowConsumer(t *testing.T) {
 // and receives events normally.
 func TestBroadcaster_Broadcast_ResyncedWatcherCanResubscribe(t *testing.T) {
 	b := NewBroadcaster(logr.Discard(), nil)
-	b.Subscribe("slow-node")
+	b.Subscribe("slow-node", nil)
 
 	event := &registrarv1.WatchEndpointsResponse{
 		Type: registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
@@ -322,7 +322,7 @@ func TestBroadcaster_Broadcast_ResyncedWatcherCanResubscribe(t *testing.T) {
 	}
 	require.Equal(t, 0, b.WatcherCount(), "watcher must be force-resynced")
 
-	ch2 := b.Subscribe("slow-node")
+	ch2 := b.Subscribe("slow-node", nil)
 	b.Broadcast([]*registrarv1.WatchEndpointsResponse{event})
 	require.Equal(t, 1, b.WatcherCount())
 	select {
@@ -350,16 +350,16 @@ func TestBroadcaster_WatcherCount(t *testing.T) {
 		{
 			name: "count reflects subscriptions",
 			actions: func(b *Broadcaster) {
-				b.Subscribe("node-1")
-				b.Subscribe("node-2")
+				b.Subscribe("node-1", nil)
+				b.Subscribe("node-2", nil)
 			},
 			wantCount: 2,
 		},
 		{
 			name: "count reflects unsubscriptions",
 			actions: func(b *Broadcaster) {
-				ch1 := b.Subscribe("node-1")
-				b.Subscribe("node-2")
+				ch1 := b.Subscribe("node-1", nil)
+				b.Subscribe("node-2", nil)
 				b.Unsubscribe("node-1", ch1)
 			},
 			wantCount: 1,
@@ -367,15 +367,15 @@ func TestBroadcaster_WatcherCount(t *testing.T) {
 		{
 			name: "re-subscribing same ID does not increase count",
 			actions: func(b *Broadcaster) {
-				b.Subscribe("node-1")
-				b.Subscribe("node-1")
+				b.Subscribe("node-1", nil)
+				b.Subscribe("node-1", nil)
 			},
 			wantCount: 1,
 		},
 		{
 			name: "unsubscribe of unknown ID does not decrement count",
 			actions: func(b *Broadcaster) {
-				b.Subscribe("node-1")
+				b.Subscribe("node-1", nil)
 				b.Unsubscribe("node-99", nil)
 			},
 			wantCount: 1,
@@ -383,8 +383,8 @@ func TestBroadcaster_WatcherCount(t *testing.T) {
 		{
 			name: "subscribe then unsubscribe all returns to zero",
 			actions: func(b *Broadcaster) {
-				ch1 := b.Subscribe("node-1")
-				ch2 := b.Subscribe("node-2")
+				ch1 := b.Subscribe("node-1", nil)
+				ch2 := b.Subscribe("node-2", nil)
 				b.Unsubscribe("node-1", ch1)
 				b.Unsubscribe("node-2", ch2)
 			},
@@ -399,4 +399,81 @@ func TestBroadcaster_WatcherCount(t *testing.T) {
 			assert.Equal(t, tt.wantCount, b.WatcherCount())
 		})
 	}
+}
+
+// TestBroadcaster_FilteredFanout verifies demand-scoped fan-out: an endpoint
+// event reaches the service's consumers and full watchers only — never
+// watchers filtered to other services or to nothing.
+func TestBroadcaster_FilteredFanout(t *testing.T) {
+	b := NewBroadcaster(logr.Discard(), nil)
+
+	chA := b.Subscribe("consumer-a", []string{"svc-a"})
+	chB := b.Subscribe("consumer-b", []string{"svc-b"})
+	chFull := b.Subscribe("full-watcher", nil)
+	chNone := b.Subscribe("empty-node", []string{})
+
+	b.Broadcast([]*registrarv1.WatchEndpointsResponse{{
+		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+		ServiceName: "svc-a",
+	}})
+
+	select {
+	case e := <-chA:
+		assert.Equal(t, "svc-a", e.GetServiceName())
+	default:
+		t.Fatal("svc-a consumer must receive the svc-a event")
+	}
+	select {
+	case e := <-chFull:
+		assert.Equal(t, "svc-a", e.GetServiceName())
+	default:
+		t.Fatal("full watcher must receive every event")
+	}
+	select {
+	case <-chB:
+		t.Fatal("svc-b consumer must not receive svc-a events")
+	default:
+	}
+	select {
+	case <-chNone:
+		t.Fatal("empty-filter watcher must receive nothing")
+	default:
+	}
+}
+
+// TestBroadcaster_ResubscribeReplacesFilter verifies a reconnect with a new
+// filter fully replaces the old index entries (no events from the old scope).
+func TestBroadcaster_ResubscribeReplacesFilter(t *testing.T) {
+	b := NewBroadcaster(logr.Discard(), nil)
+
+	chOld := b.Subscribe("node-1", []string{"svc-a"})
+	chNew := b.Subscribe("node-1", []string{"svc-b"}) // reconnect, new scope
+
+	// Old channel is closed by the replacement.
+	_, open := <-chOld
+	assert.False(t, open, "replaced subscription's channel must be closed")
+
+	b.Broadcast([]*registrarv1.WatchEndpointsResponse{
+		{Type: registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, ServiceName: "svc-a"},
+		{Type: registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, ServiceName: "svc-b"},
+	})
+
+	select {
+	case e := <-chNew:
+		assert.Equal(t, "svc-b", e.GetServiceName(), "only the new scope's events may arrive")
+	default:
+		t.Fatal("new subscription must receive svc-b")
+	}
+	select {
+	case e := <-chNew:
+		t.Fatalf("unexpected extra event for %s", e.GetServiceName())
+	default:
+	}
+
+	// Unsubscribe cleans the index: broadcasting afterwards reaches nobody.
+	b.Unsubscribe("node-1", chNew)
+	assert.Zero(t, b.WatcherCount())
+	b.Broadcast([]*registrarv1.WatchEndpointsResponse{
+		{Type: registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, ServiceName: "svc-b"},
+	})
 }

--- a/registrar/internal/server/metrics.go
+++ b/registrar/internal/server/metrics.go
@@ -28,6 +28,7 @@ type Metrics struct {
 	syncDuration    metric.Float64Histogram
 	syncErrors      metric.Int64Counter
 	syncEvents      metric.Int64Counter
+	filteredSubs    metric.Int64Gauge
 	snapshotVersion metric.Int64Gauge
 	wbQueueDepth    metric.Int64Gauge
 	wbFlushFailures metric.Int64Counter
@@ -65,6 +66,10 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		metric.WithDescription("Endpoint change events detected by the sync loop, by event type")); err != nil {
 		return nil, fmt.Errorf("sync events: %w", err)
 	}
+	if m.filteredSubs, err = meter.Int64Gauge("aether.registrar.watch.filtered_subscribers",
+		metric.WithDescription("Watch streams carrying a service filter (demand-scoped agents)")); err != nil {
+		return nil, fmt.Errorf("filtered subscribers: %w", err)
+	}
 	if m.snapshotVersion, err = meter.Int64Gauge("aether.registrar.snapshot.version",
 		metric.WithDescription("Current endpoint snapshot version (compare with aether.agent.registry.last_version for skew)")); err != nil {
 		return nil, fmt.Errorf("snapshot version: %w", err)
@@ -101,6 +106,13 @@ func (m *Metrics) watcherUnsubscribed(ctx context.Context) {
 		return
 	}
 	m.watchers.Add(ctx, -1)
+}
+
+func (m *Metrics) filteredWatchers(ctx context.Context, n int) {
+	if m == nil {
+		return
+	}
+	m.filteredSubs.Record(ctx, int64(n))
 }
 
 func (m *Metrics) eventBroadcast(ctx context.Context, eventType string) {

--- a/registrar/internal/server/metrics_test.go
+++ b/registrar/internal/server/metrics_test.go
@@ -91,7 +91,7 @@ func TestBroadcaster_DropIncrementsCounter(t *testing.T) {
 	m, reader := newTestMetrics(t)
 	b := NewBroadcaster(logr.Discard(), m)
 
-	ch := b.Subscribe("slow-watcher")
+	ch := b.Subscribe("slow-watcher", nil)
 	_ = ch // never drained: fills to capacity, then drops
 
 	// Fill the buffer, then overflow by 3.
@@ -117,14 +117,14 @@ func TestBroadcaster_WatcherCountMetric(t *testing.T) {
 	m, reader := newTestMetrics(t)
 	b := NewBroadcaster(logr.Discard(), m)
 
-	ch1 := b.Subscribe("a")
-	b.Subscribe("b")
+	ch1 := b.Subscribe("a", nil)
+	b.Subscribe("b", nil)
 	if got := collectSum(t, reader, "aether.registrar.watchers"); got != 2 {
 		t.Errorf("watchers after subscribes = %d, want 2", got)
 	}
 
 	// Reconnect with the same ID: count must not grow.
-	b.Subscribe("a")
+	b.Subscribe("a", nil)
 	if got := collectSum(t, reader, "aether.registrar.watchers"); got != 2 {
 		t.Errorf("watchers after reconnect = %d, want 2", got)
 	}

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -174,20 +174,44 @@ func (s *RegistrarServer) UnregisterEndpoint(ctx context.Context, req *registrar
 
 // WatchEndpoints streams endpoint events to the agent. It first sends a full
 // snapshot (unless the client's last_version matches the current version), then
-// forwards incremental events from the broadcaster.
+// forwards incremental events from the broadcaster. A request filter scopes
+// both the snapshot and the incremental events to the named services
+// (demand-scoped distribution): the agent re-asserts its filter on every
+// reconnect, and an unset filter preserves the full watch.
 func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest, stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse]) error {
 	watcherID := fmt.Sprintf("%s/%s", req.GetClusterName(), req.GetNodeName())
-	s.log.V(1).Info("WatchEndpoints", "watcher", watcherID, "lastVersion", req.GetLastVersion())
+
+	// nil = full watch; non-nil (possibly empty) = scoped to these services.
+	var filterServices []string
+	var filterSet map[string]struct{}
+	if f := req.GetFilter(); f != nil {
+		filterServices = f.GetServices()
+		if filterServices == nil {
+			filterServices = []string{}
+		}
+		filterSet = make(map[string]struct{}, len(filterServices))
+		for _, svc := range filterServices {
+			filterSet[svc] = struct{}{}
+		}
+	}
+	s.log.V(1).Info("WatchEndpoints", "watcher", watcherID, "lastVersion", req.GetLastVersion(),
+		"filtered", filterSet != nil, "filterServices", len(filterServices))
 
 	// Never serve a snapshot before the first sync has populated it.
 	if err := s.awaitSynced(stream.Context()); err != nil {
 		return err
 	}
 
-	// Send current snapshot unless the client is already up-to-date.
+	// Send current snapshot (scoped to the filter) unless the client is
+	// already up-to-date.
 	events, currentVersion := s.snapshot.FullSnapshotEvents()
 	if req.GetLastVersion() != currentVersion {
 		for _, event := range events {
+			if filterSet != nil {
+				if _, inScope := filterSet[event.GetServiceName()]; !inScope {
+					continue
+				}
+			}
 			if err := stream.Send(event); err != nil {
 				return fmt.Errorf("failed to send snapshot event: %w", err)
 			}
@@ -202,8 +226,8 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 		return fmt.Errorf("failed to send snapshot-complete event: %w", err)
 	}
 
-	// Subscribe and stream incremental events.
-	ch := s.broadcaster.Subscribe(watcherID)
+	// Subscribe and stream incremental events (fan-out indexed by service).
+	ch := s.broadcaster.Subscribe(watcherID, filterServices)
 	defer s.broadcaster.Unsubscribe(watcherID, ch)
 
 	for {

--- a/registrar/internal/server/server_test.go
+++ b/registrar/internal/server/server_test.go
@@ -129,3 +129,63 @@ func TestRegisterEndpointSnapshotFirst(t *testing.T) {
 	require.Contains(t, eps, "svc-new", "endpoint must be in the snapshot immediately")
 	assert.True(t, q.Shielding("svc-new", "10.0.0.9"), "external write must be queued")
 }
+
+// TestWatchEndpointsFilteredSnapshot verifies a watch carrying a service
+// filter receives only the filtered services' snapshot events (plus the
+// SNAPSHOT_COMPLETE marker), and that an explicitly empty filter receives the
+// marker alone.
+func TestWatchEndpointsFilteredSnapshot(t *testing.T) {
+	snap := NewSnapshot()
+	snap.Apply([]*registrarv1.WatchEndpointsResponse{
+		{
+			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+			ServiceName: "svc-a",
+			Protocol:    registryv1.Service_PROTOCOL_HTTP,
+			Endpoint:    &registryv1.ServiceEndpoint{Ip: "10.0.0.1"},
+		},
+		{
+			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+			ServiceName: "svc-b",
+			Protocol:    registryv1.Service_PROTOCOL_HTTP,
+			Endpoint:    &registryv1.ServiceEndpoint{Ip: "10.0.0.2"},
+		},
+	})
+	s := NewRegistrarServer(nil, snap, NewBroadcaster(logr.Discard(), nil), "127.0.0.1:0", logr.Discard(), nil)
+
+	run := func(req *registrarv1.WatchEndpointsRequest) []*registrarv1.WatchEndpointsResponse {
+		ctx, cancel := context.WithCancel(context.Background())
+		stream := &fakeWatchServerStream{ctx: ctx}
+		done := make(chan error, 1)
+		go func() { done <- s.WatchEndpoints(req, stream) }()
+		require.Eventually(t, func() bool {
+			for _, e := range stream.sent {
+				if e.GetType() == registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second, 10*time.Millisecond, "snapshot-complete marker never sent")
+		cancel()
+		<-done
+		return stream.sent
+	}
+
+	// Scoped to svc-a: exactly one FULL_SNAPSHOT (svc-a) + the marker.
+	sent := run(&registrarv1.WatchEndpointsRequest{
+		Filter: &registrarv1.ServiceFilter{Services: []string{"svc-a"}},
+	})
+	require.Len(t, sent, 2)
+	assert.Equal(t, "svc-a", sent[0].GetServiceName())
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, sent[1].GetType())
+
+	// Explicitly empty filter: marker only (a node with no mesh pods).
+	sent = run(&registrarv1.WatchEndpointsRequest{
+		Filter: &registrarv1.ServiceFilter{},
+	})
+	require.Len(t, sent, 1)
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, sent[0].GetType())
+
+	// No filter: full snapshot (both services) + marker.
+	sent = run(&registrarv1.WatchEndpointsRequest{})
+	require.Len(t, sent, 3)
+}

--- a/registrar/internal/server/sync_test.go
+++ b/registrar/internal/server/sync_test.go
@@ -144,7 +144,7 @@ func TestSyncer_Start_BroadcastsChangesOnSubsequentSync(t *testing.T) {
 	syncer, _, bc := newTestSyncer(reg, 60*time.Millisecond)
 
 	// Subscribe before starting so we catch broadcast events.
-	eventCh := bc.Subscribe("test-watcher")
+	eventCh := bc.Subscribe("test-watcher", nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
@@ -350,7 +350,7 @@ func TestSyncer_Start_NoEventsAfterInitialSync(t *testing.T) {
 
 	// Let initial sync complete, then subscribe to capture only subsequent events.
 	time.Sleep(50 * time.Millisecond)
-	eventCh := bc.Subscribe("no-change-watcher")
+	eventCh := bc.Subscribe("no-change-watcher", nil)
 
 	// Let at least two more syncs fire.
 	time.Sleep(200 * time.Millisecond)

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"math/rand/v2"
+	"slices"
 	"sync"
 	"time"
 
@@ -80,6 +81,19 @@ type RegistrarRegistry struct {
 	ready     chan struct{}
 	readyOnce sync.Once
 
+	// filterMu guards the watch service filter. filterServices nil = full
+	// watch; non-nil = scope the watch to these services (demand-scoped
+	// distribution). filterGen increments on every filter change; the watch
+	// loop compares it against the generation its stream was opened with and
+	// clears the resume token when they differ, forcing a full (re-filtered)
+	// snapshot — resuming by version would skip the newly in-scope services.
+	filterMu       sync.Mutex
+	filterServices []string
+	filterGen      uint64
+	// streamCancel ends the in-flight watch stream so the loop reconnects
+	// with the current filter.
+	streamCancel context.CancelFunc
+
 	cancel context.CancelFunc
 }
 
@@ -138,6 +152,59 @@ func (r *RegistrarRegistry) WaitReady(ctx context.Context) error {
 	case <-ctx.Done():
 		return ctx.Err()
 	}
+}
+
+// SetServiceFilter scopes the endpoint watch to the given services (the
+// node's dependency set). nil restores the full watch; an empty non-nil set
+// watches nothing. If the effective filter changed while a stream is active,
+// the stream is cancelled so the loop reconnects re-asserting the new filter
+// with a cleared resume token (the registrar must resend the snapshot — the
+// new scope may include services the old stream never delivered). It
+// satisfies the registry.WatchScoper capability.
+func (r *RegistrarRegistry) SetServiceFilter(services []string) {
+	r.filterMu.Lock()
+	if stringSetsEqual(r.filterServices, services) {
+		r.filterMu.Unlock()
+		return
+	}
+	r.filterServices = slices.Clone(services)
+	r.filterGen++
+	cancelStream := r.streamCancel
+	r.filterMu.Unlock()
+
+	r.log.V(1).Info("watch service filter updated; re-asserting on stream", "services", len(services))
+	if cancelStream != nil {
+		cancelStream()
+	}
+}
+
+// currentFilter returns the filter to assert on the next stream and its
+// generation.
+func (r *RegistrarRegistry) currentFilter() ([]string, uint64) {
+	r.filterMu.Lock()
+	defer r.filterMu.Unlock()
+	return slices.Clone(r.filterServices), r.filterGen
+}
+
+// stringSetsEqual reports whether a and b contain the same members,
+// treating nil and non-nil differently (nil = full watch).
+func stringSetsEqual(a, b []string) bool {
+	if (a == nil) != (b == nil) {
+		return false
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := set[s]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // signalChange performs a non-blocking send on the notify channel, coalescing
@@ -288,10 +355,15 @@ func (r *RegistrarRegistry) listAllEndpointsFromServer(ctx context.Context, prot
 }
 
 // watchLoop maintains a persistent WatchEndpoints stream, reconnecting with
-// exponential backoff on disconnect.
+// exponential backoff on disconnect. Every (re)connect asserts the current
+// service filter; when the filter changed since the stream the resume token
+// was earned on, the token is cleared so the registrar resends the full
+// (re-filtered) snapshot — newly in-scope services were never delivered to
+// the old stream, so resuming by version would silently skip them.
 func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 	backoff := initialBackoff
 	lastVersion := ""
+	lastFilterGen := uint64(0)
 
 	for {
 		select {
@@ -300,12 +372,30 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 		default:
 		}
 
-		stream, err := r.client.WatchEndpoints(ctx, &registrarv1.WatchEndpointsRequest{
+		services, filterGen := r.currentFilter()
+		if filterGen != lastFilterGen {
+			lastVersion = ""
+			lastFilterGen = filterGen
+		}
+		req := &registrarv1.WatchEndpointsRequest{
 			ClusterName: r.config.ClusterName,
 			NodeName:    r.config.NodeName,
 			LastVersion: lastVersion,
-		})
+		}
+		if services != nil {
+			req.Filter = &registrarv1.ServiceFilter{Services: services}
+		}
+
+		// Per-stream context so SetServiceFilter can end the stream and force
+		// a reconnect that re-asserts the new filter.
+		streamCtx, streamCancel := context.WithCancel(ctx)
+		r.filterMu.Lock()
+		r.streamCancel = streamCancel
+		r.filterMu.Unlock()
+
+		stream, err := r.client.WatchEndpoints(streamCtx, req)
 		if err != nil {
+			streamCancel()
 			r.metrics.streamFailed(ctx)
 			jitter := time.Duration(float64(backoff) * jitterFraction * rand.Float64())
 			wait := backoff + jitter
@@ -322,10 +412,11 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 		// Reset backoff on successful connection.
 		backoff = initialBackoff
 		r.metrics.streamReconnected(ctx)
-		r.log.V(1).Info("watch stream connected")
+		r.log.V(1).Info("watch stream connected", "filtered", services != nil, "filterServices", len(services))
 		r.signalReconnect()
 
 		lastVersion = r.processStream(ctx, stream, lastVersion)
+		streamCancel()
 	}
 }
 
@@ -345,6 +436,12 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 			if status.Code(err) == codes.DataLoss {
 				r.log.Info("registrar forced a resync; requesting full snapshot on reconnect")
 				return ""
+			}
+			if status.Code(err) == codes.Canceled && ctx.Err() == nil {
+				// The stream was cancelled locally (SetServiceFilter
+				// re-asserting a changed filter), not a registrar failure.
+				r.log.V(1).Info("watch stream ended for filter re-assertion")
+				return lastVersion
 			}
 			if err != io.EOF && ctx.Err() == nil {
 				r.log.Error(err, "watch stream disconnected")

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -563,3 +563,36 @@ func TestReconnectSignal(t *testing.T) {
 		t.Fatal("reconnect signal expected")
 	}
 }
+
+// TestSetServiceFilter_ReassertsOnChangeOnly verifies the filter setter
+// cancels the active stream only when the effective set changes (order
+// -insensitive), and that the generation bump clears the resume token path.
+func TestSetServiceFilter_ReassertsOnChangeOnly(t *testing.T) {
+	r := NewRegistrarRegistry(logr.Discard(), Config{Address: "test"})
+
+	cancels := 0
+	r.filterMu.Lock()
+	r.streamCancel = func() { cancels++ }
+	r.filterMu.Unlock()
+
+	r.SetServiceFilter([]string{"svc-a", "svc-b"})
+	assert.Equal(t, 1, cancels, "first filter must cancel the stream")
+
+	// Same set, different order: no re-assert.
+	r.SetServiceFilter([]string{"svc-b", "svc-a"})
+	assert.Equal(t, 1, cancels, "unchanged filter must not cancel")
+
+	// Shrink: re-assert.
+	r.SetServiceFilter([]string{"svc-a"})
+	assert.Equal(t, 2, cancels)
+
+	// Empty non-nil (watch nothing) differs from nil (full watch).
+	r.SetServiceFilter([]string{})
+	assert.Equal(t, 3, cancels)
+	r.SetServiceFilter(nil)
+	assert.Equal(t, 4, cancels)
+
+	services, gen := r.currentFilter()
+	assert.Nil(t, services)
+	assert.Equal(t, uint64(4), gen)
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -61,6 +61,16 @@ type ReconnectNotifier interface {
 	Reconnects() <-chan struct{}
 }
 
+// WatchScoper is an optional capability for Registry implementations backed
+// by a watch stream. SetServiceFilter scopes the watch to the given services
+// (the node's dependency set -- demand-scoped distribution): the registrar
+// then fans out an endpoint change only to that service's consumers. nil
+// restores the full watch; an empty non-nil set watches nothing. The
+// implementation re-asserts the filter on every reconnect.
+type WatchScoper interface {
+	SetServiceFilter(services []string)
+}
+
 // AuthoritativeLister is an optional capability for Registry implementations
 // whose ListAllEndpoints may serve from a local watch-fed cache. It lists from
 // the authoritative source (an RPC to the registrar, the external registry),


### PR DESCRIPTION
Phase 2 of proposal 004 (stacked on #158).

- `WatchEndpointsRequest.filter` (`ServiceFilter`): scoped snapshot + incremental events. Unset = full watch (compat); explicitly empty = watch nothing.
- Broadcaster indexes subscribers by service → fan-out per endpoint change is O(consumers), not O(nodes). Slow-watcher force-resync preserved (index-aware).
- Agent (`RegistrarRegistry.SetServiceFilter`, `registry.WatchScoper`): filter asserted from the node dependency set at PreListen and on every dep-set change; a change cancels the stream and reconnects with the resume token cleared (a version resume would skip newly in-scope services). Re-asserted on every reconnect, same as registrations (#149).
- Gauge: `aether.registrar.watch.filtered_subscribers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)