### PR TITLE
feat(proxy): add destination_pod label to aether_stats request counter

### DIFF
--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats.cc
@@ -47,11 +47,13 @@ FilterConfig::FilterConfig(const ProtoConfig& proto,
       source_service_(proto.source_service()),
       source_pod_(proto.emit_pod() ? proto.source_pod() : ""),
       destination_service_(proto.destination_service()),
+      destination_pod_(proto.emit_pod() ? proto.destination_pod() : ""),
       mesh_domain_(proto.mesh_domain().empty() ? "aether.internal" : proto.mesh_domain()),
       scope_(context.scope()), pool_(scope_.symbolTable()),
       requests_total_(pool_.add("aether.requests_total")), tag_reporter_(pool_.add("reporter")),
       tag_source_service_(pool_.add("source_service")), tag_source_pod_(pool_.add("source_pod")),
       tag_destination_service_(pool_.add("destination_service")),
+      tag_destination_pod_(pool_.add("destination_pod")),
       tag_response_code_(pool_.add("response_code")),
       tag_response_flags_(pool_.add("response_flags")) {}
 
@@ -73,12 +75,14 @@ void FilterConfig::record(const StreamInfo::StreamInfo& info) const {
   std::string source_service;
   std::string source_pod;
   std::string destination_service;
+  std::string destination_pod;
   absl::string_view reporter;
 
   if (is_destination_) {
     // Inbound: destination from config, source parsed from the verified peer SVID.
     reporter = "destination";
     source_service = "unknown";
+    destination_pod = destination_pod_;
     const auto ssl = info.downstreamAddressProvider().sslConnection();
     if (ssl != nullptr) {
       const auto sans = ssl->uriSanPeerCertificate();
@@ -115,6 +119,7 @@ void FilterConfig::record(const StreamInfo::StreamInfo& info) const {
       {tag_source_service_, dyn.add(source_service)},
       {tag_source_pod_, dyn.add(source_pod)},
       {tag_destination_service_, dyn.add(destination_service)},
+      {tag_destination_pod_, dyn.add(destination_pod)},
       {tag_response_code_, dyn.add(response_code)},
       {tag_response_flags_, dyn.add(response_flags)},
   };

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats.h
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats.h
@@ -41,6 +41,7 @@ private:
   const std::string source_service_;
   const std::string source_pod_; // already "" when emit_pod is false
   const std::string destination_service_;
+  const std::string destination_pod_; // already "" when emit_pod is false
   const std::string mesh_domain_;
 
   Stats::Scope& scope_;
@@ -51,6 +52,7 @@ private:
   const Stats::StatName tag_source_service_;
   const Stats::StatName tag_source_pod_;
   const Stats::StatName tag_destination_service_;
+  const Stats::StatName tag_destination_pod_;
   const Stats::StatName tag_response_code_;
   const Stats::StatName tag_response_flags_;
 };

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats.proto
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats.proto
@@ -16,11 +16,15 @@ message Config {
 
   // Local identity, injected on the inbound side (the destination).
   string destination_service = 4;
+  string destination_pod = 7;
 
   // Mesh domain suffix stripped from the routed cluster name. Default
   // "aether.internal".
   string mesh_domain = 5;
 
-  // When false, source_pod is reported as "" to bound metric cardinality.
+  // When false, source_pod/destination_pod are reported as "" to bound metric
+  // cardinality. source_pod is set only on the source (outbound) side and
+  // destination_pod only on the destination (inbound) side; the peer's pod is
+  // not carried in the SVID, so the opposite end stays "".
   bool emit_pod = 6;
 }

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats_integration_test.cc
@@ -102,12 +102,13 @@ TEST_P(AetherStatsIntegrationTest, RecordsRequestCounterUnderProdStatsConfig) {
     t2->set_regex("^listener\\.(?:inbound|out_http)(_([^.]+))\\.");
     // The aether_stats hot-restart fallback regexes (see configmap.yaml). On the
     // fresh write path the programmatic tags win (these run only on the no-tags
-    // name), so the counter must still carry exactly the 6 real tags.
+    // name), so the counter must still carry exactly the 7 real tags.
     for (const auto& [name, re] : std::vector<std::pair<std::string, std::string>>{
              {"reporter", "(\\.reporter\\.([^.]*))"},
              {"source_service", "(\\.source_service\\.([^.]*))"},
              {"source_pod", "(\\.source_pod\\.([^.]*))"},
              {"destination_service", "(\\.destination_service\\.([^.]*))"},
+             {"destination_pod", "(\\.destination_pod\\.([^.]*))"},
              {"response_code", "(\\.response_code\\.([^.]*))"},
              {"response_flags", "(\\.response_flags\\.([^.]*))"}}) {
       auto* t = sc->add_stats_tags();
@@ -146,7 +147,7 @@ TEST_P(AetherStatsIntegrationTest, RecordsRequestCounterUnderProdStatsConfig) {
   ASSERT_NE(counter, nullptr)
       << "no counter with clean tag_extracted_name 'aether.requests_total' — tags were baked into "
          "the name (see AETHER_REPRO log lines above)";
-  EXPECT_EQ(counter->tags().size(), 6) << "expected 6 stats tags on the counter";
+  EXPECT_EQ(counter->tags().size(), 7) << "expected 7 stats tags on the counter";
 }
 
 } // namespace

--- a/proxy/source/extensions/filters/http/aether_stats/aether_stats_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/aether_stats_test.cc
@@ -42,12 +42,14 @@ protected:
     return p;
   }
 
-  // "destination" reporter: destination is config-supplied, source derives from
-  // the verified peer SVID.
+  // "destination" reporter: destination (service + pod) is config-supplied,
+  // source derives from the verified peer SVID.
   ProtoConfig destConfig() {
     ProtoConfig p;
     p.set_reporter("destination");
     p.set_destination_service("payments");
+    p.set_destination_pod("payments-xyz789");
+    p.set_emit_pod(true);
     p.set_mesh_domain("aether.internal");
     return p;
   }
@@ -112,6 +114,8 @@ TEST_F(AetherStatsTest, SourceReporterDerivesDestinationFromCluster) {
   EXPECT_EQ(tags.at("source_service"), "checkout");
   EXPECT_EQ(tags.at("source_pod"), "checkout-abc123");
   EXPECT_EQ(tags.at("destination_service"), "payments");
+  // Source reporter never knows the peer's pod.
+  EXPECT_EQ(tags.at("destination_pod"), "");
   EXPECT_EQ(tags.at("response_code"), "200");
   // No flags set on a clean stream.
   EXPECT_EQ(tags.at("response_flags"),
@@ -156,8 +160,20 @@ TEST_F(AetherStatsTest, DestinationReporterParsesPeerSvid) {
   EXPECT_EQ(tags.at("reporter"), "destination");
   EXPECT_EQ(tags.at("source_service"), "checkout");
   EXPECT_EQ(tags.at("destination_service"), "payments");
+  EXPECT_EQ(tags.at("destination_pod"), "payments-xyz789");
   // Destination reporter never emits a source pod.
   EXPECT_EQ(tags.at("source_pod"), "");
+}
+
+// emit_pod=false blanks destination_pod even when config supplies it.
+TEST_F(AetherStatsTest, DestinationReporterOmitsPodWhenDisabled) {
+  setPeerUriSan("spiffe://aether.internal/ns/shop/sa/checkout");
+  auto proto = destConfig();
+  proto.set_emit_pod(false);
+
+  auto counter = recordOnce(proto);
+  ASSERT_NE(counter, nullptr);
+  EXPECT_EQ(tagsOf(*counter).at("destination_pod"), "");
 }
 
 // No client certificate -> source service is "unknown".

--- a/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
@@ -43,6 +43,7 @@ TagProducerPtr prodTagProducer() {
   add("source_service", "(\\.source_service\\.([^.]*))");
   add("source_pod", "(\\.source_pod\\.([^.]*))");
   add("destination_service", "(\\.destination_service\\.([^.]*))");
+  add("destination_pod", "(\\.destination_pod\\.([^.]*))");
   add("response_code", "(\\.response_code\\.([^.]*))");
   add("response_flags", "(\\.response_flags\\.([^.]*))");
   return TagProducerImpl::createTagProducer(config, {}).value();
@@ -58,32 +59,38 @@ std::map<std::string, std::string> extract(const std::string& name, std::string&
   return m;
 }
 
-// Inbound (destination reporter): empty source_pod, response_flags "-".
+// Inbound (destination reporter): empty source_pod, populated destination_pod
+// (the local pod), response_flags "-".
 TEST(AetherStatsTagExtraction, RecoversDestinationTags) {
   std::string extracted;
   auto m = extract("aether.requests_total.reporter.destination.source_service.loadgen.source_pod."
-                   ".destination_service.svc-1.response_code.200.response_flags.-",
+                   ".destination_service.svc-1.destination_pod.svc-1-abc123.response_code.200."
+                   "response_flags.-",
                    extracted);
   EXPECT_EQ(extracted, "aether.requests_total");
   EXPECT_EQ(m["reporter"], "destination");
   EXPECT_EQ(m["source_service"], "loadgen");
   EXPECT_EQ(m["source_pod"], "");
   EXPECT_EQ(m["destination_service"], "svc-1");
+  EXPECT_EQ(m["destination_pod"], "svc-1-abc123");
   EXPECT_EQ(m["response_code"], "200");
   EXPECT_EQ(m["response_flags"], "-");
 }
 
-// Outbound (source reporter): populated source_pod.
+// Outbound (source reporter): populated source_pod, empty destination_pod (the
+// peer's pod is not known from the routed cluster name).
 TEST(AetherStatsTagExtraction, RecoversSourceTags) {
   std::string extracted;
   auto m = extract("aether.requests_total.reporter.source.source_service.checkout.source_pod."
-                   "checkout-abc123.destination_service.payments.response_code.503.response_flags.UF",
+                   "checkout-abc123.destination_service.payments.destination_pod..response_code.503."
+                   "response_flags.UF",
                    extracted);
   EXPECT_EQ(extracted, "aether.requests_total");
   EXPECT_EQ(m["reporter"], "source");
   EXPECT_EQ(m["source_service"], "checkout");
   EXPECT_EQ(m["source_pod"], "checkout-abc123");
   EXPECT_EQ(m["destination_service"], "payments");
+  EXPECT_EQ(m["destination_pod"], "");
   EXPECT_EQ(m["response_code"], "503");
   EXPECT_EQ(m["response_flags"], "UF");
 }


### PR DESCRIPTION
## What

Adds a `destination_pod` field (proto field 7) to the `aether_stats` filter's `Config` and emits it as a tag on `aether.requests_total`. It is populated only on the **destination** (inbound) reporter from the agent-supplied local pod name, gated by the existing `emit_pod` flag. `source_pod` stays source-only. The peer's pod is not in the SPIFFE SVID (only the service identity), so the opposite end of each reporter stays `""`.

## Why

`envoy_aether_requests_total` is currently service-to-service only (`source_service`/`destination_service`). This adds the per-pod dimension. Pairs with the agent's `--stats-emit-pod` wiring and the chart's `destination_pod` stats_tag recovery regex in the companion PR (`feat/aether-stats-pod-agent`).

## Ordering

**Merge and roll out this PR first.** The agent sends `destination_pod` in the filter's TypedStruct; the old proxy proto has no field 7, so rolling the agent first risks the proxy rejecting the unknown field.

## Tests

- `tag_extraction_test.cc` — regex recovery of `destination_pod` across hot restart.
- `aether_stats_test.cc` — filter emits/omits `destination_pod` per `emit_pod`.

⚠️ Requires the custom-Envoy build in the `proxy/` workspace (v1.38.0) — CI/dedicated build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)