### PR TITLE
feat(registrar): etcd watch — sync at watch speed, not the 5s poll

### DIFF
--- a/registrar/internal/server/sync.go
+++ b/registrar/internal/server/sync.go
@@ -62,15 +62,37 @@ func (s *Syncer) UseWriteBehind(q *WriteBehindQueue) { s.writeBehind = q }
 // completed and the snapshot reflects the external registry.
 func (s *Syncer) Synced() <-chan struct{} { return s.synced }
 
-// Start runs the sync loop until the context is cancelled.
+// changeDebounce coalesces a burst of registry change signals (e.g. an etcd
+// watch firing per key during a roll) into a single sync, while still
+// reacting within a fraction of the poll interval.
+const changeDebounce = 200 * time.Millisecond
+
+// Start runs the sync loop until the context is cancelled. When the registry
+// supports change notifications (registry.ChangeNotifier — the etcd backend's
+// clientv3 watch), the loop syncs at watch speed (debounced) instead of only
+// at the poll interval; the periodic poll remains a backstop for any event
+// missed during a watch re-establish. Backends without notifications (e.g.
+// DynamoDB) fall back to poll-only, unchanged.
 func (s *Syncer) Start(ctx context.Context) error {
 	s.log.Info("starting sync loop", "interval", s.syncInterval)
 
 	// Perform an initial sync immediately.
 	s.sync(ctx)
 
+	var changes <-chan struct{}
+	if n, ok := s.registry.(registry.ChangeNotifier); ok {
+		changes = n.Changes()
+		s.log.Info("registry supports change notifications; syncing at watch speed (poll is backstop)")
+	}
+
 	ticker := time.NewTicker(s.syncInterval)
 	defer ticker.Stop()
+
+	// Debounce timer for change-driven syncs, created stopped.
+	debounce := time.NewTimer(changeDebounce)
+	if !debounce.Stop() {
+		<-debounce.C
+	}
 
 	for {
 		select {
@@ -78,6 +100,18 @@ func (s *Syncer) Start(ctx context.Context) error {
 			s.log.Info("sync loop stopped")
 			return nil
 		case <-ticker.C:
+			s.sync(ctx)
+		case <-changes:
+			// (Re)arm the debounce window so a burst of watch events triggers
+			// a single sync once they settle.
+			if !debounce.Stop() {
+				select {
+				case <-debounce.C:
+				default:
+				}
+			}
+			debounce.Reset(changeDebounce)
+		case <-debounce.C:
 			s.sync(ctx)
 		}
 	}

--- a/registrar/internal/server/sync_test.go
+++ b/registrar/internal/server/sync_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -362,4 +363,41 @@ func TestSyncer_Start_NoEventsAfterInitialSync(t *testing.T) {
 	// Because the state never changed after the first sync, no events should
 	// have been broadcast to the watcher.
 	assert.Equal(t, 0, len(eventCh), "expected no events when state is unchanged between syncs")
+}
+
+// notifyMockRegistry adds a controllable Changes() channel to mockRegistry to
+// exercise the Syncer's watch-driven (vs poll-driven) path.
+type notifyMockRegistry struct {
+	*mockRegistry
+	ch chan struct{}
+}
+
+func (n *notifyMockRegistry) Changes() <-chan struct{} { return n.ch }
+
+// TestSyncer_ChangeDrivenSync verifies that a ChangeNotifier registry triggers
+// a sync via the watch signal (debounced) well before the poll interval would.
+func TestSyncer_ChangeDrivenSync(t *testing.T) {
+	snap := NewSnapshot()
+	bc := NewBroadcaster(logr.Discard(), nil)
+	var calls atomic.Int64
+	base := &mockRegistry{listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+		calls.Add(1)
+		return map[string][]*registryv1.ServiceEndpoint{}, nil
+	}}
+	reg := &notifyMockRegistry{mockRegistry: base, ch: make(chan struct{}, 1)}
+
+	// Long poll interval so any timely sync must come from the change signal.
+	s := NewSyncer(reg, snap, bc, 1*time.Hour, logr.Discard(), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Start(ctx) }()
+
+	// Wait for the initial sync.
+	require.Eventually(t, func() bool { return calls.Load() >= 1 }, 2*time.Second, 10*time.Millisecond)
+	before := calls.Load()
+
+	// Fire a change → expect a debounced sync within ~1s, not 1h.
+	reg.ch <- struct{}{}
+	require.Eventually(t, func() bool { return calls.Load() > before }, 2*time.Second, 10*time.Millisecond,
+		"change signal must drive a sync ahead of the poll interval")
 }

--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -42,6 +42,16 @@ type EtcdRegistry struct {
 	config    Config
 	client    *clientv3.Client
 	keyPrefix string
+
+	// notify coalesces change signals from the etcd watch for consumers (the
+	// registrar Syncer). Buffered cap-1, non-blocking send: a burst of watch
+	// events collapses into a single pending signal. Satisfies
+	// registry.ChangeNotifier so the registrar reacts at watch speed (~ms)
+	// instead of waiting out the poll interval — closing the cross-replica
+	// last-old-exit skew on the etcd backend.
+	notify chan struct{}
+	// watchCancel stops the background watch loop on Close.
+	watchCancel context.CancelFunc
 }
 
 // NewEtcdRegistry creates a new etcd-backed Registry.
@@ -62,6 +72,7 @@ func NewEtcdRegistry(log logr.Logger, cfg Config) *EtcdRegistry {
 		log:       log.WithName("registry-etcd"),
 		config:    cfg,
 		keyPrefix: keyPrefix,
+		notify:    make(chan struct{}, 1),
 	}
 }
 
@@ -94,8 +105,66 @@ func (r *EtcdRegistry) Initialize(ctx context.Context) error {
 		return fmt.Errorf("failed to verify etcd connectivity: %w", err)
 	}
 
+	// Start the change watch over the key prefix so consumers learn of writes
+	// (from this replica or any other registrar/agent) at watch speed. A
+	// detached context keeps the watch alive for the registry's lifetime;
+	// Close cancels it.
+	watchCtx, cancel := context.WithCancel(context.Background())
+	r.watchCancel = cancel
+	go r.watchLoop(watchCtx)
+
 	r.log.Info("etcd registry initialized", "endpoints", r.config.Endpoints)
 	return nil
+}
+
+// Changes returns a channel that receives a (coalesced) signal whenever any
+// key under the registry prefix changes. Consumers treat each receive as
+// "something changed, re-read the registry". Satisfies registry.ChangeNotifier.
+func (r *EtcdRegistry) Changes() <-chan struct{} { return r.notify }
+
+// signalChange performs a non-blocking, coalescing send on notify.
+func (r *EtcdRegistry) signalChange() {
+	select {
+	case r.notify <- struct{}{}:
+	default:
+	}
+}
+
+// watchLoop maintains a clientv3 watch over the key prefix, signaling
+// consumers on every change. It re-establishes the watch on channel closure
+// (compaction, leader change, transient error); the consumer's periodic poll
+// is the backstop for any gap during a re-establish.
+func (r *EtcdRegistry) watchLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		// WithPrevKV is unnecessary (consumers re-read), WithPrefix watches the
+		// whole registry subtree. The watch starts from the current revision.
+		wch := r.client.Watch(ctx, r.keyPrefix, clientv3.WithPrefix())
+		r.log.V(1).Info("etcd change watch established", "prefix", r.keyPrefix)
+
+		for resp := range wch {
+			if err := resp.Err(); err != nil {
+				r.log.V(1).Info("etcd watch error; will re-establish", "error", err.Error())
+				break
+			}
+			if len(resp.Events) > 0 {
+				r.signalChange()
+			}
+		}
+
+		// Channel closed (ctx cancel or watch broke). Loop to re-establish
+		// unless we are shutting down.
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(time.Second):
+		}
+	}
 }
 
 // RegisterEndpoint registers an endpoint to a service and protocol in etcd.
@@ -259,6 +328,10 @@ func (r *EtcdRegistry) ListAllEndpoints(ctx context.Context, protocol registryv1
 
 // Close closes the etcd client connection.
 func (r *EtcdRegistry) Close() error {
+	if r.watchCancel != nil {
+		r.watchCancel()
+		r.watchCancel = nil
+	}
 	if r.client != nil {
 		err := r.client.Close()
 		r.client = nil

--- a/registry/internal/etcd/etcd_test.go
+++ b/registry/internal/etcd/etcd_test.go
@@ -416,3 +416,41 @@ func TestEtcdRegistry_CloseWithoutStart(t *testing.T) {
 	err := registry.Close()
 	assert.NoError(t, err)
 }
+
+// TestEtcdRegistry_WatchSignalsChanges verifies the etcd backend satisfies
+// registry.ChangeNotifier: a write under the prefix fires a coalesced signal
+// on Changes(), so the registrar reacts at watch speed instead of polling.
+func TestEtcdRegistry_WatchSignalsChanges(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	ctx := context.Background()
+	registry := setupRegistry(ctx, t)
+
+	notifier, ok := interface{}(registry).(interface{ Changes() <-chan struct{} })
+	require.True(t, ok, "etcd registry must implement registry.ChangeNotifier")
+
+	// Drain any startup signal.
+	select {
+	case <-notifier.Changes():
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	ep := &registryv1.ServiceEndpoint{Ip: "10.0.9.9", ClusterName: "c", Port: 8080}
+	require.NoError(t, registry.RegisterEndpoint(ctx, "watch-svc", registryv1.Service_PROTOCOL_HTTP, ep))
+
+	select {
+	case <-notifier.Changes():
+		// got the signal
+	case <-time.After(5 * time.Second):
+		t.Fatal("watch did not signal a change after RegisterEndpoint")
+	}
+
+	// A removal also signals.
+	require.NoError(t, registry.UnregisterEndpoint(ctx, "watch-svc", "10.0.9.9"))
+	select {
+	case <-notifier.Changes():
+	case <-time.After(5 * time.Second):
+		t.Fatal("watch did not signal a change after UnregisterEndpoint")
+	}
+}


### PR DESCRIPTION
The etcd backend implements `registry.ChangeNotifier` via `clientv3.Watch`; the registrar `Syncer` reacts to `Changes()` (200ms debounce) on top of the periodic poll (kept as backstop). Closes the cross-replica last-old-exit skew on etcd (~6s → sub-second) and makes cross-cluster convergence watch-speed when registrars share an external etcd. DynamoDB unchanged (poll-only). Agents still go through the registrar — never etcd directly (apiserver-style watch cache; see the registrar-etcd analysis).

Tests: etcd `Changes()` fires on register/unregister (real etcd container); Syncer change-driven sync beats the poll interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)