### PR TITLE
feat(agent): ODCDS cold path for undeclared upstreams (004 Phase 3)

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -67,10 +67,17 @@ type SnapshotCache struct {
 	// silently dropping the newer mutation until the next snapshot trigger.
 	snapshotMu sync.Mutex
 
-	// depMu guards podDeps. The node dependency set derived from it scopes
-	// which registry services the snapshot carries (proposal 004).
+	// depMu guards podDeps and observedDeps. The node dependency set derived
+	// from them scopes which registry services the snapshot carries
+	// (proposal 004).
 	depMu   sync.RWMutex
 	podDeps map[string]podDependencies // keyed by container network namespace
+	// observedDeps holds services added by the ODCDS cold path, keyed by
+	// service name with the last observation time; entries idle past
+	// observedTTL are pruned.
+	observedDeps map[string]time.Time
+	// observedTTL overrides defaultObservedTTL when > 0 (test hook).
+	observedTTL time.Duration
 	// depChanged receives a (coalesced) signal when the dependency set
 	// changes; the registry refresher rebuilds the scoped snapshot on it.
 	depChanged chan struct{}
@@ -150,6 +157,7 @@ func NewSnapshotCache(nodeName string, log logr.Logger) *SnapshotCache {
 		secrets:        make(map[string]*tlsv3.Secret),
 		localWorkloads: make(map[string]string),
 		podDeps:        make(map[string]podDependencies),
+		observedDeps:   make(map[string]time.Time),
 		depChanged:     make(chan struct{}, 1),
 		version:        atomic.NewUint64(0),
 	}

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -1,9 +1,19 @@
 package cache
 
 import (
+	"context"
+	"time"
+
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 )
+
+// defaultObservedTTL is how long an observed (ODCDS-requested) dependency
+// stays in the node dependency set without being re-requested. One-off calls
+// therefore don't pin clusters forever; a continuously used undeclared
+// upstream re-warms with one xDS round-trip after expiry — and shows up in
+// the miss metric, the signal to promote it to a declared annotation.
+const defaultObservedTTL = time.Hour
 
 // podDependencies is one local pod's contribution to the node dependency set:
 // the services the pod declares it consumes plus the pod's own service (a
@@ -51,10 +61,70 @@ func (c *SnapshotCache) removePodDependencies(netns string) {
 	}
 }
 
+// ObserveDependency records an on-demand (ODCDS) request for a service that
+// is not in the node dependency set: the observed cold path. The service
+// joins the set with a TTL'd membership (refreshed on re-request) and a
+// change signal triggers the scoped reload that delivers the cluster,
+// resuming the paused request. A request for an already-known service only
+// refreshes its observation timestamp. Returns true when the dependency is
+// new (a miss).
+func (c *SnapshotCache) ObserveDependency(ctx context.Context, service string) bool {
+	if service == "" {
+		return false
+	}
+
+	c.depMu.Lock()
+	_, known := c.dependencySetLocked()[service]
+	c.observedDeps[service] = time.Now()
+	c.depMu.Unlock()
+
+	if known {
+		return false
+	}
+
+	c.log.Info("observed undeclared upstream (ODCDS miss); adding to node dependency set",
+		"service", service, "ttl", c.observedTTLValue().String())
+	c.metrics.upstreamMiss(ctx, service)
+	c.signalDependencyChange()
+	return true
+}
+
+// PruneObservedDependencies drops observed dependencies idle past the TTL and
+// signals a dependency change when any were dropped. The refresher calls it
+// periodically; the subsequent scoped reload removes the expired clusters
+// (after the retention grace), and Envoy re-fetches via ODCDS on next use.
+func (c *SnapshotCache) PruneObservedDependencies() {
+	now := time.Now()
+	ttl := c.observedTTLValue()
+
+	c.depMu.Lock()
+	expired := 0
+	for svc, last := range c.observedDeps {
+		if now.Sub(last) > ttl {
+			delete(c.observedDeps, svc)
+			expired++
+		}
+	}
+	c.depMu.Unlock()
+
+	if expired > 0 {
+		c.log.Info("expired observed upstreams from node dependency set", "count", expired)
+		c.signalDependencyChange()
+	}
+}
+
+// observedTTLValue returns the configured observed-dependency TTL (test hook).
+func (c *SnapshotCache) observedTTLValue() time.Duration {
+	if c.observedTTL > 0 {
+		return c.observedTTL
+	}
+	return defaultObservedTTL
+}
+
 // DependencySet returns the node dependency set: the union of all local pods'
-// declared upstreams and their own services. LoadClustersFromRegistry scopes
-// the cluster/endpoint/route snapshot to this set (demand-scoped
-// distribution, proposal 004).
+// declared upstreams, their own services, and live (non-expired) observed
+// dependencies. LoadClustersFromRegistry scopes the cluster/endpoint/route
+// snapshot to this set (demand-scoped distribution, proposal 004).
 func (c *SnapshotCache) DependencySet() map[string]struct{} {
 	c.depMu.RLock()
 	defer c.depMu.RUnlock()
@@ -63,7 +133,7 @@ func (c *SnapshotCache) DependencySet() map[string]struct{} {
 
 // dependencySetLocked builds the dependency set. Caller must hold depMu.
 func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
-	set := make(map[string]struct{}, len(c.podDeps)*4)
+	set := make(map[string]struct{}, len(c.podDeps)*4+len(c.observedDeps))
 	for _, deps := range c.podDeps {
 		if deps.service != "" {
 			set[deps.service] = struct{}{}
@@ -72,7 +142,28 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 			set[u] = struct{}{}
 		}
 	}
+	now := time.Now()
+	ttl := c.observedTTLValue()
+	for svc, last := range c.observedDeps {
+		if now.Sub(last) <= ttl {
+			set[svc] = struct{}{}
+		}
+	}
 	return set
+}
+
+// observedCountLocked returns the number of live observed dependencies.
+// Caller must hold depMu.
+func (c *SnapshotCache) observedCountLocked() int {
+	now := time.Now()
+	ttl := c.observedTTLValue()
+	n := 0
+	for _, last := range c.observedDeps {
+		if now.Sub(last) <= ttl {
+			n++
+		}
+	}
+	return n
 }
 
 // declaredCountLocked returns the number of distinct declared upstream

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"testing"
+	"time"
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
@@ -136,4 +137,54 @@ func TestLoadClustersFromRegistry_EmptyDependencySet(t *testing.T) {
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(context.Background(), "cluster-1", "node-1", reg))
 	assert.Empty(t, c.clusters)
+}
+
+// TestObserveDependency_ColdPath verifies the ODCDS cold path: observing an
+// out-of-scope service adds it to the dependency set (returning true exactly
+// once), signals a dependency change, and a scoped reload then distributes
+// the service; expiry via PruneObservedDependencies removes it again.
+func TestObserveDependency_ColdPath(t *testing.T) {
+	c := newTestCache("node-1")
+	c.observedTTL = 50 * time.Millisecond
+	c.serviceRetentionGrace = time.Nanosecond // prune immediately on reload
+	ctx := context.Background()
+
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return map[string][]*registryv1.ServiceEndpoint{
+				"svc-cold": {makeEndpoint("10.0.0.5", "cluster-1", "node-2", 8080)},
+			}, nil
+		},
+	}
+
+	// Not distributed: not in the dependency set.
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	require.NotContains(t, c.clusters, "svc-cold")
+	drainDepSignal(c)
+
+	// First observation: a miss — added + signaled.
+	assert.True(t, c.ObserveDependency(ctx, "svc-cold"), "first observation is a miss")
+	assert.True(t, drainDepSignal(c), "observation must signal a dependency change")
+	assert.Contains(t, c.DependencySet(), "svc-cold")
+
+	// Re-observation refreshes the TTL without a second miss.
+	assert.False(t, c.ObserveDependency(ctx, "svc-cold"), "known dependency is not a miss")
+
+	// The scoped reload now distributes the cluster.
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	assert.Contains(t, c.clusters, "svc-cold")
+
+	// Idle past the TTL: pruned from the set and signaled.
+	time.Sleep(60 * time.Millisecond)
+	drainDepSignal(c)
+	c.PruneObservedDependencies()
+	assert.True(t, drainDepSignal(c), "expiry must signal a dependency change")
+	assert.NotContains(t, c.DependencySet(), "svc-cold")
+}
+
+// TestObserveDependency_EmptyName verifies empty names are rejected.
+func TestObserveDependency_EmptyName(t *testing.T) {
+	c := newTestCache("node-1")
+	assert.False(t, c.ObserveDependency(context.Background(), ""))
+	assert.False(t, drainDepSignal(c))
 }

--- a/agent/internal/xds/cache/metrics.go
+++ b/agent/internal/xds/cache/metrics.go
@@ -28,6 +28,12 @@ type cacheMetrics struct {
 	// upstreamsDeclared is the size of the node's declared dependency union
 	// (config.aether.io/upstreams across local pods).
 	upstreamsDeclared metric.Int64Gauge
+	// upstreamsObserved is the number of live ODCDS-observed dependencies.
+	upstreamsObserved metric.Int64Gauge
+	// upstreamsMiss counts ODCDS requests for services outside the node
+	// dependency set — each is an undeclared upstream that should be
+	// promoted to a config.aether.io/upstreams annotation.
+	upstreamsMiss metric.Int64Counter
 }
 
 // newCacheMetrics registers the snapshot instruments on the given meter.
@@ -60,17 +66,35 @@ func newCacheMetrics(meter metric.Meter) (*cacheMetrics, error) {
 		metric.WithDescription("Distinct upstream services declared by local pods (config.aether.io/upstreams union)")); err != nil {
 		return nil, fmt.Errorf("upstreams declared: %w", err)
 	}
+	if m.upstreamsObserved, err = meter.Int64Gauge("aether.agent.upstreams.observed",
+		metric.WithDescription("Live ODCDS-observed dependencies in the node dependency set")); err != nil {
+		return nil, fmt.Errorf("upstreams observed: %w", err)
+	}
+	if m.upstreamsMiss, err = meter.Int64Counter("aether.agent.upstreams.miss",
+		metric.WithDescription("ODCDS requests for services outside the node dependency set (undeclared upstreams; promote to annotations)")); err != nil {
+		return nil, fmt.Errorf("upstreams miss: %w", err)
+	}
 
 	return m, nil
 }
 
 // snapshotShape records per-snapshot size gauges.
-func (m *cacheMetrics) snapshotShape(ctx context.Context, clusters, declared int) {
+func (m *cacheMetrics) snapshotShape(ctx context.Context, clusters, declared, observed int) {
 	if m == nil {
 		return
 	}
 	m.clusters.Record(ctx, int64(clusters))
 	m.upstreamsDeclared.Record(ctx, int64(declared))
+	m.upstreamsObserved.Record(ctx, int64(observed))
+}
+
+// upstreamMiss counts one ODCDS miss. The service name is deliberately NOT a
+// metric attribute (unbounded cardinality); it is logged instead.
+func (m *cacheMetrics) upstreamMiss(ctx context.Context, _ string) {
+	if m == nil {
+		return
+	}
+	m.upstreamsMiss.Add(ctx, 1)
 }
 
 // generated records the outcome of one snapshot generation.

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -87,8 +87,9 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 
 	c.depMu.RLock()
 	declared := c.declaredCountLocked()
+	observed := c.observedCountLocked()
 	c.depMu.RUnlock()
-	c.metrics.snapshotShape(ctx, len(clusters), declared)
+	c.metrics.snapshotShape(ctx, len(clusters), declared, observed)
 
 	snapshot, err := cachev3.NewSnapshot(v, resources)
 	if err != nil {

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/on_demand/v3:on_demand",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/router/v3:router",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/listener/tls_inspector/v3:tls_inspector",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -7,6 +7,7 @@ package proxy
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
@@ -124,6 +125,13 @@ func NewAppCluster(name, netns string, port uint16) *clusterv3.Cluster {
 		// per-cluster (verified: no ClusterMinHealthyPercentages references).
 		AltStatName: "app",
 	}
+}
+
+// IsPerPodClusterName reports whether the cluster name belongs to a per-pod
+// cluster (app_<pod> delivery or health_<pod> probe), as opposed to a
+// registry-derived service cluster.
+func IsPerPodClusterName(name string) bool {
+	return strings.HasPrefix(name, appClusterPrefix) || strings.HasPrefix(name, healthProbeClusterPrefix)
 }
 
 // HealthProbeClusterName returns the name of the per-pod health-probe cluster.

--- a/agent/internal/xds/proxy/filterchain.go
+++ b/agent/internal/xds/proxy/filterchain.go
@@ -18,7 +18,10 @@ func buildDefaultOutboundHTTPFilterChain(name string) *listenerv3.FilterChain {
 
 	// Readiness probe target: answered on worker threads ahead of the router, so
 	// the CNI plugin's in-netns probe never depends on routes or upstreams.
-	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
+	// The on_demand filter (before the router) pauses requests routed to a
+	// cluster the scoped snapshot does not carry while ODCDS fetches it from
+	// the agent (proposal 004 cold path).
+	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter(), onDemandHttpFilter()}, hcm.HttpFilters...)
 
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{

--- a/agent/internal/xds/proxy/filterchain_test.go
+++ b/agent/internal/xds/proxy/filterchain_test.go
@@ -52,9 +52,10 @@ func TestOutboundChainReadinessFilter(t *testing.T) {
 	require.NoError(t, fc.GetFilters()[1].GetTypedConfig().UnmarshalTo(hcm))
 
 	httpFilters := hcm.GetHttpFilters()
-	require.Len(t, httpFilters, 2, "expected health_check + router")
+	require.Len(t, httpFilters, 3, "expected health_check + on_demand + router")
 	assert.Equal(t, httpHealthCheckFilterName, httpFilters[0].GetName())
-	assert.Equal(t, httpRouterFilterName, httpFilters[1].GetName())
+	assert.Equal(t, httpOnDemandFilterName, httpFilters[1].GetName())
+	assert.Equal(t, httpRouterFilterName, httpFilters[2].GetName())
 
 	hc := &health_checkv3.HealthCheck{}
 	require.NoError(t, httpFilters[0].GetTypedConfig().UnmarshalTo(hc))

--- a/agent/internal/xds/proxy/httpfilter.go
+++ b/agent/internal/xds/proxy/httpfilter.go
@@ -1,14 +1,18 @@
 package proxy
 
 import (
+	"time"
+
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	"github.com/bpalermo/aether/common/constants"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	health_checkv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
+	on_demandv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/on_demand/v3"
 	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -17,11 +21,35 @@ const (
 	httpRouterFilterName = "envoy.filters.http.router"
 	// httpHealthCheckFilterName is the Envoy HTTP health_check filter name
 	httpHealthCheckFilterName = "envoy.filters.http.health_check"
+	// httpOnDemandFilterName is the Envoy HTTP on_demand filter name (ODCDS)
+	httpOnDemandFilterName = "envoy.filters.http.on_demand"
+
+	// onDemandClusterTimeout bounds how long a request to a not-yet-distributed
+	// cluster is paused while ODCDS fetches it from the node-local agent. The
+	// warm path is one UDS xDS round-trip plus the agent's scoped reload
+	// (sub-second); the bound mostly caps requests to nonexistent services,
+	// which fail when it expires.
+	onDemandClusterTimeout = 5 * time.Second
 )
 
 // routerHttpFilter creates a router HTTP filter for forwarding matched requests to clusters.
 func routerHttpFilter() *http_connection_managerv3.HttpFilter {
 	return httpFilter(httpRouterFilterName, &routerv3.Router{})
+}
+
+// onDemandHttpFilter creates the on_demand HTTP filter with ODCDS pointing at
+// the agent's ADS (proposal 004 cold path): when an outbound request routes to
+// a cluster the node snapshot does not carry (an undeclared upstream, reached
+// via the catch-all authority route), the request pauses while Envoy requests
+// the cluster on demand; the agent observes the miss, adds the service to the
+// node dependency set (TTL'd), and serves it from the registrar snapshot.
+func onDemandHttpFilter() *http_connection_managerv3.HttpFilter {
+	return httpFilter(httpOnDemandFilterName, &on_demandv3.OnDemand{
+		Odcds: &on_demandv3.OnDemandCds{
+			Source:  config.XDSConfigSourceADS(),
+			Timeout: durationpb.New(onDemandClusterTimeout),
+		},
+	})
 }
 
 // readinessHttpFilter creates a non-pass-through health_check filter answering

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -48,13 +48,51 @@ func outboundRetryPolicy() *routev3.RetryPolicy {
 	}
 }
 
+// onDemandClusterHeader is the header the catch-all route resolves its cluster
+// from: ":authority" makes the requested service name the cluster name, so an
+// undeclared upstream called by its bare service name reaches the on_demand
+// filter as a well-formed cluster reference for ODCDS to fetch.
+const onDemandClusterHeader = ":authority"
+
+// buildOnDemandCatchAllVirtualHost builds the lowest-priority ("*") outbound
+// virtual host: requests whose authority matches no distributed service vhost
+// route to the cluster named by the authority. The scoped snapshot does not
+// carry that cluster, so the on_demand HTTP filter pauses the request and
+// fetches it via ODCDS (proposal 004 cold path). Cold requests therefore work
+// for bare service names (svc-name, no port); nonexistent services fail when
+// the ODCDS timeout expires.
+func buildOnDemandCatchAllVirtualHost() *routev3.VirtualHost {
+	return &routev3.VirtualHost{
+		Name:    "on_demand_catch_all",
+		Domains: []string{"*"},
+		Routes: []*routev3.Route{
+			{
+				Match: &routev3.RouteMatch{
+					PathSpecifier: &routev3.RouteMatch_Prefix{
+						Prefix: "/",
+					},
+				},
+				Action: &routev3.Route_Route{
+					Route: &routev3.RouteAction{
+						ClusterSpecifier: &routev3.RouteAction_ClusterHeader{
+							ClusterHeader: onDemandClusterHeader,
+						},
+						RetryPolicy: outboundRetryPolicy(),
+					},
+				},
+			},
+		},
+	}
+}
+
 // BuildOutboundRouteConfiguration creates a route configuration for outbound traffic.
-// It includes the provided virtual hosts along with a catch-all virtual host that returns 404.
-// Each virtual host matches requests by cluster name and FQDN.
+// It includes the provided virtual hosts plus the on-demand catch-all virtual
+// host, which routes unmatched authorities by name for ODCDS resolution.
+// Each service virtual host matches requests by cluster name and FQDN.
 func BuildOutboundRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name:         OutboundHTTPRouteName,
-		VirtualHosts: vhosts,
+		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost()),
 	}
 }
 

--- a/agent/internal/xds/proxy/route_test.go
+++ b/agent/internal/xds/proxy/route_test.go
@@ -43,7 +43,12 @@ func TestBuildOutboundRouteConfiguration(t *testing.T) {
 
 			require.NotNil(t, routeConfig)
 			assert.Equal(t, OutboundHTTPRouteName, routeConfig.GetName())
-			assert.Len(t, routeConfig.GetVirtualHosts(), tt.expectLen)
+			// Service vhosts plus the on-demand catch-all ("*"), always last.
+			require.Len(t, routeConfig.GetVirtualHosts(), tt.expectLen+1)
+			catchAll := routeConfig.GetVirtualHosts()[tt.expectLen]
+			assert.Equal(t, []string{"*"}, catchAll.GetDomains())
+			require.Len(t, catchAll.GetRoutes(), 1)
+			assert.Equal(t, onDemandClusterHeader, catchAll.GetRoutes()[0].GetRoute().GetClusterHeader())
 		})
 	}
 }

--- a/agent/internal/xds/server/BUILD.bazel
+++ b/agent/internal/xds/server/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "server",
     srcs = [
+        "odcds.go",
         "refresh.go",
         "server.go",
     ],
@@ -11,11 +12,15 @@ go_library(
     deps = [
         "//agent/constants",
         "//agent/internal/xds/cache",
+        "//agent/internal/xds/proxy",
         "//agent/storage",
         "//api/aether/cni/v1:cni",
         "//common/xds",
         "//registry",
+        "@com_github_envoyproxy_go_control_plane//pkg/resource/v3:resource",
         "@com_github_envoyproxy_go_control_plane//pkg/server/v3:server",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
+        "@com_github_envoyproxy_go_control_plane_envoy//service/discovery/v3:discovery",
         "@com_github_go_logr_logr//:logr",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_metric//:metric",
@@ -25,6 +30,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "odcds_test.go",
         "refresh_test.go",
         "server_integration_test.go",
         "server_test.go",

--- a/agent/internal/xds/server/odcds.go
+++ b/agent/internal/xds/server/odcds.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	"github.com/go-logr/logr"
+)
+
+// onDemandObserver watches the discovery streams for on-demand CDS
+// subscriptions (proposal 004 cold path): Envoy's CDS subscription is
+// otherwise wildcard, so a *named* cluster subscription is the on_demand
+// HTTP filter requesting a cluster the scoped snapshot does not carry. The
+// observer records it as an observed dependency, which triggers the scoped
+// reload that delivers the cluster and resumes the paused request.
+type onDemandObserver struct {
+	cache *cache.SnapshotCache
+	log   logr.Logger
+}
+
+// newOnDemandObserver creates an onDemandObserver over the snapshot cache.
+func newOnDemandObserver(snapshotCache *cache.SnapshotCache, log logr.Logger) *onDemandObserver {
+	return &onDemandObserver{
+		cache: snapshotCache,
+		log:   log.WithName("odcds"),
+	}
+}
+
+// Callbacks returns the go-control-plane server callbacks feeding this
+// observer (the agent's proxy speaks delta ADS, so only the delta hook is
+// wired).
+func (o *onDemandObserver) Callbacks() serverv3.Callbacks {
+	return serverv3.CallbackFuncs{
+		StreamDeltaRequestFunc: o.onDeltaRequest,
+	}
+}
+
+// onDeltaRequest inspects delta CDS subscriptions for on-demand cluster
+// names. The wildcard subscription ("*" or empty) is the normal CDS stream;
+// per-pod clusters (app_/health_) can never be on-demand requests.
+func (o *onDemandObserver) onDeltaRequest(_ int64, req *discoveryv3.DeltaDiscoveryRequest) error {
+	if req.GetTypeUrl() != resourcev3.ClusterType {
+		return nil
+	}
+	for _, name := range req.GetResourceNamesSubscribe() {
+		if name == "*" || name == "" || proxy.IsPerPodClusterName(name) {
+			continue
+		}
+		o.cache.ObserveDependency(context.Background(), name)
+	}
+	return nil
+}
+
+// combinedCallbacks dispatches every go-control-plane server callback to all
+// members, in order. Errors short-circuit (first error wins), matching how a
+// single callback would fail the stream.
+type combinedCallbacks []serverv3.Callbacks
+
+var _ serverv3.Callbacks = combinedCallbacks{}
+
+func (c combinedCallbacks) OnFetchRequest(ctx context.Context, req *discoveryv3.DiscoveryRequest) error {
+	for _, cb := range c {
+		if err := cb.OnFetchRequest(ctx, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c combinedCallbacks) OnFetchResponse(req *discoveryv3.DiscoveryRequest, resp *discoveryv3.DiscoveryResponse) {
+	for _, cb := range c {
+		cb.OnFetchResponse(req, resp)
+	}
+}
+
+func (c combinedCallbacks) OnStreamOpen(ctx context.Context, streamID int64, typeURL string) error {
+	for _, cb := range c {
+		if err := cb.OnStreamOpen(ctx, streamID, typeURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c combinedCallbacks) OnStreamClosed(streamID int64, node *corev3.Node) {
+	for _, cb := range c {
+		cb.OnStreamClosed(streamID, node)
+	}
+}
+
+func (c combinedCallbacks) OnStreamRequest(streamID int64, req *discoveryv3.DiscoveryRequest) error {
+	for _, cb := range c {
+		if err := cb.OnStreamRequest(streamID, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c combinedCallbacks) OnStreamResponse(ctx context.Context, streamID int64, req *discoveryv3.DiscoveryRequest, resp *discoveryv3.DiscoveryResponse) {
+	for _, cb := range c {
+		cb.OnStreamResponse(ctx, streamID, req, resp)
+	}
+}
+
+func (c combinedCallbacks) OnDeltaStreamOpen(ctx context.Context, streamID int64, typeURL string) error {
+	for _, cb := range c {
+		if err := cb.OnDeltaStreamOpen(ctx, streamID, typeURL); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c combinedCallbacks) OnDeltaStreamClosed(streamID int64, node *corev3.Node) {
+	for _, cb := range c {
+		cb.OnDeltaStreamClosed(streamID, node)
+	}
+}
+
+func (c combinedCallbacks) OnStreamDeltaRequest(streamID int64, req *discoveryv3.DeltaDiscoveryRequest) error {
+	for _, cb := range c {
+		if err := cb.OnStreamDeltaRequest(streamID, req); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c combinedCallbacks) OnStreamDeltaResponse(streamID int64, req *discoveryv3.DeltaDiscoveryRequest, resp *discoveryv3.DeltaDiscoveryResponse) {
+	for _, cb := range c {
+		cb.OnStreamDeltaResponse(streamID, req, resp)
+	}
+}

--- a/agent/internal/xds/server/odcds_test.go
+++ b/agent/internal/xds/server/odcds_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOnDemandObserver_RecordsNamedCDSSubscriptions verifies a named delta
+// CDS subscription (the on_demand filter requesting an undistributed cluster)
+// lands in the dependency set, while wildcard subscriptions, per-pod cluster
+// names, and other type URLs are ignored.
+func TestOnDemandObserver_RecordsNamedCDSSubscriptions(t *testing.T) {
+	c := cache.NewSnapshotCache("node-1", logr.Discard())
+	o := newOnDemandObserver(c, logr.Discard())
+
+	// Named CDS subscription: observed.
+	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl:                resourcev3.ClusterType,
+		ResourceNamesSubscribe: []string{"svc-on-demand"},
+	}))
+	assert.Contains(t, c.DependencySet(), "svc-on-demand")
+
+	// Wildcard and per-pod names: ignored.
+	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl:                resourcev3.ClusterType,
+		ResourceNamesSubscribe: []string{"*", "", "app_pod-1", "health_pod-1"},
+	}))
+	deps := c.DependencySet()
+	assert.NotContains(t, deps, "*")
+	assert.NotContains(t, deps, "app_pod-1")
+	assert.NotContains(t, deps, "health_pod-1")
+
+	// EDS subscriptions are named per cluster; they must not be observed.
+	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl:                resourcev3.EndpointType,
+		ResourceNamesSubscribe: []string{"svc-eds-sub"},
+	}))
+	assert.NotContains(t, c.DependencySet(), "svc-eds-sub")
+}
+
+// TestCombinedCallbacks_Dispatch verifies the combiner reaches every member.
+func TestCombinedCallbacks_Dispatch(t *testing.T) {
+	c1 := cache.NewSnapshotCache("node-1", logr.Discard())
+	c2 := cache.NewSnapshotCache("node-1", logr.Discard())
+	combined := combinedCallbacks{
+		newOnDemandObserver(c1, logr.Discard()).Callbacks(),
+		newOnDemandObserver(c2, logr.Discard()).Callbacks(),
+	}
+
+	require.NoError(t, combined.OnStreamDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl:                resourcev3.ClusterType,
+		ResourceNamesSubscribe: []string{"svc-x"},
+	}))
+	assert.Contains(t, c1.DependencySet(), "svc-x")
+	assert.Contains(t, c2.DependencySet(), "svc-x")
+
+	// Unwired hooks are nil-safe.
+	require.NoError(t, combined.OnStreamOpen(context.Background(), 1, resourcev3.ClusterType))
+	combined.OnStreamClosed(1, nil)
+}

--- a/agent/internal/xds/server/refresh.go
+++ b/agent/internal/xds/server/refresh.go
@@ -16,6 +16,10 @@ import (
 // snapshot replay) into a single reload.
 const defaultRefreshDebounce = 250 * time.Millisecond
 
+// observedPruneInterval is how often ODCDS-observed dependencies are checked
+// against their idle TTL (default 1h; minute-level expiry precision is fine).
+const observedPruneInterval = time.Minute
+
 // RegistryRefresher is a controller-runtime runnable that rebuilds the xDS
 // cluster/endpoint/route snapshot whenever the registry reports endpoint
 // changes. It bridges a registry.ChangeNotifier to the snapshot cache's
@@ -109,6 +113,11 @@ func (r *RegistryRefresher) Start(ctx context.Context) error {
 		<-timer.C
 	}
 
+	// Periodically expire ODCDS-observed dependencies idle past their TTL;
+	// an expiry signals a dependency change, funneling into the same reload.
+	pruneTicker := time.NewTicker(observedPruneInterval)
+	defer pruneTicker.Stop()
+
 	r.log.V(1).Info("watching registry for endpoint changes")
 
 	// arm (re)arms the debounce window. Stop+drain before Reset so a prior
@@ -135,10 +144,15 @@ func (r *RegistryRefresher) Start(ctx context.Context) error {
 		case <-changes:
 			arm()
 		case <-depChanges:
-			// The node dependency set changed (pod add/remove or changed
-			// declared upstreams): the scoped cluster set must be
-			// recomputed even though the registry contents are unchanged.
+			// The node dependency set changed (pod add/remove, changed
+			// declared upstreams, or an ODCDS observation): the scoped
+			// cluster set must be recomputed even though the registry
+			// contents are unchanged.
 			arm()
+		case <-pruneTicker.C:
+			// Signals a dependency change (handled above) when anything
+			// expired.
+			r.cache.PruneObservedDependencies()
 		case <-timer.C:
 			// Re-assert the watch filter from the current dependency set
 			// before reloading: a grown set must reach the registrar so the

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -49,8 +49,16 @@ func NewAgentXdsServer(ctx context.Context, clusterName string, nodeName string,
 		xds.WithUDS(constants.DefaultXdsSocketPath),
 	)
 
+	// Watch the discovery streams for on-demand CDS subscriptions (ODCDS cold
+	// path) alongside the caller's callbacks (the ACK tracker).
+	observer := newOnDemandObserver(snapshotCache, log)
+	combined := combinedCallbacks{observer.Callbacks()}
+	if callbacks != nil {
+		combined = append(combined, callbacks)
+	}
+
 	aXdsServer := &AgentXdsServer{
-		XdsServer:   xds.NewXdsServer(ctx, cfg, snapshotCache, callbacks, log),
+		XdsServer:   xds.NewXdsServer(ctx, cfg, snapshotCache, combined, log),
 		log:         log.WithName("agent-xds"),
 		clusterName: clusterName,
 		nodeName:    nodeName,

--- a/docs/workload-requirements.md
+++ b/docs/workload-requirements.md
@@ -46,6 +46,7 @@ spec:
 | `endpoint.aether.io/health-path` | `/` | Path the node-local agent health-checks (delegated liveness) |
 | `endpoint.aether.io/health-check-mode` | `eds` | `eds`: node-local agent vets the endpoint once and publishes health over EDS (endpoints enter clients pre-warmed). `active`: every client proxy probes the endpoint itself |
 | `metadata.endpoint.aether.io/<key>` | — | Free-form endpoint metadata (subset keys) |
+| `config.aether.io/upstreams` | — | Comma-separated services this pod **calls** (see "Declaring upstreams") |
 
 ## Calling other services
 
@@ -53,6 +54,33 @@ Apps reach the mesh through the outbound listener: `http://127.0.0.1:18081`
 with the destination service in the `Host` header (`Host: my-svc` or
 `my-svc.aether.internal`). Every hop is mTLS between workload identities; the
 callee sees the caller's SPIFFE ID in `x-forwarded-client-cert`.
+
+### Declaring upstreams
+
+The mesh distributes a service's clusters/endpoints/routes only to nodes that
+need them (demand-scoped distribution, proposal 004). Declare what a pod
+calls:
+
+```yaml
+metadata:
+  annotations:
+    config.aether.io/upstreams: "svc-payments,svc-ledger,svc-audit"
+```
+
+- **Declared upstreams are warm before first use** — the node's proxy carries
+  them the moment the pod lands. Declare everything latency- or
+  correctness-critical. The list is also reviewable architecture
+  documentation, exactly like `minReadySeconds`/`preStop` above.
+- **Undeclared upstreams still work** (cold path): the first request pauses
+  ~one node-local xDS round-trip while the cluster is fetched on demand
+  (ODCDS), then stays warm while used (1h idle TTL). Cold-path calls must use
+  the **bare service name** in `Host` (no port, no `.aether.internal`
+  suffix). Requests to nonexistent services fail after the 5s on-demand
+  timeout instead of an immediate 404.
+- Every miss increments `aether.agent.upstreams.miss` (and is logged with the
+  service name) — the signal to promote an undeclared dependency to the
+  annotation.
+- A pod's **own** service is always in scope; it never needs declaring.
 
 **Use keepalive (or HTTP/2) connections to the outbound listener.** The mesh
 pools upstream mTLS connections *per downstream connection* (this is what


### PR DESCRIPTION
Phase 3 of proposal 004 (stacked on #159).

- `envoy.filters.http.on_demand` with `odcds` → agent ADS on the outbound HCM; catch-all `*` vhost with `cluster_header: ":authority"` so undeclared bare-name calls become well-formed cluster references.
- Agent observes named delta-CDS subscriptions (wildcard otherwise) via a callbacks combiner around the ACK tracker → `ObserveDependency`: TTL'd membership (1h idle), refresher prunes every minute; expiry drops the cluster and the next use re-warms via ODCDS.
- Observed clusters ride the normal snapshot path, so the per-source mTLS transport-socket matcher and `connection_pool_per_downstream_connection` apply to them identically (the two flagged interactions — validated in vivo in the final e2e).
- Metrics: `aether.agent.upstreams.miss`, `aether.agent.upstreams.observed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)