### PR TITLE
fix(chart): push + pin the custom proxy image in the agent chart

### DIFF
--- a/charts/agent/BUILD.bazel
+++ b/charts/agent/BUILD.bazel
@@ -17,6 +17,7 @@ helm_chart(
     images = [
         "//agent/cmd/agent:image_push",
         "//cni/cmd/cni-install:image_push",
+        "//proxy:image_push",
     ],
     login_url = "ghcr.io",
     registry_url = "oci://ghcr.io/bpalermo/aether/charts",


### PR DESCRIPTION
#179 set the agent chart's `proxy.image.ref` to `{@//proxy:image_push}` but didn't add `//proxy:image_push` to the chart's `images` list. As a result:

- the placeholder was left **unsubstituted** (literal `{@//proxy:image_push}` in the packaged chart), and
- `agent.push` never **published** the custom `aether-proxy` image.

A helm upgrade to that chart would deploy a broken proxy image ref. Adding it to `images` fixes both — the digest is substituted and the image is pushed alongside the chart.

Verified: the built chart's `proxy.image.ref` now resolves to `ghcr.io/bpalermo/aether/aether-proxy@sha256:…`; chart template + lint tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)