### PR TITLE
fix(telemetry): per-node identity for static infra cluster stats (agent_xds)

### DIFF
--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.2.2-{GIT_COMMIT}"
+version: "0.2.3-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/agent/templates/configmap.yaml
+++ b/charts/agent/templates/configmap.yaml
@@ -45,6 +45,23 @@ data:
           grpc_service:
             envoy_grpc:
               cluster_name: otel_collector
+          # Populate the OTLP Resource with this proxy's k8s identity (OTel
+          # semantic-convention k8s.* attributes: node/namespace/pod/uid), sourced
+          # from OTEL_RESOURCE_ATTRIBUTES on the container (see proxy.yaml). Without
+          # a resource_detector the sink emits an EMPTY resource
+          # (open_telemetry_impl.cc builds the resource solely from these
+          # detectors), so every proxy's stats land on one identityless series per
+          # aether.cluster. That collapse is correct for per-service mesh clusters
+          # (bounds cardinality at the node-count target) but breaks the static
+          # infra clusters (agent_xds, otel_collector): one such cluster exists per
+          # node, so N proxies multiplex N cumulative counters onto a single series
+          # and rate()/increase() fabricate phantom resets/cx-fails. The collector
+          # promotes k8s.node.name -> a `node` label ONLY for those infra clusters
+          # (selective transform/promote), so mesh stats stay collapsed.
+          resource_detectors:
+            - name: envoy.tracers.opentelemetry.resource_detectors.environment
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.resource_detectors.v3.EnvironmentResourceDetectorConfig
           prefix: envoy
           # Export the tag-extracted name with tags as OTLP attributes: one
           # metric family per stat, labeled by aether.cluster (see stats_tags)

--- a/charts/agent/templates/proxy.yaml
+++ b/charts/agent/templates/proxy.yaml
@@ -95,6 +95,37 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.uid
+            # Per-node/pod identity for the OTLP stats Resource, using OTel k8s.*
+            # semantic-convention attribute names. The environment resource
+            # detector (configmap.yaml stats_sinks) parses OTEL_RESOURCE_ATTRIBUTES
+            # into the Resource; the collector promotes k8s.node.name -> a `node`
+            # label ONLY on the static infra clusters (agent_xds, otel_collector),
+            # whose one-series-per-node counters otherwise collide into a single
+            # identityless series and make rate()/increase() fabricate resets and
+            # connect-failures. Mesh clusters carry the resource attrs but are not
+            # promoted, so they stay collapsed (cardinality bounded at the node
+            # target). k8s.node.name (not k8s.pod.name) is promoted: it is stable
+            # across proxy hot-restarts, so the per-node counter series — and its
+            # rate() — survive restarts cleanly. (k8s.deployment.name and
+            # k8s.pod.start_time are omitted: N/A for a DaemonSet pod / not
+            # available via the downward API.) $(VAR) expands from the env above.
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(NODE_NAME),k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME),k8s.pod.uid=$(POD_UID)"
             - name: REGION
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
## Problem

The Grafana panels
`rate(envoy_cluster_upstream_rq_tx_reset_total{aether_cluster="agent_xds"})` and
`rate(envoy_cluster_upstream_cx_connect_fail_total{aether_cluster="agent_xds"})`
show a flat, constant ~2.8/s fleet rate — alarming, but **not a real failure**.

`agent_xds` is the static bootstrap cluster every Envoy uses to reach its
co-located agent xDS over the UDS pipe. Investigation on talos-main:

- The ADS stream is **healthy** (`cx_active=1`, `rq_active=1`, clean proxy logs, config flowing). The data plane (mesh clusters) has **zero** connect failures.
- The `agent_xds` metric is a **single fleet-wide series carrying only the `aether_cluster` label** — no pod/node identity.

The OTLP stat sink builds its Resource solely from configured `resource_detectors` (`open_telemetry_impl.cc`), and there were none, so the Resource is empty. All 5 proxies therefore push their **cumulative** counters onto the *same* identityless series. `rate()`/`increase()` over that colliding series interpret the interleaved per-proxy values as a continuous stream of increments + resets → a phantom constant rate. The collapse is correct for per-service mesh clusters (bounds cardinality at the node target) but wrong for the static infra clusters, of which exactly one exists per node.

## Fix

- Add the `environment` resource detector to the OTLP stat sink (already compiled into the custom proxy — **config-only, no rebuild**).
- Stamp OTel `k8s.*` semantic-convention attributes (`k8s.node.name`, `k8s.namespace.name`, `k8s.pod.name`, `k8s.pod.uid`) into the Resource via `OTEL_RESOURCE_ATTRIBUTES` from the downward API.
- Bump agent chart `0.2.2 → 0.2.3`.

## Companion change (already applied in-cluster)

The otel-collector already promoted `host.name → node` **globally**. That has been changed (helm `otel-collector`, o11y, rev 14) to source from `k8s.node.name` and promote **only** for `agent_xds`/`otel_collector`:

```
set(attributes["node"], resource.attributes["k8s.node.name"])
  where resource.attributes["k8s.node.name"] != nil
    and (attributes["aether.cluster"] == "agent_xds" or attributes["aether.cluster"] == "otel_collector")
```

This keeps mesh stats collapsed (no per-node cardinality split at the 10k-node target) while giving the infra clusters per-node identity. `k8s.node.name` (not `k8s.pod.name`) is promoted so the per-node counter series survives proxy hot-restarts cleanly. The collector change was applied **first**, so there is no window where mesh stats split when this chart deploys.

## Validation

- Chart renders; extracted `envoy.yaml` parses with the detector in place.
- Detector field/type/category verified against the custom Envoy's own protos; extension confirmed in the curated build set.
- Collector upgrade rolled out clean; OTTL statement parsed and accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)