### PR TITLE
feat(telemetry): wire aether_stats destination reporter on inbound HCMs (proposal 007 Phase 2)

### DIFF
--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -117,10 +117,14 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string) *listenerv3.FilterChain {
 	hcm := buildHTTPConnectionManager("inbound", buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
 	// Liveness/readiness are answered locally before the router; everything else
-	// passes through to the pod's application.
+	// passes through to the pod's application. The stats filter sits after the
+	// health-check filters (so locally-answered probe requests are not counted)
+	// and before the router, recording the destination-reported edge at the log
+	// phase (proposal 007 Phase 2).
 	hcm.HttpFilters = []*http_connection_managerv3.HttpFilter{
 		buildLivenessHealthCheckFilter(),
 		buildReadinessHealthCheckFilter(HealthProbeClusterName(cniPod)),
+		inboundStatsFilter(cniPod),
 		routerHttpFilter(),
 	}
 	// SANITIZE_SET replaces any client-supplied XFCC with details derived from the

--- a/agent/internal/xds/proxy/ingress_test.go
+++ b/agent/internal/xds/proxy/ingress_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/bpalermo/aether/common/constants"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	dynamic_modules_filterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/dynamic_modules/v3"
 	healthcheckv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func TestNewInboundListener(t *testing.T) {
@@ -41,11 +43,13 @@ func TestNewInboundListener(t *testing.T) {
 	assert.Equal(t, http_connection_managerv3.HttpConnectionManager_SANITIZE_SET, hcm.GetForwardClientCertDetails())
 	assert.True(t, hcm.GetSetCurrentClientCertDetails().GetUri())
 
-	// Liveness + readiness health-check filters precede the router.
-	require.Len(t, hcm.GetHttpFilters(), 3)
+	// Liveness + readiness health-check filters, then the stats module (proposal
+	// 007 Phase 2), then the router.
+	require.Len(t, hcm.GetHttpFilters(), 4)
 	assert.Equal(t, livenessHealthCheckFilterName, hcm.GetHttpFilters()[0].GetName())
 	assert.Equal(t, readinessHealthCheckFilterName, hcm.GetHttpFilters()[1].GetName())
-	assert.Equal(t, "envoy.filters.http.router", hcm.GetHttpFilters()[2].GetName())
+	assert.Equal(t, statsFilterName, hcm.GetHttpFilters()[2].GetName())
+	assert.Equal(t, "envoy.filters.http.router", hcm.GetHttpFilters()[3].GetName())
 
 	live := decodeHealthCheck(t, hcm.GetHttpFilters()[0])
 	assert.False(t, live.GetPassThroughMode().GetValue())
@@ -124,4 +128,39 @@ func TestInboundFilterChains_MultiPort(t *testing.T) {
 	assert.Equal(t, "app_mp_9090", clusterOf(bySNI["9090"]))
 	assert.Equal(t, "app_mp_8080", clusterOf(bySNI["8080"]))
 	assert.Equal(t, "app_mp_8080", clusterOf(defaultChain), "default chain → primary port")
+}
+
+// TestInboundChainStatsFilter verifies the stats dynamic module (proposal 007
+// Phase 2) sits after the two health-check filters (so locally-answered probes
+// are not counted) and before the router on the inbound HCM, carrying the local
+// pod's destination identity and reporter=destination in its filter_config.
+func TestInboundChainStatsFilter(t *testing.T) {
+	pod := &cniv1.CNIPod{
+		Name:             "checkout-abc",
+		Namespace:        "default",
+		ServiceAccount:   "checkout",
+		NetworkNamespace: "/var/run/netns/cni-a",
+		Ips:              []string{"10.0.0.1"},
+	}
+	l, err := NewInboundListener(pod, "aether.internal")
+	require.NoError(t, err)
+	require.NotEmpty(t, l.GetFilterChains())
+
+	hcm := &http_connection_managerv3.HttpConnectionManager{}
+	require.NoError(t, l.GetFilterChains()[0].GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
+
+	filters := hcm.GetHttpFilters()
+	require.Len(t, filters, 4, "expected liveness + readiness + stats + router")
+	assert.Equal(t, statsFilterName, filters[2].GetName())
+	assert.Equal(t, httpRouterFilterName, filters[3].GetName())
+
+	dm := &dynamic_modules_filterv3.DynamicModuleFilter{}
+	require.NoError(t, filters[2].GetTypedConfig().UnmarshalTo(dm))
+	assert.Equal(t, statsModuleName, dm.GetDynamicModuleConfig().GetName())
+	assert.Equal(t, statsFilterEntry, dm.GetFilterName())
+
+	cfg := &wrapperspb.StringValue{}
+	require.NoError(t, dm.GetFilterConfig().UnmarshalTo(cfg))
+	assert.Contains(t, cfg.GetValue(), `"reporter":"destination"`)
+	assert.Contains(t, cfg.GetValue(), `"destination_service":"checkout"`)
 }

--- a/agent/internal/xds/proxy/stats_filter.go
+++ b/agent/internal/xds/proxy/stats_filter.go
@@ -24,14 +24,17 @@ const (
 
 // statsFilterConfig is the per-pod JSON passed as the dynamic module's
 // filter_config. The module records aether_requests_total at stream completion,
-// dimensioned by this source identity plus the per-request destination service,
-// response code, and cause flag (proposal 007).
+// dimensioned by the local pod's identity plus the per-request remote service,
+// response code, and cause flag (proposal 007). One half of the identity is
+// agent-injected (constant for the listener), the other is derived per request
+// by the module: outbound injects source_*, inbound injects destination_service.
 type statsFilterConfig struct {
-	Reporter      string `json:"reporter"`
-	SourceService string `json:"source_service"`
-	SourcePod     string `json:"source_pod"`
-	MeshDomain    string `json:"mesh_domain"`
-	EmitPod       bool   `json:"emit_pod"`
+	Reporter           string `json:"reporter"`
+	SourceService      string `json:"source_service"`
+	SourcePod          string `json:"source_pod"`
+	DestinationService string `json:"destination_service"`
+	MeshDomain         string `json:"mesh_domain"`
+	EmitPod            bool   `json:"emit_pod"`
 }
 
 // outboundStatsFilter builds the source-reported stats dynamic-module HTTP
@@ -39,23 +42,41 @@ type statsFilterConfig struct {
 // mesh service name, pod name) is constant for this listener, so it travels in
 // the per-instance filter_config; the destination is derived per request from
 // the routed cluster.
-//
-// The module .so must be mounted on the proxy (image volume) — referencing an
-// absent dynamic module makes Envoy reject the listener. The chart mounts it
-// unconditionally alongside attaching this filter.
 func outboundStatsFilter(cniPod *cniv1.CNIPod, meshDomain string) *http_connection_managerv3.HttpFilter {
 	// source_pod is omitted from the emitted series by default (emit_pod=false)
 	// to bound cardinality; the module still receives it for future use.
-	cfg, _ := json.Marshal(statsFilterConfig{
+	return statsFilter(statsFilterConfig{
 		Reporter:      "source",
 		SourceService: cniPod.GetServiceAccount(),
 		SourcePod:     cniPod.GetName(),
 		MeshDomain:    meshDomain,
 		EmitPod:       false,
 	})
+}
+
+// inboundStatsFilter builds the destination-reported stats dynamic-module HTTP
+// filter for a local pod's inbound HCM. The local pod is the destination, so its
+// service travels in the per-instance filter_config; the module derives the
+// source per request by parsing the verified peer SVID's URI SAN (proposal 007
+// Phase 2). The mesh domain is not needed here — the source is path-parsed from
+// the SPIFFE SAN, not stripped from a cluster name.
+func inboundStatsFilter(cniPod *cniv1.CNIPod) *http_connection_managerv3.HttpFilter {
+	return statsFilter(statsFilterConfig{
+		Reporter:           "destination",
+		DestinationService: cniPod.GetServiceAccount(),
+		EmitPod:            false,
+	})
+}
+
+// statsFilter builds the aether_stats dynamic-module HTTP filter from the given
+// per-instance config. The module .so must be mounted on the proxy (image
+// volume) — referencing an absent dynamic module makes Envoy reject the
+// listener. The chart mounts it unconditionally alongside attaching this filter.
+func statsFilter(cfg statsFilterConfig) *http_connection_managerv3.HttpFilter {
+	raw, _ := json.Marshal(cfg)
 	return httpFilter(statsFilterName, &dynamic_modules_filterv3.DynamicModuleFilter{
 		DynamicModuleConfig: &dynamic_modulesv3.DynamicModuleConfig{Name: statsModuleName},
 		FilterName:          statsFilterEntry,
-		FilterConfig:        config.TypedConfig(wrapperspb.String(string(cfg))),
+		FilterConfig:        config.TypedConfig(wrapperspb.String(string(raw))),
 	})
 }


### PR DESCRIPTION
## What

PR-B of the Phase 2 stack — the **agent wiring half**. Builds on the module support merged in #184. Attaches `aether_stats` to each per-pod **inbound** HCM with `reporter=destination`, so the destination side of every mesh edge is now reported.

- `stats_filter.go`: add `destination_service` to `statsFilterConfig`; add `inboundStatsFilter` (`reporter=destination`, `destination_service=ServiceAccount`); factor the shared `DynamicModuleFilter` construction into `statsFilter()`.
- `ingress.go`: insert `inboundStatsFilter` into the inbound HCM **after** the two health-check filters (so locally-answered liveness/readiness probes aren't counted) and **before** the router, mirroring the outbound placement.

The local pod is the destination, so its service travels in `filter_config`; the module derives the source per request by parsing the verified peer SVID's URI SAN (`ConnectionUriSanPeerCertificate`, HTTP-filter-native per the #184 spike).

## Notes

- **No chart/bootstrap change** — reuses the existing counter vector. Once deployed, `aether_requests_total` gains a `reporter="destination"` view that reconciles with the existing `reporter="source"` view across every edge.
- `mesh_domain` is intentionally not passed on the inbound side — the source is path-parsed from the SPIFFE SAN, not stripped from a cluster name.
- Inert until the proxy image carrying the #184 module is live (already shipped — module name unchanged).

## Tests

- Updated `TestNewInboundListener` for the added filter (4 filters; stats at index 2).
- New `TestInboundChainStatsFilter`: asserts placement (after health filters, before router) + `reporter=destination` + `destination_service`.
- Full agent unit suite green; `make gazelle` / `make format` clean.

## Follow-up (Phase 3)

Fuzz the SPIFFE SAN parser, cardinality cap + overflow bucket, duration histogram, `destination_pod` behind `emit_pod`, drop-attribution e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)