### PR TITLE
ci(proxy): RBE config overlay (base + per-arch); arm64 stays native pending toolchain

### DIFF
--- a/.github/workflows/proxy-pr.yml
+++ b/.github/workflows/proxy-pr.yml
@@ -1,9 +1,9 @@
 name: proxy-pr
 
 # PR validation for the custom Envoy (//proxy, a separate Bazel workspace, 7.7.1):
-# `bazel test //...` on BuildBuddy RBE, one leg per arch routed to its native
-# executor pool (amd64 + arm64 — no cross-compile). Both legs run on ubuntu-latest
-# since the build/tests execute remotely; the runner only drives Bazel.
+# `bazel test //...` per arch — amd64 on BuildBuddy's x64 RBE pool (ubuntu-latest),
+# arm64 NATIVELY on a GitHub arm runner with BuildBuddy as a remote cache (the
+# proxy has no arm64-exec C++ toolchain for RBE yet — see .bazelrc).
 # Does NOT build/push the image — that happens on merge (proxy-release.yml).
 on:
   pull_request:
@@ -28,14 +28,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both arches offload the heavy compile to BuildBuddy RBE, each to its
-          # native executor pool (no cross-compile). The runner only drives Bazel,
-          # so both use ubuntu-latest (x64); the build runs on remote x64 / arm64.
+          # amd64 offloads the heavy compile to BuildBuddy's x64 RBE pool.
           - arch: amd64
-            bazel_config: rbe-buildbuddy
+            runner: ubuntu-latest
+            bazel_config: rbe-buildbuddy-amd64
+          # arm64 builds NATIVELY on the GitHub arm runner with BuildBuddy as a
+          # remote cache. BuildBuddy now has an arm64 RBE pool, but the proxy lacks
+          # an arm64-exec C++ toolchain (see --config=rbe-buildbuddy-arm64).
           - arch: arm64
-            bazel_config: rbe-buildbuddy-arm64
-    runs-on: ubuntu-latest
+            runner: ubuntu-24.04-arm
+            bazel_config: bb-cache
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -45,6 +48,13 @@ jobs:
         with:
           bazelisk-cache: true
           repository-cache: true
+
+      # The NATIVE (arm64) build compiles locally and needs the hermetic clang's
+      # libtinfo.so.5 (LLVM 18.1.8 leaks it; ubuntu-24.04 ships only .so.6). The
+      # RBE leg compiles remotely, so it doesn't.
+      - name: Setup LLVM runtime libs
+        if: matrix.bazel_config == 'bb-cache'
+        uses: ./.github/actions/setup-llvm-libs
 
       - name: Test (${{ matrix.arch }}, ${{ matrix.bazel_config }})
         # //... runs //:image_test (compiles Envoy + validates the image structure).

--- a/.github/workflows/proxy-pr.yml
+++ b/.github/workflows/proxy-pr.yml
@@ -1,8 +1,9 @@
 name: proxy-pr
 
 # PR validation for the custom Envoy (//proxy, a separate Bazel workspace, 7.7.1):
-# `bazel test` built NATIVELY per arch (amd64 on ubuntu-latest, arm64 on the
-# GitHub arm runner), with BuildBuddy as a remote CACHE only (no RBE executor).
+# `bazel test //...` on BuildBuddy RBE, one leg per arch routed to its native
+# executor pool (amd64 + arm64 — no cross-compile). Both legs run on ubuntu-latest
+# since the build/tests execute remotely; the runner only drives Bazel.
 # Does NOT build/push the image — that happens on merge (proxy-release.yml).
 on:
   pull_request:
@@ -27,16 +28,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # amd64 offloads the heavy compile to BuildBuddy RBE (x64 executors).
+          # Both arches offload the heavy compile to BuildBuddy RBE, each to its
+          # native executor pool (no cross-compile). The runner only drives Bazel,
+          # so both use ubuntu-latest (x64); the build runs on remote x64 / arm64.
           - arch: amd64
-            runner: ubuntu-latest
             bazel_config: rbe-buildbuddy
-          # arm64 builds NATIVELY on the GitHub arm runner (BuildBuddy has no arm
-          # pool) with BuildBuddy as a remote cache.
           - arch: arm64
-            runner: ubuntu-24.04-arm
-            bazel_config: bb-cache
-    runs-on: ${{ matrix.runner }}
+            bazel_config: rbe-buildbuddy-arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -46,14 +45,6 @@ jobs:
         with:
           bazelisk-cache: true
           repository-cache: true
-
-      # Only the NATIVE (arm64) build compiles locally and needs the hermetic
-      # clang's libtinfo.so.5 (LLVM 18.1.8 leaks it; ubuntu-24.04 ships only .so.6,
-      # and a symlink fails — clang needs the versioned NCURSES_TINFO_5.0 symbols).
-      # amd64 compiles remotely (RBE), so its runner doesn't need it.
-      - name: Setup LLVM runtime libs
-        if: matrix.bazel_config == 'bb-cache'
-        uses: ./.github/actions/setup-llvm-libs
 
       - name: Test (${{ matrix.arch }}, ${{ matrix.bazel_config }})
         # //... runs //:image_test (compiles Envoy + validates the image structure).

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -1,10 +1,10 @@
 name: proxy-release
 
-# Post-merge release for the custom Envoy (//proxy): build each arch on BuildBuddy
-# RBE (routed to its native executor pool — no cross-compile), push each arch by
-# DIGEST (no per-arch tags), then assemble one multi-arch manifest tagged with the
-# commit SHA. `bazel run //:push` runs the pusher locally, so each leg's runner
-# arch matches its image (amd64 on ubuntu-latest, arm64 on the GitHub arm runner).
+# Post-merge release for the custom Envoy (//proxy): build per arch — amd64 on
+# BuildBuddy's x64 RBE pool, arm64 NATIVELY on a GitHub arm runner (BuildBuddy as
+# remote cache; no arm64-exec toolchain for RBE yet) — push each arch by DIGEST
+# (no per-arch tags), then assemble one multi-arch manifest tagged with the commit
+# SHA. `bazel run //:push` runs the pusher locally, so each runner arch matches.
 on:
   push:
     branches: [main]
@@ -25,17 +25,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both arches offload the heavy compile to BuildBuddy RBE, each to its
-          # native executor pool (no cross-compile). `bazel run //:push` runs the
-          # pusher locally, so each leg's runner arch must match its image: amd64
-          # on ubuntu-latest, arm64 on the GitHub arm runner. The runner only
-          # pushes; the compile happens on RBE.
+          # amd64 offloads the heavy compile to BuildBuddy's x64 RBE pool.
           - arch: amd64
             runner: ubuntu-latest
-            bazel_config: rbe-buildbuddy
+            bazel_config: rbe-buildbuddy-amd64
+          # arm64 builds NATIVELY on the GitHub arm runner with BuildBuddy as a
+          # remote cache (the proxy has no arm64-exec C++ toolchain for RBE yet —
+          # see --config=rbe-buildbuddy-arm64).
           - arch: arm64
             runner: ubuntu-24.04-arm
-            bazel_config: rbe-buildbuddy-arm64
+            bazel_config: bb-cache
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -49,6 +48,12 @@ jobs:
         with:
           bazelisk-cache: true
           repository-cache: true
+
+      # The NATIVE (arm64) build compiles locally and needs the hermetic clang's
+      # libtinfo.so.5. The RBE leg compiles remotely, so it doesn't.
+      - name: Setup LLVM runtime libs
+        if: matrix.bazel_config == 'bb-cache'
+        uses: ./.github/actions/setup-llvm-libs
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -1,9 +1,10 @@
 name: proxy-release
 
-# Post-merge release for the custom Envoy (//proxy): build each arch NATIVELY
-# (amd64 on ubuntu-latest, arm64 on the GitHub arm runner) with BuildBuddy as a
-# remote cache, push each arch by DIGEST (no per-arch tags), then assemble one
-# multi-arch manifest tagged with the commit SHA.
+# Post-merge release for the custom Envoy (//proxy): build each arch on BuildBuddy
+# RBE (routed to its native executor pool — no cross-compile), push each arch by
+# DIGEST (no per-arch tags), then assemble one multi-arch manifest tagged with the
+# commit SHA. `bazel run //:push` runs the pusher locally, so each leg's runner
+# arch matches its image (amd64 on ubuntu-latest, arm64 on the GitHub arm runner).
 on:
   push:
     branches: [main]
@@ -24,14 +25,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # amd64 offloads the heavy compile to BuildBuddy RBE (x64 executors).
+          # Both arches offload the heavy compile to BuildBuddy RBE, each to its
+          # native executor pool (no cross-compile). `bazel run //:push` runs the
+          # pusher locally, so each leg's runner arch must match its image: amd64
+          # on ubuntu-latest, arm64 on the GitHub arm runner. The runner only
+          # pushes; the compile happens on RBE.
           - arch: amd64
             runner: ubuntu-latest
             bazel_config: rbe-buildbuddy
-          # arm64 builds NATIVELY on the GitHub arm runner (no BuildBuddy arm pool).
           - arch: arm64
             runner: ubuntu-24.04-arm
-            bazel_config: bb-cache
+            bazel_config: rbe-buildbuddy-arm64
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -45,12 +49,6 @@ jobs:
         with:
           bazelisk-cache: true
           repository-cache: true
-
-      # Only the NATIVE (arm64) build compiles locally and needs the hermetic
-      # clang's libtinfo.so.5. amd64 compiles remotely (RBE), so it doesn't.
-      - name: Setup LLVM runtime libs
-        if: matrix.bazel_config == 'bb-cache'
-        uses: ./.github/actions/setup-llvm-libs
 
       - name: Log in to GHCR
         uses: docker/login-action@v3

--- a/proxy/.bazelrc
+++ b/proxy/.bazelrc
@@ -55,20 +55,20 @@ build:bb-cache --noslim_profile
 build:bb-cache --experimental_profile_include_target_label
 build:bb-cache --experimental_profile_include_primary_output
 
-# BuildBuddy Remote Build Execution (RBE) — for LOCAL dev: offload the heavy Envoy
-# compile to BuildBuddy executors (executor + cache + BES). Invoke
-# `--config=rbe-buildbuddy`. CI does NOT use this (it builds natively per-arch with
-# --config=bb-cache); this is the fast path for a single-arch local build.
+# BuildBuddy Remote Build Execution (RBE) — offload the heavy Envoy compile to
+# BuildBuddy executors (executor + cache + BES). Pick an arch overlay:
+#   --config=rbe-buildbuddy-amd64   (x64 pool)
+#   --config=rbe-buildbuddy-arm64   (arm64 pool — see caveat below)
 #
-# Reuses Envoy's hermetic `--config=clang`, whose exec/host platform
-# @clang_platform already declares the container-image + docker capabilities. The
-# only fix is dockerNetwork, which @clang_platform sets to "standard" (an EngFlow
-# value BuildBuddy rejects) — overridden to "off" via //bazel/platforms:rbe_buildbuddy.
+# `rbe-buildbuddy` is the shared BASE (common executor/cache/BES flags, NO
+# platform); the overlays add only the host/exec platform via `--config` chaining.
+# Don't pass `--config=rbe-buildbuddy` on its own — it has no platform. Reuses
+# Envoy's hermetic `--config=clang`; @clang_platform sets dockerNetwork "standard"
+# (an EngFlow value BuildBuddy rejects) — the platforms below override it to "off".
 #
-# Auth (gitignored user.bazelrc): build:rbe-buildbuddy --remote_header=x-buildbuddy-api-key=KEY
+# Auth goes on the base so both overlays inherit it (gitignored user.bazelrc):
+#   build:rbe-buildbuddy --remote_header=x-buildbuddy-api-key=KEY
 build:rbe-buildbuddy --config=clang
-build:rbe-buildbuddy --host_platform=//bazel/platforms:rbe_buildbuddy
-build:rbe-buildbuddy --extra_execution_platforms=//bazel/platforms:rbe_buildbuddy
 build:rbe-buildbuddy --remote_executor=grpcs://remote.buildbuddy.io
 build:rbe-buildbuddy --remote_cache=grpcs://remote.buildbuddy.io
 build:rbe-buildbuddy --bes_backend=grpcs://remote.buildbuddy.io
@@ -82,17 +82,18 @@ build:rbe-buildbuddy --jobs=200
 build:rbe-buildbuddy --remote_download_toplevel
 build:rbe-buildbuddy --spawn_strategy=remote,local
 
-# arm64 variant of --config=rbe-buildbuddy: same BuildBuddy RBE, but host/exec
-# platform is the native arm64 pool (//bazel/platforms:rbe_buildbuddy_arm64).
-build:rbe-buildbuddy-arm64 --config=clang
+# x64 overlay: host/exec = BuildBuddy x64 pool.
+build:rbe-buildbuddy-amd64 --config=rbe-buildbuddy
+build:rbe-buildbuddy-amd64 --host_platform=//bazel/platforms:rbe_buildbuddy
+build:rbe-buildbuddy-amd64 --extra_execution_platforms=//bazel/platforms:rbe_buildbuddy
+
+# arm64 overlay: host/exec = BuildBuddy's native arm64 pool. CAVEAT: the pool
+# routes correctly (Arch=arm64, validated by a remote `uname -m`), but a native
+# arm64 BUILD needs an arm64-EXEC C++ toolchain — Envoy's hermetic clang
+# (envoy_toolchains) only registers one for the driver host's arch, so on an x64
+# driver there is NO aarch64-exec toolchain and `//:envoy` fails toolchain
+# resolution. Until that's wired, arm64 CI builds on a native arm runner
+# (--config=bb-cache). Kept for that follow-up and for native-arm local dev.
+build:rbe-buildbuddy-arm64 --config=rbe-buildbuddy
 build:rbe-buildbuddy-arm64 --host_platform=//bazel/platforms:rbe_buildbuddy_arm64
 build:rbe-buildbuddy-arm64 --extra_execution_platforms=//bazel/platforms:rbe_buildbuddy_arm64
-build:rbe-buildbuddy-arm64 --remote_executor=grpcs://remote.buildbuddy.io
-build:rbe-buildbuddy-arm64 --remote_cache=grpcs://remote.buildbuddy.io
-build:rbe-buildbuddy-arm64 --bes_backend=grpcs://remote.buildbuddy.io
-build:rbe-buildbuddy-arm64 --bes_results_url=https://app.buildbuddy.io/invocation/
-build:rbe-buildbuddy-arm64 --nolegacy_important_outputs
-build:rbe-buildbuddy-arm64 --remote_cache_compression
-build:rbe-buildbuddy-arm64 --remote_timeout=3600s
-build:rbe-buildbuddy-arm64 --remote_download_toplevel
-build:rbe-buildbuddy-arm64 --spawn_strategy=remote,local

--- a/proxy/.bazelrc
+++ b/proxy/.bazelrc
@@ -81,3 +81,18 @@ build:rbe-buildbuddy --grpc_keepalive_time=30s
 build:rbe-buildbuddy --jobs=200
 build:rbe-buildbuddy --remote_download_toplevel
 build:rbe-buildbuddy --spawn_strategy=remote,local
+
+# arm64 variant of --config=rbe-buildbuddy: same BuildBuddy RBE, but host/exec
+# platform is the native arm64 pool (//bazel/platforms:rbe_buildbuddy_arm64).
+build:rbe-buildbuddy-arm64 --config=clang
+build:rbe-buildbuddy-arm64 --host_platform=//bazel/platforms:rbe_buildbuddy_arm64
+build:rbe-buildbuddy-arm64 --extra_execution_platforms=//bazel/platforms:rbe_buildbuddy_arm64
+build:rbe-buildbuddy-arm64 --remote_executor=grpcs://remote.buildbuddy.io
+build:rbe-buildbuddy-arm64 --remote_cache=grpcs://remote.buildbuddy.io
+build:rbe-buildbuddy-arm64 --bes_backend=grpcs://remote.buildbuddy.io
+build:rbe-buildbuddy-arm64 --bes_results_url=https://app.buildbuddy.io/invocation/
+build:rbe-buildbuddy-arm64 --nolegacy_important_outputs
+build:rbe-buildbuddy-arm64 --remote_cache_compression
+build:rbe-buildbuddy-arm64 --remote_timeout=3600s
+build:rbe-buildbuddy-arm64 --remote_download_toplevel
+build:rbe-buildbuddy-arm64 --spawn_strategy=remote,local

--- a/proxy/.bazelrc
+++ b/proxy/.bazelrc
@@ -84,8 +84,8 @@ build:rbe-buildbuddy --spawn_strategy=remote,local
 
 # x64 overlay: host/exec = BuildBuddy x64 pool.
 build:rbe-buildbuddy-amd64 --config=rbe-buildbuddy
-build:rbe-buildbuddy-amd64 --host_platform=//bazel/platforms:rbe_buildbuddy
-build:rbe-buildbuddy-amd64 --extra_execution_platforms=//bazel/platforms:rbe_buildbuddy
+build:rbe-buildbuddy-amd64 --host_platform=//bazel/platforms:rbe_buildbuddy_amd64
+build:rbe-buildbuddy-amd64 --extra_execution_platforms=//bazel/platforms:rbe_buildbuddy_amd64
 
 # arm64 overlay: host/exec = BuildBuddy's native arm64 pool. CAVEAT: the pool
 # routes correctly (Arch=arm64, validated by a remote `uname -m`), but a native

--- a/proxy/bazel/platforms/BUILD.bazel
+++ b/proxy/bazel/platforms/BUILD.bazel
@@ -1,4 +1,4 @@
-# RBE execution platform for BuildBuddy (local `--config=rbe-buildbuddy` builds).
+# RBE execution platform for BuildBuddy's x64 pool (--config=rbe-buildbuddy-amd64).
 #
 # Inherits Envoy's RBE platform (@clang_platform = @envoy//bazel/platforms/rbe:
 # linux_x64) — keeping its container-image (the Envoy build image), docker
@@ -7,7 +7,7 @@
 # "standard" (an EngFlow value); BuildBuddy errors with "Unsupported dockerNetwork
 # property value: standard". Hermetic RBE actions don't need network, so "off".
 platform(
-    name = "rbe_buildbuddy",
+    name = "rbe_buildbuddy_amd64",
     exec_properties = {
         "dockerNetwork": "off",
     },

--- a/proxy/bazel/platforms/BUILD.bazel
+++ b/proxy/bazel/platforms/BUILD.bazel
@@ -14,3 +14,20 @@ platform(
     parents = ["@envoy//bazel/platforms/rbe:linux_x64"],
     visibility = ["//visibility:public"],
 )
+
+# RBE execution platform for BuildBuddy's native arm64 (aarch64) pool. Inherits
+# Envoy's arm64 RBE platform (multi-arch worker image + aarch64 cpu constraint)
+# but: drops the EngFlow "arm" Pool (BuildBuddy routes by Arch), sets Arch=arm64
+# to select BuildBuddy's arm64 executors, and forces dockerNetwork "off"
+# (BuildBuddy rejects Envoy's "standard"). Native arm64 build — no cross-compile,
+# so it avoids the LuaJIT host-linker failure that broke the x64-pool attempt.
+platform(
+    name = "rbe_buildbuddy_arm64",
+    exec_properties = {
+        "dockerNetwork": "off",
+        "Pool": "",
+        "Arch": "arm64",
+    },
+    parents = ["@envoy//bazel/platforms/rbe:linux_arm64"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## Summary
Started as "build arm64 on BuildBuddy's new arm64 RBE pool". The pool **routing works** (validated: a remote `uname -m` under `--config=rbe-buildbuddy-arm64` returned `aarch64`), but the native arm64 **build** hit a real blocker: with an arm64 *exec* platform, **no CC toolchain resolves**. Envoy's hermetic clang (`envoy_toolchains`) registers a toolchain only for the **driver host's** arch — on an x64 driver there's no aarch64-exec clang (the aarch64 entries are cross-compile sysroots = the LuaJIT-breaking path). So this lands the parts that are ready and defers the toolchain.

## What's in
- **RBE config overlay**: a shared base `rbe-buildbuddy` (common executor/cache/BES flags) + thin overlays `rbe-buildbuddy-amd64` / `rbe-buildbuddy-arm64` that add only the host/exec platform via `--config` chaining. Removes the duplicated block; the auth header lives on the base and propagates to both.
- **amd64** CI + release -> `rbe-buildbuddy-amd64` (BuildBuddy x64 pool).
- Platforms renamed for symmetry: `//bazel/platforms:rbe_buildbuddy_amd64` + `:rbe_buildbuddy_arm64`.
- `rbe-buildbuddy-arm64` kept as **documented groundwork** (`Arch: arm64`, cleared EngFlow `Pool`, `dockerNetwork: off`).

## What's deferred
- **arm64 stays NATIVE** (`ubuntu-24.04-arm` + `bb-cache` + `setup-llvm-libs`) until an **arm64-exec C++ toolchain** is registered (an aarch64 hermetic LLVM toolchain, or the in-container clang from the Envoy RBE image). The config + platform are ready for that follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)