### PR TITLE
chore: move hack/ to scripts/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
           # Full history so the PR base commit is reachable for the diff.
           fetch-depth: 0
       - name: Require a Chart.yaml version bump for chart changes
-        run: hack/check-chart-version-bump.sh "${{ github.event.pull_request.base.sha }}"
+        run: scripts/check-chart-version-bump.sh "${{ github.event.pull_request.base.sha }}"
 
   ci:
     runs-on: ubuntu-latest

--- a/scripts/check-chart-version-bump.sh
+++ b/scripts/check-chart-version-bump.sh
@@ -5,7 +5,7 @@
 # The in-repo version is "MAJOR.MINOR.PATCH-{GIT_COMMIT}" (the suffix is a literal
 # placeholder stamped only at publish time), so the SemVer base is what we compare.
 #
-# Usage: hack/check-chart-version-bump.sh [BASE_REF]
+# Usage: scripts/check-chart-version-bump.sh [BASE_REF]
 #   BASE_REF defaults to origin/main. CI passes the PR base SHA.
 set -euo pipefail
 


### PR DESCRIPTION
Renames the `hack/` directory to `scripts/`. The directory held a single file, `check-chart-version-bump.sh`.

Updated references:
- `.github/workflows/ci.yaml` — the CI invocation path
- the script's own usage comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)