### PR TITLE
feat(devcontainer): add dev container with Claude Code and repo tooling

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,42 @@
+# syntax=docker/dockerfile:1
+#
+# Aether dev container image.
+#
+# Matches the CI runner (ubuntu-24.04). The language/build toolchains
+# (Bazel, Go, Node, kubectl, helm, kind, Docker, Claude Code) are layered on
+# via devcontainer "features" in devcontainer.json — this Dockerfile only
+# carries the OS-level bits that have no clean feature equivalent.
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+# Base packages used directly by the repo workflow:
+#   - openssl:        e2e cert generation (e2e/Makefile)
+#   - make/git/curl:  Makefile targets, dependency fetch, repo ops
+#   - build-essential/pkg-config: host C toolchain for any cgo / local tooling
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        make \
+        openssl \
+        pkg-config \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# libtinfo5 for the hermetic toolchains_llvm clang.
+#
+# The pinned LLVM 18.1.8 static build leaks a shared dependency on
+# libtinfo.so.5 (llvm/llvm-project#75490), but ubuntu-24.04 ships only
+# libtinfo.so.6 (a .6->.5 symlink fails: clang needs the versioned
+# NCURSES_TINFO_5.0 symbols). Fetch the real ncurses5 .deb from Debian —
+# the same workaround used in CI (.github/actions/setup-llvm-libs) and by
+# Envoy (envoyproxy/envoy#42397). See //bazel/llvm and MODULE.bazel.
+RUN arch="$(dpkg --print-architecture)" \
+    && deb="libtinfo5_6.4-4_${arch}.deb" \
+    && curl -fsSLO "http://deb.debian.org/debian/pool/main/n/ncurses/${deb}" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends "./${deb}" \
+    && rm -f "${deb}" \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,75 @@
+{
+  "name": "Aether",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+
+  // Order matters: docker-in-docker first so kind/testcontainers have a
+  // daemon; node before claude-code (the feature needs a Node runtime).
+  "features": {
+    // Docker daemon inside the container, for `bazel run //...:image_load`
+    // (rules_img) and the testcontainers-go integration tests (etcd,
+    // DynamoDB Local). kind also talks to this daemon.
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": true
+    },
+    // Host Go matching go.mod (rules_go is hermetic, but this powers gopls
+    // and `bazel run @rules_go//go get`).
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.26.2"
+    },
+    // Bazelisk -> bazel; reads .bazelversion (9.1.1) automatically.
+    "ghcr.io/devcontainers-extra/features/bazelisk:1": {},
+    // kubectl + helm for the charts/ and e2e workflows (skip minikube; we use kind).
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "latest",
+      "helm": "latest",
+      "minikube": "none"
+    },
+    // kind: the e2e suite (test/e2e) spins up a kind cluster.
+    "ghcr.io/devcontainers-extra/features/kind:1": {},
+    // Node runtime for Claude Code.
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    // Claude Code CLI.
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+  },
+
+  // Persist the Bazel cache across container rebuilds — a cold Aether build
+  // (LLVM sysroots, Rust + Go SDKs, Envoy) is expensive to redownload.
+  "mounts": [
+    "source=aether-bazel-cache,target=/home/vscode/.cache/bazel,type=volume"
+  ],
+
+  // The bind-mounted workspace and the cache volume are owned by root until
+  // chowned; fix ownership for the non-root user.
+  "postCreateCommand": "sudo chown -R vscode:vscode /home/vscode/.cache/bazel && bazel version",
+
+  "remoteUser": "vscode",
+
+  "customizations": {
+    // IntelliJ IDEA Ultimate backend (JetBrains Gateway / Remote Dev).
+    "jetbrains": {
+      "backend": "IntelliJ",
+      "plugins": [
+        // Bazel via BSP — matches the repo's .bazelbsp/ project + aspects.
+        "org.jetbrains.bazel",
+        // Go support in IDEA Ultimate.
+        "org.jetbrains.plugins.go",
+        // Protobuf editing for api/*.proto.
+        "idea.plugin.protoeditor",
+        // Kubernetes + Helm chart support for charts/ and e2e.
+        "com.intellij.kubernetes"
+      ]
+    }
+  },
+
+  // The JetBrains backend IDE runs in-container on top of an already
+  // memory-hungry build (Bazel image builds, LLVM cross-compile), so give it
+  // more headroom than a VS Code setup would need.
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "12gb"
+  }
+}


### PR DESCRIPTION
## Summary

Adds a `.devcontainer/` optimized for **IntelliJ IDEA** (JetBrains Gateway / Remote Dev) that provisions the full Aether toolchain plus Claude Code, so the repo can be worked on in a reproducible container.

### Toolchain
- **Bazelisk** — reads `.bazelversion` (9.1.1) automatically
- **Go 1.26.2** — matches `go.mod` (powers gopls / `bazel run @rules_go//go get`)
- **docker-in-docker** — for `bazel run //...:image_load` (rules_img) and the testcontainers-go integration tests (etcd, DynamoDB Local)
- **kind + kubectl + helm** — for `charts/` and the `test/e2e` suite
- **libtinfo5** (Dockerfile) — so the hermetic `toolchains_llvm` clang (LLVM 18.1.8) resolves `libtinfo.so.5`; mirrors `.github/actions/setup-llvm-libs`
- **Node + Claude Code CLI**

### IntelliJ
- `customizations.jetbrains` requests the IDEA Ultimate backend and the plugins that match this repo: Bazel (via BSP, matching the existing `.bazelbsp/` project), Go, protobuf, and Kubernetes
- Persistent named volume for `~/.cache/bazel` so cold builds survive rebuilds
- 12 GB / 4 CPU host hint for the in-container backend IDE

Formatters/linters (gofumpt, buildifier, shfmt, buf, shellcheck) and the Rust/LLVM toolchains are intentionally left off the host since they're already Bazel-managed/hermetic.

## Test plan
- [ ] `devcontainer.json` parses as valid JSONC ✅ (verified locally)
- [ ] Build the container via JetBrains Gateway → Dev Containers and confirm `bazel version`, `kubectl version --client`, `helm version`, `kind version`, and `claude --version` resolve
- [ ] Smoke-test the Bazel BSP import in IntelliJ against `.bazelbsp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)