### PR TITLE
feat(agent): per-pod aether_stats labels + drop envoy_ prefix on the request metric

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -30,6 +30,10 @@ type AgentConfig struct {
 	// (<service>.<mesh-domain>); see constants.DefaultMeshDomain.
 	MeshDomain string
 
+	// EmitStatsPod enables per-pod labels (source_pod/destination_pod) on the
+	// aether_stats request counter. Off by default to bound cardinality.
+	EmitStatsPod bool
+
 	// SpireEnabled controls whether the SPIRE bridge is started
 	SpireEnabled bool
 	// SpireAdminSocketPath is the path to the SPIRE agent admin socket

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -97,6 +97,7 @@ func init() {
 
 	// Mesh routing configuration
 	rootCmd.Flags().StringVar(&cfg.MeshDomain, "mesh-domain", cfg.MeshDomain, "DNS-style domain mesh authorities live under (clients call <service>.<mesh-domain>)")
+	rootCmd.Flags().BoolVar(&cfg.EmitStatsPod, "stats-emit-pod", cfg.EmitStatsPod, "emit per-pod labels (source_pod/destination_pod) on the aether_stats request counter (raises cardinality)")
 
 	// SPIRE and security configuration
 	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", true, "Whether to enable SPIRE integration for X.509 SVID management and mTLS")
@@ -181,6 +182,7 @@ func runAgent(ctx context.Context) (retErr error) {
 
 	snapshotCache := cache.NewSnapshotCache(cfg.NodeName, l)
 	snapshotCache.SetMeshDomain(cfg.MeshDomain)
+	snapshotCache.SetEmitStatsPod(cfg.EmitStatsPod)
 
 	// Tracks Envoy's delta-xDS ACK/NACKs so the CNI server can confirm (and
 	// diagnose) config delivery without polling the Envoy admin interface.

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -71,6 +71,12 @@ type SnapshotCache struct {
 	// runtime.
 	meshDomain string
 
+	// emitStatsPod enables per-pod labels (source_pod/destination_pod) on the
+	// aether_stats request counter. Off by default to bound cardinality; set
+	// once before the manager starts (SetEmitStatsPod) and read without locking
+	// on every listener build.
+	emitStatsPod bool
+
 	listenerMu sync.RWMutex
 	listeners  map[string]listenerEntry // keyed by container network namespace
 
@@ -238,6 +244,13 @@ func (c *SnapshotCache) SetMeshDomain(domain string) {
 // MeshDomain returns the configured mesh domain.
 func (c *SnapshotCache) MeshDomain() string {
 	return c.meshDomain
+}
+
+// SetEmitStatsPod enables per-pod labels on the aether_stats request counter
+// (--stats-emit-pod flag). Must be called before the manager starts; the flag
+// is read without locking on every listener build.
+func (c *SnapshotCache) SetEmitStatsPod(enabled bool) {
+	c.emitStatsPod = enabled
 }
 
 // setLocalWorkload records a local pod's network namespace -> SPIFFE ID mapping

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -20,7 +20,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	netns := cniPod.GetNetworkNamespace()
 	c.log.V(2).Info("adding listeners for pod", "pod", cniPod.GetName(), "namespace", cniPod.GetNamespace(), "netns", netns)
 
-	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain, c.meshDomain)
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain, c.meshDomain, c.emitStatsPod)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 		netns := pod.GetNetworkNamespace()
 		c.log.V(2).Info("generating listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace(), "netns", netns)
 
-		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain)
+		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain, c.emitStatsPod)
 		if listenerErr != nil {
 			c.log.V(1).Error(listenerErr, "failed to generate listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace())
 			errs = append(errs, listenerErr)

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "networkfilter_test.go",
         "route_test.go",
         "spiffe_test.go",
+        "stats_filter_test.go",
         "subset_test.go",
         "transportsocket_test.go",
         "transportsocketmatch_test.go",
@@ -99,5 +100,6 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/agent/internal/xds/proxy/filterchain.go
+++ b/agent/internal/xds/proxy/filterchain.go
@@ -19,7 +19,7 @@ import (
 // before the router so it observes the final route/cluster. The chart mounts the
 // module .so on the proxy unconditionally; Envoy rejects the listener if the
 // referenced dynamic module is absent.
-func buildDefaultOutboundHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string) *listenerv3.FilterChain {
+func buildDefaultOutboundHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool) *listenerv3.FilterChain {
 	hcm := buildHTTPConnectionManager("outbound_http", nil)
 
 	// strip_any_host_port stays OFF: the authority port is a first-class routing
@@ -41,7 +41,7 @@ func buildDefaultOutboundHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string
 		readinessHttpFilter(),
 		subsetHeadersHttpFilter(),
 		onDemandHttpFilter(),
-		outboundStatsFilter(cniPod, meshDomain),
+		outboundStatsFilter(cniPod, meshDomain, emitStatsPod),
 	}
 	hcm.HttpFilters = append(prefix, hcm.HttpFilters...)
 

--- a/agent/internal/xds/proxy/filterchain_test.go
+++ b/agent/internal/xds/proxy/filterchain_test.go
@@ -32,7 +32,7 @@ func TestBuildDefaultOutboundHTTPFilterChain(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fc := buildDefaultOutboundHTTPFilterChain(&cniv1.CNIPod{Name: tt.podName}, "aether.internal")
+			fc := buildDefaultOutboundHTTPFilterChain(&cniv1.CNIPod{Name: tt.podName}, "aether.internal", false)
 
 			require.NotNil(t, fc)
 			assert.Equal(t, tt.expectedChainName, fc.GetName())
@@ -47,7 +47,7 @@ func TestBuildDefaultOutboundHTTPFilterChain(t *testing.T) {
 // non-pass-through health_check readiness filter ahead of the router, matched
 // on the shared readiness path probed by the CNI plugin from inside the netns.
 func TestOutboundChainReadinessFilter(t *testing.T) {
-	fc := buildDefaultOutboundHTTPFilterChain(&cniv1.CNIPod{Name: "my-pod"}, "aether.internal")
+	fc := buildDefaultOutboundHTTPFilterChain(&cniv1.CNIPod{Name: "my-pod"}, "aether.internal", false)
 	require.Len(t, fc.GetFilters(), 2)
 
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
@@ -80,7 +80,7 @@ func TestOutboundChainStatsFilter(t *testing.T) {
 	pod := &cniv1.CNIPod{Name: "my-pod", ServiceAccount: "checkout"}
 
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
-	fc := buildDefaultOutboundHTTPFilterChain(pod, "aether.internal")
+	fc := buildDefaultOutboundHTTPFilterChain(pod, "aether.internal", false)
 	require.NoError(t, fc.GetFilters()[1].GetTypedConfig().UnmarshalTo(hcm))
 
 	filters := hcm.GetHttpFilters()
@@ -96,4 +96,8 @@ func TestOutboundChainStatsFilter(t *testing.T) {
 	fields := ts.GetValue().GetFields()
 	assert.Equal(t, "source", fields["reporter"].GetStringValue())
 	assert.Equal(t, "checkout", fields["source_service"].GetStringValue())
+	// source_pod always travels in the config; the C++ filter drops it unless
+	// emit_pod is set (off by default here).
+	assert.Equal(t, "my-pod", fields["source_pod"].GetStringValue())
+	assert.False(t, fields["emit_pod"].GetBoolValue())
 }

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -49,7 +49,7 @@ func InboundListenerName(cniPod *cniv1.CNIPod) string {
 // verified peer (SANITIZE_SET), and forwards the request to the pod's application
 // on loopback (app_<pod>). Because the listener lives in the pod's netns, it follows
 // the pod's lifecycle (drains on removal) and pod-scoped network policy applies to it.
-func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.Listener, error) {
+func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod bool) (*listenerv3.Listener, error) {
 	if cniPod == nil {
 		return nil, fmt.Errorf("pod is required")
 	}
@@ -83,7 +83,7 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.L
 		StatPrefix:       fmt.Sprintf("inbound_%s", cniPod.GetName()),
 		TrafficDirection: corev3.TrafficDirection_INBOUND,
 		ListenerFilters:  buildInboundListenerFilters(),
-		FilterChains:     buildInboundFilterChains(cniPod, tlsCertificateSecretName, validationContextName),
+		FilterChains:     buildInboundFilterChains(cniPod, tlsCertificateSecretName, validationContextName, emitStatsPod),
 	}, nil
 }
 
@@ -93,17 +93,17 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string) (*listenerv3.L
 // (no-SNI) chain targeting the primary port for back-compat and clients that
 // send no SNI. Each port's chain can run its own codec, so ports may differ in
 // protocol. SNI is routing only — identity stays the terminated mTLS SVID.
-func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, validationContextName string) []*listenerv3.FilterChain {
+func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) []*listenerv3.FilterChain {
 	defaultPort := AppPortFromPod(cniPod)
 	ports := AppPortsFromPod(cniPod)
 
 	chains := make([]*listenerv3.FilterChain, 0, len(ports)+1)
 	// Default chain (no server_names): primary port. Matches no-SNI clients and
 	// any SNI that doesn't match a port chain.
-	chains = append(chains, buildInboundFilterChain(cniPod, "", defaultPort, tlsCertificateSecretName, validationContextName))
+	chains = append(chains, buildInboundFilterChain(cniPod, "", defaultPort, tlsCertificateSecretName, validationContextName, emitStatsPod))
 	// One chain per served port, SNI-matched on the port number.
 	for _, port := range ports {
-		chains = append(chains, buildInboundFilterChain(cniPod, strconv.Itoa(int(port)), port, tlsCertificateSecretName, validationContextName))
+		chains = append(chains, buildInboundFilterChain(cniPod, strconv.Itoa(int(port)), port, tlsCertificateSecretName, validationContextName, emitStatsPod))
 	}
 	return chains
 }
@@ -114,7 +114,7 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 // sni is non-empty the chain is SNI-matched (server_names); the empty-sni chain
 // is the default (no match criteria). chainPort selects both the app cluster
 // and the chain name suffix.
-func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string) *listenerv3.FilterChain {
+func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) *listenerv3.FilterChain {
 	hcm := buildHTTPConnectionManager("inbound", buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
 	// Liveness/readiness are answered locally before the router; everything else
 	// passes through to the pod's application. The stats filter sits after the
@@ -124,7 +124,7 @@ func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16,
 	hcm.HttpFilters = []*http_connection_managerv3.HttpFilter{
 		buildLivenessHealthCheckFilter(),
 		buildReadinessHealthCheckFilter(HealthProbeClusterName(cniPod)),
-		inboundStatsFilter(cniPod),
+		inboundStatsFilter(cniPod, emitStatsPod),
 		routerHttpFilter(),
 	}
 	// SANITIZE_SET replaces any client-supplied XFCC with details derived from the

--- a/agent/internal/xds/proxy/ingress_test.go
+++ b/agent/internal/xds/proxy/ingress_test.go
@@ -23,7 +23,7 @@ func TestNewInboundListener(t *testing.T) {
 		Ips:              []string{"10.0.0.1"},
 	}
 
-	l, err := NewInboundListener(pod, "example.org")
+	l, err := NewInboundListener(pod, "example.org", false)
 	require.NoError(t, err)
 	assert.Equal(t, InboundListenerName(pod), l.GetName())
 
@@ -70,10 +70,10 @@ func TestNewInboundListener(t *testing.T) {
 }
 
 func TestNewInboundListener_Errors(t *testing.T) {
-	_, err := NewInboundListener(nil, "example.org")
+	_, err := NewInboundListener(nil, "example.org", false)
 	require.Error(t, err)
 
-	_, err = NewInboundListener(&cniv1.CNIPod{Name: "no-netns"}, "example.org")
+	_, err = NewInboundListener(&cniv1.CNIPod{Name: "no-netns"}, "example.org", false)
 	require.Error(t, err)
 }
 
@@ -103,7 +103,7 @@ func TestInboundFilterChains_MultiPort(t *testing.T) {
 		Ips:              []string{"10.0.0.1"},
 		Annotations:      map[string]string{constants.AnnotationEndpointPorts: "8080,9090"},
 	}
-	l, err := NewInboundListener(pod, "example.org")
+	l, err := NewInboundListener(pod, "example.org", false)
 	require.NoError(t, err)
 
 	bySNI := map[string]*listenerv3.FilterChain{}
@@ -141,7 +141,7 @@ func TestInboundChainStatsFilter(t *testing.T) {
 		NetworkNamespace: "/var/run/netns/cni-a",
 		Ips:              []string{"10.0.0.1"},
 	}
-	l, err := NewInboundListener(pod, "aether.internal")
+	l, err := NewInboundListener(pod, "aether.internal", false)
 	require.NoError(t, err)
 	require.NotEmpty(t, l.GetFilterChains())
 
@@ -159,4 +159,8 @@ func TestInboundChainStatsFilter(t *testing.T) {
 	fields := ts.GetValue().GetFields()
 	assert.Equal(t, "destination", fields["reporter"].GetStringValue())
 	assert.Equal(t, "checkout", fields["destination_service"].GetStringValue())
+	// destination_pod (the local pod) always travels; the C++ filter drops it
+	// unless emit_pod is set (off by default here).
+	assert.Equal(t, "checkout-abc", fields["destination_pod"].GetStringValue())
+	assert.False(t, fields["emit_pod"].GetBoolValue())
 }

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -42,13 +42,13 @@ func OutboundListenerName(cniPod *cniv1.CNIPod) string {
 // appClusters is one per served port (the SNI-selected inbound chains forward
 // to these); healthCluster is the single delegated-liveness probe on the
 // primary port.
-func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string, meshDomain string) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, appClusters []*clusterv3.Cluster, healthCluster *clusterv3.Cluster, err error) {
-	inbound, err = NewInboundListener(cniPod, trustDomain)
+func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string, meshDomain string, emitStatsPod bool) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, appClusters []*clusterv3.Cluster, healthCluster *clusterv3.Cluster, err error) {
+	inbound, err = NewInboundListener(cniPod, trustDomain, emitStatsPod)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 
-	outbound, err = generateOutboundHTTPListener(cniPod, meshDomain)
+	outbound, err = generateOutboundHTTPListener(cniPod, meshDomain, emitStatsPod)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -82,7 +82,7 @@ func SpiffeIDFromPod(cniPod *cniv1.CNIPod, trustDomain string) string {
 	return fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, cniPod.GetNamespace(), cniPod.GetServiceAccount())
 }
 
-func generateOutboundHTTPListener(cniPod *cniv1.CNIPod, meshDomain string) (*listenerv3.Listener, error) {
+func generateOutboundHTTPListener(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool) (*listenerv3.Listener, error) {
 	if cniPod == nil {
 		return nil, fmt.Errorf("pod is required")
 	}
@@ -111,7 +111,7 @@ func generateOutboundHTTPListener(cniPod *cniv1.CNIPod, meshDomain string) (*lis
 		StatPrefix:       fmt.Sprintf("out_http_%s", cniPod.GetName()),
 		TrafficDirection: corev3.TrafficDirection_OUTBOUND,
 		FilterChains: []*listenerv3.FilterChain{
-			buildDefaultOutboundHTTPFilterChain(cniPod, meshDomain),
+			buildDefaultOutboundHTTPFilterChain(cniPod, meshDomain, emitStatsPod),
 		},
 	}, nil
 }

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -44,7 +44,7 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(tt.cniPod, "example.org", "example.org")
+			inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(tt.cniPod, "example.org", "example.org", false)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -110,7 +110,7 @@ func TestGenerateOutboundHTTPListener(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			listener, err := generateOutboundHTTPListener(tt.cniPod, "aether.internal")
+			listener, err := generateOutboundHTTPListener(tt.cniPod, "aether.internal", false)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -147,7 +147,7 @@ func TestPerConnectionBufferLimits(t *testing.T) {
 		Name:             "buf-pod",
 		NetworkNamespace: "/var/run/netns/buf",
 	}
-	inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(pod, "aether.internal", "aether.internal")
+	inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(pod, "aether.internal", "aether.internal", false)
 	require.NotEmpty(t, appClusters)
 	appCluster := appClusters[0]
 	require.NoError(t, err)

--- a/agent/internal/xds/proxy/stats_filter.go
+++ b/agent/internal/xds/proxy/stats_filter.go
@@ -33,6 +33,7 @@ type statsFilterConfig struct {
 	SourceService      string
 	SourcePod          string
 	DestinationService string
+	DestinationPod     string
 	MeshDomain         string
 	EmitPod            bool
 }
@@ -41,15 +42,15 @@ type statsFilterConfig struct {
 // pod's outbound HCM. The pod's identity (service account = mesh service name,
 // pod name) is constant for this listener, so it travels in the per-instance
 // config; the destination is derived per request from the routed cluster.
-func outboundStatsFilter(cniPod *cniv1.CNIPod, meshDomain string) *http_connection_managerv3.HttpFilter {
-	// source_pod is omitted from the emitted series by default (emit_pod=false)
-	// to bound cardinality; the filter still receives it for future use.
+func outboundStatsFilter(cniPod *cniv1.CNIPod, meshDomain string, emitPod bool) *http_connection_managerv3.HttpFilter {
+	// source_pod is emitted only when emitPod is set (--stats-emit-pod); off by
+	// default to bound cardinality. The filter still receives it either way.
 	return statsFilter(statsFilterConfig{
 		Reporter:      "source",
 		SourceService: cniPod.GetServiceAccount(),
 		SourcePod:     cniPod.GetName(),
 		MeshDomain:    meshDomain,
-		EmitPod:       false,
+		EmitPod:       emitPod,
 	})
 }
 
@@ -59,11 +60,14 @@ func outboundStatsFilter(cniPod *cniv1.CNIPod, meshDomain string) *http_connecti
 // by parsing the verified peer SVID's URI SAN (proposal 007 Phase 2). The mesh
 // domain is not needed here — the source is path-parsed from the SPIFFE SAN, not
 // stripped from a cluster name.
-func inboundStatsFilter(cniPod *cniv1.CNIPod) *http_connection_managerv3.HttpFilter {
+func inboundStatsFilter(cniPod *cniv1.CNIPod, emitPod bool) *http_connection_managerv3.HttpFilter {
+	// destination_pod is the local pod (same value as the listener aether_pod
+	// tag); emitted only when emitPod is set (--stats-emit-pod) to bound cardinality.
 	return statsFilter(statsFilterConfig{
 		Reporter:           "destination",
 		DestinationService: cniPod.GetServiceAccount(),
-		EmitPod:            false,
+		DestinationPod:     cniPod.GetName(),
+		EmitPod:            emitPod,
 	})
 }
 
@@ -81,6 +85,7 @@ func statsFilter(cfg statsFilterConfig) *http_connection_managerv3.HttpFilter {
 		"source_service":      cfg.SourceService,
 		"source_pod":          cfg.SourcePod,
 		"destination_service": cfg.DestinationService,
+		"destination_pod":     cfg.DestinationPod,
 		"mesh_domain":         cfg.MeshDomain,
 		"emit_pod":            cfg.EmitPod,
 	})

--- a/agent/internal/xds/proxy/stats_filter_test.go
+++ b/agent/internal/xds/proxy/stats_filter_test.go
@@ -1,0 +1,55 @@
+package proxy
+
+import (
+	"testing"
+
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	xdstypev3 "github.com/cncf/xds/go/xds/type/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// statsConfigFields unmarshals an aether_stats HTTP filter's TypedStruct config
+// and returns its fields for assertion.
+func statsConfigFields(t *testing.T, f *http_connection_managerv3.HttpFilter) map[string]*structpb.Value {
+	t.Helper()
+	assert.Equal(t, statsFilterName, f.GetName())
+	ts := &xdstypev3.TypedStruct{}
+	require.NoError(t, f.GetTypedConfig().UnmarshalTo(ts))
+	require.Equal(t, statsConfigTypeURL, ts.GetTypeUrl())
+	return ts.GetValue().GetFields()
+}
+
+// TestOutboundStatsFilterEmitPod verifies the --stats-emit-pod flag flips the
+// emit_pod field while source_pod always carries the local pod name.
+func TestOutboundStatsFilterEmitPod(t *testing.T) {
+	pod := &cniv1.CNIPod{Name: "shop-1", ServiceAccount: "shop"}
+
+	off := statsConfigFields(t, outboundStatsFilter(pod, "aether.internal", false))
+	assert.Equal(t, "source", off["reporter"].GetStringValue())
+	assert.Equal(t, "shop", off["source_service"].GetStringValue())
+	assert.Equal(t, "shop-1", off["source_pod"].GetStringValue())
+	assert.False(t, off["emit_pod"].GetBoolValue())
+
+	on := statsConfigFields(t, outboundStatsFilter(pod, "aether.internal", true))
+	assert.True(t, on["emit_pod"].GetBoolValue())
+	assert.Equal(t, "shop-1", on["source_pod"].GetStringValue())
+}
+
+// TestInboundStatsFilterEmitPod verifies the inbound (destination-reported)
+// filter carries destination_pod and honors the emit_pod flag.
+func TestInboundStatsFilterEmitPod(t *testing.T) {
+	pod := &cniv1.CNIPod{Name: "shop-1", ServiceAccount: "shop"}
+
+	off := statsConfigFields(t, inboundStatsFilter(pod, false))
+	assert.Equal(t, "destination", off["reporter"].GetStringValue())
+	assert.Equal(t, "shop", off["destination_service"].GetStringValue())
+	assert.Equal(t, "shop-1", off["destination_pod"].GetStringValue())
+	assert.False(t, off["emit_pod"].GetBoolValue())
+
+	on := statsConfigFields(t, inboundStatsFilter(pod, true))
+	assert.True(t, on["emit_pod"].GetBoolValue())
+	assert.Equal(t, "shop-1", on["destination_pod"].GetStringValue())
+}

--- a/agent/internal/xds/server/server_integration_test.go
+++ b/agent/internal/xds/server/server_integration_test.go
@@ -122,7 +122,7 @@ func setConsistentSnapshot(t *testing.T, ctx context.Context, snapshotCache cach
 		Ips:              []string{"10.0.0.1"},
 	}
 
-	inbound, outbound, appClusters, _, err := proxy.GenerateListenersFromRegistryPod(pod, "example.org", "example.org")
+	inbound, outbound, appClusters, _, err := proxy.GenerateListenersFromRegistryPod(pod, "example.org", "example.org", false)
 	require.NoError(t, err)
 
 	serviceName := "my-service"

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.2.0-{GIT_COMMIT}"
+version: "0.2.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -51,6 +51,41 @@ data:
           # instead of a name per cluster.
           emit_tags_as_attributes: true
           use_tag_extracted_name: true
+          # Drop the "envoy" prefix from JUST the aether_stats request counter so
+          # it exports as `aether_requests_total` (not envoy_aether_requests_total)
+          # while every standard envoy_* stat keeps the prefix. Envoy's OTLP sink
+          # applies ConversionAction.metric_name verbatim — no prefix prepend (see
+          # getMetricName in open_telemetry_impl.cc) — so this both strips the
+          # prefix and collapses the per-request inlined-name variants into one
+          # attribute-labeled metric. Istio's custom-stat-namespace trick is admin
+          # /stats/prometheus-only and does not apply to the OTLP sink; this is the
+          # OTLP-native equivalent.
+          # NOTE: any custom_metric_conversions turns on sink-wide metric
+          # AGGREGATION (one Metric, attribute-keyed data points) for ALL stats
+          # (enable_metric_aggregation_ = has_custom_metric_conversions). Distinct
+          # tag sets stay distinct data points, so Prometheus output is unchanged —
+          # validate in e2e before relying on it.
+          custom_metric_conversions:
+            matcher_list:
+              matchers:
+                - predicate:
+                    single_predicate:
+                      input:
+                        name: stat_full_name_match_input
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.matching.common_inputs.stats.v3.StatFullNameMatchInput
+                      value_match:
+                        safe_regex:
+                          google_re2: {}
+                          # Full stat name carries the inlined tag values
+                          # (aether.requests_total.reporter.<v>.…); match them all.
+                          regex: "aether\\.requests_total.*"
+                  on_match:
+                    action:
+                      name: otlp_metric_conversion
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig.ConversionAction
+                        metric_name: aether.requests_total
 {{- end }}
 
     # Bound stats-memory growth (measured 2026-06-11: ~5.1k stats/proxy at
@@ -104,8 +139,8 @@ data:
         # gone and the values collapse into the metric name with empty labels
         # (the talos-main symptom). These regexes re-derive the six tags from
         # the name exactly the way aether.cluster survives — tag_name MUST match
-        # the programmatic keys in aether_stats.cc so fresh and merged counters
-        # export identical labels. Values are dot-free, so [^.]* is exact.
+        # the seven programmatic keys in aether_stats.cc so fresh and merged
+        # counters export identical labels. Values are dot-free, so [^.]* is exact.
         # Guarded by //source/extensions/filters/http/aether_stats:tag_extraction_test.
         - tag_name: reporter
           regex: "(\\.reporter\\.([^.]*))"
@@ -115,6 +150,8 @@ data:
           regex: "(\\.source_pod\\.([^.]*))"
         - tag_name: destination_service
           regex: "(\\.destination_service\\.([^.]*))"
+        - tag_name: destination_pod
+          regex: "(\\.destination_pod\\.([^.]*))"
         - tag_name: response_code
           regex: "(\\.response_code\\.([^.]*))"
         - tag_name: response_flags

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -83,7 +83,7 @@ proxy:
     # publishing commit SHA (multi-arch manifest). This `ref` is auto-pinned to
     # that SHA by proxy-release (a bump-chart PR) on each proxy release — an
     # immutable pin (the :dev placeholder below is just the pre-first-release seed).
-    ref: "ghcr.io/bpalermo/aether/aether-proxy:14039c55668d0ea9d85216c88da5766644f8fb7e"
+    ref: "ghcr.io/bpalermo/aether/aether-proxy:d86328b772ee5f6bf86fcd725eff0e2ff3e645f3"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application (operational) logs as one JSON object per line


### PR DESCRIPTION
## What

Two telemetry changes to `envoy_aether_requests_total`:

1. **Per-pod labels.** New `--stats-emit-pod` agent flag (default **off**), threaded through the snapshot cache to the inbound/outbound stats filters. When set, source-reported series carry `source_pod` and destination-reported series carry `destination_pod`. Off by default to bound cardinality.
2. **Drop the `envoy_` prefix** for just this metric. The OTLP stat sink's `custom_metric_conversions` renames `aether.requests_total` verbatim (no prefix prepend — see `getMetricName` in Envoy's `open_telemetry_impl.cc`), so it exports as **`aether_requests_total`** while every other stat keeps `envoy_`.

Also adds the `destination_pod` stats_tag recovery regex (hot-restart tag survival) and bumps the agent chart **0.2.0 → 0.2.1**.

## How Istio does it (researched)

Istio's `istio_*` metrics drop `envoy_` via Envoy **custom Prometheus stat namespaces** (`registerPrometheusNamespace`), which are honored **only by the admin `/stats/prometheus` formatter** — NOT by the OTLP stats sink aether uses. So Istio's mechanism does not port; `custom_metric_conversions` is the OTLP-native equivalent.

## ⚠️ Risk to validate

Setting `custom_metric_conversions` enables **sink-wide metric aggregation** for ALL stats (`enable_metric_aggregation_ = has_custom_metric_conversions`). Distinct tag sets stay distinct data points, so Prometheus output should be unchanged — **validate in e2e** before relying on it.

## Ordering

Depends on **#207** (adds the `destination_pod` proto field). Merge + roll out the proxy image first.

## Tests

`bazel test //agent/internal/xds/proxy //agent/internal/xds/cache //agent/internal/cmd //agent/internal/xds/server` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
