### PR TITLE
feat(agent): expose --stats-emit-pod via telemetry.statsEmitPod chart value

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.2.1-{GIT_COMMIT}"
+version: "0.2.2-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -60,6 +60,9 @@ spec:
             {{- with .Values.telemetry.otlpEndpoint }}
             - "--otlp-endpoint={{ . }}"
             {{- end }}
+            {{- if .Values.telemetry.statsEmitPod }}
+            - "--stats-emit-pod"
+            {{- end }}
             {{- if .Values.telemetry.tracing.enabled }}
             - "--tracing-enabled=true"
             - "--trace-sample-rate={{ .Values.telemetry.tracing.sampleRate }}"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -39,6 +39,12 @@ telemetry:
   # OTLP gRPC collector endpoint (host:port, insecure), e.g.
   # "otel-collector.observability.svc:4317". Empty disables push everywhere.
   otlpEndpoint: ""
+  # Emit per-pod labels (source_pod on source-reported series, destination_pod
+  # on destination-reported series) on the aether_stats request counter
+  # (`--stats-emit-pod`). Off by default — raises metric cardinality by the
+  # local pod count. The metric itself ships regardless; this only adds the pod
+  # dimension.
+  statsEmitPod: false
   tracing:
     # Enables OTLP trace export on the agent (`--tracing-enabled`);
     # requires otlpEndpoint.


### PR DESCRIPTION
## What
Wire the `--stats-emit-pod` agent flag (added in #208) into the chart: new `telemetry.statsEmitPod` value (default **false**) that conditionally passes `--stats-emit-pod` to the agent DaemonSet. Chart bump 0.2.1 → 0.2.2.

## Why
#208 added the CLI flag and the C++/proxy support (#207), but `daemonset.yaml` hardcodes args with no `--stats-emit-pod` and no `extraArgs` — so per-pod `aether_stats` labels (`source_pod`/`destination_pod`) were unreachable via helm. The metric itself (and the `envoy_`-prefix strip) ships regardless; this only adds the opt-in pod dimension.

## Use
`helm upgrade … --set telemetry.statsEmitPod=true` (raises cardinality by the local pod count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)