### PR TITLE
build: hermetic LLVM toolchain (replace Zig) + hermetic SDK bindgen

### DIFF
--- a/.github/actions/setup-llvm-libs/action.yml
+++ b/.github/actions/setup-llvm-libs/action.yml
@@ -1,20 +1,21 @@
 name: Setup LLVM runtime libs
 description: >-
-  Provide libtinfo.so.5 for the hermetic toolchains_llvm clang. The pinned LLVM
-  18.1.8 prebuilt (LLVM.org's ubuntu-18.04 build, matching Envoy's hermetic pin)
-  links libtinfo.so.5, but ubuntu-24.04 runners ship only libtinfo.so.6. This is
-  a build-host prerequisite for running the pinned clang (it does not affect build
-  reproducibility); ncurses 6 is ABI-compatible for the terminfo symbols clang
-  uses. See //bazel/llvm and MODULE.bazel.
+  Install libtinfo5 for the hermetic toolchains_llvm clang. The pinned LLVM 18.1.8
+  static build leaks a shared dependency on libtinfo.so.5
+  (llvm/llvm-project#75490), but ubuntu-24.04 runners ship only libtinfo.so.6
+  (and a .6->.5 symlink fails: clang needs the versioned NCURSES_TINFO_5.0
+  symbols). Fetch the real ncurses5 .deb from Debian — the same workaround Envoy
+  uses (envoyproxy/envoy#42397). Build-host prerequisite only; does not affect
+  build reproducibility. See //bazel/llvm and MODULE.bazel.
 
 runs:
   using: composite
   steps:
-    - name: Symlink libtinfo.so.5 -> libtinfo.so.6
+    - name: Install libtinfo5
       shell: bash
       run: |
-        for dir in /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu; do
-          if [ -e "$dir/libtinfo.so.6" ] && [ ! -e "$dir/libtinfo.so.5" ]; then
-            sudo ln -sf "$dir/libtinfo.so.6" "$dir/libtinfo.so.5"
-          fi
-        done
+        arch="$(dpkg --print-architecture)"
+        deb="libtinfo5_6.4-4_${arch}.deb"
+        curl -fsSLO "http://deb.debian.org/debian/pool/main/n/ncurses/${deb}"
+        sudo dpkg -i "${deb}"
+        rm -f "${deb}"

--- a/.github/actions/setup-llvm-libs/action.yml
+++ b/.github/actions/setup-llvm-libs/action.yml
@@ -13,9 +13,12 @@ runs:
   steps:
     - name: Install libtinfo5
       shell: bash
+      # libtinfo5 was dropped from the ubuntu-24.04 apt repos (replaced by
+      # libtinfo6), so fetch the Debian .deb and let apt install it (resolving
+      # any deps). Same package Envoy uses (envoyproxy/envoy#42397).
       run: |
         arch="$(dpkg --print-architecture)"
         deb="libtinfo5_6.4-4_${arch}.deb"
         curl -fsSLO "http://deb.debian.org/debian/pool/main/n/ncurses/${deb}"
-        sudo dpkg -i "${deb}"
+        sudo apt-get install -y --no-install-recommends "./${deb}"
         rm -f "${deb}"

--- a/.github/actions/setup-llvm-libs/action.yml
+++ b/.github/actions/setup-llvm-libs/action.yml
@@ -1,0 +1,20 @@
+name: Setup LLVM runtime libs
+description: >-
+  Provide libtinfo.so.5 for the hermetic toolchains_llvm clang. The pinned LLVM
+  18.1.8 prebuilt (LLVM.org's ubuntu-18.04 build, matching Envoy's hermetic pin)
+  links libtinfo.so.5, but ubuntu-24.04 runners ship only libtinfo.so.6. This is
+  a build-host prerequisite for running the pinned clang (it does not affect build
+  reproducibility); ncurses 6 is ABI-compatible for the terminfo symbols clang
+  uses. See //bazel/llvm and MODULE.bazel.
+
+runs:
+  using: composite
+  steps:
+    - name: Symlink libtinfo.so.5 -> libtinfo.so.6
+      shell: bash
+      run: |
+        for dir in /usr/lib/x86_64-linux-gnu /usr/lib/aarch64-linux-gnu; do
+          if [ -e "$dir/libtinfo.so.6" ] && [ ! -e "$dir/libtinfo.so.5" ]; then
+            sudo ln -sf "$dir/libtinfo.so.6" "$dir/libtinfo.so.5"
+          fi
+        done

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/integration-cni-server.yaml
+++ b/.github/workflows/integration-cni-server.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/integration-dynamodb.yaml
+++ b/.github/workflows/integration-dynamodb.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/integration-etcd.yaml
+++ b/.github/workflows/integration-etcd.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/integration-xds-server.yaml
+++ b/.github/workflows/integration-xds-server.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Setup LLVM runtime libs
+        uses: ./.github/actions/setup-llvm-libs
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.18.0
         with:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 module(name = "aether")
 
 bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "protobuf", version = "34.1")
 bazel_dep(name = "rules_go", version = "0.60.0")
 bazel_dep(name = "gazelle", version = "0.51.0")
@@ -23,12 +24,14 @@ bazel_dep(name = "rules_buf", version = "0.5.4")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
 bazel_dep(name = "rules_helm", version = "0.29.0")
 
-# Rust toolchain for in-tree dynamic modules (see docs/proposals/008).
-# hermetic_cc_toolchain provides a Zig-based hermetic C/linker for cdylibs and
-# amd64/arm64 cross-compilation; registered libc-aware (opt-in) so it does not
-# override the repo's default C++ toolchain used by the Go/protobuf builds.
+# Rust toolchain for in-tree dynamic modules (see docs/proposals/008), plus a
+# hermetic LLVM (clang/lld + glibc sysroots) that cross-compiles the proxy cdylib
+# for amd64/arm64 and supplies libclang to the SDK bindgen build script. The LLVM
+# toolchains are registered opt-in (only for //bazel/llvm/platform:linux_* via
+# the :hermetic constraint), so the default host C++ toolchain used by the
+# Go/protobuf builds is untouched — the same approach as the prior Zig setup.
 bazel_dep(name = "rules_rust", version = "0.70.0")
-bazel_dep(name = "hermetic_cc_toolchain", version = "4.1.0")
+bazel_dep(name = "toolchains_llvm", version = "1.7.0")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(version = "1.26.2")
@@ -182,8 +185,27 @@ use_repo(envoy, "envoy_abi_h")
 # //proxy/filters/telemetry:abi_h.
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 crate.annotation(
-    build_script_data = ["@@//proxy/filters/telemetry:abi_h"],
-    build_script_env = {"AETHER_ABI_H": "$(execpath @@//proxy/filters/telemetry:abi_h)"},
+    # Hermetic bindgen: the SDK build script parses abi.h with the hermetic LLVM
+    # libclang + a hermetic glibc sysroot — no host clang/headers (see the patch).
+    # Routed through the MAIN repo (//bazel/llvm) — the crate_universe-generated
+    # SDK repo can't see external repos by apparent name. The clang resource +
+    # libc++ headers and the glibc sysroot tree come in via the (now default) LLVM
+    # cc toolchain that cargo_build_script pulls in; supplying them here too would
+    # collide in the sandbox. We add only libclang itself (not a toolchain input)
+    # and the sysroot marker (for --sysroot).
+    build_script_data = [
+        "@@//proxy/filters/telemetry:abi_h",
+        "@@//bazel/llvm:libclang",  # libclang soname chain present in the sandbox
+        "@@//bazel/llvm:libclang_so",  # the file LIBCLANG_PATH points at
+        "@@//bazel/llvm:sysroot_amd64_marker",  # sysroot-root marker for --sysroot
+    ],
+    build_script_env = {
+        "AETHER_ABI_H": "$(execpath @@//proxy/filters/telemetry:abi_h)",
+        # clang-sys accepts a file path for LIBCLANG_PATH — pins libclang hermetically.
+        "LIBCLANG_PATH": "$(execpath @@//bazel/llvm:libclang_so)",
+        # The patch three-parents this marker to derive --sysroot.
+        "AETHER_SYSROOT": "$(execpath @@//bazel/llvm:sysroot_amd64_marker)",
+    },
     crate = "envoy-proxy-dynamic-modules-rust-sdk",
     patch_args = ["-p1"],
     patches = ["@@//proxy/filters/telemetry/patches:sdk_abi_header.patch"],
@@ -195,11 +217,39 @@ crate.from_cargo(
 )
 use_repo(crate, "crates")
 
-# Hermetic Zig C/C++ toolchain for linking cdylibs and amd64/arm64
-# cross-compilation. libc-aware toolchains only resolve for libc-aware
-# platforms (@zig_sdk//libc_aware/platform:...), so the repo's default C++
-# toolchain is unaffected; cross builds select them via --platforms.
-zig = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
-use_repo(zig, "zig_sdk")
+# Hermetic glibc sysroots (chromium bullseye, glibc 2.31 <= the proxy distroless
+# base) for the LLVM toolchain and the SDK bindgen — see //bazel/llvm.
+sysroots = use_extension("//bazel/llvm:extensions.bzl", "sysroots")
+use_repo(sysroots, "sysroot_linux_amd64", "sysroot_linux_arm64")
 
-register_toolchains("@zig_sdk//libc_aware/toolchain/...")
+# Hermetic LLVM C/C++ toolchain (clang 18.1.8 — matches Envoy's hermetic pin;
+# keep in lockstep with //bazel/llvm:version.bzl LLVM_VERSION), registered as the
+# default toolchain for host + linux amd64/arm64, each with its matching glibc
+# sysroot. This is the repo's single C/C++ toolchain (it replaced Zig): the Go
+# and protobuf builds use no cgo / cc_* targets, so making clang the default is
+# transparent to them, while the proxy cdylib cross-compiles against an
+# old-enough glibc to load on the Envoy distroless base.
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "18.1.8",
+    # The LLVM dist ships only host-arch libc++.a, so its default static libc++
+    # can't satisfy a cross-compile; point the C++ stdlib at the per-arch sysroot
+    # libstdc++ instead. The cdylib is pure Rust, so --as-needed drops libstdc++
+    # entirely anyway — the resulting .so needs only libgcc_s/libc/pthread (max
+    # GLIBC 2.18), matching the prior Zig output.
+    stdlib = {"": "dynamic-stdc++"},
+)
+llvm.sysroot(
+    name = "llvm_toolchain",
+    label = "@sysroot_linux_amd64//:sysroot",
+    targets = ["linux-x86_64"],
+)
+llvm.sysroot(
+    name = "llvm_toolchain",
+    label = "@sysroot_linux_arm64//:sysroot",
+    targets = ["linux-aarch64"],
+)
+use_repo(llvm, "llvm_toolchain", "llvm_toolchain_llvm")
+
+register_toolchains("@llvm_toolchain//:all")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -65,7 +65,9 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.32.0/MODULE.bazel": "095d67022a58cb20f7e20e1aefecfa65257a222c18a938e2914fd257b5f1ccdc",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
+    "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
     "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
+    "https://bcr.bazel.build/modules/bazel_features/1.38.0/MODULE.bazel": "f9b8a9c890ebd216b4049fd12a31d3c2602e3403c7af636b04fbbd7453edc9c9",
     "https://bcr.bazel.build/modules/bazel_features/1.39.0/MODULE.bazel": "28739425c1fc283c91931619749c832b555e60bcd1010b40d8441ce0a5cf726d",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
@@ -150,8 +152,8 @@
     "https://bcr.bazel.build/modules/grpc/1.56.3.bcr.1/MODULE.bazel": "cd5b1eb276b806ec5ab85032921f24acc51735a69ace781be586880af20ab33f",
     "https://bcr.bazel.build/modules/grpc/1.66.0.bcr.2/MODULE.bazel": "0fa2b0fd028ce354febf0fe90f1ed8fecfbfc33118cddd95ac0418cc283333a0",
     "https://bcr.bazel.build/modules/grpc/1.66.0.bcr.2/source.json": "d2b273a925507d47b5e2d6852f194e70d2991627d71b13793cc2498400d4f99e",
-    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.1.0/MODULE.bazel": "b512c9698968bd4548eecec8fb9bab4327c6f50fb0d12cc56e9a4d32a9a78458",
-    "https://bcr.bazel.build/modules/hermetic_cc_toolchain/4.1.0/source.json": "25ec6993f3acde436250883f3ab7945ff90a2fe42407af2c66f65f0f3e5b2959",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/MODULE.bazel": "3a4be20f6fc13be32ad44643b8252ef5af09eee936f1d943cd4fd7867fa92826",
+    "https://bcr.bazel.build/modules/helly25_bzl/0.3.1/source.json": "b129ab1828492de2c163785bbeb4065c166de52d932524b4317beb5b7f917994",
     "https://bcr.bazel.build/modules/hermetic_launcher/0.0.5/MODULE.bazel": "0e00b51788823b75b4273aedbc6ba21f64dad453f7567f9359a2e96eb6ec101c",
     "https://bcr.bazel.build/modules/hermetic_launcher/0.0.5/source.json": "eb5cf0f29fb36c10c2fde8f660cf5edfd377d8ea167f277fff9a811fd0a26028",
     "https://bcr.bazel.build/modules/jq.bzl/0.1.0/MODULE.bazel": "2ce69b1af49952cd4121a9c3055faa679e748ce774c7f1fda9657f936cae902f",
@@ -399,7 +401,10 @@
     "https://bcr.bazel.build/modules/swift_argument_parser/1.3.1.2/source.json": "5fba48bbe0ba48761f9e9f75f92876cafb5d07c0ce059cc7a8027416de94a05b",
     "https://bcr.bazel.build/modules/tar.bzl/0.2.1/MODULE.bazel": "52d1c00a80a8cc67acbd01649e83d8dd6a9dc426a6c0b754a04fe8c219c76468",
     "https://bcr.bazel.build/modules/tar.bzl/0.5.1/MODULE.bazel": "7c2eb3dcfc53b0f3d6f9acdfd911ca803eaf92aadf54f8ca6e4c1f3aee288351",
-    "https://bcr.bazel.build/modules/tar.bzl/0.5.1/source.json": "deed3094f7cc779ed1d37a68403847b0e38d9dd9d931e03cb90825f3368b515f",
+    "https://bcr.bazel.build/modules/tar.bzl/0.6.0/MODULE.bazel": "a3584b4edcfafcabd9b0ef9819808f05b372957bbdff41601429d5fd0aac2e7c",
+    "https://bcr.bazel.build/modules/tar.bzl/0.6.0/source.json": "4a620381df075a16cb3a7ed57bd1d05f7480222394c64a20fa51bdb636fda658",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/MODULE.bazel": "55aca6a8c5b372651f663c5e22faf3664d81165e40074c98fb8a30ee5af83272",
+    "https://bcr.bazel.build/modules/toolchains_llvm/1.7.0/source.json": "cda5fa1abeab5561e811860222952f6cb9373f34b88c5b3f4417459dca057a6d",
     "https://bcr.bazel.build/modules/upb/0.0.0-20211020-160625a/MODULE.bazel": "6cced416be2dc5b9c05efd5b997049ba795e5e4e6fafbe1624f4587767638928",
     "https://bcr.bazel.build/modules/upb/0.0.0-20220923-a547704/MODULE.bazel": "7298990c00040a0e2f121f6c32544bab27d4452f80d9ce51349b1a28f3005c43",
     "https://bcr.bazel.build/modules/upb/0.0.0-20230516-61a97ef/MODULE.bazel": "c0df5e35ad55e264160417fd0875932ee3c9dda63d9fccace35ac62f45e1b6f9",
@@ -433,6 +438,39 @@
               "sha256": "5c54bfc141a7cc45974781ce9bb3bc291f6911aced7970a96009e19ba95ab445",
               "urls": [
                 "https://raw.githubusercontent.com/envoyproxy/envoy/v1.38.0/source/extensions/dynamic_modules/abi/abi.h"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "//bazel/llvm:extensions.bzl%sysroots": {
+      "general": {
+        "bzlTransitiveDigest": "ywk/mU/iaw3iyHuXwXiRfvy8gmKuShL1nljiLR9BFxw=",
+        "usagesDigest": "58C1RV7+ghz3nTpg5atabxKYQ2H/k4W1r0kYIvBqCVU=",
+        "recordedInputs": [
+          "REPO_MAPPING:,bazel_tools bazel_tools"
+        ],
+        "generatedRepoSpecs": {
+          "sysroot_linux_amd64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"sysroot\",\n    # lib/systemd has unit files with backslash-escaped names ('\\x2d') that are\n    # invalid Bazel target names; they are irrelevant to a compile/link sysroot.\n    srcs = glob([\"**\"], exclude = [\"BUILD.bazel\", \"lib/systemd/**\"]),\n    visibility = [\"//visibility:public\"],\n)\n\nexports_files([\"usr/include/stdint.h\"])\n",
+              "sha256": "52d61d4446ffebfaa3dda2cd02da4ab4876ff237853f46d273e7f9b666652e1d",
+              "type": "tar.xz",
+              "urls": [
+                "https://commondatastorage.googleapis.com/chrome-linux-sysroot/52d61d4446ffebfaa3dda2cd02da4ab4876ff237853f46d273e7f9b666652e1d"
+              ]
+            }
+          },
+          "sysroot_linux_arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file_content": "filegroup(\n    name = \"sysroot\",\n    # lib/systemd has unit files with backslash-escaped names ('\\x2d') that are\n    # invalid Bazel target names; they are irrelevant to a compile/link sysroot.\n    srcs = glob([\"**\"], exclude = [\"BUILD.bazel\", \"lib/systemd/**\"]),\n    visibility = [\"//visibility:public\"],\n)\n\nexports_files([\"usr/include/stdint.h\"])\n",
+              "sha256": "c7176a4c7aacbf46bda58a029f39f79a68008d3dee6518f154dcf5161a5486d8",
+              "type": "tar.xz",
+              "urls": [
+                "https://commondatastorage.googleapis.com/chrome-linux-sysroot/c7176a4c7aacbf46bda58a029f39f79a68008d3dee6518f154dcf5161a5486d8"
               ]
             }
           }
@@ -1508,13 +1546,13 @@
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
         "bzlTransitiveDigest": "oP+eVPYEdZ1zfCZVUhMb06jlnK3HDPpFurlg8SO6alU=",
-        "usagesDigest": "N+1Hwa6chPLwqm6kaCTc9k/l0BjoODoS/9Ils3OEXAU=",
+        "usagesDigest": "sHQUTjj+pib10PaGiE3kT/3Gh2DADEODrGxxLUBwuRI=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
           "ENV:CARGO_BAZEL_GENERATOR_SHA256 \\0",
           "ENV:CARGO_BAZEL_GENERATOR_URL \\0",
           "ENV:CARGO_BAZEL_ISOLATED \\0",
-          "ENV:CARGO_BAZEL_REPIN 1",
+          "ENV:CARGO_BAZEL_REPIN \\0",
           "ENV:CARGO_BAZEL_REPIN_ONLY \\0",
           "ENV:CARGO_BAZEL_TIMEOUT \\0",
           "ENV:REPIN \\0",
@@ -1673,7 +1711,7 @@
                 "@@//proxy/filters/telemetry/patches:sdk_abi_header.patch"
               ],
               "remote": "https://github.com/envoyproxy/envoy",
-              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'aether'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"envoy_proxy_dynamic_modules_rust_sdk\",\n    deps = [\n        \"@crates__envoy-proxy-dynamic-modules-rust-sdk-0.1.0//:build_script_build\",\n        \"@crates__mockall-0.13.1//:mockall\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=envoy-proxy-dynamic-modules-rust-sdk\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.1.0\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    build_script_env = {\n        \"AETHER_ABI_H\": \"$(execpath @@//proxy/filters/telemetry:abi_h)\",\n    },\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ) + [\n        \"@@//proxy/filters/telemetry:abi_h\",\n    ],\n    deps = [\n        \"@crates__bindgen-0.70.1//:bindgen\",\n    ],\n    edition = \"2021\",\n    pkg_name = \"envoy-proxy-dynamic-modules-rust-sdk\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=envoy-proxy-dynamic-modules-rust-sdk\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n",
+              "build_file_content": "###############################################################################\n# @generated\n# DO NOT MODIFY: This file is auto-generated by a crate_universe tool. To \n# regenerate this file, run the following:\n#\n#     bazel mod show_repo 'aether'\n###############################################################################\n\nload(\n    \"@rules_rust//cargo:defs.bzl\",\n    \"cargo_build_script\",\n    \"cargo_toml_env_vars\",\n)\n\nload(\"@rules_rust//rust:defs.bzl\", \"rust_library\")\n\n# buildifier: disable=bzl-visibility\nload(\"@rules_rust//crate_universe/private:selects.bzl\", \"selects\")\n\npackage(default_visibility = [\"//visibility:public\"])\n\ncargo_toml_env_vars(\n    name = \"cargo_toml_env_vars\",\n    src = \"Cargo.toml\",\n)\n\nrust_library(\n    name = \"envoy_proxy_dynamic_modules_rust_sdk\",\n    deps = [\n        \"@crates__envoy-proxy-dynamic-modules-rust-sdk-0.1.0//:build_script_build\",\n        \"@crates__mockall-0.13.1//:mockall\",\n    ],\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_root = \"src/lib.rs\",\n    edition = \"2021\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=envoy-proxy-dynamic-modules-rust-sdk\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    target_compatible_with = select({\n        \"@rules_rust//rust/platform:aarch64-apple-darwin\": [],\n        \"@rules_rust//rust/platform:aarch64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:wasm32-unknown-unknown\": [],\n        \"@rules_rust//rust/platform:wasm32-wasip1\": [],\n        \"@rules_rust//rust/platform:x86_64-pc-windows-msvc\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-linux-gnu\": [],\n        \"@rules_rust//rust/platform:x86_64-unknown-nixos-gnu\": [],\n        \"//conditions:default\": [\"@platforms//:incompatible\"],\n    }),\n    version = \"0.1.0\",\n)\n\ncargo_build_script(\n    name = \"_bs\",\n    build_script_env = {\n        \"AETHER_ABI_H\": \"$(execpath @@//proxy/filters/telemetry:abi_h)\",\n        \"AETHER_SYSROOT\": \"$(execpath @@//bazel/llvm:sysroot_amd64_marker)\",\n        \"LIBCLANG_PATH\": \"$(execpath @@//bazel/llvm:libclang_so)\",\n    },\n    compile_data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \"**/*.rs\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ),\n    crate_name = \"build_script_build\",\n    crate_root = \"build.rs\",\n    data = glob(\n        allow_empty = True,\n        include = [\"**\"],\n        exclude = [\n            \"**/* *\",\n            \".tmp_git_root/**/*\",\n            \"BUILD\",\n            \"BUILD.bazel\",\n            \"WORKSPACE\",\n            \"WORKSPACE.bazel\",\n        ],\n    ) + [\n        \"@@//bazel/llvm:libclang\",\n        \"@@//bazel/llvm:libclang_so\",\n        \"@@//bazel/llvm:sysroot_amd64_marker\",\n        \"@@//proxy/filters/telemetry:abi_h\",\n    ],\n    deps = [\n        \"@crates__bindgen-0.70.1//:bindgen\",\n    ],\n    edition = \"2021\",\n    pkg_name = \"envoy-proxy-dynamic-modules-rust-sdk\",\n    rustc_env_files = [\n        \":cargo_toml_env_vars\",\n    ],\n    rustc_flags = [\n        \"--cap-lints=allow\",\n    ],\n    srcs = glob(\n        allow_empty = True,\n        include = [\"**/*.rs\"],\n    ),\n    tags = [\n        \"cargo-bazel\",\n        \"crate-name=envoy-proxy-dynamic-modules-rust-sdk\",\n        \"manual\",\n        \"noclippy\",\n        \"norustfmt\",\n    ],\n    version = \"0.1.0\",\n    visibility = [\"//visibility:private\"],\n)\n\nalias(\n    name = \"build_script_build\",\n    actual = \":_bs\",\n    tags = [\"manual\"],\n)\n",
               "strip_prefix": "source/extensions/dynamic_modules/sdk/rust",
               "commit": "f1dd21b16c244bda00edfb5ffce577e12d0d2ec2"
             }
@@ -2206,57 +2244,6 @@
           "explicitRootModuleDirectDevDeps": [],
           "useAllRepos": "NO",
           "reproducible": false
-        }
-      }
-    },
-    "@@tar.bzl+//tar:extensions.bzl%toolchains": {
-      "general": {
-        "bzlTransitiveDigest": "/2afh6fPjq/rcyE/jztQDK3ierehmFFngfvmqyRv72M=",
-        "usagesDigest": "maF8qsAIqeH1ey8pxP0gNZbvJt34kLZvTFeQ0ntrJVA=",
-        "recordedInputs": [],
-        "generatedRepoSpecs": {
-          "bsd_tar_toolchains": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:toolchain.bzl%tar_toolchains_repo",
-            "attributes": {
-              "user_repository_name": "bsd_tar_toolchains"
-            }
-          },
-          "bsd_tar_toolchains_darwin_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_amd64"
-            }
-          },
-          "bsd_tar_toolchains_darwin_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "darwin_arm64"
-            }
-          },
-          "bsd_tar_toolchains_linux_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_amd64"
-            }
-          },
-          "bsd_tar_toolchains_linux_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "linux_arm64"
-            }
-          },
-          "bsd_tar_toolchains_windows_amd64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_amd64"
-            }
-          },
-          "bsd_tar_toolchains_windows_arm64": {
-            "repoRuleId": "@@tar.bzl+//tar/toolchain:platforms.bzl%bsdtar_binary_repo",
-            "attributes": {
-              "platform": "windows_arm64"
-            }
-          }
         }
       }
     },

--- a/bazel/llvm/BUILD.bazel
+++ b/bazel/llvm/BUILD.bazel
@@ -1,0 +1,39 @@
+load(":version.bzl", "LLVM_MAJOR_MINOR", "LLVM_VERSION")
+
+# Bindgen inputs for the proxy SDK build script. These re-export targets from the
+# external @llvm_toolchain_llvm / @sysroot_linux_* repos through the MAIN repo,
+# because the crate_universe-generated SDK repo can't see external repos by their
+# apparent name — only the main repo via @@// (same reason //...:abi_h exists).
+# The clang/libc++/sysroot header trees themselves arrive via the default LLVM cc
+# toolchain; we only re-export libclang (not a toolchain input) and the sysroot
+# marker here.
+
+# The hermetic libclang soname chain (libclang.so -> .so.18.1 -> .so.18.1.8); all
+# three names must be present so the symlinks resolve in the action sandbox.
+# Pinned to LLVM_VERSION.
+filegroup(
+    name = "libclang",
+    srcs = [
+        "@llvm_toolchain_llvm//:lib/libclang.so",
+        "@llvm_toolchain_llvm//:lib/libclang.so.{}".format(LLVM_MAJOR_MINOR),
+        "@llvm_toolchain_llvm//:lib/libclang.so.{}".format(LLVM_VERSION),
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Just the libclang.so symlink — LIBCLANG_PATH ($(execpath ...)) needs one file.
+filegroup(
+    name = "libclang_so",
+    srcs = ["@llvm_toolchain_llvm//:lib/libclang.so"],
+    visibility = ["//visibility:public"],
+)
+
+# Marker file ($(execpath ...)) the build script three-parents to the sysroot
+# root for --sysroot. The sysroot header tree itself is staged by the LLVM cc
+# toolchain (exec is amd64); bindgen only parses, so the amd64 sysroot is fine
+# regardless of exec arch.
+filegroup(
+    name = "sysroot_amd64_marker",
+    srcs = ["@sysroot_linux_amd64//:usr/include/stdint.h"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/llvm/extensions.bzl
+++ b/bazel/llvm/extensions.bzl
@@ -1,0 +1,52 @@
+"""Hermetic glibc sysroots for the LLVM C/C++ toolchain (and the proxy SDK's
+bindgen).
+
+Chromium's prebuilt Debian **bullseye** sysroots (glibc 2.31) — older than the
+Envoy distroless proxy base (glibc 2.36), so the dynamic-module `.so` links
+against an old-enough glibc to load there (the reason the previous Zig toolchain
+targeted an old glibc). Kept out of MODULE.bazel to keep it clean.
+
+The download URL is content-addressed: `<base>/<sha256>` (see chromium's
+build/linux/sysroot_scripts/install-sysroot.py). To bump: update the Sha256Sum
+from chromium's sysroots.json — the URL follows.
+"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+_SYSROOT_BASE = "https://commondatastorage.googleapis.com/chrome-linux-sysroot/"
+
+# The archive extracts a real sysroot at its root (usr/include, lib/..., with
+# only relative symlinks), so the repo root *is* the sysroot: a filegroup whose
+# package path toolchains_llvm uses for --sysroot, plus the stdint.h marker the
+# bindgen build script three-parents up to recover that root (execpath yields a
+# file, not a dir).
+_SYSROOT_BUILD = """\
+filegroup(
+    name = "sysroot",
+    # lib/systemd has unit files with backslash-escaped names ('\\x2d') that are
+    # invalid Bazel target names; they are irrelevant to a compile/link sysroot.
+    srcs = glob(["**"], exclude = ["BUILD.bazel", "lib/systemd/**"]),
+    visibility = ["//visibility:public"],
+)
+
+exports_files(["usr/include/stdint.h"])
+"""
+
+# Debian bullseye sysroots, sha256 == the content-addressed URL path segment.
+_SYSROOTS = {
+    "sysroot_linux_amd64": "52d61d4446ffebfaa3dda2cd02da4ab4876ff237853f46d273e7f9b666652e1d",
+    "sysroot_linux_arm64": "c7176a4c7aacbf46bda58a029f39f79a68008d3dee6518f154dcf5161a5486d8",
+}
+
+def _sysroots_impl(_module_ctx):
+    for name, sha in _SYSROOTS.items():
+        http_archive(
+            name = name,
+            build_file_content = _SYSROOT_BUILD,
+            sha256 = sha,
+            # The content-addressed URL has no extension; declare the type.
+            type = "tar.xz",
+            urls = [_SYSROOT_BASE + sha],
+        )
+
+sysroots = module_extension(implementation = _sysroots_impl)

--- a/bazel/llvm/platform/BUILD.bazel
+++ b/bazel/llvm/platform/BUILD.bazel
@@ -1,0 +1,24 @@
+# Cross-compile target platforms for the proxy dynamic-module .so. The default
+# hermetic LLVM toolchain (clang + lld + the matching glibc sysroot, registered
+# in MODULE.bazel) is selected per cpu/os — replacing the prior
+# @zig_sdk//libc_aware/platform:* targets. Build the .so for an arch with, e.g.:
+#   bazel build //proxy/filters/telemetry:aether_telemetry \
+#     --platforms=//bazel/llvm/platform:linux_amd64
+
+platform(
+    name = "linux_amd64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+platform(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/llvm/version.bzl
+++ b/bazel/llvm/version.bzl
@@ -1,0 +1,16 @@
+"""Pinned hermetic LLVM version — the single source of truth for the libclang
+file paths below. Matches Envoy's hermetic toolchain pin (bazel/toolchains.bzl
+_LLVM_VERSION_HERMETIC) and the abi.h/SDK era.
+
+MODULE.bazel can't load() this, so the llvm.toolchain(llvm_version=...) string
+there must be kept in lockstep with LLVM_VERSION.
+"""
+
+LLVM_VERSION = "18.1.8"
+
+# Components of LLVM_VERSION used to address files inside @llvm_toolchain_llvm:
+# the libclang soname chain (libclang.so -> .so.18.1 -> .so.18.1.8) and the
+# clang resource dir (lib/clang/18).
+LLVM_MAJOR = "18"
+
+LLVM_MAJOR_MINOR = "18.1"

--- a/docs/proposals/008_rust-in-bazel.md
+++ b/docs/proposals/008_rust-in-bazel.md
@@ -35,7 +35,16 @@ follow-up PR stacked on this one.
 `crate_universe` is added here; external-crate management arrives with the first
 consumer that needs it (proposal 007).
 
-### hermetic_cc_toolchain (the C linker + cross-compile)
+> **Superseded (LLVM migration):** the C/C++ toolchain described below was later
+> replaced by a hermetic LLVM (`toolchains_llvm`, clang 18.1.8 — matching Envoy's
+> hermetic pin — + chromium glibc sysroots), which is now the repo's single
+> registered C/C++ toolchain and additionally supplies `libclang` to the SDK
+> bindgen build script (fully hermetic, no host clang/headers). See `//bazel/llvm`
+> and `MODULE.bazel`. The Zig (`@zig_sdk`) sections below are kept for history;
+> `--platforms=//bazel/llvm/platform:linux_{amd64,arm64}` replaces the
+> `@zig_sdk//libc_aware/platform:*` invocations.
+
+### hermetic_cc_toolchain (the C linker + cross-compile) — superseded
 `hermetic_cc_toolchain` 4.1.0 provides a Zig-based C/C++ toolchain
 (`@zig_sdk`). It is the Bazel-native equivalent of the `cargo-zigbuild` approach
 the upstream dynamic-module examples use for multi-arch.

--- a/proxy/filters/telemetry/BUILD.bazel
+++ b/proxy/filters/telemetry/BUILD.bazel
@@ -20,9 +20,9 @@ alias(
 # aether_telemetry edge-telemetry dynamic module (proposal 007, Phase 1).
 # Produces libaether_telemetry.so, loaded by the stock Envoy proxy via a
 # K8s image volume (ENVOY_DYNAMIC_MODULES_SEARCH_PATH). Cross-compile for the
-# proxy arches with the hermetic Zig toolchain, e.g.:
+# proxy arches with the hermetic LLVM toolchain (clang/lld + glibc sysroot), e.g.:
 #   bazel build //proxy/filters/telemetry:aether_telemetry \
-#     --platforms=@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.28
+#     --platforms=//bazel/llvm/platform:linux_amd64
 rust_shared_library(
     name = "aether_telemetry",
     srcs = ["src/lib.rs"],

--- a/proxy/filters/telemetry/README.md
+++ b/proxy/filters/telemetry/README.md
@@ -42,11 +42,12 @@ code at completion. Set `emit_pod:true` only when per-pod cardinality is wanted.
 # Host build (uses the default CC toolchain):
 bazel build //proxy/filters/telemetry:aether_telemetry
 
-# Hermetic cross-compile for the proxy arches (Zig via hermetic_cc_toolchain):
+# Hermetic cross-compile for the proxy arches (clang/lld + glibc sysroot via
+# toolchains_llvm; see //bazel/llvm):
 bazel build //proxy/filters/telemetry:aether_telemetry \
-  --platforms=@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.28
+  --platforms=//bazel/llvm/platform:linux_amd64
 bazel build //proxy/filters/telemetry:aether_telemetry \
-  --platforms=@zig_sdk//libc_aware/platform:linux_arm64_gnu.2.28
+  --platforms=//bazel/llvm/platform:linux_arm64
 # -> bazel-bin/proxy/filters/telemetry/libaether_telemetry.so
 ```
 
@@ -65,9 +66,15 @@ that crate_universe's per-crate sandbox excludes — so:
 - `patches/sdk_abi_header.patch` redirects the build script to read the header
   via the `AETHER_ABI_H` env var, which `MODULE.bazel` points at that alias.
 
-bindgen's libclang is provided by rules_rust. On an Envoy bump: update the tag in
-`Cargo.toml` and the `@envoy_abi_h` URL + `sha256` in `MODULE.bazel`,
-`CARGO_BAZEL_REPIN=1 bazel build …`, and re-verify the patch still applies.
+- bindgen is **fully hermetic**: it parses `abi.h` with the hermetic LLVM
+  `libclang` (`@llvm_toolchain_llvm`, via `LIBCLANG_PATH`) against a hermetic
+  glibc sysroot (chromium, `//bazel/llvm`) — no host clang or system headers.
+  The patch derives `--sysroot` from the `AETHER_SYSROOT` marker.
+
+On an Envoy bump: update the tag in `Cargo.toml` and the `@envoy_abi_h` URL +
+`sha256` in `//bazel/envoy`, `CARGO_BAZEL_REPIN=1 bazel build …`, and re-verify
+the patch still applies. On an LLVM bump: update `//bazel/llvm:version.bzl` +
+`llvm_version` in `MODULE.bazel`.
 
 ## Cargo (dev convenience)
 

--- a/proxy/filters/telemetry/patches/sdk_abi_header.patch
+++ b/proxy/filters/telemetry/patches/sdk_abi_header.patch
@@ -1,16 +1,45 @@
-Aether: the SDK build script reads abi.h via ../../abi/abi.h, a sibling of the
-crate package. crate_universe's per-crate sandbox does not include it, so we
-supply the (pinned) header via the AETHER_ABI_H env var (Bazel build_script_data)
-instead. See MODULE.bazel (@envoy_abi_h) and docs/proposals/007.
+Aether: make the SDK's bindgen build script hermetic.
+
+1. The SDK reads abi.h via ../../abi/abi.h, a sibling of the crate package that
+   crate_universe's per-crate sandbox excludes. Feed the pinned, fetched header
+   (see //bazel/envoy @envoy_abi_h) via the AETHER_ABI_H env var instead.
+2. Parse abi.h against the hermetic LLVM libclang (LIBCLANG_PATH, set in
+   MODULE.bazel) + a hermetic glibc sysroot (chromium, see //bazel/llvm) rather
+   than whatever clang/headers happen to be on the host. AETHER_SYSROOT is the
+   execpath of <sysroot>/usr/include/stdint.h; the build script recovers the
+   sysroot root (three parents up — execpath yields a file, not a directory) and
+   passes it to clang as --sysroot.
+
+See MODULE.bazel (crate.annotation) and docs/proposals/008.
 
 --- a/build.rs
 +++ b/build.rs
-@@ -15,7 +15,7 @@
+@@ -14,9 +14,25 @@ fn main() {
+
    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
 
-   let bindings = bindgen::Builder::default()
+-  let bindings = bindgen::Builder::default()
 -    .header("../../abi/abi.h")
+-    .clang_arg("-v")
++  let mut builder = bindgen::Builder::default()
++    // Aether: feed the pinned, fetched abi.h (the SDK's ../../abi/abi.h is
++    // outside the crate sandbox) via AETHER_ABI_H.
 +    .header(std::env::var("AETHER_ABI_H").expect("AETHER_ABI_H not set"))
-     .clang_arg("-v")
++    .clang_arg("-v");
++
++  // Aether: hermetic glibc headers via the chromium sysroot (no host headers).
++  // AETHER_SYSROOT is the execpath of <sysroot>/usr/include/stdint.h; the
++  // sysroot root is three parents up (execpath yields a file, not a dir).
++  if let Ok(marker) = std::env::var("AETHER_SYSROOT") {
++    let root = std::path::Path::new(&marker)
++      .parent()
++      .and_then(|p| p.parent())
++      .and_then(|p| p.parent())
++      .expect("AETHER_SYSROOT not deep enough");
++    builder = builder.clang_arg(format!("--sysroot={}", root.display()));
++  }
++
++  let bindings = builder
      .default_enum_style(bindgen::EnumVariation::Rust {
        non_exhaustive: false,
+     })


### PR DESCRIPTION
## What

Replaces the Zig `hermetic_cc_toolchain` with a hermetic **LLVM** toolchain
(`toolchains_llvm`, **clang 18.1.8** — matching Envoy's hermetic pin
`_LLVM_VERSION_HERMETIC`) as the repo's single C/C++ toolchain, and makes the
proxy dynamic-modules SDK **bindgen** build script fully hermetic — no host
clang or system headers (the root cause of the recent `ci` bindgen flakes).

This is the foundational toolchain PR; the telemetry stats-filter work (#179)
rebases on top to use `//bazel/llvm/platform:*` and drop its host-clang
workaround.

## How

- **`//bazel/llvm`** — pinned `LLVM_VERSION`, chromium **bullseye** glibc
  sysroots (amd64 + arm64, content-addressed `http_archive` in an extension),
  `libclang` re-export filegroups, and the cross platforms
  `//bazel/llvm/platform:linux_{amd64,arm64}` (replacing
  `@zig_sdk//libc_aware/platform:*`).
- **`MODULE.bazel`** — LLVM registered as the default toolchain for host + both
  linux arches, each with its glibc sysroot. Go/protobuf use no cgo / `cc_*`
  targets, so clang-as-default is transparent; the proxy cdylib cross-compiles
  against an old-enough glibc (max symbol **GLIBC_2.18**) to load on the Envoy
  distroless base. `stdlib=dynamic-stdc++` lets the cross link resolve the C++
  stdlib from the per-arch sysroot (the single-arch LLVM dist ships only host
  `libc++.a`); `--as-needed` drops it from the pure-Rust `.so`, leaving the same
  runtime deps as the prior Zig output (`libgcc_s`/`libc`/`pthread`).
- **Bindgen** — parses `abi.h` with the hermetic `libclang` (`LIBCLANG_PATH`)
  against the chromium sysroot (`--sysroot`, derived in `sdk_abi_header.patch`
  from a marker file). Inputs routed through `//bazel/llvm` (the crate_universe
  SDK repo can't see external repos by apparent name).

## Validation

- `bazel build //...` green under the LLVM default toolchain.
- 33 unit tests + lint pass (`--config=ci --test_tag_filters=-integration`).
- host + amd64 + arm64 cdylib cross-compiles; `proxy_test` confirms the trimmed-
  enum SDK bindings still compile.
- **Hermeticity probe**: rebuilding the `.so` with host clang binaries + host
  clang resource headers blocked from the sandbox still succeeds — bindgen uses
  only the hermetic libclang + sysroot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)