### PR TITLE
fix(proxy): distroless/cc base + Envoy binary so the module's libgcc_s resolves

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -167,12 +167,14 @@ pull(
 # matches the Envoy release's glibc.
 pull(
     name = "distroless_cc",
-    digest = "sha256:d703b626ba455c4e6c6fbe5f36e6f427c85d51445598d564652a2f334179f96e",
+    digest = "sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985",
     layer_handling = "lazy",
     registry = "gcr.io",
     repository = "distroless/cc-debian12",
-    # root variant (the proxy runs privileged as uid 0).
-    tag = "latest",
+    # nonroot variant (USER 65532), mirroring the official distroless default. The
+    # chart's privileged securityContext still overrides to uid 0 at runtime for
+    # the data plane; this just keeps the image's own default nonroot.
+    tag = "nonroot",
 )
 
 # --- Rust toolchains (in-tree dynamic modules; see docs/proposals/008) ---

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -160,6 +160,21 @@ pull(
     tag = "nonroot",
 )
 
+# Base for the custom aether-proxy image (//proxy:image): distroless/cc ships
+# libstdc++ + libgcc_s + glibc, which the Envoy binary and the Rust dynamic
+# module need at runtime (the Envoy distroless image is built on distroless/base
+# and lacks libgcc_s, so the module's unwinder fails to load there). debian12
+# matches the Envoy release's glibc.
+pull(
+    name = "distroless_cc",
+    digest = "sha256:d703b626ba455c4e6c6fbe5f36e6f427c85d51445598d564652a2f334179f96e",
+    layer_handling = "lazy",
+    registry = "gcr.io",
+    repository = "distroless/cc-debian12",
+    # root variant (the proxy runs privileged as uid 0).
+    tag = "latest",
+)
+
 # --- Rust toolchains (in-tree dynamic modules; see docs/proposals/008) ---
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
@@ -171,10 +186,10 @@ use_repo(rust, "rust_toolchains")
 
 register_toolchains("@rust_toolchains//:all")
 
-# Envoy artifacts — abi.h header + the @envoy_distroless proxy-image base, both
-# version-pinned via ENVOY_VERSION (see //bazel/envoy:extensions.bzl).
+# Envoy artifacts — abi.h header + the official Envoy release binaries baked into
+# //proxy:image, all version-pinned via ENVOY_VERSION (see //bazel/envoy).
 envoy = use_extension("//bazel/envoy:extensions.bzl", "envoy")
-use_repo(envoy, "envoy_abi_h", "envoy_distroless")
+use_repo(envoy, "envoy_abi_h", "envoy_bin_amd64", "envoy_bin_arm64")
 
 # Rust crate graph for the proxy dynamic modules (proposal 007), resolved from
 # proxy/filters/telemetry's Cargo.toml/Cargo.lock — includes the Envoy SDK as a

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -425,14 +425,10 @@
   "moduleExtensions": {
     "//bazel/envoy:extensions.bzl%envoy": {
       "general": {
-        "bzlTransitiveDigest": "cQg6Ld6bdeimF/jQyKypDwFUSRV0kTcmmKjS6nFMmA8=",
+        "bzlTransitiveDigest": "tyCBjsucDNfIhuYXTI/mdPco8uCEH0juK2+0IQWuo5Q=",
         "usagesDigest": "MueWQw6tIUQ5Dcgx8SLg65NzM0evS9ArXQ+upvsQQ/A=",
         "recordedInputs": [
-          "REPO_MAPPING:,bazel_tools bazel_tools",
-          "REPO_MAPPING:,rules_img rules_img+",
-          "REPO_MAPPING:rules_img+,bazel_skylib bazel_skylib+",
-          "REPO_MAPPING:rules_img+,pull_hub_repo rules_img++pull_tool+pull_hub_repo",
-          "REPO_MAPPING:rules_img++pull_tool+pull_hub_repo,rules_img rules_img+"
+          "REPO_MAPPING:,bazel_tools bazel_tools"
         ],
         "generatedRepoSpecs": {
           "envoy_abi_h": {
@@ -445,14 +441,26 @@
               ]
             }
           },
-          "envoy_distroless": {
-            "repoRuleId": "@@rules_img+//img/private/repository_rules:pull.bzl%pull",
+          "envoy_bin_amd64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
             "attributes": {
-              "digest": "sha256:a7a56545102f7a682e0cafea2c9b8448af1b09ebb710eab688dfb931e3ec7ff6",
-              "layer_handling": "lazy",
-              "registry": "index.docker.io",
-              "repository": "envoyproxy/envoy",
-              "tag": "distroless-v1.38.0"
+              "downloaded_file_path": "envoy",
+              "executable": true,
+              "sha256": "cca312a7c3f91852f2849995c895130c59842e21ba787dc90bafa4026d6c5ecc",
+              "urls": [
+                "https://github.com/envoyproxy/envoy/releases/download/v1.38.0/envoy-1.38.0-linux-x86_64"
+              ]
+            }
+          },
+          "envoy_bin_arm64": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "downloaded_file_path": "envoy",
+              "executable": true,
+              "sha256": "9f00678c0cc433d7a342c422415eb3fdd163e77414aee5c5b57c04bd7d579454",
+              "urls": [
+                "https://github.com/envoyproxy/envoy/releases/download/v1.38.0/envoy-1.38.0-linux-aarch_64"
+              ]
             }
           }
         }

--- a/bazel/envoy/BUILD.bazel
+++ b/bazel/envoy/BUILD.bazel
@@ -1,1 +1,12 @@
 # Envoy artifact fetches live in extensions.bzl (see //bazel/envoy:extensions.bzl).
+
+# The official Envoy release binary for the target arch, baked into //proxy:image.
+# select() resolves per-arch under the image_index platform transition.
+filegroup(
+    name = "envoy_bin",
+    srcs = select({
+        "@platforms//cpu:x86_64": ["@envoy_bin_amd64//file"],
+        "@platforms//cpu:aarch64": ["@envoy_bin_arm64//file"],
+    }),
+    visibility = ["//visibility:public"],
+)

--- a/bazel/envoy/extensions.bzl
+++ b/bazel/envoy/extensions.bzl
@@ -1,23 +1,30 @@
 """Pinned Envoy artifacts fetched for the proxy build (proposals 007/008).
 
 The single source of truth for the Envoy version (ENVOY_VERSION) — the abi.h
-fetch, the aether-proxy image base (@envoy_distroless), and their version-derived
-tags/URLs all come from here, keeping the version out of MODULE.bazel. On an
-Envoy upgrade bump ENVOY_VERSION + the two digests below, and the SDK git tag in
-proxy/filters/telemetry/Cargo.toml (a static manifest that can't read this).
+fetch and the official Envoy release binary (baked into the custom aether-proxy
+image, //proxy:image) all derive their URLs from here, keeping the version out of
+MODULE.bazel. On an Envoy upgrade bump ENVOY_VERSION + the sha256s below, and the
+SDK git tag in proxy/filters/telemetry/Cargo.toml (a static manifest that can't
+read this).
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-load("@rules_img//img:pull.bzl", "pull")
 
 ENVOY_VERSION = "v1.38.0"
+
+# ENVOY_VERSION without the leading "v" — release-asset filenames use it.
+_V = ENVOY_VERSION[1:]
 
 # source/extensions/dynamic_modules/abi/abi.h @ ENVOY_VERSION
 _ABI_H_SHA256 = "5c54bfc141a7cc45974781ce9bb3bc291f6911aced7970a96009e19ba95ab445"
 
-# Multi-arch index digest of envoyproxy/envoy:distroless-{ENVOY_VERSION}, the
-# base for the custom aether-proxy image (//proxy:image).
-_DISTROLESS_DIGEST = "sha256:a7a56545102f7a682e0cafea2c9b8448af1b09ebb710eab688dfb931e3ec7ff6"
+# Official Envoy release binaries (github releases), per arch — baked at
+# /usr/local/bin/envoy in //proxy:image on a distroless/cc base (which provides
+# the libstdc++/libgcc_s/glibc runtime the binary and the Rust module need).
+_ENVOY_BIN = {
+    "envoy_bin_amd64": ("x86_64", "cca312a7c3f91852f2849995c895130c59842e21ba787dc90bafa4026d6c5ecc"),
+    "envoy_bin_arm64": ("aarch_64", "9f00678c0cc433d7a342c422415eb3fdd163e77414aee5c5b57c04bd7d579454"),
+}
 
 def _envoy_impl(_module_ctx):
     # The dynamic-modules ABI header. The SDK's bindgen build script reads it
@@ -32,15 +39,19 @@ def _envoy_impl(_module_ctx):
         ],
     )
 
-    # Stock upstream Envoy distroless image — the base for //proxy:image (Envoy
-    # base + baked stats module). Tag derived from ENVOY_VERSION.
-    pull(
-        name = "envoy_distroless",
-        digest = _DISTROLESS_DIGEST,
-        layer_handling = "lazy",
-        registry = "index.docker.io",
-        repository = "envoyproxy/envoy",
-        tag = "distroless-{}".format(ENVOY_VERSION),
-    )
+    for name, (arch, sha) in _ENVOY_BIN.items():
+        http_file(
+            name = name,
+            downloaded_file_path = "envoy",
+            executable = True,
+            sha256 = sha,
+            urls = [
+                "https://github.com/envoyproxy/envoy/releases/download/{ver}/envoy-{v}-linux-{arch}".format(
+                    ver = ENVOY_VERSION,
+                    v = _V,
+                    arch = arch,
+                ),
+            ],
+        )
 
 envoy = module_extension(implementation = _envoy_impl)

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -77,12 +77,12 @@ cniInstall:
 proxy:
   enabled: true
   image:
-    # Custom aether-proxy = stock Envoy distroless base + baked-in
+    # Custom aether-proxy = distroless/cc base + official Envoy binary + baked-in
     # aether_stats_filter dynamic module (proposal 007), built and pinned by
     # //proxy:image_push. The module's search path is baked into the image —
     # self-contained, no K8s image volume. The Envoy version is pinned via
-    # //bazel/envoy ENVOY_VERSION (the @envoy_distroless base); keep that in
-    # lockstep with the SDK/abi.h.
+    # //bazel/envoy ENVOY_VERSION (the release binary); keep that in lockstep
+    # with the SDK/abi.h.
     ref: "{@//proxy:image_push}"
     pullPolicy: Always
   logLevel: info

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -1,18 +1,30 @@
-# Custom aether-proxy image: stock Envoy distroless base + baked-in dynamic
-# modules. Lives at //proxy (not under a specific filter) so future proxy
-# customizations — additional dynamic modules, bootstrap assets — append to the
-# same image rather than forking a new one.
+# Custom aether-proxy image: distroless/cc base + the official Envoy binary +
+# baked-in dynamic modules. Lives at //proxy (not under a specific filter) so
+# future proxy customizations — additional dynamic modules, bootstrap assets —
+# append to the same image rather than forking a new one.
 #
-# The Envoy base (@envoy_distroless) is pinned via //bazel/envoy ENVOY_VERSION;
-# keep that in lockstep with the SDK git tag (proxy/filters/telemetry/Cargo.toml)
-# and abi.h. The //bazel/llvm/platform:linux_* platforms build the module .so via
-# the hermetic LLVM toolchain against an old glibc sysroot (max symbol GLIBC_2.18,
-# loads on the distroless base); the pure-Rust .so needs only libgcc_s/libc/pthread.
+# Base is gcr.io/distroless/cc (not the stock envoyproxy/envoy:distroless, which
+# is built on distroless/base and lacks libgcc_s.so.1): cc ships libstdc++ +
+# libgcc_s + glibc, which the Envoy binary and the Rust dynamic module's unwinder
+# both need at runtime. The Envoy binary and abi.h are version-pinned via
+# //bazel/envoy ENVOY_VERSION; keep in lockstep with the SDK git tag
+# (proxy/filters/telemetry/Cargo.toml). The //bazel/llvm/platform:linux_*
+# platforms cross-build the module .so with the hermetic LLVM toolchain against an
+# old glibc sysroot (max symbol GLIBC_2.18) so it loads on the base.
 
 load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "file_metadata", "image_layer")
 load("@rules_img//img:load.bzl", "image_load")
 load("@rules_img//img:push.bzl", "image_push")
+
+# The official Envoy release binary (per-arch via //bazel/envoy:envoy_bin select).
+image_layer(
+    name = "envoy_layer",
+    srcs = {"/usr/local/bin/envoy": "//bazel/envoy:envoy_bin"},
+    compress = "zstd",
+    default_metadata = file_metadata(mode = "0755"),
+    include_runfiles = False,
+)
 
 # aether_stats_filter module .so at /modules, where the proxy loads it via the
 # baked-in ENVOY_DYNAMIC_MODULES_SEARCH_PATH. Future modules add layers here.
@@ -26,12 +38,20 @@ image_layer(
 
 image_manifest(
     name = "image_manifest",
-    base = "@envoy_distroless",
-    # Self-contained: the search path is baked into the image, so the proxy
-    # loads /modules/*.so with no chart-supplied env and no K8s image volume
-    # (drops the containerd >= 2.0 image-volume runtime dependency).
+    base = "@distroless_cc",
+    # distroless/cc has no default entrypoint (the stock Envoy image did); set it
+    # so the image behaves like envoyproxy/envoy. The chart overrides command for
+    # the hot-restart supervisor, but keep this for parity + direct `docker run`.
+    entrypoint = ["/usr/local/bin/envoy"],
+    # Self-contained: the module search path is baked in, so the proxy loads
+    # /modules/*.so with no chart-supplied env and no K8s image volume (drops the
+    # containerd >= 2.0 image-volume runtime dependency). libgcc_s/libstdc++ come
+    # from the distroless/cc base, on the default loader path (no LD_LIBRARY_PATH).
     env = {"ENVOY_DYNAMIC_MODULES_SEARCH_PATH": "/modules"},
-    layers = [":stats_filter_layer"],
+    layers = [
+        ":envoy_layer",
+        ":stats_filter_layer",
+    ],
     visibility = ["//visibility:private"],
 )
 

--- a/proxy/filters/telemetry/README.md
+++ b/proxy/filters/telemetry/README.md
@@ -76,17 +76,22 @@ bazel build …`, re-verify the patch. On an LLVM bump: update
 
 `//proxy:image` builds a **custom `aether-proxy` image** (the image targets live
 at `//proxy`, not under this filter, so future proxy customizations share it):
-the stock Envoy distroless base (`@envoy_distroless`, pinned via `//bazel/envoy`
-`ENVOY_VERSION`) with the module `.so` baked at `/modules/libaether_stats_filter.so`
-and `ENVOY_DYNAMIC_MODULES_SEARCH_PATH=/modules` baked into the image config — so
-the proxy loads it **self-contained, with no K8s image volume and no chart env**
-(drops the containerd ≥ 2.0 image-volume runtime dependency). Multi-arch; pushed
-by `//proxy:image_push` → `ghcr.io/bpalermo/aether/aether-proxy`; the chart's
+a **`gcr.io/distroless/cc` base** + the **official Envoy release binary** at
+`/usr/local/bin/envoy` (both pinned via `//bazel/envoy` `ENVOY_VERSION`) + the
+module `.so` baked at `/modules/libaether_stats_filter.so`, with
+`ENVOY_DYNAMIC_MODULES_SEARCH_PATH=/modules` in the image config — so the proxy
+loads it **self-contained, with no K8s image volume and no chart env** (drops the
+containerd ≥ 2.0 image-volume runtime dependency). Multi-arch; pushed by
+`//proxy:image_push` → `ghcr.io/bpalermo/aether/aether-proxy`; the chart's
 `proxy.image.ref` is substituted from it.
 
-The LLVM-built `.so` links against an old glibc sysroot (max symbol `GLIBC_2.18`,
-well under the distroless base) and needs only `libgcc_s`/`libc`/`pthread` (the
-pure-Rust lib drops libstdc++ via `--as-needed`). Validated:
+**Why distroless/cc, not `envoyproxy/envoy:distroless`:** the LLVM-built `.so`
+needs `libgcc_s.so.1` at runtime (its unwinder; the old Zig build avoided it via
+compiler-rt, but the single-arch LLVM dist can't cross-compile compiler-rt for
+arm64). The stock Envoy distroless image is built on distroless/**base** and
+lacks `libgcc_s`, so the module fails to load there. distroless/**cc** ships
+`libstdc++` + `libgcc_s` + glibc (debian12, matching the Envoy release), which
+both the Envoy binary and the module need. Validated:
 `Dynamic module ABI version v0.1.0 matched` + `configuration OK` loading the
 baked module from the image with no volume/env.
 


### PR DESCRIPTION
## Problem (talos-main rev 89 outage)

Deploying the stats filter to talos-main failed: the proxy rejected **every outbound listener** with
```
Failed to load dynamic module: /modules/libaether_stats_filter.so :
libgcc_s.so.1: cannot open shared object file: No such file or directory
```
The LLVM-built module needs `libgcc_s.so.1` at runtime (its unwinder — the prior Zig build avoided it via compiler-rt, but the single-arch LLVM dist can't cross-compile compiler-rt for arm64). The stock `envoyproxy/envoy:distroless` image is built on distroless/**base** and lacks libgcc_s. (Rolled back to rev 88; CI e2e missed this because kind doesn't exercise outbound-through-proxy module loading.)

## Fix

Re-base the custom proxy image on **`gcr.io/distroless/cc-debian12`** (ships `libstdc++` + `libgcc_s` + glibc, debian12 matching the Envoy release) and bake the **official Envoy release binary** at `/usr/local/bin/envoy` (per-arch `http_file` from `//bazel/envoy`, pinned via `ENVOY_VERSION`) + set the image entrypoint. Drops the `@envoy_distroless` pull.

(An earlier attempt to bake libgcc_s from the chromium sysroot **segfaulted** — that file was a 12 KB stub. A real, version-matched libgcc_s from distroless/cc resolves it.)

## Validation

- `docker run … --mode validate` on the new image: `Dynamic module ABI version v0.1.0 matched`, exit 0, **no segfault, no libgcc error**.
- Envoy binary runs on distroless/cc (`envoy --version` → 1.38.0).
- host + amd64 + arm64 `.so`, multi-arch `//proxy:image`, full `--config=ci` build + lint (33 tests) — all green.
- Chart still substitutes `proxy.image.ref` to the new digest.

After merge + publish, re-attempt the talos-main helm upgrade + e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)