### PR TITLE
fix(proxy): aether_stats double-registration crash + boot/validate integration test

### DIFF
--- a/proxy/source/extensions/filters/http/aether_stats/BUILD
+++ b/proxy/source/extensions/filters/http/aether_stats/BUILD
@@ -61,3 +61,19 @@ envoy_cc_test(
         "@envoy//test/mocks/upstream:cluster_info_mocks",
     ],
 )
+
+# Boots a real Envoy with the filter wired as the agent emits it (TypedStruct)
+# and drives a request through it. Catches a static-init abort (the binary won't
+# start) and factory-resolution failures, which the unit test and the tar-driver
+# image_test cannot. Links :config so the factory is registered in the test
+# binary.
+envoy_cc_test(
+    name = "aether_stats_integration_test",
+    srcs = ["aether_stats_integration_test.cc"],
+    repository = "@envoy",
+    deps = [
+        ":config",
+        "@envoy//test/integration:http_integration_lib",
+        "@envoy//test/test_common:utility_lib",
+    ],
+)

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
@@ -1,0 +1,82 @@
+#include <string>
+
+#include "test/integration/http_integration.h"
+#include "test/test_common/utility.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace HttpFilters {
+namespace AetherStats {
+namespace {
+
+// Boots a real Envoy with the aether_stats filter wired exactly as the agent
+// emits it (an xds.type.v3.TypedStruct typed_config whose inner type is the
+// native extension's Config proto), sends a request through it, and asserts the
+// native counter increments.
+//
+// This is the guard that the unit test and the tar-driver image_test cannot
+// provide: it actually starts the binary (a "Double registration" static-init
+// abort fails here — the bug that broke the first in-vivo roll) and resolves
+// the filter factory by config type from the TypedStruct (a missing/renamed
+// factory or a config-field mismatch fails here too).
+class AetherStatsIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                   public HttpIntegrationTest {
+public:
+  AetherStatsIntegrationTest() : HttpIntegrationTest(Http::CodecType::HTTP1, GetParam()) {}
+
+  void initializeFilter() {
+    // Mirrors agent/internal/xds/proxy/stats_filter.go: source reporter,
+    // identity in the per-instance config, destination derived from the routed
+    // cluster.
+    config_helper_.prependFilter(R"EOF(
+name: aether.filters.http.aether_stats
+typed_config:
+  "@type": type.googleapis.com/xds.type.v3.TypedStruct
+  type_url: type.googleapis.com/aether.filters.http.aether_stats.v3.Config
+  value:
+    reporter: source
+    source_service: checkout
+    mesh_domain: aether.internal
+)EOF");
+    initialize();
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, AetherStatsIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()));
+
+TEST_P(AetherStatsIntegrationTest, RecordsRequestCounter) {
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}});
+
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+
+  ASSERT_TRUE(response->waitForEndStream());
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_EQ("200", response->headers().getStatusValue());
+
+  // The filter records at stream completion. Find the lone
+  // aether.requests_total counter (tagged, so look it up by tag-extracted name)
+  // and assert it fired.
+  Stats::CounterSharedPtr counter;
+  for (const auto& c : test_server_->counters()) {
+    if (c->tagExtractedName() == "aether.requests_total") {
+      counter = c;
+      break;
+    }
+  }
+  ASSERT_NE(counter, nullptr) << "aether.requests_total counter was not created";
+  EXPECT_GE(counter->value(), 1);
+}
+
+} // namespace
+} // namespace AetherStats
+} // namespace HttpFilters
+} // namespace Extensions
+} // namespace Envoy

--- a/proxy/source/extensions/filters/http/aether_stats/config.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/config.cc
@@ -25,10 +25,12 @@ ProtobufTypes::MessagePtr AetherStatsFilterFactory::createEmptyConfigProto() {
   return std::make_unique<ProtoConfig>();
 }
 
-// Compiled into the custom Envoy binary; the agent attaches the filter by name.
-LEGACY_REGISTER_FACTORY(AetherStatsFilterFactory,
-                        Server::Configuration::NamedHttpFilterConfigFactory,
-                        "aether.filters.http.aether_stats");
+// Compiled into the custom Envoy binary; the agent attaches the filter by the
+// config proto type. Registers under factory.name() only —
+// LEGACY_REGISTER_FACTORY adds a *second* (deprecated) name, which aborts at
+// static init with "Double registration" when that name equals name() (the
+// Envoy binary won't boot).
+REGISTER_FACTORY(AetherStatsFilterFactory, Server::Configuration::NamedHttpFilterConfigFactory);
 
 } // namespace AetherStats
 } // namespace HttpFilters


### PR DESCRIPTION
## What happened
The first in-vivo roll of the native `aether_stats` extension on talos-main **crash-looped every new proxy pod**:

```
EnvoyException: Double registration for name: 'aether.filters.http.aether_stats'
```

`LEGACY_REGISTER_FACTORY(FACTORY, BASE, DEPRECATED_NAME)` registers the factory under **both** `factory.name()` and `DEPRECATED_NAME`. We passed the same string for both, so the name was registered twice and Envoy aborted at **static init — before `main()`**, so the binary never booted.

It slipped through because the unit test doesn't start a server and the tar-driver `image_test` can't execute the binary. The roll was held back by surge/`maxUnavailable=0` (data plane stayed up on the old proxies), but the new agent had already switched to the `TypedStruct` config, so the old proxies NACKed those listeners. I rolled the release back to the matched revision; cluster is healthy.

## Fix
- Use `REGISTER_FACTORY` (registers under `name()` only).
- Add an Envoy `HttpIntegrationTest` (`aether_stats_integration_test.cc`) that **boots a real Envoy** with the filter wired exactly as the agent emits it (`xds.type.v3.TypedStruct`, inner type `aether.filters.http.aether_stats.v3.Config`), drives a request through, and asserts `aether.requests_total` increments. This:
  - boots the binary → catches the static-init abort (the actual bug),
  - resolves the factory **by config type** from the TypedStruct → catches missing/renamed factory or config-field drift.

## Verification
- `bazel test //source/extensions/filters/http/aether_stats:aether_stats_integration_test` (and the unit test) **pass on RBE**, both IP versions.

## Follow-up (separate)
Once merged, proxy-release republishes the proxy image at the new commit; then re-pin the chart and re-run the talos-main e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)