### PR TITLE
feat(registrar): mesh-wide service catalog in every agent (hybrid index)

### DIFF
--- a/agent/internal/xds/server/odcds.go
+++ b/agent/internal/xds/server/odcds.go
@@ -5,11 +5,14 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"github.com/bpalermo/aether/registry"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // onDemandObserver watches the discovery streams for on-demand CDS
@@ -19,16 +22,29 @@ import (
 // observer records it as an observed dependency, which triggers the scoped
 // reload that delivers the cluster and resumes the paused request.
 type onDemandObserver struct {
-	cache *cache.SnapshotCache
-	log   logr.Logger
+	cache    *cache.SnapshotCache
+	registry registry.Registry
+	log      logr.Logger
+	// rejected counts on-demand requests refused because the service does
+	// not exist in the catalog (nil if instrumentation disabled).
+	rejected metric.Int64Counter
 }
 
 // newOnDemandObserver creates an onDemandObserver over the snapshot cache.
-func newOnDemandObserver(snapshotCache *cache.SnapshotCache, log logr.Logger) *onDemandObserver {
-	return &onDemandObserver{
-		cache: snapshotCache,
-		log:   log.WithName("odcds"),
+// reg provides the service catalog (registry.ServiceCatalog capability) used
+// to reject nonexistent services before they pollute the dependency set.
+func newOnDemandObserver(snapshotCache *cache.SnapshotCache, reg registry.Registry, log logr.Logger) *onDemandObserver {
+	o := &onDemandObserver{
+		cache:    snapshotCache,
+		registry: reg,
+		log:      log.WithName("odcds"),
 	}
+	var err error
+	if o.rejected, err = otel.Meter("aether/agent-odcds").Int64Counter("aether.agent.upstreams.rejected",
+		metric.WithDescription("On-demand requests refused: the service has no endpoints anywhere in the mesh (catalog miss)")); err != nil {
+		o.log.Error(err, "failed to create rejected counter; continuing without instrumentation")
+	}
+	return o
 }
 
 // Callbacks returns the go-control-plane server callbacks feeding this
@@ -58,6 +74,18 @@ func (o *onDemandObserver) onDeltaRequest(_ int64, req *discoveryv3.DeltaDiscove
 		service, ok := proxy.ServiceFromClusterName(name, o.cache.MeshDomain())
 		if !ok {
 			o.log.V(1).Info("ignoring on-demand subscription outside the mesh domain", "name", name)
+			continue
+		}
+		// Existence gate: the local service catalog (full mesh index, every
+		// agent) rejects nonexistent services here — no dependency-set
+		// pollution, no watch-filter churn, no reload. The paused request
+		// fails at the on_demand timeout; a service registered moments later
+		// is admitted on the client's retry (catalog events propagate in ms).
+		if cat, hasCatalog := o.registry.(registry.ServiceCatalog); hasCatalog && !cat.HasService(service) {
+			o.log.Info("rejecting on-demand request for unknown service", "service", service)
+			if o.rejected != nil {
+				o.rejected.Add(context.Background(), 1)
+			}
 			continue
 		}
 		o.cache.ObserveDependency(context.Background(), service)

--- a/agent/internal/xds/server/odcds_test.go
+++ b/agent/internal/xds/server/odcds_test.go
@@ -18,7 +18,7 @@ import (
 // names, and other type URLs are ignored.
 func TestOnDemandObserver_RecordsNamedCDSSubscriptions(t *testing.T) {
 	c := cache.NewSnapshotCache("node-1", logr.Discard())
-	o := newOnDemandObserver(c, logr.Discard())
+	o := newOnDemandObserver(c, &mockRegistry{}, logr.Discard())
 
 	// Named CDS subscription for a mesh authority: observed under the bare
 	// service name (the suffix is the deterministic bridge between the
@@ -51,8 +51,8 @@ func TestCombinedCallbacks_Dispatch(t *testing.T) {
 	c1 := cache.NewSnapshotCache("node-1", logr.Discard())
 	c2 := cache.NewSnapshotCache("node-1", logr.Discard())
 	combined := combinedCallbacks{
-		newOnDemandObserver(c1, logr.Discard()).Callbacks(),
-		newOnDemandObserver(c2, logr.Discard()).Callbacks(),
+		newOnDemandObserver(c1, &mockRegistry{}, logr.Discard()).Callbacks(),
+		newOnDemandObserver(c2, &mockRegistry{}, logr.Discard()).Callbacks(),
 	}
 
 	require.NoError(t, combined.OnStreamDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
@@ -65,4 +65,28 @@ func TestCombinedCallbacks_Dispatch(t *testing.T) {
 	// Unwired hooks are nil-safe.
 	require.NoError(t, combined.OnStreamOpen(context.Background(), 1, resourcev3.ClusterType))
 	combined.OnStreamClosed(1, nil)
+}
+
+// catalogRegistry wraps mockRegistry with a fixed service catalog.
+type catalogRegistry struct {
+	*mockRegistry
+	known map[string]bool
+}
+
+func (c *catalogRegistry) HasService(name string) bool { return c.known[name] }
+
+// TestOnDemandObserver_CatalogGate verifies nonexistent services are rejected
+// before touching the dependency set, while known services are observed.
+func TestOnDemandObserver_CatalogGate(t *testing.T) {
+	c := cache.NewSnapshotCache("node-1", logr.Discard())
+	reg := &catalogRegistry{mockRegistry: &mockRegistry{}, known: map[string]bool{"svc-real": true}}
+	o := newOnDemandObserver(c, reg, logr.Discard())
+
+	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl:                resourcev3.ClusterType,
+		ResourceNamesSubscribe: []string{"svc-real.aether.internal", "svc-ghost.aether.internal"},
+	}))
+	deps := c.DependencySet()
+	assert.Contains(t, deps, "svc-real", "catalog hit is observed")
+	assert.NotContains(t, deps, "svc-ghost", "catalog miss never pollutes the dependency set")
 }

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -51,7 +51,7 @@ func NewAgentXdsServer(ctx context.Context, clusterName string, nodeName string,
 
 	// Watch the discovery streams for on-demand CDS subscriptions (ODCDS cold
 	// path) alongside the caller's callbacks (the ACK tracker).
-	observer := newOnDemandObserver(snapshotCache, log)
+	observer := newOnDemandObserver(snapshotCache, registry, log)
 	combined := combinedCallbacks{observer.Callbacks()}
 	if callbacks != nil {
 		combined = append(combined, callbacks)

--- a/api/aether/registrar/v1/registrar.proto
+++ b/api/aether/registrar/v1/registrar.proto
@@ -67,6 +67,17 @@ message WatchEndpointsResponse {
     // Carries the snapshot version; has no service_name/endpoint. Clients use
     // it to know their cache is complete before deriving config from it.
     EVENT_TYPE_SNAPSHOT_COMPLETE = 5;
+
+    // Service-catalog events: a service exists while it has at least one
+    // endpoint in the registrar snapshot. Unlike endpoint events, these
+    // BYPASS the watch filter and reach every watcher (they are rare --
+    // deploy-time transitions, not pod churn), giving each agent a full
+    // local index of service names: the on-demand (ODCDS) cold path answers
+    // existence locally instead of stalling on nonexistent services. The
+    // full catalog is replayed as SERVICE_ADDED events on every (re)connect
+    // before SNAPSHOT_COMPLETE. Carries service_name only.
+    EVENT_TYPE_SERVICE_ADDED = 6;
+    EVENT_TYPE_SERVICE_REMOVED = 7;
   }
 
   EventType type = 1;

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -179,6 +179,15 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 
 	b.mu.RLock()
 	for _, event := range events {
+		// Service-catalog events bypass the watch filter: every agent keeps
+		// the full service-name index (rare, deploy-time transitions).
+		if event.GetType() == registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED ||
+			event.GetType() == registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED {
+			for id, w := range b.watchers {
+				send(id, w, event)
+			}
+			continue
+		}
 		for id, w := range b.byService[event.GetServiceName()] {
 			send(id, w, event)
 		}

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -119,7 +119,8 @@ func (s *RegistrarServer) RegisterEndpoint(ctx context.Context, req *registrarv1
 		Protocol:    req.GetProtocol(),
 		Endpoint:    req.GetEndpoint(),
 	}}
-	version := s.snapshot.Apply(events)
+	version, transitions := s.snapshot.Apply(events)
+	events = append(events, transitions...)
 	for _, e := range events {
 		e.Version = version
 	}
@@ -162,7 +163,8 @@ func (s *RegistrarServer) UnregisterEndpoint(ctx context.Context, req *registrar
 			Endpoint:    &registryv1.ServiceEndpoint{Ip: ip},
 		})
 	}
-	version := s.snapshot.Apply(events)
+	version, transitions := s.snapshot.Apply(events)
+	events = append(events, transitions...)
 	for _, e := range events {
 		e.Version = version
 	}
@@ -217,6 +219,22 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 			}
 		}
 	}
+	// Replay the full service catalog (every watcher, regardless of filter):
+	// agents keep a local index of service names so the on-demand cold path
+	// answers existence locally. Skipped when the client is current (its
+	// catalog is too: transitions ride the same versioned stream).
+	if req.GetLastVersion() != currentVersion {
+		for _, name := range s.snapshot.ServiceNames() {
+			if err := stream.Send(&registrarv1.WatchEndpointsResponse{
+				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED,
+				ServiceName: name,
+				Version:     currentVersion,
+			}); err != nil {
+				return fmt.Errorf("failed to send service catalog event: %w", err)
+			}
+		}
+	}
+
 	// Mark the snapshot boundary so the client knows its cache is complete
 	// (sent even when the snapshot was skipped: the client is current).
 	if err := stream.Send(&registrarv1.WatchEndpointsResponse{

--- a/registrar/internal/server/server_test.go
+++ b/registrar/internal/server/server_test.go
@@ -170,22 +170,37 @@ func TestWatchEndpointsFilteredSnapshot(t *testing.T) {
 		return stream.sent
 	}
 
-	// Scoped to svc-a: exactly one FULL_SNAPSHOT (svc-a) + the marker.
+	// The service CATALOG (every service's name) is replayed to every
+	// watcher regardless of filter; endpoint snapshots stay filtered.
+	countByType := func(sent []*registrarv1.WatchEndpointsResponse, t registrarv1.WatchEndpointsResponse_EventType) int {
+		n := 0
+		for _, e := range sent {
+			if e.GetType() == t {
+				n++
+			}
+		}
+		return n
+	}
+
+	// Scoped to svc-a: one FULL_SNAPSHOT (svc-a) + full catalog + marker.
 	sent := run(&registrarv1.WatchEndpointsRequest{
 		Filter: &registrarv1.ServiceFilter{Services: []string{"svc-a"}},
 	})
-	require.Len(t, sent, 2)
+	require.Len(t, sent, 4)
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT, sent[0].GetType())
 	assert.Equal(t, "svc-a", sent[0].GetServiceName())
-	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, sent[1].GetType())
+	assert.Equal(t, 2, countByType(sent, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED), "catalog bypasses the filter")
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, sent[3].GetType())
 
-	// Explicitly empty filter: marker only (a node with no mesh pods).
+	// Explicitly empty filter: catalog + marker only (node with no mesh pods).
 	sent = run(&registrarv1.WatchEndpointsRequest{
 		Filter: &registrarv1.ServiceFilter{},
 	})
-	require.Len(t, sent, 1)
-	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, sent[0].GetType())
-
-	// No filter: full snapshot (both services) + marker.
-	sent = run(&registrarv1.WatchEndpointsRequest{})
 	require.Len(t, sent, 3)
+	assert.Equal(t, 0, countByType(sent, registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT))
+	assert.Equal(t, 2, countByType(sent, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED))
+
+	// No filter: full snapshot (both services) + catalog + marker.
+	sent = run(&registrarv1.WatchEndpointsRequest{})
+	require.Len(t, sent, 5)
 }

--- a/registrar/internal/server/snapshot.go
+++ b/registrar/internal/server/snapshot.go
@@ -4,6 +4,7 @@ package server
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
 
@@ -39,6 +40,41 @@ func NewSnapshot() *Snapshot {
 	return &Snapshot{
 		entries: make(map[serviceKey]*snapshotEntry),
 	}
+}
+
+// serviceCountLocked returns the number of endpoints stored for a service
+// across protocols. Caller must hold mu (read or write).
+func (s *Snapshot) serviceCountLocked(serviceName string) int {
+	n := 0
+	for key := range s.entries {
+		if key.ServiceName == serviceName {
+			n++
+		}
+	}
+	return n
+}
+
+// serviceTransition builds a catalog event (SERVICE_ADDED/SERVICE_REMOVED).
+func serviceTransition(t registrarv1.WatchEndpointsResponse_EventType, serviceName string) *registrarv1.WatchEndpointsResponse {
+	return &registrarv1.WatchEndpointsResponse{Type: t, ServiceName: serviceName}
+}
+
+// ServiceNames returns the sorted names of all services currently holding at
+// least one endpoint — the service catalog replayed to every new watcher.
+func (s *Snapshot) ServiceNames() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	set := make(map[string]struct{})
+	for key := range s.entries {
+		set[key.ServiceName] = struct{}{}
+	}
+	names := make([]string, 0, len(set))
+	for name := range set {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // Version returns the current snapshot version as a string.
@@ -142,10 +178,17 @@ func (s *Snapshot) Diff(newEndpoints map[string]map[registryv1.Service_Protocol]
 }
 
 // Replace atomically replaces the entire snapshot contents with the provided
-// endpoints and bumps the version. It returns the new version string.
-func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint) string {
+// endpoints and bumps the version. It returns the new version string plus
+// the service-catalog transitions (see Apply) between the old and new
+// contents; the caller stamps and broadcasts them.
+func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint) (string, []*registrarv1.WatchEndpointsResponse) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	oldServices := make(map[string]struct{})
+	for key := range s.entries {
+		oldServices[key.ServiceName] = struct{}{}
+	}
 
 	s.entries = make(map[serviceKey]*snapshotEntry)
 	for svcName, protocols := range endpoints {
@@ -161,19 +204,48 @@ func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol]
 		}
 	}
 
-	return s.nextVersion()
+	newServices := make(map[string]struct{})
+	for key := range s.entries {
+		newServices[key.ServiceName] = struct{}{}
+	}
+	var transitions []*registrarv1.WatchEndpointsResponse
+	for name := range newServices {
+		if _, ok := oldServices[name]; !ok {
+			transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, name))
+		}
+	}
+	for name := range oldServices {
+		if _, ok := newServices[name]; !ok {
+			transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, name))
+		}
+	}
+	// Deterministic broadcast order (map iteration above is random).
+	sort.Slice(transitions, func(i, j int) bool {
+		if transitions[i].GetType() != transitions[j].GetType() {
+			return transitions[i].GetType() < transitions[j].GetType()
+		}
+		return transitions[i].GetServiceName() < transitions[j].GetServiceName()
+	})
+
+	return s.nextVersion(), transitions
 }
 
 // Apply applies a set of events to the snapshot, updating it in place.
-// It returns the new version string.
-func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) string {
+// It returns the new version string plus the service-catalog transitions the
+// events caused (a service's endpoint count crossing 0<->1 emits
+// SERVICE_ADDED/SERVICE_REMOVED): deriving transitions inside Apply makes
+// the catalog impossible to desync from the endpoint data it summarizes.
+// Transitions are unversioned; the caller stamps and broadcasts them with
+// the batch.
+func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) (string, []*registrarv1.WatchEndpointsResponse) {
 	if len(events) == 0 {
-		return s.Version()
+		return s.Version(), nil
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	var transitions []*registrarv1.WatchEndpointsResponse
 	for _, event := range events {
 		key := serviceKey{
 			ServiceName: event.GetServiceName(),
@@ -183,17 +255,26 @@ func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) string {
 
 		switch event.GetType() {
 		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED:
+			before := s.serviceCountLocked(key.ServiceName)
 			s.entries[key] = &snapshotEntry{
 				ServiceName: event.GetServiceName(),
 				Protocol:    event.GetProtocol(),
 				Endpoint:    event.GetEndpoint(),
 			}
+			if before == 0 {
+				transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, key.ServiceName))
+			}
 		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED:
-			delete(s.entries, key)
+			if _, existed := s.entries[key]; existed {
+				delete(s.entries, key)
+				if s.serviceCountLocked(key.ServiceName) == 0 {
+					transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, key.ServiceName))
+				}
+			}
 		}
 	}
 
-	return s.nextVersion()
+	return s.nextVersion(), transitions
 }
 
 // FullSnapshotEvents returns the current contents of the snapshot as a slice of

--- a/registrar/internal/server/snapshot_test.go
+++ b/registrar/internal/server/snapshot_test.go
@@ -41,7 +41,7 @@ func TestVersion(t *testing.T) {
 		{
 			name: "version increments after Replace",
 			applyOperations: func(s *Snapshot) {
-				s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
+				_, _ = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
 			},
 			expectedVersion: "1",
 		},
@@ -62,16 +62,16 @@ func TestVersion(t *testing.T) {
 		{
 			name: "version does not increment after Apply with empty events",
 			applyOperations: func(s *Snapshot) {
-				s.Apply([]*registrarv1.WatchEndpointsResponse{})
+				_, _ = s.Apply([]*registrarv1.WatchEndpointsResponse{})
 			},
 			expectedVersion: "0",
 		},
 		{
 			name: "version increments multiple times",
 			applyOperations: func(s *Snapshot) {
-				s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
-				s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
-				s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
+				_, _ = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
+				_, _ = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
+				_, _ = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{})
 			},
 			expectedVersion: "3",
 		},
@@ -149,7 +149,7 @@ func TestGetAll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSnapshot()
-			s.Replace(tt.seed)
+			_, _ = s.Replace(tt.seed)
 
 			got := s.GetAll(tt.protocol)
 
@@ -196,7 +196,7 @@ func TestGetAllWithVersion(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSnapshot()
-			s.Replace(tt.seed)
+			_, _ = s.Replace(tt.seed)
 
 			got, version := s.GetAllWithVersion(tt.protocol)
 
@@ -323,7 +323,7 @@ func TestDiff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSnapshot()
-			s.Replace(tt.initial)
+			_, _ = s.Replace(tt.initial)
 
 			versionBefore := s.Version()
 			events := s.Diff(tt.newEndpoints)
@@ -401,9 +401,9 @@ func TestReplace(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSnapshot()
-			s.Replace(tt.initial)
+			_, _ = s.Replace(tt.initial)
 
-			newVersion := s.Replace(tt.replacement)
+			newVersion, _ := s.Replace(tt.replacement)
 
 			assert.Equal(t, tt.expectedVersion, newVersion)
 			assert.Equal(t, tt.expectedVersion, s.Version())
@@ -577,10 +577,10 @@ func TestApply(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSnapshot()
 			if len(tt.initial) > 0 {
-				s.Replace(tt.initial)
+				_, _ = s.Replace(tt.initial)
 			}
 
-			gotVersion := s.Apply(tt.events)
+			gotVersion, _ := s.Apply(tt.events)
 
 			assert.Equal(t, tt.expectedVersion, gotVersion)
 			assert.Equal(t, tt.expectedVersion, s.Version())
@@ -634,7 +634,7 @@ func TestFullSnapshotEvents(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := NewSnapshot()
-			s.Replace(tt.seed)
+			_, _ = s.Replace(tt.seed)
 
 			events, version := s.FullSnapshotEvents()
 
@@ -679,9 +679,9 @@ func TestSnapshotThreadSafety(t *testing.T) {
 			defer wg.Done()
 			switch i % 5 {
 			case 0:
-				s.Replace(seed)
+				_, _ = s.Replace(seed)
 			case 1:
-				s.Apply(addEvent)
+				_, _ = s.Apply(addEvent)
 			case 2:
 				s.GetAll(registryv1.Service_PROTOCOL_HTTP)
 			case 3:
@@ -694,4 +694,58 @@ func TestSnapshotThreadSafety(t *testing.T) {
 
 	wg.Wait()
 	// If we reach here without a panic or race condition, the test passes.
+}
+
+// TestSnapshot_ServiceCatalogTransitions verifies SERVICE_ADDED/REMOVED are
+// emitted exactly on a service's endpoint count crossing 0<->1 (Apply) and
+// on service-set diffs (Replace), and that ServiceNames lists the catalog.
+func TestSnapshot_ServiceCatalogTransitions(t *testing.T) {
+	s := NewSnapshot()
+
+	add := func(svc, ip string) *registrarv1.WatchEndpointsResponse {
+		return &registrarv1.WatchEndpointsResponse{
+			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
+			ServiceName: svc, Protocol: registryv1.Service_PROTOCOL_HTTP,
+			Endpoint: &registryv1.ServiceEndpoint{Ip: ip},
+		}
+	}
+	rm := func(svc, ip string) *registrarv1.WatchEndpointsResponse {
+		return &registrarv1.WatchEndpointsResponse{
+			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED,
+			ServiceName: svc, Protocol: registryv1.Service_PROTOCOL_HTTP,
+			Endpoint: &registryv1.ServiceEndpoint{Ip: ip},
+		}
+	}
+
+	// First endpoint: SERVICE_ADDED. Second: no transition.
+	_, tr := s.Apply([]*registrarv1.WatchEndpointsResponse{add("svc-a", "10.0.0.1")})
+	require.Len(t, tr, 1)
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, tr[0].GetType())
+	assert.Equal(t, "svc-a", tr[0].GetServiceName())
+	_, tr = s.Apply([]*registrarv1.WatchEndpointsResponse{add("svc-a", "10.0.0.2")})
+	assert.Empty(t, tr, "1->2 is not a transition")
+	assert.Equal(t, []string{"svc-a"}, s.ServiceNames())
+
+	// Removing one of two: no transition. Removing the last: SERVICE_REMOVED.
+	_, tr = s.Apply([]*registrarv1.WatchEndpointsResponse{rm("svc-a", "10.0.0.2")})
+	assert.Empty(t, tr)
+	_, tr = s.Apply([]*registrarv1.WatchEndpointsResponse{rm("svc-a", "10.0.0.1")})
+	require.Len(t, tr, 1)
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, tr[0].GetType())
+	assert.Empty(t, s.ServiceNames())
+
+	// Removing a nonexistent endpoint: no spurious transition.
+	_, tr = s.Apply([]*registrarv1.WatchEndpointsResponse{rm("ghost", "10.9.9.9")})
+	assert.Empty(t, tr)
+
+	// Replace: diff of the service sets.
+	_, _ = s.Apply([]*registrarv1.WatchEndpointsResponse{add("svc-old", "10.0.1.1")})
+	_, tr = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
+		"svc-new": {registryv1.Service_PROTOCOL_HTTP: {{Ip: "10.0.2.1"}}},
+	})
+	require.Len(t, tr, 2)
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, tr[0].GetType())
+	assert.Equal(t, "svc-new", tr[0].GetServiceName())
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, tr[1].GetType())
+	assert.Equal(t, "svc-old", tr[1].GetServiceName())
 }

--- a/registrar/internal/server/sync.go
+++ b/registrar/internal/server/sync.go
@@ -119,7 +119,8 @@ func (s *Syncer) sync(ctx context.Context) {
 
 	// Compute diff and apply.
 	events := s.snapshot.Diff(newState)
-	version := s.snapshot.Replace(newState)
+	version, transitions := s.snapshot.Replace(newState)
+	events = append(events, transitions...)
 	span.SetAttributes(
 		attribute.Int("aether.sync.events", len(events)),
 		telemetry.AttrSnapshotVersion.String(version),

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -60,6 +60,11 @@ type RegistrarRegistry struct {
 
 	mu    sync.RWMutex
 	cache map[string][]*registryv1.ServiceEndpoint // keyed by serviceName
+	// services is the full mesh service-name catalog (every watcher receives
+	// catalog events regardless of filter): the ODCDS cold path answers
+	// existence locally instead of stalling on nonexistent services. Replayed
+	// on every reconnect; swapped atomically at SNAPSHOT_COMPLETE.
+	services map[string]struct{}
 
 	// notify coalesces endpoint-change signals for consumers (e.g. the agent
 	// xDS cache). It is buffered with capacity 1 and written non-blocking, so a
@@ -111,6 +116,7 @@ func NewRegistrarRegistry(log logr.Logger, cfg Config) *RegistrarRegistry {
 		config:      cfg,
 		metrics:     metrics,
 		cache:       make(map[string][]*registryv1.ServiceEndpoint),
+		services:    make(map[string]struct{}),
 		notify:      make(chan struct{}, 1),
 		ready:       make(chan struct{}),
 		reconnected: make(chan struct{}, 1),
@@ -139,6 +145,16 @@ func (r *RegistrarRegistry) signalReconnect() {
 	case r.reconnected <- struct{}{}:
 	default:
 	}
+}
+
+// HasService reports whether the named service currently has at least one
+// endpoint anywhere in the mesh, answered from the local catalog. It
+// satisfies the registry.ServiceCatalog capability.
+func (r *RegistrarRegistry) HasService(name string) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	_, ok := r.services[name]
+	return ok
 }
 
 // WaitReady blocks until the watch cache holds a complete snapshot (the first
@@ -424,6 +440,12 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 // It returns the last version seen, for use as a resume token.
 func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv1.RegistrarService_WatchEndpointsClient, lastVersion string) string {
 	snapshotCleared := false
+	// Catalog replay: SERVICE_ADDED events before SNAPSHOT_COMPLETE rebuild
+	// the service set, swapped in at the marker — but only when the server
+	// actually resent state (the marker's version differs from our resume
+	// token); a current client keeps its catalog.
+	connectVersion := lastVersion
+	catalogReplay := make(map[string]struct{})
 
 	for {
 		event, err := stream.Recv()
@@ -457,7 +479,31 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 			snapshotCleared = true
 		}
 
-		if event.GetType() == registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE {
+		switch event.GetType() {
+		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED:
+			if catalogReplay != nil {
+				// Pre-marker: catalog replay, accumulated and swapped at the
+				// marker so a reconnect can't leave stale names behind.
+				catalogReplay[event.GetServiceName()] = struct{}{}
+			} else {
+				// Post-marker: incremental transition.
+				r.mu.Lock()
+				r.services[event.GetServiceName()] = struct{}{}
+				r.mu.Unlock()
+			}
+		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED:
+			r.mu.Lock()
+			delete(r.services, event.GetServiceName())
+			r.mu.Unlock()
+		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE:
+			if catalogReplay != nil && event.GetVersion() != connectVersion {
+				// The server resent state: swap the catalog wholesale
+				// (possibly to empty — a fresh registrar with no services).
+				r.mu.Lock()
+				r.services = catalogReplay
+				r.mu.Unlock()
+			}
+			catalogReplay = nil
 			// The cache now holds a complete world view.
 			r.readyOnce.Do(func() { close(r.ready) })
 		}

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -596,3 +596,50 @@ func TestSetServiceFilter_ReassertsOnChangeOnly(t *testing.T) {
 	assert.Nil(t, services)
 	assert.Equal(t, uint64(4), gen)
 }
+
+// TestServiceCatalog_ReplayAndIncrementals verifies the client catalog:
+// replay accumulates and swaps at SNAPSHOT_COMPLETE (when the server resent
+// state), stale names from a previous connection are dropped by the swap,
+// and post-marker transitions apply incrementally.
+func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
+	r := NewRegistrarRegistry(logr.Discard(), Config{Address: "test"})
+
+	ev := func(t registrarv1.WatchEndpointsResponse_EventType, svc, version string) *registrarv1.WatchEndpointsResponse {
+		return &registrarv1.WatchEndpointsResponse{Type: t, ServiceName: svc, Version: version}
+	}
+
+	// First connection: replay svc-a, svc-b; complete at version 5.
+	stream := &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-a", "5"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-b", "5"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "5"),
+		// Post-marker incremental transitions.
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-c", "6"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, "svc-b", "7"),
+	}}
+	last := r.processStream(context.Background(), stream, "")
+	assert.Equal(t, "7", last)
+	assert.True(t, r.HasService("svc-a"))
+	assert.False(t, r.HasService("svc-b"), "incremental removal applies")
+	assert.True(t, r.HasService("svc-c"))
+	assert.False(t, r.HasService("ghost"))
+
+	// Reconnect where the server RESENT state (version moved): the swap must
+	// drop names the new catalog doesn't carry.
+	stream = &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-z", "9"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "9"),
+	}}
+	_ = r.processStream(context.Background(), stream, "7")
+	assert.True(t, r.HasService("svc-z"))
+	assert.False(t, r.HasService("svc-a"), "swap drops stale catalog entries")
+	assert.False(t, r.HasService("svc-c"))
+
+	// Reconnect where the client is CURRENT (marker version == resume token):
+	// no replay was sent; the catalog must survive.
+	stream = &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "9"),
+	}}
+	_ = r.processStream(context.Background(), stream, "9")
+	assert.True(t, r.HasService("svc-z"), "current client keeps its catalog")
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -61,6 +61,17 @@ type ReconnectNotifier interface {
 	Reconnects() <-chan struct{}
 }
 
+// ServiceCatalog is an optional capability for Registry implementations
+// that maintain a full local index of mesh service names (the registrar
+// watch streams catalog events to every watcher, unfiltered — service
+// existence is low-churn, unlike endpoints). HasService reports whether the
+// named service currently has at least one endpoint mesh-wide; the ODCDS
+// cold path consults it to reject nonexistent services locally instead of
+// polluting the dependency set and watch filter.
+type ServiceCatalog interface {
+	HasService(name string) bool
+}
+
 // WatchScoper is an optional capability for Registry implementations backed
 // by a watch stream. SetServiceFilter scopes the watch to the given services
 // (the node's dependency set -- demand-scoped distribution): the registrar


### PR DESCRIPTION
Part 1 of the ODCDS convergence plan (hybrid full-name-index / scoped-endpoints, per design discussion).

- `SERVICE_ADDED`/`SERVICE_REMOVED` on the existing watch stream; transitions derived inside `Snapshot.Apply`/`Replace` (0↔1 endpoint crossings) — impossible to desync.
- Catalog events bypass the per-service broadcaster index (rare, deploy-time); full catalog replay on (re)connect, client swaps wholesale at `SNAPSHOT_COMPLETE` (only when state was resent — a current client keeps its catalog).
- ODCDS observer gates on `registry.ServiceCatalog`: ghosts never touch dep set/filter/reload; `aether.agent.upstreams.rejected` counter.
- Phase 2 fan-out property fully preserved; agent memory cost ≈ service-name strings.

Part 2 (next PR): catalog-gated RPC-fill in the reload + leading-edge dep-change trigger + watch-cache purge on filter shrink + on_demand timeout 5s→2s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)