### PR TITLE
test(registrar): terminate catalog test stream with io.EOF

### DIFF
--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -616,7 +616,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 		// Post-marker incremental transitions.
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-c", "6"),
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, "svc-b", "7"),
-	}}
+	}, err: io.EOF}
 	last := r.processStream(context.Background(), stream, "")
 	assert.Equal(t, "7", last)
 	assert.True(t, r.HasService("svc-a"))
@@ -629,7 +629,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 	stream = &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-z", "9"),
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "9"),
-	}}
+	}, err: io.EOF}
 	_ = r.processStream(context.Background(), stream, "7")
 	assert.True(t, r.HasService("svc-z"))
 	assert.False(t, r.HasService("svc-a"), "swap drops stale catalog entries")
@@ -639,7 +639,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 	// no replay was sent; the catalog must survive.
 	stream = &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "9"),
-	}}
+	}, err: io.EOF}
 	_ = r.processStream(context.Background(), stream, "9")
 	assert.True(t, r.HasService("svc-z"), "current client keeps its catalog")
 }


### PR DESCRIPTION
Hotfix: `TestServiceCatalog_ReplayAndIncrementals` (#169) didn't set the fake stream's terminating `io.EOF`, so `processStream` spins forever → `registrar_test` TIMEOUT on main and all branches. The fix existed on the #169 branch but the merge raced ahead of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)