### PR TITLE
chore: fix make format-check + exclude proxy workspace from root formatter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,11 @@ BUILD.bazel linguist-generated=true
 BUILD linguist-generated=true
 MODULE.bazel.lock linguist-generated=true
 go.sum linguist-generated=true
+
+# The proxy/ tree is a separate Bazel workspace (own WORKSPACE + Bazel 7.7.1,
+# Envoy-derived tooling; //.bazelignore excludes it from the root build). The
+# root formatter discovers files via `git ls-files`, which ignores .bazelignore,
+# so it would otherwise reformat proxy Starlark/shell (e.g. the upstream-mirrored
+# extensions_build_config.bzl) and fight the proxy's own conventions. rules_lint
+# honors `rules-lint-ignored`, so mark the whole tree out of the root format/lint.
+proxy/** rules-lint-ignored=true

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,3 +15,10 @@ alias(
     name = "format",
     actual = "//bazel/format",
 )
+
+# format_multirun also generates a `.check` sibling (no-write, fails on diff)
+# used by `make format-check`; alias it so it is reachable as //:format.check.
+alias(
+    name = "format.check",
+    actual = "//bazel/format:format.check",
+)


### PR DESCRIPTION
## Summary
`make format-check` was broken and, once fixed, revealed the root formatter reaching into the separate `proxy/` workspace.

- **`//:format.check` alias** — `make format-check` ran `bazel run //:format.check`, but the root `BUILD.bazel` only aliased `//:format`. `format_multirun` generates the check sibling as `//bazel/format:format.check`, so the `//:` form never existed. Added the matching alias.
- **Exclude `proxy/` from root format/lint** — the formatter discovers files via `git ls-files` (which ignores `//.bazelignore`), so it swept the separate proxy Bazel workspace and wanted to reformat its Starlark/shell, including the **upstream-mirrored** `extensions_build_config.bzl` (634-line churn that breaks diffing against Envoy). `aspect_rules_lint` honors the `rules-lint-ignored` git attribute, so `proxy/** rules-lint-ignored=true` keeps the root tooling out of a workspace that has its own Envoy-derived formatters.

## Verification
- `make format-check` → exit 0 (was: `no such target '//:format.check'`).
- `make format` is idempotent — no proxy files touched; `git check-attr rules-lint-ignored` reports `true` for proxy paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)