### PR TITLE
feat(proxy): multi-arch (amd64+arm64) proxy image + commit-pinned tag

### DIFF
--- a/.github/workflows/proxy-pr.yml
+++ b/.github/workflows/proxy-pr.yml
@@ -36,8 +36,9 @@ jobs:
           repository-cache: true
 
       - name: Test (BuildBuddy RBE)
-        # The compile runs remotely on BuildBuddy. //... runs the build_test (which
-        # compiles the custom Envoy + assembles the image) plus any unit tests.
+        # The compile runs remotely on BuildBuddy. //... runs //:image_test (compiles
+        # the amd64 Envoy + validates the image). //:image_index additionally builds
+        # the arm64 cross-compile so multi-arch breakage is caught pre-merge.
         # --config=ci adds the release build + static BuildBuddy metadata; dynamic
         # metadata (https://www.buildbuddy.io/docs/guide-metadata) is attached here.
         run: |
@@ -48,4 +49,4 @@ jobs:
             --build_metadata=COMMIT_SHA=${{ github.event.pull_request.head.sha }} \
             --build_metadata=REPO_URL=https://github.com/${{ github.repository }} \
             --build_metadata=BRANCH_NAME=${{ github.head_ref }} \
-            //...
+            //... //:image_index

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -43,9 +43,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build + push image (BuildBuddy RBE)
-        # The compile runs remotely; oci_push runs on the runner (the image is
-        # downloaded via --remote_download_toplevel from --config=rbe-buildbuddy).
-        # --config=ci bakes the optimized/stripped binary + adds static metadata.
+        # The amd64 + arm64 compiles run remotely; oci_push (the multi-arch index)
+        # runs on the runner (the image is downloaded via --remote_download_toplevel
+        # from --config=rbe-buildbuddy). --config=ci bakes the optimized/stripped
+        # binary. `--tag dev-<sha>` adds a commit-pinned tag alongside the BUILD-time
+        # "dev" tag (oci_push applies both).
         run: |
           bazel run \
             --config=ci \
@@ -54,4 +56,4 @@ jobs:
             --build_metadata=COMMIT_SHA=${{ github.sha }} \
             --build_metadata=REPO_URL=https://github.com/${{ github.repository }} \
             --build_metadata=BRANCH_NAME=${{ github.ref_name }} \
-            //:push
+            //:push -- --tag dev-${{ github.sha }}

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@container_structure_test//:defs.bzl", "container_structure_test")
 load("@envoy//bazel:envoy_build_system.bzl", "envoy_cc_binary")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load", "oci_push")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_load", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 
 # Custom aether Envoy. The compiled-in extension set comes from
@@ -30,8 +30,8 @@ pkg_tar(
 
 # Custom aether-proxy image: distroless/cc base + the custom Envoy binary. The
 # aether_stats dynamic module is intentionally not baked in yet (filter
-# customization is unwired until the proposal-010 follow-up); this is a vanilla
-# custom Envoy image, which is the current build goal.
+# customization is unwired until the proposal-010 follow-up). This is the
+# single-arch image; the oci_image_index below builds it for amd64 + arm64.
 oci_image(
     name = "image",
     base = "@distroless_cc",
@@ -43,9 +43,23 @@ oci_image(
     workdir = "/",
 )
 
+# Multi-arch image. The transition cross-compiles the Envoy binary for each
+# platform (Envoy's hermetic toolchain ships the aarch64 sysroot + libcxx).
+oci_image_index(
+    name = "image_index",
+    images = [":image"],
+    platforms = [
+        "@envoy//bazel/platforms:linux_x64",
+        "@envoy//bazel/platforms:linux_arm64",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+# Pushes the multi-arch index. The release workflow appends a commit-pinned tag
+# (dev-<sha>) at push time via `bazel run //:push -- --tag dev-<commit>`.
 oci_push(
     name = "push",
-    image = ":image",
+    image = ":image_index",
     remote_tags = ["dev"],
     repository = "ghcr.io/bpalermo/aether/aether-proxy",
 )

--- a/proxy/bazel/oci/images.bzl
+++ b/proxy/bazel/oci/images.bzl
@@ -11,8 +11,9 @@ def oci_images():
         name = "distroless_cc",
         digest = "sha256:b0ae8e989418b458e0f25489bc3be523718938a2b70864cc0f6a00af1ddbd985",
         image = "gcr.io/distroless/cc-debian12",
+        # The index lists arm64 as arm64/v8 (the variant must be matched exactly).
         platforms = [
             "linux/amd64",
-            "linux/arm64",
+            "linux/arm64/v8",
         ],
     )


### PR DESCRIPTION
Builds the custom aether-proxy image for **both amd64 and arm64** (`rules_oci` `oci_image_index`) and stamps a commit-pinned tag.

## What
- **Multi-arch**: `oci_image_index` transitions the image across `@envoy//bazel/platforms:linux_{x64,arm64}`; the Envoy hermetic toolchain cross-compiles aarch64 (ships the arm64 sysroot + libcxx). `oci_push` publishes the multi-arch index.
- **Base image**: the distroless/cc index lists arm64 as `arm64/v8` — matched explicitly in the pull.
- **Tags**: BUILD-time `dev` + `dev-<commit>` appended at push time (`//:push -- --tag dev-<sha>`), matching aether's `dev` / `dev-<commit>` convention.
- **CI**: `proxy-pr` now builds `//:image_index` (so arm64 breakage is caught pre-merge) alongside the amd64 `//:image_test`; `proxy-release` pushes the multi-arch index.

## Validation
Analysis verified locally — amd64 **and** arm64 toolchain resolution + base-manifest match all pass. The full arm64 cross-compile runs on CI (this PR's `proxy-pr`).

> Note: an earlier attempt to switch to `rules_img` (for parity with the control plane) was abandoned — its `image_push` is effectively bzlmod-only (`@hermetic_launcher` cascade) and won't load in the proxy's WORKSPACE workspace. Revisit when Envoy 1.39 lets the proxy move to bzlmod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)