### PR TITLE
fix(telemetry): recover aether_stats tags across hot restart + JSON proxy logs

### DIFF
--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -14,6 +14,24 @@ data:
           address: 127.0.0.1
           port_value: 9901
 
+{{- if .Values.proxy.jsonLogs }}
+    # Emit Envoy's own application logs as one JSON object per line. This is the
+    # supported JSON path (vs a raw --log-format string): %j escapes the message
+    # as a JSON string and the trailing %* (added by Envoy) injects any
+    # ENVOY_TAGGED_LOG key/values as sibling fields. %v and %_ are NOT allowed in
+    # JSON format. Mutually exclusive with the --log-format CLI flag, which the
+    # proxy command intentionally does not pass.
+    application_log_config:
+      log_format:
+        json_format:
+          time: "%Y-%m-%dT%T.%e%z"
+          level: "%l"
+          name: "%n"
+          thread: "%t"
+          source: "%g:%#"
+          message: "%j"
+{{- end }}
+
 {{- if .Values.telemetry.otlpEndpoint }}
     # Push Envoy stats to the OTel collector over OTLP. Push-first like the
     # rest of the mesh telemetry: the admin /stats endpoint renders on Envoy's
@@ -74,6 +92,33 @@ data:
         # collapse to listener.{inbound,out_http}.* labeled by aether.pod.
         - tag_name: aether.pod
           regex: "^listener\\.(?:inbound|out_http)(_([^.]+))\\."
+        # aether_stats (proposal 012) records via counterFromStatNameWithTags,
+        # which inlines the tag VALUES into the full stat name
+        # (aether.requests_total.reporter.<v>.source_service.<v>.…). On the
+        # filter's own write path those values are real Stats tags — but the
+        # node proxy hot-restarts on every config change (talos-main hit epoch
+        # 53), and Envoy's StatMerger re-creates each counter across a restart
+        # via counterFromStatName() with NO tags
+        # ("TODO(snowp): Propagate tag values during hot restarts" in
+        # stat_merger.cc). After the first restart the programmatic tags are
+        # gone and the values collapse into the metric name with empty labels
+        # (the talos-main symptom). These regexes re-derive the six tags from
+        # the name exactly the way aether.cluster survives — tag_name MUST match
+        # the programmatic keys in aether_stats.cc so fresh and merged counters
+        # export identical labels. Values are dot-free, so [^.]* is exact.
+        # Guarded by //source/extensions/filters/http/aether_stats:tag_extraction_test.
+        - tag_name: reporter
+          regex: "(\\.reporter\\.([^.]*))"
+        - tag_name: source_service
+          regex: "(\\.source_service\\.([^.]*))"
+        - tag_name: source_pod
+          regex: "(\\.source_pod\\.([^.]*))"
+        - tag_name: destination_service
+          regex: "(\\.destination_service\\.([^.]*))"
+        - tag_name: response_code
+          regex: "(\\.response_code\\.([^.]*))"
+        - tag_name: response_flags
+          regex: "(\\.response_flags\\.([^.]*))"
       stats_matcher:
         exclusion_list:
           patterns:

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -86,6 +86,13 @@ proxy:
     ref: "ghcr.io/bpalermo/aether/aether-proxy:0d0a5a37a4eb7d75231027a11fe385d9275d265c"
     pullPolicy: Always
   logLevel: info
+  # Emit Envoy's own application (operational) logs as one JSON object per line
+  # so the node log pipeline can parse them structurally instead of scraping the
+  # default `[ts][thread][level][name] file:line msg` text. Wired via the
+  # bootstrap `application_log_config` (the supported JSON path), NOT a
+  # `--log-format` CLI flag — Envoy rejects setting both. Set false to fall back
+  # to Envoy's default text format.
+  jsonLogs: true
   # SPIKE (Strategy A): run the Envoy hot-restart supervisor (agent
   # proxy-supervisor) as the proxy entrypoint instead of launching Envoy
   # directly, so bootstrap-config changes hot-restart in place without dropping

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -83,7 +83,7 @@ proxy:
     # publishing commit SHA (multi-arch manifest). This `ref` is auto-pinned to
     # that SHA by proxy-release (a bump-chart PR) on each proxy release — an
     # immutable pin (the :dev placeholder below is just the pre-first-release seed).
-    ref: "ghcr.io/bpalermo/aether/aether-proxy:0d0a5a37a4eb7d75231027a11fe385d9275d265c"
+    ref: "ghcr.io/bpalermo/aether/aether-proxy:14039c55668d0ea9d85216c88da5766644f8fb7e"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application (operational) logs as one JSON object per line


### PR DESCRIPTION
> ✅ **Gate satisfied.** The proxy version carrying the `tag_extraction_test` guard (#203, commit `14039c5`) is published, and `proxy.image.ref` is bumped to it (`aether-proxy:14039c55668d0ea9d85216c88da5766644f8fb7e`, manifest verified). Ready to merge.

## Problem

`aether_stats` exported on talos-main with all six tags **baked into the metric name** and empty labels, in both the Envoy admin `/stats/prometheus` and Prometheus via OTLP:

```
envoy_aether_requests_total_reporter_destination_source_service_loadgen_source_pod__destination_service_svc_1_response_code_200_response_flags__{} 400441
```

## Root cause: Envoy hot restart (not the sink, not Prometheus)

The filter records via `counterFromStatNameWithTags`, which inlines the tag values into the full stat name. The node proxy hot-restarts on every config change (**epoch 53**); Envoy's `StatMerger::mergeCounters` re-creates each counter via `counterFromStatName()` with **no tags** (`// TODO(snowp): Propagate tag values during hot restarts`). After the first restart the programmatic tags are gone. This is exactly why regex-extracted tags (`aether.cluster`) survive but programmatic ones don't.

Verified: under the *identical* production `stats_config`, a fresh (epoch-0) Envoy yields a clean counter (`tag_extracted=aether.requests_total`, 6 tags); the live epoch-53 proxy is mangled — same image, same Envoy v1.38.0.

## Changes

1. **Tag recovery** — add `stats_tags` regexes that re-derive the six tags from the name (the same mechanism `aether.cluster` uses and how Envoy labels its own stats in `well_known_names.cc`). `tag_name` matches the programmatic keys in `aether_stats.cc` so fresh and merged counters export identical labels. The fresh write path still uses programmatic tags (regexes only run on the no-tags name a merge produces). Guarded by `tag_extraction_test` (#203).
2. **JSON node-proxy logs** — emit the proxy's own application logs as one JSON object per line via the bootstrap `application_log_config` (`%j` escapes the message, `%*` injects tagged-log fields), gated by `proxy.jsonLogs` (default on). Uses the bootstrap rather than `--log-format` so it covers both the supervisor and direct-launch command paths.
3. **Proxy image pin** — bump `proxy.image.ref` to the #203 build (`14039c5`), since proxy-release's own bump-chart step can't open PRs (Actions lacks PR-create permission).

Configmap/values only — deploys via `--watch-config`, no further rebuild.

## Note

Recovers labels for newly-created series going forward; already-mangled series in Prometheus age out on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
