### PR TITLE
test(proxy): guard aether_stats tag recovery across hot restart

### DIFF
--- a/proxy/source/extensions/filters/http/aether_stats/BUILD
+++ b/proxy/source/extensions/filters/http/aether_stats/BUILD
@@ -62,6 +62,18 @@ envoy_cc_test(
     ],
 )
 
+# Guards the stats_tags regexes in charts/agent/templates/configmap.yaml that let
+# the aether_stats tags survive a hot restart (StatMerger drops programmatic tags).
+envoy_cc_test(
+    name = "tag_extraction_test",
+    srcs = ["tag_extraction_test.cc"],
+    repository = "@envoy",
+    deps = [
+        "@envoy//source/common/stats:tag_producer_lib",
+        "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
+    ],
+)
+
 # Boots a real Envoy with the filter wired as the agent emits it (TypedStruct)
 # and drives a request through it. Catches a static-init abort (the binary won't
 # start) and factory-resolution failures, which the unit test and the tar-driver
@@ -73,7 +85,10 @@ envoy_cc_test(
     repository = "@envoy",
     deps = [
         ":config",
+        "@com_google_absl//absl/strings",
+        "@envoy//source/common/common:minimal_logger_lib",
         "@envoy//test/integration:http_integration_lib",
         "@envoy//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
     ],
 )

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
@@ -1,8 +1,16 @@
 #include <string>
+#include <utility>
+#include <vector>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+
+#include "source/common/common/logger.h"
 
 #include "test/integration/http_integration.h"
 #include "test/test_common/utility.h"
 
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
 #include "gtest/gtest.h"
 
 namespace Envoy {
@@ -73,6 +81,72 @@ TEST_P(AetherStatsIntegrationTest, RecordsRequestCounter) {
   }
   ASSERT_NE(counter, nullptr) << "aether.requests_total counter was not created";
   EXPECT_GE(counter->value(), 1);
+}
+
+// Reproduction: boot Envoy with the SAME bootstrap stats_config the agent ships
+// in production (charts/agent/templates/configmap.yaml): use_all_default_tags
+// off + custom stats_tags (aether.cluster/aether.pod) + a stats_matcher
+// exclusion_list. On talos-main the aether.requests_total counter exports with
+// the tags baked into the name and empty labels; this test asserts the tags
+// survive as real Stats tags under that config, to localize whether the break is
+// at the Envoy counter or downstream in the OTLP->Prometheus pipeline.
+TEST_P(AetherStatsIntegrationTest, RecordsRequestCounterUnderProdStatsConfig) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    auto* sc = bootstrap.mutable_stats_config();
+    sc->mutable_use_all_default_tags()->set_value(false);
+    auto* t1 = sc->add_stats_tags();
+    t1->set_tag_name("aether.cluster");
+    t1->set_regex("^cluster\\.(([^.]+)\\.)");
+    auto* t2 = sc->add_stats_tags();
+    t2->set_tag_name("aether.pod");
+    t2->set_regex("^listener\\.(?:inbound|out_http)(_([^.]+))\\.");
+    // The aether_stats hot-restart fallback regexes (see configmap.yaml). On the
+    // fresh write path the programmatic tags win (these run only on the no-tags
+    // name), so the counter must still carry exactly the 6 real tags.
+    for (const auto& [name, re] : std::vector<std::pair<std::string, std::string>>{
+             {"reporter", "(\\.reporter\\.([^.]*))"},
+             {"source_service", "(\\.source_service\\.([^.]*))"},
+             {"source_pod", "(\\.source_pod\\.([^.]*))"},
+             {"destination_service", "(\\.destination_service\\.([^.]*))"},
+             {"response_code", "(\\.response_code\\.([^.]*))"},
+             {"response_flags", "(\\.response_flags\\.([^.]*))"}}) {
+      auto* t = sc->add_stats_tags();
+      t->set_tag_name(name);
+      t->set_regex(re);
+    }
+    auto* excl = sc->mutable_stats_matcher()->mutable_exclusion_list();
+    excl->add_patterns()->set_contains("ssl.certificate.");
+    excl->add_patterns()->mutable_safe_regex()->set_regex("^cluster\\..*\\.health_check\\..*");
+  });
+  initializeFilter();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}});
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
+  ASSERT_TRUE(response->waitForEndStream());
+
+  // Dump every counter that mentions "aether_requests"/"requests_total" so the
+  // test log shows exactly what name/tag_extracted_name/tags the counter carries.
+  Stats::CounterSharedPtr counter;
+  for (const auto& c : test_server_->counters()) {
+    if (absl::StrContains(c->name(), "requests_total")) {
+      std::string tagstr;
+      for (const auto& t : c->tags()) {
+        absl::StrAppend(&tagstr, t.name_, "=", t.value_, " ");
+      }
+      ENVOY_LOG_MISC(critical, "AETHER_REPRO name='{}' tag_extracted='{}' tags=[{}]", c->name(),
+                     c->tagExtractedName(), tagstr);
+      if (c->tagExtractedName() == "aether.requests_total") {
+        counter = c;
+      }
+    }
+  }
+  ASSERT_NE(counter, nullptr)
+      << "no counter with clean tag_extracted_name 'aether.requests_total' — tags were baked into "
+         "the name (see AETHER_REPRO log lines above)";
+  EXPECT_EQ(counter->tags().size(), 6) << "expected 6 stats tags on the counter";
 }
 
 } // namespace

--- a/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
@@ -1,0 +1,103 @@
+#include <map>
+#include <string>
+
+#include "envoy/config/metrics/v3/stats.pb.h"
+
+#include "source/common/stats/tag_producer_impl.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace Stats {
+namespace {
+
+// Builds the production stats tag producer (mirrors the stats_tags in
+// charts/agent/templates/configmap.yaml) and asserts the aether_stats tags are
+// recovered by regex from the full counter name.
+//
+// Why this matters: the aether_stats filter records via
+// counterFromStatNameWithTags, which inlines the tag VALUES into the full stat
+// name. Across a hot restart (the node proxy hot-restarts on every config
+// change — talos-main was at epoch 53), Envoy's StatMerger re-materialises the
+// counter via counterFromStatName(full_name) with NO tags
+// ("TODO(snowp): Propagate tag values during hot restarts" in stat_merger.cc).
+// The only thing that then recovers reporter/source_service/... as real tags is
+// regex extraction — exactly how aether.cluster already survives. Without these
+// regexes the tags collapse into the metric name with empty labels, which is the
+// talos-main symptom.
+TagProducerPtr prodTagProducer() {
+  envoy::config::metrics::v3::StatsConfig config;
+  config.mutable_use_all_default_tags()->set_value(false);
+  const auto add = [&](absl::string_view name, absl::string_view re) {
+    auto* t = config.add_stats_tags();
+    t->set_tag_name(std::string(name));
+    t->set_regex(std::string(re));
+  };
+  // Pre-existing tags.
+  add("aether.cluster", "^cluster\\.(([^.]+)\\.)");
+  add("aether.pod", "^listener\\.(?:inbound|out_http)(_([^.]+))\\.");
+  // aether_stats tags — names MUST match the programmatic tag keys in
+  // aether_stats.cc so a fresh (epoch-0) counter and a hot-restart-merged
+  // counter export identical labels.
+  add("reporter", "(\\.reporter\\.([^.]*))");
+  add("source_service", "(\\.source_service\\.([^.]*))");
+  add("source_pod", "(\\.source_pod\\.([^.]*))");
+  add("destination_service", "(\\.destination_service\\.([^.]*))");
+  add("response_code", "(\\.response_code\\.([^.]*))");
+  add("response_flags", "(\\.response_flags\\.([^.]*))");
+  return TagProducerImpl::createTagProducer(config, {}).value();
+}
+
+std::map<std::string, std::string> extract(const std::string& name, std::string& tag_extracted) {
+  TagVector tags;
+  tag_extracted = prodTagProducer()->produceTags(name, tags);
+  std::map<std::string, std::string> m;
+  for (const auto& t : tags) {
+    m[t.name_] = t.value_;
+  }
+  return m;
+}
+
+// Inbound (destination reporter): empty source_pod, response_flags "-".
+TEST(AetherStatsTagExtraction, RecoversDestinationTags) {
+  std::string extracted;
+  auto m = extract("aether.requests_total.reporter.destination.source_service.loadgen.source_pod."
+                   ".destination_service.svc-1.response_code.200.response_flags.-",
+                   extracted);
+  EXPECT_EQ(extracted, "aether.requests_total");
+  EXPECT_EQ(m["reporter"], "destination");
+  EXPECT_EQ(m["source_service"], "loadgen");
+  EXPECT_EQ(m["source_pod"], "");
+  EXPECT_EQ(m["destination_service"], "svc-1");
+  EXPECT_EQ(m["response_code"], "200");
+  EXPECT_EQ(m["response_flags"], "-");
+}
+
+// Outbound (source reporter): populated source_pod.
+TEST(AetherStatsTagExtraction, RecoversSourceTags) {
+  std::string extracted;
+  auto m = extract("aether.requests_total.reporter.source.source_service.checkout.source_pod."
+                   "checkout-abc123.destination_service.payments.response_code.503.response_flags.UF",
+                   extracted);
+  EXPECT_EQ(extracted, "aether.requests_total");
+  EXPECT_EQ(m["reporter"], "source");
+  EXPECT_EQ(m["source_service"], "checkout");
+  EXPECT_EQ(m["source_pod"], "checkout-abc123");
+  EXPECT_EQ(m["destination_service"], "payments");
+  EXPECT_EQ(m["response_code"], "503");
+  EXPECT_EQ(m["response_flags"], "UF");
+}
+
+// The new regexes must not perturb unrelated stats (e.g. the cluster path that
+// already works) — aether.cluster still extracts and nothing else matches.
+TEST(AetherStatsTagExtraction, LeavesClusterStatsIntact) {
+  std::string extracted;
+  auto m = extract("cluster.svc-1.upstream_rq_total", extracted);
+  EXPECT_EQ(extracted, "cluster.upstream_rq_total");
+  EXPECT_EQ(m["aether.cluster"], "svc-1");
+  EXPECT_EQ(m.count("reporter"), 0);
+}
+
+} // namespace
+} // namespace Stats
+} // namespace Envoy


### PR DESCRIPTION
## What

Test-only guards (no proxy binary / filter change) for the `aether_stats` hot-restart tag-recovery fix. The actual fix is `stats_tags` regexes in the agent chart, shipped in a **follow-up chart PR after this proxy version is published**.

## Why

`aether_stats` exported on talos-main with all six tags baked into the metric name and empty labels:

```
envoy_aether_requests_total_reporter_destination_source_service_loadgen_source_pod__destination_service_svc_1_response_code_200_response_flags__{} 400441
```

**Root cause: Envoy hot restart.** The filter records via `counterFromStatNameWithTags`, which inlines the tag values into the full stat name. The node proxy hot-restarts on every config change (talos was at **epoch 53**); Envoy's `StatMerger::mergeCounters` re-creates each counter via `counterFromStatName()` with **no tags** — the code carries `// TODO(snowp): Propagate tag values during hot restarts`. After the first restart the programmatic tags are gone. This is exactly why regex-extracted tags (`aether.cluster`) survive but programmatic ones don't.

The recovery is `stats_tags` regexes that re-derive the six tags from the name (Envoy's own idiom for labeled stats — see `well_known_names.cc`). There's no extension hook for tag extractors and the hot-restart payload carries no tags, so this can't be fixed in the filter without patching core hot-restart logic.

## Tests

- **`tag_extraction_test`** (new): builds the production `TagProducer` and asserts the six tags are recovered from the inlined name (incl. the empty `source_pod` case), the tag-extracted name is clean `aether.requests_total`, and `cluster.*` extraction is unaffected.
- **`aether_stats_integration_test`**: adds a case booting real Envoy under the production `stats_config` (`use_all_default_tags` off + the new `stats_tags` + `stats_matcher`) and asserts the fresh write path still carries exactly six real tags.

All green via RBE.

## Follow-up

Chart PR adds the matching `stats_tags` regexes to `charts/agent/templates/configmap.yaml`; it should merge **after** this proxy version is published. This test is the drift guard for those regexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
