### PR TITLE
chore(proxy): pin agent chart to aether-proxy:0d0a5a37 (double-registration fix)

### DIFF
--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -83,7 +83,7 @@ proxy:
     # publishing commit SHA (multi-arch manifest). This `ref` is auto-pinned to
     # that SHA by proxy-release (a bump-chart PR) on each proxy release — an
     # immutable pin (the :dev placeholder below is just the pre-first-release seed).
-    ref: "ghcr.io/bpalermo/aether/aether-proxy:a54eef170b9f8439d9c31cc94524fb7e3d212cc9"
+    ref: "ghcr.io/bpalermo/aether/aether-proxy:0d0a5a37a4eb7d75231027a11fe385d9275d265c"
     pullPolicy: Always
   logLevel: info
   # SPIKE (Strategy A): run the Envoy hot-restart supervisor (agent


### PR DESCRIPTION
Pins the agent chart's proxy image to the multi-arch `aether-proxy:0d0a5a37a4eb7d75231027a11fe385d9275d265c` — the first proxy build with the `aether_stats` double-registration fix (#198). The previous pin (`a54eef17`) crash-loops on boot.

Auto-generated by `proxy-release`; opened manually because the Actions PR-creation setting blocks the bot. Required to re-run the talos-main e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)