### PR TITLE
feat(proxy): pin upstream peer identity to the service's SPIFFE IDs

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -148,6 +148,12 @@ type clusterEntry struct {
 	loadAssignment *endpointv3.ClusterLoadAssignment
 	endpoints      map[string]*endpointv3.LocalityLbEndpoints // keyed by IP, for granular add/remove
 	vhost          *routev3.VirtualHost
+	// sanNamespaces is the sorted union of the service's endpoints'
+	// Kubernetes namespaces. At snapshot time it renders the expected server
+	// SPIFFE IDs (spiffe://<td>/ns/<ns>/sa/<service>) pinned on the cluster's
+	// upstream mTLS validation (anti registry-poisoning). Empty disables
+	// pinning for the service (bundle-only validation).
+	sanNamespaces []string
 	// absentSince is non-zero while the service is missing from the registry
 	// listing. Such entries are retained (with empty endpoints) for
 	// serviceRetentionGrace before being pruned: during pod churn a service

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -88,7 +89,8 @@ func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.
 		ids = append(ids, id)
 	}
 	nodeSpiffeID := c.nodeSpiffeID
-	validationContextName := fmt.Sprintf("spiffe://%s", c.trustDomain)
+	trustDomain := c.trustDomain
+	validationContextName := fmt.Sprintf("spiffe://%s", trustDomain)
 	c.localMu.RUnlock()
 
 	c.clusterMu.RLock()
@@ -97,11 +99,18 @@ func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.
 	clusters := make([]types.Resource, 0, len(c.clusters))
 	clas := make([]types.Resource, 0, len(c.clusters))
 	vhosts := make([]*routev3.VirtualHost, 0, len(c.clusters))
-	for _, entry := range c.clusters {
+	for serviceName, entry := range c.clusters {
 		cluster := entry.cluster
 		if nodeSpiffeID != "" {
+			// Expected server identities for this service: one SPIFFE ID per
+			// endpoint namespace. The handshake then proves the peer IS the
+			// service asked for, not merely some workload in the trust domain.
+			sanURIs := make([]string, 0, len(entry.sanNamespaces))
+			for _, ns := range entry.sanNamespaces {
+				sanURIs = append(sanURIs, fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ns, serviceName))
+			}
 			cl, _ := proto.Clone(entry.cluster).(*clusterv3.Cluster)
-			proxy.InjectUpstreamMTLS(cl, netnsToID, ids, nodeSpiffeID, validationContextName)
+			proxy.InjectUpstreamMTLS(cl, netnsToID, ids, nodeSpiffeID, validationContextName, sanURIs)
 			cluster = cl
 		}
 		clusters = append(clusters, cluster)
@@ -185,6 +194,20 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 		// The outbound service cluster speaks per-source mTLS HTTP/2 to each
 		// destination pod's mesh inbound (pod_ip:15008). The per-source mTLS transport
 		// socket is injected at snapshot time (clustersEndpointsAndVhosts).
+		// Server-identity pinning: the union of the endpoints' namespaces
+		// renders the service's expected SPIFFE IDs at snapshot time.
+		nsSet := make(map[string]struct{})
+		for _, endpoint := range endpoints {
+			if ns := endpoint.GetKubernetesMetadata().GetNamespace(); ns != "" {
+				nsSet[ns] = struct{}{}
+			}
+		}
+		sanNamespaces := make([]string, 0, len(nsSet))
+		for ns := range nsSet {
+			sanNamespaces = append(sanNamespaces, ns)
+		}
+		sort.Strings(sanNamespaces)
+
 		// Provider-defined subset keys: the union of this service's endpoint
 		// metadata keys becomes its subset selectors, and the node-wide union
 		// (below) the shared subset-headers ECDS mapping — the provider's
@@ -221,6 +244,7 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 			loadAssignment: cla,
 			endpoints:      epMap,
 			vhost:          vhost,
+			sanNamespaces:  sanNamespaces,
 		}
 	}
 

--- a/agent/internal/xds/cache/outbound_mtls_test.go
+++ b/agent/internal/xds/cache/outbound_mtls_test.go
@@ -7,6 +7,7 @@ import (
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,4 +80,55 @@ func TestServiceClusterNoMTLSWithoutNodeIdentity(t *testing.T) {
 	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo.aether.internal"].(*clusterv3.Cluster)
 	require.True(t, ok, "echo cluster must be present")
 	assert.Nil(t, echo.GetTransportSocketMatcher(), "no mTLS matcher before the node SVID is served")
+}
+
+// TestServiceClusterSANPinning verifies the snapshot-time injection pins the
+// upstream peer identity to the service's expected SPIFFE IDs, derived from
+// its endpoints' namespaces — on the per-source matches AND the no-match
+// (node identity) path alike. This is the anti-registry-poisoning control: a
+// valid-but-wrong SVID must fail the handshake.
+func TestServiceClusterSANPinning(t *testing.T) {
+	c := newTestCache("node-1")
+	ctx := context.Background()
+
+	pod := &cniv1.CNIPod{
+		Name:             "echo-1",
+		Namespace:        "aether-test",
+		ServiceAccount:   "echo",
+		NetworkNamespace: "/var/run/netns/cni-a",
+	}
+	require.NoError(t, c.AddPod(ctx, pod, "aether.internal"))
+	require.NoError(t, c.SetNodeIdentity(ctx, nodeIdentity))
+
+	ep1 := makeEndpoint("10.0.0.9", "cluster-1", "node-1", 18080) // ns "default" (makeEndpoint)
+	ep2 := makeEndpoint("10.0.0.10", "cluster-1", "node-2", 18080)
+	ep2.KubernetesMetadata.Namespace = "aether-test"
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return map[string][]*registryv1.ServiceEndpoint{"echo": {ep1, ep2}}, nil
+		},
+	}
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+
+	snap, err := c.GetSnapshot("node-1")
+	require.NoError(t, err)
+	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo.aether.internal"].(*clusterv3.Cluster)
+	require.True(t, ok)
+
+	wantSANs := []string{
+		"spiffe://aether.internal/ns/aether-test/sa/echo",
+		"spiffe://aether.internal/ns/default/sa/echo",
+	}
+	require.NotEmpty(t, echo.GetTransportSocketMatches())
+	for _, m := range echo.GetTransportSocketMatches() {
+		utc := &tlsv3.UpstreamTlsContext{}
+		require.NoError(t, m.GetTransportSocket().GetTypedConfig().UnmarshalTo(utc))
+		combined := utc.GetCommonTlsContext().GetCombinedValidationContext()
+		require.NotNil(t, combined, "every per-source socket pins the server identity (match %s)", m.GetName())
+		var got []string
+		for _, sm := range combined.GetDefaultValidationContext().GetMatchTypedSubjectAltNames() {
+			got = append(got, sm.GetMatcher().GetExact())
+		}
+		assert.Equal(t, wantSANs, got, "sorted namespace union renders the expected identities")
+	}
 }

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -173,16 +173,18 @@ func NewServiceCluster(serviceName, meshDomain string, subsetKeys []string) *clu
 // transport_socket_matches are set in that branch: without the matcher Envoy
 // falls back to legacy metadata matching, where an empty match criteria set
 // would select the first entry for every endpoint.
-func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]string, spiffeIDs []string, nodeSpiffeID, validationContextName string) {
+// sanURIs (the service's expected server SPIFFE IDs) pin the upstream peer
+// identity on every emitted socket; empty disables pinning (bundle-only).
+func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]string, spiffeIDs []string, nodeSpiffeID, validationContextName string, sanURIs []string) {
 	matcher := UpstreamTransportSocketMatcher(netnsToSpiffeID)
 	if matcher == nil {
-		cluster.TransportSocket = UpstreamTransportSocket(nodeSpiffeID, validationContextName)
+		cluster.TransportSocket = UpstreamTransportSocket(nodeSpiffeID, validationContextName, sanURIs)
 		return
 	}
 	matcher.OnNoMatch = transportSocketNameOnMatch(nodeSpiffeID)
 
 	cluster.TransportSocketMatcher = matcher
-	cluster.TransportSocketMatches = UpstreamTransportSocketMatches(append(spiffeIDs, nodeSpiffeID), validationContextName)
+	cluster.TransportSocketMatches = UpstreamTransportSocketMatches(append(spiffeIDs, nodeSpiffeID), validationContextName, sanURIs)
 }
 
 // EndpointPriority maps an endpoint's locality distance from this node into

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -61,7 +61,7 @@ func TestInjectUpstreamMTLS(t *testing.T) {
 	node := "spiffe://example.org/ns/aether-system/sa/aether-agent"
 
 	c := NewServiceCluster("svc-a", "aether.internal", nil)
-	InjectUpstreamMTLS(c, netnsToID, ids, node, "spiffe://example.org")
+	InjectUpstreamMTLS(c, netnsToID, ids, node, "spiffe://example.org", nil)
 
 	// Per-source mTLS: a match per workload identity + the node identity, and
 	// on-no-match presents the node identity.
@@ -92,7 +92,7 @@ func TestInjectUpstreamMTLS_NoLocalWorkloads(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			c := NewServiceCluster("svc-a", "aether.internal", nil)
-			InjectUpstreamMTLS(c, netnsToID, nil, node, "spiffe://example.org")
+			InjectUpstreamMTLS(c, netnsToID, nil, node, "spiffe://example.org", nil)
 
 			assert.Nil(t, c.GetTransportSocketMatcher(), "no matcher without local workloads")
 			assert.Empty(t, c.GetTransportSocketMatches(), "no legacy matches without the matcher")

--- a/agent/internal/xds/proxy/transportsocket.go
+++ b/agent/internal/xds/proxy/transportsocket.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	transport_sockets_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -40,23 +41,49 @@ func DownstreamTransportSocket(tlsCertificateSecretName string, validationContex
 }
 
 // UpstreamTransportSocket creates a TLS transport socket for upstream (outbound) connections.
-// It uses mTLS with both a client certificate and validation context fetched via ADS-served SDS.
-func UpstreamTransportSocket(tlsCertificateSecretName string, validationContextName string) *corev3.TransportSocket {
-	upstreamTlsContext := &transport_sockets_v3.UpstreamTlsContext{
-		CommonTlsContext: &transport_sockets_v3.CommonTlsContext{
-			// Clusters speak HTTP/2 upstream; advertise it so the mTLS handshake
-			// negotiates h2 (matches the inbound listener's codec).
-			AlpnProtocols: []string{"h2"},
-			TlsCertificateSdsSecretConfigs: []*transport_sockets_v3.SdsSecretConfig{
-				sdsSecretConfig(tlsCertificateSecretName),
-			},
-			ValidationContextType: &transport_sockets_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
-				ValidationContextSdsSecretConfig: sdsSecretConfig(validationContextName),
-			},
+// It uses mTLS with both a client certificate and validation context fetched via
+// ADS-served SDS. sanURIs, when non-empty, pins the SERVER identity: the
+// presented SVID's URI SAN must exactly match one of the expected per-service
+// SPIFFE IDs (spiffe://<td>/ns/<ns>/sa/<service>), layered over the
+// SDS-rotated trust bundle via a combined validation context. Without it the
+// handshake only proves trust-domain membership — any mesh workload — which
+// leaves registry poisoning able to impersonate a service (an attacker-
+// registered endpoint would present a valid but WRONG identity).
+func UpstreamTransportSocket(tlsCertificateSecretName string, validationContextName string, sanURIs []string) *corev3.TransportSocket {
+	common := &transport_sockets_v3.CommonTlsContext{
+		// Clusters speak HTTP/2 upstream; advertise it so the mTLS handshake
+		// negotiates h2 (matches the inbound listener's codec).
+		AlpnProtocols: []string{"h2"},
+		TlsCertificateSdsSecretConfigs: []*transport_sockets_v3.SdsSecretConfig{
+			sdsSecretConfig(tlsCertificateSecretName),
 		},
 	}
 
-	return transportSocket(upstreamTlsContext)
+	if len(sanURIs) == 0 {
+		common.ValidationContextType = &transport_sockets_v3.CommonTlsContext_ValidationContextSdsSecretConfig{
+			ValidationContextSdsSecretConfig: sdsSecretConfig(validationContextName),
+		}
+	} else {
+		matchers := make([]*transport_sockets_v3.SubjectAltNameMatcher, 0, len(sanURIs))
+		for _, uri := range sanURIs {
+			matchers = append(matchers, &transport_sockets_v3.SubjectAltNameMatcher{
+				SanType: transport_sockets_v3.SubjectAltNameMatcher_URI,
+				Matcher: &matcherv3.StringMatcher{
+					MatchPattern: &matcherv3.StringMatcher_Exact{Exact: uri},
+				},
+			})
+		}
+		common.ValidationContextType = &transport_sockets_v3.CommonTlsContext_CombinedValidationContext{
+			CombinedValidationContext: &transport_sockets_v3.CommonTlsContext_CombinedCertificateValidationContext{
+				DefaultValidationContext: &transport_sockets_v3.CertificateValidationContext{
+					MatchTypedSubjectAltNames: matchers,
+				},
+				ValidationContextSdsSecretConfig: sdsSecretConfig(validationContextName),
+			},
+		}
+	}
+
+	return transportSocket(&transport_sockets_v3.UpstreamTlsContext{CommonTlsContext: common})
 }
 
 // transportSocket creates a TLS transport socket from the given TLS context message.

--- a/agent/internal/xds/proxy/transportsocket_test.go
+++ b/agent/internal/xds/proxy/transportsocket_test.go
@@ -27,7 +27,7 @@ func TestDownstreamTransportSocket(t *testing.T) {
 }
 
 func TestUpstreamTransportSocket(t *testing.T) {
-	ts := UpstreamTransportSocket("spiffe://example.org/ns/default/sa/my-sa", "spiffe://example.org")
+	ts := UpstreamTransportSocket("spiffe://example.org/ns/default/sa/my-sa", "spiffe://example.org", nil)
 
 	require.NotNil(t, ts)
 	assert.Equal(t, tlsTransportSocketName, ts.GetName())
@@ -41,4 +41,37 @@ func TestUpstreamTransportSocket(t *testing.T) {
 	assert.Equal(t, "spiffe://example.org/ns/default/sa/my-sa", ctx.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()[0].GetName())
 	assert.Equal(t, "spiffe://example.org", ctx.GetCommonTlsContext().GetValidationContextSdsSecretConfig().GetName())
 	assert.Equal(t, []string{"h2"}, ctx.GetCommonTlsContext().GetAlpnProtocols())
+}
+
+// TestUpstreamTransportSocket_SANPinning verifies server-identity pinning:
+// with expected SPIFFE IDs the validation context becomes a combined context
+// (inline exact URI SAN matchers layered over the SDS trust bundle), and
+// without them validation stays bundle-only.
+func TestUpstreamTransportSocket_SANPinning(t *testing.T) {
+	sans := []string{
+		"spiffe://aether.internal/ns/aether-test/sa/svc-1",
+		"spiffe://aether.internal/ns/other/sa/svc-1",
+	}
+	ts := UpstreamTransportSocket("spiffe://aether.internal/ns/x/sa/client", "spiffe://aether.internal", sans)
+
+	utc := &transport_sockets_v3.UpstreamTlsContext{}
+	require.NoError(t, ts.GetTypedConfig().UnmarshalTo(utc))
+	combined := utc.GetCommonTlsContext().GetCombinedValidationContext()
+	require.NotNil(t, combined, "SAN pinning uses the combined validation context")
+	assert.Equal(t, "spiffe://aether.internal", combined.GetValidationContextSdsSecretConfig().GetName(),
+		"trust bundle still rotates over SDS")
+
+	matchers := combined.GetDefaultValidationContext().GetMatchTypedSubjectAltNames()
+	require.Len(t, matchers, 2)
+	for i, m := range matchers {
+		assert.Equal(t, transport_sockets_v3.SubjectAltNameMatcher_URI, m.GetSanType())
+		assert.Equal(t, sans[i], m.GetMatcher().GetExact())
+	}
+
+	// No expected identities: bundle-only (legacy shape).
+	ts = UpstreamTransportSocket("spiffe://aether.internal/ns/x/sa/client", "spiffe://aether.internal", nil)
+	utc = &transport_sockets_v3.UpstreamTlsContext{}
+	require.NoError(t, ts.GetTypedConfig().UnmarshalTo(utc))
+	assert.Nil(t, utc.GetCommonTlsContext().GetCombinedValidationContext())
+	require.NotNil(t, utc.GetCommonTlsContext().GetValidationContextSdsSecretConfig())
 }

--- a/agent/internal/xds/proxy/transportsocketmatch.go
+++ b/agent/internal/xds/proxy/transportsocketmatch.go
@@ -35,7 +35,7 @@ const (
 // re-warm cycle each time (observed as `cds: N added/updated, skipped 0
 // unmodified` + `initial fetch timed out` every push, and unbounded proxy
 // memory growth under long-lived downstream connections).
-func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName string) []*clusterv3.Cluster_TransportSocketMatch {
+func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName string, sanURIs []string) []*clusterv3.Cluster_TransportSocketMatch {
 	unique := make([]string, 0, len(spiffeIDs))
 	seen := make(map[string]struct{}, len(spiffeIDs))
 	for _, id := range spiffeIDs {
@@ -55,7 +55,7 @@ func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName st
 		matches = append(matches, &clusterv3.Cluster_TransportSocketMatch{
 			Name:            id,
 			Match:           &structpb.Struct{},
-			TransportSocket: UpstreamTransportSocket(id, validationContextName),
+			TransportSocket: UpstreamTransportSocket(id, validationContextName, sanURIs),
 		})
 	}
 	return matches

--- a/agent/internal/xds/proxy/transportsocketmatch_test.go
+++ b/agent/internal/xds/proxy/transportsocketmatch_test.go
@@ -16,7 +16,7 @@ func TestUpstreamTransportSocketMatches(t *testing.T) {
 
 	// Duplicate idA (two pods, same service account) collapses to one match;
 	// empty IDs are skipped.
-	matches := UpstreamTransportSocketMatches([]string{idA, idB, idA, ""}, "spiffe://aether.internal")
+	matches := UpstreamTransportSocketMatches([]string{idA, idB, idA, ""}, "spiffe://aether.internal", nil)
 
 	require.Len(t, matches, 2)
 	names := []string{matches[0].GetName(), matches[1].GetName()}
@@ -72,8 +72,8 @@ func TestUpstreamTransportSocketMatchesDeterministic(t *testing.T) {
 	idB := "spiffe://aether.internal/ns/aether-test/sa/client"
 	idC := "spiffe://aether.internal/ns/aether-test/sa/loadgen"
 
-	a := UpstreamTransportSocketMatches([]string{idC, idA, idB}, "spiffe://aether.internal")
-	b := UpstreamTransportSocketMatches([]string{idB, idC, idA, idB}, "spiffe://aether.internal")
+	a := UpstreamTransportSocketMatches([]string{idC, idA, idB}, "spiffe://aether.internal", nil)
+	b := UpstreamTransportSocketMatches([]string{idB, idC, idA, idB}, "spiffe://aether.internal", nil)
 
 	require.Len(t, a, 3)
 	require.Len(t, b, 3)


### PR DESCRIPTION
Closes the registry-poisoning impersonation gap: upstream mTLS validated trust-domain membership only (bare bundle, no SAN matching) — any mesh workload's SVID passed when dialing any service.

- `CombinedValidationContext` per service cluster: exact URI SAN matchers (`spiffe://<td>/ns/<ns>/sa/<svc>`, namespace union from the endpoints, sorted for hash stability) + the SDS trust bundle.
- Applied at snapshot time to all per-source sockets and the on-no-match node-identity socket; ODCDS clusters included automatically.
- No-namespace endpoints → bundle-only fallback (logged shape preserved).
- Inbound unchanged (authn + XFCC; authz stays app-layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)