### PR TITLE
ci: also exclude proxy workflow files from aether workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "proxy/**"
+      - ".github/workflows/proxy-*.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "proxy/**"
+      - ".github/workflows/proxy-*.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/integration-cni-server.yaml
+++ b/.github/workflows/integration-cni-server.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "proxy/**"
+      - ".github/workflows/proxy-*.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/integration-dynamodb.yaml
+++ b/.github/workflows/integration-dynamodb.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "proxy/**"
+      - ".github/workflows/proxy-*.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/integration-etcd.yaml
+++ b/.github/workflows/integration-etcd.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "proxy/**"
+      - ".github/workflows/proxy-*.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/integration-xds-server.yaml
+++ b/.github/workflows/integration-xds-server.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths-ignore:
       - "proxy/**"
+      - ".github/workflows/proxy-*.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
The aether PR workflows (`ci`, `e2e`, `integration-*`) already `paths-ignore: proxy/**`, but the proxy workspace's workflows live at `.github/workflows/proxy-*.yml` — **outside** `proxy/` — so a proxy-only PR that touches them still triggered all the aether workflows.

Add `.github/workflows/proxy-*.yml` to each workflow's `paths-ignore`, so a change confined to the proxy workspace (its sources and/or its own workflows) never runs the aether workflows. The proxy workspace has its own `proxy-pr` / `proxy-release`.

Mixed PRs (touching aether *and* proxy) still run both, as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)