### PR TITLE
chore(proxy): pin agent chart to aether-proxy:85581a0bf62171d56d4fe571e0c9a0ae93395957

### DIFF
--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -83,7 +83,7 @@ proxy:
     # publishing commit SHA (multi-arch manifest). This `ref` is auto-pinned to
     # that SHA by proxy-release (a bump-chart PR) on each proxy release — an
     # immutable pin (the :dev placeholder below is just the pre-first-release seed).
-    ref: "ghcr.io/bpalermo/aether/aether-proxy:dev"
+    ref: "ghcr.io/bpalermo/aether/aether-proxy:85581a0bf62171d56d4fe571e0c9a0ae93395957"
     pullPolicy: Always
   logLevel: info
   # SPIKE (Strategy A): run the Envoy hot-restart supervisor (agent


### PR DESCRIPTION
Pins the agent chart's proxy image to the multi-arch image published by `proxy-release` for commit `85581a0bf62171d56d4fe571e0c9a0ae93395957` (amd64 RBE + arm64 native → manifest `aether-proxy:85581a0bf62171d56d4fe571e0c9a0ae93395957`).

This is the branch `proxy-release`'s `bump-chart` job already pushed; opening the PR manually since GitHub Actions isn't permitted to create PRs (add a `CHART_BUMP_PAT` secret to automate future bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)