### PR TITLE
fix(agent): drop out-of-scope services immediately — retention is for in-scope churn only

### DIFF
--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -248,10 +248,23 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 		}
 	}
 
-	// Retain recently disappeared services with an empty endpoint set.
+	// Retain recently disappeared services with an empty endpoint set —
+	// but only services still IN the dependency set (a destination mid-churn
+	// can transiently empty its endpoint listing; the retained empty cluster
+	// keeps clients on fast retriable 503s instead of ODCDS stalls until the
+	// endpoints return). A service that LEFT the dependency set is dropped
+	// immediately: post-FQDN its authority cannot 404 (the *.<mesh-domain>
+	// catch-all is the structural backstop), and retaining its vhost only
+	// shadows the on-demand cold path — the stale-503 outage behind #167.
+	// Any further traffic re-warms it as an observed dependency, which is
+	// the truthful state for traffic nobody on the node declares.
 	now := time.Now()
 	for name, entry := range prev {
 		if _, present := c.clusters[name]; present {
+			continue
+		}
+		if _, inScope := deps[name]; !inScope {
+			c.log.Info("service left dependency set; dropping cluster/vhost (cold path takes over)", "service", name)
 			continue
 		}
 		if entry.absentSince.IsZero() {

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -284,11 +284,11 @@ func TestSignalIfRetentionExpired(t *testing.T) {
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
 
-	// The service vanishes (and leaves the dep set); one reload retains it.
+	// The service's endpoints vanish while it stays DECLARED (in scope);
+	// one reload retains it for the grace.
 	data = map[string][]*registryv1.ServiceEndpoint{}
-	declareDeps(c) // no upstreams anymore
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
-	require.Contains(t, c.clusters, "svc-gone", "retained during grace")
+	require.Contains(t, c.clusters, "svc-gone", "in-scope absence is retained during grace")
 	drainDepSignal(c)
 
 	// Within the grace: no signal.
@@ -305,4 +305,37 @@ func TestSignalIfRetentionExpired(t *testing.T) {
 	// Idempotent: nothing retained, no signal.
 	c.SignalIfRetentionExpired()
 	assert.False(t, drainDepSignal(c))
+}
+
+// TestLoadClustersFromRegistry_DropsOutOfScopeImmediately pins the #167
+// follow-up: a service that LEFT the dependency set is dropped in the same
+// reload — no retention, no stale window — so the next request falls through
+// to the on-demand catch-all instead of a retained empty vhost's 503s.
+func TestLoadClustersFromRegistry_DropsOutOfScopeImmediately(t *testing.T) {
+	c := newTestCache("node-1")
+	c.serviceRetentionGrace = time.Hour // retention must NOT be what drops it
+	declareDeps(c, "svc-moved")
+	ctx := context.Background()
+
+	// Registry keeps serving the endpoints throughout: the service is alive
+	// elsewhere, it just has no consumer/provider on this node anymore.
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return map[string][]*registryv1.ServiceEndpoint{
+				"svc-moved": {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
+			}, nil
+		},
+	}
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	require.Contains(t, c.clusters, "svc-moved")
+
+	// The declaring pod leaves: the very next reload drops cluster AND vhost.
+	declareDeps(c)
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	assert.NotContains(t, c.clusters, "svc-moved", "out-of-scope service must drop immediately")
+
+	// And the ODCDS path re-warms it as an observed dependency.
+	c.ObserveDependency(ctx, "svc-moved")
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	assert.Contains(t, c.clusters, "svc-moved", "observed traffic re-warms the dropped service")
 }


### PR DESCRIPTION
Follow-up to #167: the 2.5-minute worst-case stale window (grace 90s + tick 60s) is unacceptable for the departure case — and unnecessary.

- **In scope + endpoints transiently empty** (rev-66 case): grace unchanged — retained fast-503s beat ODCDS stalls mid-churn.
- **Left the dependency set**: dropped in the same reload. FQDN authorities can't 404 (catch-all backstop), so the retained vhost only shadowed ODCDS. Recovery = first-request observed warm (~600ms), zero stale window.
- #167's tick stays as backstop for declared-but-extinct services.

🤖 Generated with [Claude Code](https://claude.com/claude-code)