### PR TITLE
fix(agent): time-driven retention expiry — stale empty vhost shadowed ODCDS

### DIFF
--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -284,6 +284,34 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 // Sized to outlast a rolling-restart churn window (~40s observed) with margin.
 const defaultServiceRetentionGrace = 90 * time.Second
 
+// SignalIfRetentionExpired emits a dependency-change signal when any retained
+// (absent) service has outlived the retention grace, so the refresher runs a
+// reload that prunes it. Pruning is otherwise reload-driven — and under
+// demand-scoped watches a node in steady state receives NO events once a
+// service leaves its dependency set, so the retained empty cluster/vhost
+// would shadow the on-demand catch-all forever (fast 503 instead of ODCDS;
+// observed in vivo 2026-06-12: svc-4's pods moved off a node and the stale
+// vhost stuck). The refresher calls this from its periodic prune tick.
+func (c *SnapshotCache) SignalIfRetentionExpired() {
+	now := time.Now()
+	grace := c.retentionGrace()
+
+	c.clusterMu.RLock()
+	expired := false
+	for _, entry := range c.clusters {
+		if !entry.absentSince.IsZero() && now.Sub(entry.absentSince) > grace {
+			expired = true
+			break
+		}
+	}
+	c.clusterMu.RUnlock()
+
+	if expired {
+		c.log.V(1).Info("retained service past grace in steady state; triggering prune reload")
+		c.signalDependencyChange()
+	}
+}
+
 // retentionGrace returns the configured service retention grace (test hook).
 func (c *SnapshotCache) retentionGrace() time.Duration {
 	if c.serviceRetentionGrace > 0 {

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -262,3 +262,47 @@ func TestSetNodeLocality_SignalsAndPrioritizes(t *testing.T) {
 	assert.Equal(t, uint32(0), prios["10.0.0.1"], "same zone is P0")
 	assert.Equal(t, uint32(2), prios["10.0.0.2"], "other region is P2")
 }
+
+// TestSignalIfRetentionExpired covers the steady-state retention bug
+// (2026-06-12): a service leaving the dependency set is retained empty for
+// the grace, but under scoped watches no further events arrive to trigger
+// the pruning reload — its stale vhost then shadows the ODCDS catch-all
+// forever. Time-driven expiry must signal the reload instead.
+func TestSignalIfRetentionExpired(t *testing.T) {
+	c := newTestCache("node-1")
+	c.serviceRetentionGrace = 30 * time.Millisecond
+	declareDeps(c, "svc-gone")
+	ctx := context.Background()
+
+	data := map[string][]*registryv1.ServiceEndpoint{
+		"svc-gone": {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
+	}
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return data, nil
+		},
+	}
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+
+	// The service vanishes (and leaves the dep set); one reload retains it.
+	data = map[string][]*registryv1.ServiceEndpoint{}
+	declareDeps(c) // no upstreams anymore
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	require.Contains(t, c.clusters, "svc-gone", "retained during grace")
+	drainDepSignal(c)
+
+	// Within the grace: no signal.
+	c.SignalIfRetentionExpired()
+	assert.False(t, drainDepSignal(c), "no signal while inside the grace")
+
+	// Past the grace: the tick signals, and the triggered reload prunes.
+	time.Sleep(40 * time.Millisecond)
+	c.SignalIfRetentionExpired()
+	require.True(t, drainDepSignal(c), "expiry must signal the pruning reload")
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	assert.NotContains(t, c.clusters, "svc-gone", "stale retained service pruned")
+
+	// Idempotent: nothing retained, no signal.
+	c.SignalIfRetentionExpired()
+	assert.False(t, drainDepSignal(c))
+}

--- a/agent/internal/xds/server/refresh.go
+++ b/agent/internal/xds/server/refresh.go
@@ -16,8 +16,9 @@ import (
 // snapshot replay) into a single reload.
 const defaultRefreshDebounce = 250 * time.Millisecond
 
-// observedPruneInterval is how often ODCDS-observed dependencies are checked
-// against their idle TTL (default 1h; minute-level expiry precision is fine).
+// observedPruneInterval is how often time-driven expiry runs: ODCDS-observed
+// dependencies against their idle TTL, and retained absent services against
+// the retention grace (worst-case stale-retention window = grace + this).
 const observedPruneInterval = time.Minute
 
 // RegistryRefresher is a controller-runtime runnable that rebuilds the xDS
@@ -150,9 +151,13 @@ func (r *RegistryRefresher) Start(ctx context.Context) error {
 			// contents are unchanged.
 			arm()
 		case <-pruneTicker.C:
-			// Signals a dependency change (handled above) when anything
-			// expired.
+			// Each signals a dependency change (handled above) when anything
+			// expired: observed (ODCDS) entries past their idle TTL, and
+			// retained absent services past the retention grace — the latter
+			// receive no watch events in steady state under scoped watches,
+			// so expiry must be time-driven, not event-driven.
 			r.cache.PruneObservedDependencies()
+			r.cache.SignalIfRetentionExpired()
 		case <-timer.C:
 			// Re-assert the watch filter from the current dependency set
 			// before reloading: a grown set must reach the registrar so the


### PR DESCRIPTION
Found during the SAN+multi-key e2e: svc-4's pods moved off worker-03 mid-roll → service left the node's dep set → retained empty (90s 404-protection grace) → **no further watch events under scoped watches** → never pruned → the stale vhost shadowed the `*.aether.internal` catch-all and every svc-4 request from that node fast-503'd indefinitely.

Fix: the refresher's 1-minute prune tick (added for ODCDS TTLs) now also signals a reload when any retained entry outlives the grace. Regression test reproduces the steady-state sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)