### PR TITLE
feat(proxy): multi-key subset selection

### DIFF
--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -211,12 +211,13 @@ func TestLoadClustersFromRegistry_SubsetVocabulary(t *testing.T) {
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
 
-	// Cluster selectors: ip, pod + derived (sorted).
+	// Cluster selectors: ip, pod + derived power set (sorted).
 	entry := c.clusters["svc-a"]
 	sel := entry.cluster.GetLbSubsetConfig().GetSubsetSelectors()
-	require.Len(t, sel, 4)
+	require.Len(t, sel, 5)
 	assert.Equal(t, []string{"shard"}, sel[2].GetKeys())
 	assert.Equal(t, []string{"version"}, sel[3].GetKeys())
+	assert.Equal(t, []string{"shard", "version"}, sel[4].GetKeys())
 
 	// Node union published for the shared ECDS mapping.
 	c.subsetMu.RLock()

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -53,26 +53,84 @@ func ServiceFromClusterName(clusterName, meshDomain string) (string, bool) {
 // from the current local workloads; connection_pool_per_downstream_connection
 // keeps a source pod's connection (and therefore its certificate) from being
 // reused for another source.
-// subsetSelectors builds the cluster's subset index: the always-on ip/pod
-// pinning selectors plus one selector per provider-defined key (derived from
-// the service's endpoint metadata, pre-sorted). Every selector is
-// NO_FALLBACK — a request asking for a subset that doesn't exist fails
-// (pin-or-fail; spilling a version=v2 request onto v1 is the canary-poisoning
-// failure mode; deterministic exclusion over spraying, same doctrine as
-// panic-0). Criteria-LESS traffic never consults selectors and rides the
-// cluster-level ANY_ENDPOINT fallback. Multi-key criteria match no selector
-// (single-key selectors only) and also fall back: one subset header per
-// request.
+// maxSubsetComboKeys caps how many provider-defined keys participate in
+// multi-key combinations: the selector count is 2 + 2^k - 1, and a service
+// with more than 4 routing dimensions is an architecture smell, not a config
+// to silently honor. Beyond the cap, the lexicographically-first keys keep
+// full combinations and the rest are emitted as singletons only.
+const maxSubsetComboKeys = 4
+
+// subsetSelectors builds the cluster's subset index:
+//
+//   - The always-on ip/pod pinning selectors. These identify ONE endpoint by
+//     construction and are therefore never combined with other keys (pin
+//     headers are exclusive — mixing a pin with subset headers matches no
+//     selector and falls back to normal balancing). single_host_per_subset
+//     tells Envoy each subset holds exactly one host, replacing the
+//     per-value subset maps with a direct host index.
+//   - The power set of the provider-defined keys (derived from the service's
+//     endpoint metadata, pre-sorted): a request carrying N subset headers
+//     routes to endpoints matching ALL N dimensions. Combos are emitted in
+//     deterministic order (by length, then lexicographically) — selector
+//     order is part of the CDS resource bytes (delta-xDS hashing).
+//
+// Every selector is NO_FALLBACK — a request asking for a subset that doesn't
+// exist fails (pin-or-fail; spilling a version=v2 request onto v1 is the
+// canary-poisoning failure mode; deterministic exclusion over spraying, same
+// doctrine as panic-0). Criteria-LESS traffic never consults selectors and
+// rides the cluster-level ANY_ENDPOINT fallback.
 func subsetSelectors(subsetKeys []string) []*clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector {
-	keys := append([]string{subsetIPKey, subsetPodNameKey}, subsetKeys...)
-	selectors := make([]*clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector, 0, len(keys))
-	for _, key := range keys {
+	selectors := []*clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector{
+		{
+			Keys:                []string{subsetIPKey},
+			FallbackPolicy:      clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector_NO_FALLBACK,
+			SingleHostPerSubset: true,
+		},
+		{
+			Keys:                []string{subsetPodNameKey},
+			FallbackPolicy:      clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector_NO_FALLBACK,
+			SingleHostPerSubset: true,
+		},
+	}
+	for _, combo := range subsetKeyCombos(subsetKeys) {
 		selectors = append(selectors, &clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector{
-			Keys:           []string{key},
+			Keys:           combo,
 			FallbackPolicy: clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector_NO_FALLBACK,
 		})
 	}
 	return selectors
+}
+
+// subsetKeyCombos returns every non-empty combination of the (sorted) keys,
+// ordered by size then lexicographically. Keys beyond maxSubsetComboKeys
+// participate as singletons only.
+func subsetKeyCombos(keys []string) [][]string {
+	comboKeys := keys
+	var singletonOnly []string
+	if len(keys) > maxSubsetComboKeys {
+		comboKeys = keys[:maxSubsetComboKeys]
+		singletonOnly = keys[maxSubsetComboKeys:]
+	}
+
+	var combos [][]string
+	n := len(comboKeys)
+	for size := 1; size <= n; size++ {
+		var build func(start int, cur []string)
+		build = func(start int, cur []string) {
+			if len(cur) == size {
+				combos = append(combos, append([]string(nil), cur...))
+				return
+			}
+			for i := start; i < n; i++ {
+				build(i+1, append(cur, comboKeys[i]))
+			}
+		}
+		build(0, nil)
+	}
+	for _, k := range singletonOnly {
+		combos = append(combos, []string{k})
+	}
+	return combos
 }
 
 func NewServiceCluster(serviceName, meshDomain string, subsetKeys []string) *clusterv3.Cluster {

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -208,10 +208,11 @@ func TestServiceFromClusterName(t *testing.T) {
 func TestNewServiceCluster_DerivedSubsetSelectors(t *testing.T) {
 	c := NewServiceCluster("svc-a", "aether.internal", []string{"shard", "version"})
 	selectors := c.GetLbSubsetConfig().GetSubsetSelectors()
-	require.Len(t, selectors, 4)
+	require.Len(t, selectors, 5)
 	assert.Equal(t, []string{"shard"}, selectors[2].GetKeys())
 	assert.Equal(t, []string{"version"}, selectors[3].GetKeys())
-	assert.Equal(t, clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector_NO_FALLBACK, selectors[3].GetFallbackPolicy())
+	assert.Equal(t, []string{"shard", "version"}, selectors[4].GetKeys())
+	assert.Equal(t, clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector_NO_FALLBACK, selectors[4].GetFallbackPolicy())
 }
 
 // TestEndpointPriority pins the locality-failover priority mapping.
@@ -244,4 +245,52 @@ func TestServiceLocalityLbEndpoint_Priority(t *testing.T) {
 	assert.Equal(t, uint32(1), lle.GetPriority(), "same region, different zone")
 	lle = ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "r1", "z2")
 	assert.Equal(t, uint32(0), lle.GetPriority(), "same zone")
+}
+
+// TestSubsetKeyCombos pins multi-key combination generation: power set in
+// (length, lexicographic) order; keys past the cap fall back to singletons.
+func TestSubsetKeyCombos(t *testing.T) {
+	assert.Empty(t, subsetKeyCombos(nil))
+	assert.Equal(t, [][]string{{"a"}}, subsetKeyCombos([]string{"a"}))
+	assert.Equal(t, [][]string{{"a"}, {"b"}, {"a", "b"}}, subsetKeyCombos([]string{"a", "b"}))
+	assert.Equal(t, [][]string{
+		{"a"},
+		{"b"},
+		{"c"},
+		{"a", "b"},
+		{"a", "c"},
+		{"b", "c"},
+		{"a", "b", "c"},
+	}, subsetKeyCombos([]string{"a", "b", "c"}))
+
+	// Six keys: first four (lexicographic input order) combine fully
+	// (2^4-1 = 15), the rest are singletons.
+	combos := subsetKeyCombos([]string{"a", "b", "c", "d", "e", "f"})
+	assert.Len(t, combos, 15+2)
+	assert.Equal(t, []string{"e"}, combos[15])
+	assert.Equal(t, []string{"f"}, combos[16])
+}
+
+// TestSubsetSelectors_MultiKey verifies the full selector shape: pinned
+// ip/pod singletons (single_host_per_subset, never combined) followed by the
+// derived-key power set, all NO_FALLBACK.
+func TestSubsetSelectors_MultiKey(t *testing.T) {
+	c := NewServiceCluster("svc-a", "aether.internal", []string{"shard", "version"})
+	sel := c.GetLbSubsetConfig().GetSubsetSelectors()
+	require.Len(t, sel, 2+3)
+
+	assert.Equal(t, []string{"ip"}, sel[0].GetKeys())
+	assert.True(t, sel[0].GetSingleHostPerSubset(), "ip subsets hold exactly one host")
+	assert.Equal(t, []string{"pod"}, sel[1].GetKeys())
+	assert.True(t, sel[1].GetSingleHostPerSubset())
+
+	assert.Equal(t, []string{"shard"}, sel[2].GetKeys())
+	assert.Equal(t, []string{"version"}, sel[3].GetKeys())
+	assert.Equal(t, []string{"shard", "version"}, sel[4].GetKeys(), "multi-key intersection selector")
+	for i, s := range sel {
+		assert.Equal(t, clusterv3.Cluster_LbSubsetConfig_LbSubsetSelector_NO_FALLBACK, s.GetFallbackPolicy(), "selector %d", i)
+		if i >= 2 {
+			assert.False(t, s.GetSingleHostPerSubset(), "derived selectors are not single-host")
+		}
+	}
 }

--- a/docs/workload-requirements.md
+++ b/docs/workload-requirements.md
@@ -135,8 +135,16 @@ plane — consumers declare nothing; any key published by an in-scope service
 is routable from every pod on the node. Selection is strict (NO_FALLBACK):
 asking for a subset that has no endpoints fails rather than spilling onto
 the rest of the service. Keys must be lowercase DNS-label shaped
-(`[a-z0-9-]`); `ip`, `pod`, `cluster`, `namespace` are reserved. One subset
-header per request (multi-key selection falls back to normal balancing).
+(`[a-z0-9-]`); `ip`, `pod`, `cluster`, `namespace` are reserved.
+
+**Multiple subset headers intersect**: a request carrying
+`x-aether-subset-version: v2` and `x-aether-subset-shard: s1` routes only to
+endpoints matching both, or fails. Up to 4 keys per service combine; beyond
+that, extra keys select individually only. **Pin headers are exclusive**:
+`x-aether-ip`/`x-aether-pod` identify a single endpoint by design and never
+combine — mixing a pin with subset headers matches no selector and falls
+back to normal balancing.
+
 Requests without subset headers are balanced across all healthy endpoints,
 unchanged. Note: a *cold* (ODCDS) first request to an undeclared upstream
 routes before that service's vocabulary lands (~ms); declare upstreams whose


### PR DESCRIPTION
Stacked on #165 (will retarget to main after it merges — base branch kept until then).

- Power-set selectors over the service's derived keys (≤4 combine; deterministic (length, lex) order for delta-xDS hash stability); intersection semantics, NO_FALLBACK throughout.
- `ip`/`pod` remain singleton pins, never combined (per design discussion); they gain `single_host_per_subset`.
- Closes the multi-header → silent ANY_ENDPOINT spill.
- Zero ECDS/filter changes; docs updated (intersection + "pin headers are exclusive").

🤖 Generated with [Claude Code](https://claude.com/claude-code)