### PR TITLE
fix(telemetry): recover aether_stats tags across hot restart + JSON proxy logs

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -14,6 +14,24 @@ data:
           address: 127.0.0.1
           port_value: 9901
 
+{{- if .Values.proxy.jsonLogs }}
+    # Emit Envoy's own application logs as one JSON object per line. This is the
+    # supported JSON path (vs a raw --log-format string): %j escapes the message
+    # as a JSON string and the trailing %* (added by Envoy) injects any
+    # ENVOY_TAGGED_LOG key/values as sibling fields. %v and %_ are NOT allowed in
+    # JSON format. Mutually exclusive with the --log-format CLI flag, which the
+    # proxy command intentionally does not pass.
+    application_log_config:
+      log_format:
+        json_format:
+          time: "%Y-%m-%dT%T.%e%z"
+          level: "%l"
+          name: "%n"
+          thread: "%t"
+          source: "%g:%#"
+          message: "%j"
+{{- end }}
+
 {{- if .Values.telemetry.otlpEndpoint }}
     # Push Envoy stats to the OTel collector over OTLP. Push-first like the
     # rest of the mesh telemetry: the admin /stats endpoint renders on Envoy's
@@ -74,6 +92,33 @@ data:
         # collapse to listener.{inbound,out_http}.* labeled by aether.pod.
         - tag_name: aether.pod
           regex: "^listener\\.(?:inbound|out_http)(_([^.]+))\\."
+        # aether_stats (proposal 012) records via counterFromStatNameWithTags,
+        # which inlines the tag VALUES into the full stat name
+        # (aether.requests_total.reporter.<v>.source_service.<v>.…). On the
+        # filter's own write path those values are real Stats tags — but the
+        # node proxy hot-restarts on every config change (talos-main hit epoch
+        # 53), and Envoy's StatMerger re-creates each counter across a restart
+        # via counterFromStatName() with NO tags
+        # ("TODO(snowp): Propagate tag values during hot restarts" in
+        # stat_merger.cc). After the first restart the programmatic tags are
+        # gone and the values collapse into the metric name with empty labels
+        # (the talos-main symptom). These regexes re-derive the six tags from
+        # the name exactly the way aether.cluster survives — tag_name MUST match
+        # the programmatic keys in aether_stats.cc so fresh and merged counters
+        # export identical labels. Values are dot-free, so [^.]* is exact.
+        # Guarded by //source/extensions/filters/http/aether_stats:tag_extraction_test.
+        - tag_name: reporter
+          regex: "(\\.reporter\\.([^.]*))"
+        - tag_name: source_service
+          regex: "(\\.source_service\\.([^.]*))"
+        - tag_name: source_pod
+          regex: "(\\.source_pod\\.([^.]*))"
+        - tag_name: destination_service
+          regex: "(\\.destination_service\\.([^.]*))"
+        - tag_name: response_code
+          regex: "(\\.response_code\\.([^.]*))"
+        - tag_name: response_flags
+          regex: "(\\.response_flags\\.([^.]*))"
       stats_matcher:
         exclusion_list:
           patterns:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -86,6 +86,13 @@ proxy:
     ref: "ghcr.io/bpalermo/aether/aether-proxy:0d0a5a37a4eb7d75231027a11fe385d9275d265c"
     pullPolicy: Always
   logLevel: info
+  # Emit Envoy's own application (operational) logs as one JSON object per line
+  # so the node log pipeline can parse them structurally instead of scraping the
+  # default `[ts][thread][level][name] file:line msg` text. Wired via the
+  # bootstrap `application_log_config` (the supported JSON path), NOT a
+  # `--log-format` CLI flag — Envoy rejects setting both. Set false to fall back
+  # to Envoy's default text format.
+  jsonLogs: true
   # SPIKE (Strategy A): run the Envoy hot-restart supervisor (agent
   # proxy-supervisor) as the proxy entrypoint instead of launching Envoy
   # directly, so bootstrap-config changes hot-restart in place without dropping

--- a/proxy/source/extensions/filters/http/aether_stats/BUILD
+++ b/proxy/source/extensions/filters/http/aether_stats/BUILD
@@ -62,6 +62,18 @@ envoy_cc_test(
     ],
 )
 
+# Guards the stats_tags regexes in charts/agent/templates/configmap.yaml that let
+# the aether_stats tags survive a hot restart (StatMerger drops programmatic tags).
+envoy_cc_test(
+    name = "tag_extraction_test",
+    srcs = ["tag_extraction_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//source/common/stats:tag_producer_lib",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
 # Boots a real Envoy with the filter wired as the agent emits it (TypedStruct)
 # and drives a request through it. Catches a static-init abort (the binary won't
 # start) and factory-resolution failures, which the unit test and the tar-driver
@@ -73,7 +85,10 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":config",
+        "@com_google_absl//absl/strings",
+        "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//test/integration:http_integration_lib",
         "@envoy//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
     ],
 )

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
@@ -1,8 +1,16 @@
 #include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+#include "source/common/common/logger.h"
 
 #include "test/integration/http_integration.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -73,6 +81,72 @@ TEST_P(AetherStatsIntegrationTest, RecordsRequestCounter) {
   }
   ASSERT_NE(counter, nullptr) << "aether.requests_total counter was not created";
   EXPECT_GE(counter->value(), 1);
+}
+
+// Reproduction: boot Envoy with the SAME bootstrap stats_config the agent ships
+// in production (charts/agent/templates/configmap.yaml): use_all_default_tags
+// off + custom stats_tags (aether.cluster/aether.pod) + a stats_matcher
+// exclusion_list. On talos-main the aether.requests_total counter exports with
+// the tags baked into the name and empty labels; this test asserts the tags
+// survive as real Stats tags under that config, to localize whether the break is
+// at the Envoy counter or downstream in the OTLP->Prometheus pipeline.
+TEST_P(AetherStatsIntegrationTest, RecordsRequestCounterUnderProdStatsConfig) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* sc = bootstrap.mutable_stats_config();
+    sc->mutable_use_all_default_tags()->set_value(false);
+    auto* t1 = sc->add_stats_tags();
+    t1->set_tag_name("aether.cluster");
+    t1->set_regex("^cluster\\.(([^.]+)\\.)");
+    auto* t2 = sc->add_stats_tags();
+    t2->set_tag_name("aether.pod");
+    t2->set_regex("^listener\\.(?:inbound|out_http)(_([^.]+))\\.");
+    // The aether_stats hot-restart fallback regexes (see configmap.yaml). On the
+    // fresh write path the programmatic tags win (these run only on the no-tags
+    // name), so the counter must still carry exactly the 6 real tags.
+    for (const auto& [name, re] : std::vector<std::pair<std::string, std::string>>{
+             {"reporter", "(\\.reporter\\.([^.]*))"},
+             {"source_service", "(\\.source_service\\.([^.]*))"},
+             {"source_pod", "(\\.source_pod\\.([^.]*))"},
+             {"destination_service", "(\\.destination_service\\.([^.]*))"},
+             {"response_code", "(\\.response_code\\.([^.]*))"},
+             {"response_flags", "(\\.response_flags\\.([^.]*))"}}) {
+      auto* t = sc->add_stats_tags();
+      t->set_tag_name(name);
+      t->set_regex(re);
+    }
+    auto* excl = sc->mutable_stats_matcher()->mutable_exclusion_list();
+    excl->add_patterns()->set_contains("ssl.certificate.");
+    excl->add_patterns()->mutable_safe_regex()->set_regex("^cluster\\..*\\.health_check\\..*");
+  });
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}});
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Dump every counter that mentions "aether_requests"/"requests_total" so the
+  // test log shows exactly what name/tag_extracted_name/tags the counter carries.
+  Stats::CounterSharedPtr counter;
+  for (const auto& c : test_server_->counters()) {
+    if (absl::StrContains(c->name(), "requests_total")) {
+      std::string tagstr;
+      for (const auto& t : c->tags()) {
+        absl::StrAppend(&tagstr, t.name_, "=", t.value_, " ");
+      }
+      ENVOY_LOG_MISC(critical, "AETHER_REPRO name='{}' tag_extracted='{}' tags=[{}]", c->name(),
+                     c->tagExtractedName(), tagstr);
+      if (c->tagExtractedName() == "aether.requests_total") {
+        counter = c;
+      }
+    }
+  }
+  ASSERT_NE(counter, nullptr)
+      << "no counter with clean tag_extracted_name 'aether.requests_total' — tags were baked into "
+         "the name (see AETHER_REPRO log lines above)";
+  EXPECT_EQ(counter->tags().size(), 6) << "expected 6 stats tags on the counter";
 }
 
 } // namespace

--- a/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
@@ -1,0 +1,103 @@
+#include <map>
+#include <string>
+
+#include "envoy/config/metrics/v3/stats.pb.h"
+
+#include "source/common/stats/tag_producer_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Stats {
+namespace {
+
+// Builds the production stats tag producer (mirrors the stats_tags in
+// charts/agent/templates/configmap.yaml) and asserts the aether_stats tags are
+// recovered by regex from the full counter name.
+//
+// Why this matters: the aether_stats filter records via
+// counterFromStatNameWithTags, which inlines the tag VALUES into the full stat
+// name. Across a hot restart (the node proxy hot-restarts on every config
+// change — talos-main was at epoch 53), Envoy's StatMerger re-materialises the
+// counter via counterFromStatName(full_name) with NO tags
+// ("TODO(snowp): Propagate tag values during hot restarts" in stat_merger.cc).
+// The only thing that then recovers reporter/source_service/... as real tags is
+// regex extraction — exactly how aether.cluster already survives. Without these
+// regexes the tags collapse into the metric name with empty labels, which is the
+// talos-main symptom.
+TagProducerPtr prodTagProducer() {
+  envoy::config::metrics::v3::StatsConfig config;
+  config.mutable_use_all_default_tags()->set_value(false);
+  const auto add = [&](absl::string_view name, absl::string_view re) {
+    auto* t = config.add_stats_tags();
+    t->set_tag_name(std::string(name));
+    t->set_regex(std::string(re));
+  };
+  // Pre-existing tags.
+  add("aether.cluster", "^cluster\\.(([^.]+)\\.)");
+  add("aether.pod", "^listener\\.(?:inbound|out_http)(_([^.]+))\\.");
+  // aether_stats tags — names MUST match the programmatic tag keys in
+  // aether_stats.cc so a fresh (epoch-0) counter and a hot-restart-merged
+  // counter export identical labels.
+  add("reporter", "(\\.reporter\\.([^.]*))");
+  add("source_service", "(\\.source_service\\.([^.]*))");
+  add("source_pod", "(\\.source_pod\\.([^.]*))");
+  add("destination_service", "(\\.destination_service\\.([^.]*))");
+  add("response_code", "(\\.response_code\\.([^.]*))");
+  add("response_flags", "(\\.response_flags\\.([^.]*))");
+  return TagProducerImpl::createTagProducer(config, {}).value();
+}
+
+std::map<std::string, std::string> extract(const std::string& name, std::string& tag_extracted) {
+  TagVector tags;
+  tag_extracted = prodTagProducer()->produceTags(name, tags);
+  std::map<std::string, std::string> m;
+  for (const auto& t : tags) {
+    m[t.name_] = t.value_;
+  }
+  return m;
+}
+
+// Inbound (destination reporter): empty source_pod, response_flags "-".
+TEST(AetherStatsTagExtraction, RecoversDestinationTags) {
+  std::string extracted;
+  auto m = extract("aether.requests_total.reporter.destination.source_service.loadgen.source_pod."
+                   ".destination_service.svc-1.response_code.200.response_flags.-",
+                   extracted);
+  EXPECT_EQ(extracted, "aether.requests_total");
+  EXPECT_EQ(m["reporter"], "destination");
+  EXPECT_EQ(m["source_service"], "loadgen");
+  EXPECT_EQ(m["source_pod"], "");
+  EXPECT_EQ(m["destination_service"], "svc-1");
+  EXPECT_EQ(m["response_code"], "200");
+  EXPECT_EQ(m["response_flags"], "-");
+}
+
+// Outbound (source reporter): populated source_pod.
+TEST(AetherStatsTagExtraction, RecoversSourceTags) {
+  std::string extracted;
+  auto m = extract("aether.requests_total.reporter.source.source_service.checkout.source_pod."
+                   "checkout-abc123.destination_service.payments.response_code.503.response_flags.UF",
+                   extracted);
+  EXPECT_EQ(extracted, "aether.requests_total");
+  EXPECT_EQ(m["reporter"], "source");
+  EXPECT_EQ(m["source_service"], "checkout");
+  EXPECT_EQ(m["source_pod"], "checkout-abc123");
+  EXPECT_EQ(m["destination_service"], "payments");
+  EXPECT_EQ(m["response_code"], "503");
+  EXPECT_EQ(m["response_flags"], "UF");
+}
+
+// The new regexes must not perturb unrelated stats (e.g. the cluster path that
+// already works) — aether.cluster still extracts and nothing else matches.
+TEST(AetherStatsTagExtraction, LeavesClusterStatsIntact) {
+  std::string extracted;
+  auto m = extract("cluster.svc-1.upstream_rq_total", extracted);
+  EXPECT_EQ(extracted, "cluster.upstream_rq_total");
+  EXPECT_EQ(m["aether.cluster"], "svc-1");
+  EXPECT_EQ(m.count("reporter"), 0);
+}
+
+} // namespace
+} // namespace Stats
+} // namespace Envoy


### PR DESCRIPTION
## Problem

`aether_stats` exported on talos-main with all six tags **baked into the metric name** and empty labels — in both the Envoy admin `/stats/prometheus` and Prometheus via OTLP:

```
envoy_aether_requests_total_reporter_destination_source_service_loadgen_source_pod__destination_service_svc_1_response_code_200_response_flags__{} 400441
```

## Root cause: Envoy hot restart (not the sink, not Prometheus)

The filter records via `counterFromStatNameWithTags`, which inlines the tag **values** into the full stat name. The node proxy hot-restarts on every config change (**talos was at epoch 53**), and Envoy's `StatMerger::mergeCounters` re-creates each parent counter via `counterFromStatName()` with **no tags** — the code even carries `// TODO(snowp): Propagate tag values during hot restarts`. After the first restart, `tagExtractedName` == the inlined name and `tags()` is empty.

This is exactly why regex-extracted tags (`aether.cluster`) survive hot restart but programmatic `*WithTags` tags don't: extraction re-derives tags from the name on re-creation; programmatic tags are dropped.

**Proven:** under the *identical* production `stats_config`, a fresh (epoch-0) Envoy yields a clean counter (`tag_extracted=aether.requests_total`, 6 tags); the live epoch-53 proxy is mangled — same image, same Envoy v1.38.0. There's no Envoy extension hook for tag extractors and the hot-restart payload carries no tags, so this can't be fixed in the filter without patching core hot-restart logic.

## Fix

Add `stats_tags` regexes that re-derive the six tags from the name — the same mechanism `aether.cluster` already uses and how Envoy labels its own stats (`well_known_names.cc`). `tag_name` matches the programmatic keys in `aether_stats.cc` so fresh and merged counters export identical labels. The fresh write path still uses programmatic tags (regexes only run on the no-tags name a merge produces). **Configmap-only — no proxy rebuild**, deploys via `--watch-config`.

`tag_extraction_test` (new) pins the regexes to real Envoy `TagProducer` behavior incl. the empty-`source_pod` case, so they can't silently drift from the filter's tag keys. The integration test gains a prod-`stats_config` case asserting the fresh counter still carries six real tags.

## Also: JSON node-proxy logs

Emit the proxy's own application logs as one JSON object per line via the bootstrap `application_log_config` (the supported JSON path: `%j` escapes the message, `%*` injects tagged-log fields), gated by `proxy.jsonLogs` (default on). Uses the bootstrap rather than a `--log-format` CLI flag so it covers both the supervisor and direct-launch command paths — Envoy rejects setting both.

## Testing

- `tag_extraction_test`, `aether_stats_test`, `aether_stats_integration_test` (incl. new prod-config case) — all green via RBE.
- Chart renders; `envoy.yaml` parses; `stats_tags` has all 8 entries; `proxy.jsonLogs=false` omits the block.

## Note

Recovers labels for newly-created series going forward; already-mangled series in Prometheus age out on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
