### PR TITLE
feat(telemetry): aether_stats request-duration histogram + SAN-parser fuzz test (proposal 007 Phase 3)

### DIFF
--- a/proxy/filters/http/aether_stats/README.md
+++ b/proxy/filters/http/aether_stats/README.md
@@ -18,12 +18,24 @@ envoy.dynamicmodulescustom.aether_requests_total{
   response_code, response_flags }
 ```
 
+Plus a request-duration histogram on a deliberately leaner label set (a
+histogram multiplies series by its bucket count):
+
+```
+envoy.dynamicmodulescustom.aether_request_duration_milliseconds{
+  reporter, source_service, destination_service }
+```
+
 In Prometheus: `envoy_dynamicmodulescustom_aether_requests_total{...}`.
 
 `response_flags` is a bounded cause label (`UF`/`UH`/`NC`/`NR`/`UO`/`UT`/`UR`,
 `-` for upstream/success). The `ResponseFlags` attribute isn't exposed to
 dynamic-module HTTP filters at v1.38, so the module derives it from the
 `on_local_reply` details — reproducing Istio's `toShortString` vocabulary.
+
+Duration is likewise measured in-module (`std::time::Instant`, request start →
+`on_stream_complete`): no request-duration attribute is exposed to HTTP filters
+at v1.38, and the unit lives in the metric name.
 
 ## How identity is resolved
 
@@ -99,10 +111,28 @@ Default-on: the agent always attaches the filter, and the proxy image always
 carries the module — they move together. First rollout introducing it has a
 brief agent↔proxy skew window (independent DaemonSets) — see the release note.
 
+## Testing & fuzzing
+
+Unit tests run under Bazel: `bazel test //proxy/filters/http/aether_stats:aether_stats_test`.
+The HTTP hooks are exercised against the SDK's `MockEnvoyHttpFilter`.
+
+`spiffe_service()` parses the peer SVID URI SAN — the only untrusted input — so
+it has a torture test (`spiffe_service_never_panics_on_adversarial_input`) that
+sweeps every byte plus pathological/large inputs and asserts the parser is total
+(never panics, always returns a substring or `None`).
+
+For deeper coverage you can run a libFuzzer target locally (kept out of the
+hermetic Bazel build — it needs a nightly toolchain):
+
+```
+cd proxy/filters/http/aether_stats
+cargo +nightly fuzz run spiffe_service   # requires a fuzz/ target wrapping spiffe_service
+```
+
 ## Status
 
-Phase-1 validated 2026-06-13/14: builds (host + LLVM cross amd64/arm64), loads on stock
-distroless Envoy, records `aether_requests_total` with `response_flags` (UF on
-connect-refused), exported via the OTel sink. Agent wiring + chart image-volume
-done. Remaining: helm upgrade + e2e on talos. Phase 2 = inbound/destination-
-reported (peer URI SAN).
+Phase 1 + Phase 2 shipped and e2e-validated on talos-main (rev 93): emits both
+`reporter=source` (outbound) and `reporter=destination` (inbound, source parsed
+from the peer URI SAN). Phase 3 (in progress): request-duration histogram + SAN
+parser fuzz hardening; next is `destination_pod` behind `emit_pod` and a
+drop-attribution e2e. Deferred: cardinality cap + overflow bucket.

--- a/proxy/filters/http/aether_stats/src/lib.rs
+++ b/proxy/filters/http/aether_stats/src/lib.rs
@@ -16,6 +16,7 @@
 
 use envoy_proxy_dynamic_modules_rust_sdk::*;
 use serde::Deserialize;
+use std::time::Instant;
 
 declare_init_functions!(init, new_http_filter_config_fn);
 
@@ -57,6 +58,7 @@ pub struct FilterConfig {
     destination_service: String,
     mesh_domain: String,
     requests_total: EnvoyCounterVecId,
+    request_duration_ms: EnvoyHistogramVecId,
 }
 
 impl FilterConfig {
@@ -86,6 +88,17 @@ impl FilterConfig {
                 ],
             )
             .ok()?;
+        // Request-duration histogram. Deliberately a LEANER label set than the
+        // counter — a histogram multiplies series by its bucket count, so it
+        // omits source_pod/response_code/response_flags and keeps only the edge
+        // identity. Duration is measured in-module (no Envoy duration attribute
+        // is exposed to HTTP filters); the unit lives in the metric name.
+        let request_duration_ms = ec
+            .define_histogram_vec(
+                "aether_request_duration_milliseconds",
+                &["reporter", "source_service", "destination_service"],
+            )
+            .ok()?;
         Some(Self {
             reporter: c.reporter,
             source_service: c.source_service,
@@ -97,6 +110,7 @@ impl FilterConfig {
             destination_service: c.destination_service,
             mesh_domain: c.mesh_domain,
             requests_total,
+            request_duration_ms,
         })
     }
 }
@@ -110,6 +124,10 @@ impl<EHF: EnvoyHttpFilter> HttpFilterConfig<EHF> for FilterConfig {
             destination_service: self.destination_service.clone(),
             mesh_domain: self.mesh_domain.clone(),
             requests_total: self.requests_total,
+            request_duration_ms: self.request_duration_ms,
+            // Filters are created per stream at request start, so this is the
+            // earliest observable point for the request-duration measurement.
+            start: Instant::now(),
             dest_cluster: String::new(),
             local_reply_details: String::new(),
             recorded: false,
@@ -124,6 +142,8 @@ pub struct Filter {
     destination_service: String,
     mesh_domain: String,
     requests_total: EnvoyCounterVecId,
+    request_duration_ms: EnvoyHistogramVecId,
+    start: Instant,
     dest_cluster: String,
     local_reply_details: String,
     recorded: bool,
@@ -190,6 +210,14 @@ impl Filter {
                 response_flags,
             ],
             1,
+        );
+
+        // Request duration on the lean {reporter, source, destination} label set.
+        let elapsed_ms = self.start.elapsed().as_millis().min(u64::MAX as u128) as u64;
+        let _ = envoy.record_histogram_value_vec(
+            self.request_duration_ms,
+            &[&self.reporter, &source_service, &destination_service],
+            elapsed_ms,
         );
     }
 
@@ -399,6 +427,8 @@ mod tests {
             destination_service: String::new(),
             mesh_domain: "aether.internal".to_string(),
             requests_total: EnvoyCounterVecId(0),
+            request_duration_ms: EnvoyHistogramVecId(0),
+            start: Instant::now(),
             dest_cluster: String::new(),
             local_reply_details: String::new(),
             recorded: false,
@@ -415,6 +445,8 @@ mod tests {
             destination_service: "checkout".to_string(),
             mesh_domain: "aether.internal".to_string(),
             requests_total: EnvoyCounterVecId(0),
+            request_duration_ms: EnvoyHistogramVecId(0),
+            start: Instant::now(),
             dest_cluster: String::new(),
             local_reply_details: String::new(),
             recorded: false,
@@ -528,7 +560,9 @@ mod tests {
 
     // Collects the label vector passed to increment_counter_vec so tests can
     // assert the exact (reporter, source_service, source_pod, destination,
-    // response_code, response_flags) tuple recorded.
+    // response_code, response_flags) tuple recorded. Also stubs the duration
+    // histogram record() always emits alongside the counter, so the strict mock
+    // does not fail on the unexpected call.
     fn expect_record(mock: &mut MockEnvoyHttpFilter) -> Arc<Mutex<Vec<String>>> {
         let labels = Arc::new(Mutex::new(Vec::new()));
         let sink = labels.clone();
@@ -538,6 +572,9 @@ mod tests {
                 *sink.lock().unwrap() = ls.iter().map(|s| s.to_string()).collect();
                 Ok(())
             });
+        mock.expect_record_histogram_value_vec()
+            .times(1)
+            .returning(|_id, _ls, _value| Ok(()));
         labels
     }
 
@@ -724,5 +761,79 @@ mod tests {
             *labels.lock().unwrap(),
             vec!["source", "cart", "cart-abc", "checkout", "503", "UF"]
         );
+    }
+
+    // ---- duration histogram ---------------------------------------------
+
+    #[test]
+    fn record_emits_duration_histogram_on_lean_labels() {
+        // The histogram carries only {reporter, source_service, destination_service}
+        // — not source_pod/response_code/response_flags — to bound bucket×label
+        // cardinality.
+        let mut mock = MockEnvoyHttpFilter::default();
+        mock.expect_get_attribute_int()
+            .times(1)
+            .returning(|_| Some(200));
+        mock.expect_increment_counter_vec()
+            .times(1)
+            .returning(|_, _, _| Ok(()));
+        let hist_labels = Arc::new(Mutex::new(Vec::new()));
+        let sink = hist_labels.clone();
+        mock.expect_record_histogram_value_vec()
+            .times(1)
+            .returning(move |_id, ls, _value| {
+                *sink.lock().unwrap() = ls.iter().map(|s| s.to_string()).collect();
+                Ok(())
+            });
+
+        let mut f = test_filter();
+        f.dest_cluster = "checkout.aether.internal".to_string();
+        f.record(&mut mock);
+
+        assert_eq!(
+            *hist_labels.lock().unwrap(),
+            vec!["source", "cart", "checkout"]
+        );
+    }
+
+    // ---- spiffe_service fuzz/torture -------------------------------------
+
+    #[test]
+    fn spiffe_service_never_panics_on_adversarial_input() {
+        // The peer SAN is the only untrusted input. The parser must be total:
+        // never panic, always terminate, and only ever return a slice that is a
+        // substring of its input. Exercise pathological shapes plus a sweep of
+        // every single byte and some large/repetitive inputs.
+        let mut cases: Vec<String> = vec![
+            String::new(),
+            "spiffe://".to_string(),
+            "spiffe:///".to_string(),
+            "spiffe://td/sa".to_string(),
+            "spiffe://td/sa/".to_string(),
+            "sa/x".to_string(),
+            "/////".to_string(),
+            "spiffe://td/sa/svc/sa/other".to_string(),
+            "spiffe://td/ns//sa//".to_string(),
+            "\0\0\0".to_string(),
+            "spiffe://td/\u{0}/sa/\u{0}svc".to_string(),
+            "spiffe://td/ns/默认/sa/服务".to_string(),
+        ];
+        // Single-byte inputs (control chars, high bytes via lossy decode).
+        for b in 0u8..=255 {
+            cases.push(String::from_utf8_lossy(&[b]).into_owned());
+        }
+        // Large and repetitive shapes.
+        cases.push("a".repeat(1 << 20));
+        cases.push("/".repeat(100_000));
+        cases.push(format!("spiffe://td/{}/sa/svc", "x/".repeat(50_000)));
+        cases.push(format!("spiffe://td/ns/d/sa/{}", "s".repeat(1 << 20)));
+
+        for c in &cases {
+            if let Some(svc) = spiffe_service(c) {
+                // The result is always a non-empty substring of the input.
+                assert!(!svc.is_empty());
+                assert!(c.contains(svc));
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

PR-1 of Phase 3 (hardening) — two **module-only** items, no agent/chart change:

### Request-duration histogram
New `aether_request_duration_milliseconds` on a deliberately **lean** label set `{reporter, source_service, destination_service}` — a histogram multiplies series by its bucket count, so it omits `source_pod`/`response_code`/`response_flags`.

Duration is measured **in-module** (`std::time::Instant` from the per-stream filter's creation → `on_stream_complete`) because no request-duration attribute is exposed to dynamic-module HTTP filters at v1.38 (same gap as `ResponseFlags`). The unit lives in the metric name. As a new metric name it's created fresh, so it's natively tagged from day one (unlike the legacy source counter — see the hot-restart-inheritance note in prior findings).

### SAN-parser fuzz/torture test
`spiffe_service()` parses the peer SVID URI SAN — the only untrusted input the module touches (the proposal's named hardening gate). New `spiffe_service_never_panics_on_adversarial_input` sweeps every byte value plus pathological/large/repetitive inputs and asserts the parser is **total**: never panics, always terminates, only ever returns a substring of its input or `None`. The README documents an optional out-of-bazel `cargo-fuzz` target for deeper local fuzzing (kept out of hermetic Bazel — needs nightly).

## Tests
25 unit tests pass (23 + histogram-label assertion + torture test); cdylib builds; rustfmt clean.

## Follow-ups (Phase 3, separate PRs)
- `destination_pod` behind `emit_pod` (PR-2)
- drop-attribution e2e (kill last-old pod mid-roll → `UF` source→dest edge)
- deferred: cardinality cap + overflow bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)