### PR TITLE
docs: amend proposal 013 — probe proxy local-reply liveness endpoint

### DIFF
--- a/docs/proposals/013_mesh-availability-prober.md
+++ b/docs/proposals/013_mesh-availability-prober.md
@@ -1,6 +1,7 @@
 # Proposal: synthetic mesh-availability prober
 
-**Status:** Design — 2026-06-17
+**Status:** Design — 2026-06-17 (amended 2026-06-17: probe a proxy local-reply
+liveness endpoint, not a real service)
 **Relates:** proposal 007 (telemetry filter), proposal 004 (demand-scoped distribution)
 **Motivated by:** 1h distributed churn soak (2026-06-17)
 
@@ -33,19 +34,63 @@ first-class component — and the soak also showed the load **must be distribute
 ## What it is
 
 A small Go binary, `prober`, deployed as a **DaemonSet (one pod per node)**,
-**mesh-managed** like any client (`aether.io/managed=true` +
-`config.aether.io/upstreams`). Each pod issues a steady, low-rate stream of HTTP
-probes through its node's local egress listener
-(`GET http://127.0.0.1:18081/` with `Host: <target>.aether.internal`) and emits
-its **own** pass/fail counter via OTel. Because the prober (not the proxy) emits
-the metric, it survives proxy restarts and records connection-level failures the
-mesh metric cannot.
+**mesh-managed** like any client (`aether.io/managed=true`). Each pod issues a
+steady, low-rate stream of HTTP probes through its node's local egress listener
+(`127.0.0.1:18081`) and emits its **own** pass/fail counter via OTel. Because the
+prober (not the proxy) emits the metric, it survives proxy restarts and records
+the connection-level failures the mesh metric cannot.
 
-One-per-node is load-bearing: each node's prober observes *its* proxy's roll, so a
+**Probe target is a proxy local-reply, not a real service.** Probing
+`svc-1/2/3` would fold the *application's* health into the mesh SLI — the same
+app-vs-mesh confusion we removed from the dashboard. Instead the prober hits a
+liveness endpoint the proxy answers **locally** (`direct_response`, no upstream),
+so a non-200 / connection error is unambiguously the **mesh's** fault, decoupled
+from both the app and upstream reachability.
+
+One-per-node is load-bearing: each node's prober observes *its* proxy, so a
 node-proxy outage shows as that node's prober failing — the correct attribution,
 since that node's real clients would fail too.
 
+## Two tiers: liveness (primary) vs reachability (optional)
+
+A local-reply probe is green even if the proxy can't route anywhere (no clusters,
+stale EDS). So it measures **liveness**, not **reachability**. This mirrors the
+mesh's own structural-health split (local-pod HC = liveness, tunnel HC =
+reachability):
+
+| Tier | Target | Proves | Decoupled from |
+|---|---|---|---|
+| **Liveness** (primary) | egress `/-/-/live` local-reply (`direct_response` 200) | source proxy listener serving + config loaded + mTLS up | app **and** upstream |
+| **Reachability** (optional) | a dedicated trivial **echo** upstream, full round-trip | routing + EDS propagation + transport + dest-proxy inbound | app health (echo is always-up) |
+
+With both you can distinguish *"proxy down"* (liveness dips — the hot-restart gap)
+from *"proxy up but can't deliver"* (reachability dips — EDS/propagation lag during
+a deploy). A third, cheaper middle option is the existing `/healthz/<cluster>`
+health gateway (`agent/internal/xds/proxy/healthgateway.go`), which surfaces the
+proxy's *own* active-HC verdict as a local reply — reachability signal without a
+real round-trip, but it is the proxy's self-assessment, so the echo round-trip is
+the truly independent reachability check.
+
+aether already has the liveness primitive on the **inbound** listener
+(`agent/internal/xds/proxy/ingress.go`):
+
+- `MeshLivePath = "/-/-/live"` — 200 proves config loaded + listener serving +
+  mTLS up (no app, no upstream).
+- `MeshReadyPath = "/-/-/ready"` — liveness **plus** the pod's app-health cluster;
+  re-couples app health, so **not** a mesh-SLI target.
+
 ## Design
+
+### Small agent xDS addition (prerequisite for the liveness tier)
+
+The prober is an **egress** client, but `/-/-/live` exists only on the inbound
+listener. So the agent emits a reserved liveness route on the **egress** route
+config: `direct_response: { status: 200 }` for a reserved authority/path (e.g.
+`127.0.0.1:18081/-/-/live`). This is nearly free — the agent already generates the
+egress route config and already uses `direct_response` (the catch-all 404 in
+`route.go`, the `/healthz/<cluster>` gateway). The route is always present,
+independent of EDS/clusters/apps, so a 200 means "this node's egress data plane is
+serving" and a connection error means the listener is down.
 
 ### Component layout (mirrors `agent` / `registrar` / `cni`)
 
@@ -58,130 +103,129 @@ prober/
                               # agent/internal/proxy/hotrestart/telemetry.go)
 ```
 
-Build via Bazel exactly like the other binaries: `go_binary` +
+Build via Bazel like the other binaries: `go_binary` +
 `//bazel/img:go_multi_arch_image` → distroless image; `make gazelle`.
 
-### Sampler (open-loop, per target)
+### Sampler (open-loop)
 
-- One goroutine per target driven by a `time.Ticker` at `--rate` probes/sec
-  (default 5/s/target). **Open-loop on purpose** (same rationale as the k6
-  `constant-arrival-rate` rule): never back off when latency rises, or a slow
-  hop hides the very dip we measure.
+- A `time.Ticker` at `--rate` probes/sec (default 5/s) issues
+  `GET http://127.0.0.1:18081/-/-/live` (liveness tier) and, if enabled, a
+  round-trip to each `--reachability-target` (reachability tier).
+- **Open-loop on purpose** (same rationale as the k6 `constant-arrival-rate` rule):
+  never back off when latency rises, or a slow hop hides the dip we measure.
 - A bounded worker pool services ticks so a hung probe never blocks the next tick;
-  if in-flight exceeds the cap, the tick is counted as a `saturated` result rather
-  than dropped silently.
-- Per-probe: `GET http://127.0.0.1:18081/<path>` with
-  `Host: <target>.aether.internal`, `--timeout` (default 2s), no keep-alive reuse
-  across the handoff boundary is forced off — actually *do* keep a small idle pool
-  to mirror real clients, configurable via `--reuse-conns`.
+  over-cap ticks count as `saturated` rather than silently dropping.
+- `--timeout` (default 2s) per probe.
 
 ### Result classification (the whole point)
 
-Map the Go client outcome to a small, low-cardinality `result`:
-
 | `result` | condition | mesh self-metric sees it? |
 |---|---|---|
-| `success` | nil err, 2xx | yes |
-| `http_4xx` / `http_5xx` | nil err, non-2xx | usually (flagged 503) |
+| `success` | nil err, 200 | yes |
+| `http_error` | nil err, non-2xx | usually (flagged 503) |
 | `connection_error` | dial refused / reset (`ECONNREFUSED`/`ECONNRESET`) | **no — the blind spot** |
 | `timeout` | context deadline exceeded | rarely |
 | `saturated` | worker pool full (prober-side) | n/a |
 
-`connection_error` is the class the mesh cannot record and the reason this
-component exists.
+`connection_error` against the **liveness** endpoint is the unambiguous
+"mesh/proxy down" signal and the reason this component exists.
 
 ### Metrics (the SLI)
 
 Emitted through the existing OTel → `otel-collector` → Prometheus pipeline:
 
-- `aether_probe_requests_total{target, result}` — counter.
-- `aether_probe_request_duration_seconds{target}` — histogram (optional latency SLO).
+- `aether_probe_requests_total{tier, target, result}` — counter
+  (`tier` = `liveness` | `reachability`).
+- `aether_probe_request_duration_seconds{tier, target}` — histogram (optional).
 
 Per-node de-collapse via `OTEL_RESOURCE_ATTRIBUTES=k8s.node.name=$(NODE_NAME)`
-(downward API `spec.nodeName`) + the collector `transform/promote` already in
-place — same approach as PR #210 for the infra clusters. Keep cardinality low:
-`result` is bucketed (no raw status codes), `target` is the short list, `node`
-comes from the resource attr.
+(downward API) + the collector `transform/promote` already in place (à la PR #210).
+Cardinality stays low: `result` is bucketed (no raw status codes), `tier`/`target`
+are tiny, `node` from the resource attr.
 
-**SLI** = `sum(rate(...{result="success"})) / sum(rate(aether_probe_requests_total))`,
-sliceable by `target` and `node`. This is the trustworthy availability number
-across churn.
+**Liveness SLI** =
+`sum(rate(...{tier="liveness",result="success"})) / sum(rate(...{tier="liveness"}))`,
+sliceable by `node`. This is the trustworthy data-plane-availability number across
+churn.
 
 ### Configuration (flags, with env fallbacks)
 
 | flag | default | meaning |
 |---|---|---|
-| `--targets` | (required) | `svc-1,svc-2,svc-3` — probed services |
 | `--egress` | `127.0.0.1:18081` | local mesh egress listener |
-| `--mesh-domain` | `aether.internal` | Host authority suffix |
-| `--rate` | `5` | probes/sec **per target** |
+| `--liveness-path` | `/-/-/live` | proxy local-reply liveness route |
+| `--rate` | `5` | probes/sec |
 | `--timeout` | `2s` | per-probe deadline |
-| `--path` | `/` | request path |
+| `--reachability-targets` | "" (disabled) | optional echo upstreams, full round-trip |
+| `--mesh-domain` | `aether.internal` | Host authority suffix (reachability tier) |
 | `--otlp-endpoint` | "" | collector; empty disables telemetry |
 
-The chart templates `config.aether.io/upstreams` from `--targets` so the agent
-programs the matching clusters (demand-scoped distribution, proposal 004).
+Note the liveness tier needs **no** `config.aether.io/upstreams` — it never leaves
+the proxy. Only the optional reachability tier requires the echo upstream to be
+declared (demand-scoped distribution, proposal 004).
 
 ### Deployment
 
-New optional chart `charts/prober` (DaemonSet + values), **off by default**,
-enabled per-cluster. Non-hostNetwork pod (so the CNI plumbs the per-pod
-`127.0.0.1:18081`, as `loadgen` does), `aether.io/managed=true`,
-`NODE_NAME` via downward API. Minimal resources; rate kept low (it is an SLI
-sampler, not load).
+New optional chart `charts/prober` (DaemonSet + values), **off by default**.
+Non-hostNetwork pod (so the CNI plumbs the per-pod `127.0.0.1:18081`, as `loadgen`
+does), `aether.io/managed=true`, `NODE_NAME` via downward API. Minimal resources;
+rate kept low (it is an SLI sampler, not load).
 
 ### Observability wiring (follow-up, not this component)
 
 - Add a **"Mesh Availability (synthetic)"** dashboard row on
-  `aether_probe_requests_total` — overall + per-node + per-target — and make it the
-  **headline SLO**. Demote/relabel the self-reported "Mesh Request Success Rate"
-  panel ("proxy-observed, not churn-safe").
-- Alert (burn-rate) on probe success, never on `aether_stats`.
+  `aether_probe_requests_total{tier="liveness"}` — overall + per-node — as the
+  **headline SLO**, and demote/relabel the self-reported "Mesh Request Success
+  Rate" panel ("proxy-observed, not churn-safe"). Add a reachability panel from
+  `tier="reachability"`.
+- Alert (burn-rate) on the liveness SLI, never on `aether_stats`.
 - Overlay `aether_supervisor_epoch` bumps so a dip maps to a node/epoch.
 
-Division of labor: **prober = availability SLO**; `aether_stats` flag breakdown =
-failure-**mode** diagnosis; supervisor metrics = **when/where** churn happened.
+Division of labor: **prober liveness = availability SLO**; prober reachability =
+delivery health; `aether_stats` flag breakdown = failure-**mode** diagnosis;
+supervisor metrics = **when/where** churn happened.
 
 ## Alternatives considered
 
+- **Probe a real service (`svc-1/2/3`)** — rejected: folds app health into the
+  mesh SLI (the app-vs-mesh confusion already removed from the dashboard) and adds
+  load to real services. The local-reply liveness endpoint isolates the mesh.
 - **Permanent k6 DaemonSet** — proved the concept in the soak, but its
-  OTLP-exported counter *magnitudes* are unreliable (read 720/s then 60M for the
-  same load; only the ratio is usable) and it is heavyweight for an always-on
+  OTLP-exported counter *magnitudes* are unreliable (720/s then 60M for the same
+  load; only the ratio is usable) and it is heavyweight for an always-on
   component. A purpose-built Go counter is exact and tiny.
-- **blackbox-exporter** — pull-model and not mesh-native; would still need a
-  mesh-managed sidecar to reach `127.0.0.1:18081` and can't express the
-  Host-authority egress cleanly. More moving parts, less control over result
-  classification.
+- **blackbox-exporter** — pull-model, not mesh-native; still needs a mesh-managed
+  sidecar to reach `127.0.0.1:18081`, with less control over result classification.
 - **Access-log scraping** — same data-plane origin, same blind spot, plus volume.
-- **In-app client instrumentation** — requires touching every workload; the mesh
-  should provide an availability signal without that.
+- **In-app client instrumentation** — requires touching every workload.
 
 ## Open questions
 
-1. **Probe targets:** real services (`svc-1/2/3` — real-path coverage, tiny added
-   load) vs a dedicated lightweight echo target (isolates the prober from app
-   load). Recommend configurable; default to real services in `aether-test`.
+1. **Reachability echo target:** ship a dedicated always-up echo service (a tiny
+   `direct_response`-style backend) for the reachability tier, or defer the tier
+   entirely and start liveness-only? (Liveness alone already closes the soak's
+   blind spot.)
 2. **Rate vs sensitivity:** 5/s/node catches ~hundreds-of-ms gaps; raise to
-   10–20/s/node for sub-second-blip detection. One knob, documented.
-3. **Inbound coverage:** start with egress (the SLI that matters); consider an
-   inbound/per-pod variant later.
-4. **Identity/authz:** the prober gets a SPIFFE SVID like any managed pod; confirm
-   its `source_service` (ServiceAccount) and that `config.aether.io/upstreams`
-   authorizes its targets.
-5. **Latency SLO:** ship the duration histogram now or defer.
+   10–20/s for sub-second-blip detection. One knob, documented.
+3. **Identity/authz:** the prober gets a SPIFFE SVID like any managed pod; the
+   liveness tier needs no upstream authz; the reachability tier needs its echo
+   target in `config.aether.io/upstreams`.
+4. **Latency SLO:** ship the duration histogram now or defer.
 
 ## Rollout
 
-1. `prober` binary + Bazel + image (no cluster impact).
-2. `charts/prober` (off by default); enable on talos-main; validate the SLI tracks
-   k6 during a manual proxy roll.
-3. Dashboard row + alerts; demote the self-reported panel.
+1. Agent egress liveness `direct_response` route (small xDS change) + a route test.
+2. `prober` binary + Bazel + image (no cluster impact).
+3. `charts/prober` (off by default); enable on talos-main; validate the liveness
+   SLI tracks k6 during a manual proxy roll.
+4. Dashboard row + alerts; demote the self-reported panel. Reachability tier later.
 
 ## Validation
 
-Reproduce the soak: enable the prober, run a proxy hot-restart
-(`kubectl rollout restart ds/aether-proxy`) and a service deploy, and confirm the
-prober SLI dips/records `connection_error` while `aether_requests_total` shows ~0
-infra failures — i.e., the prober sees what the mesh cannot. Confirm per-node
-attribution (only the rolling node's prober dips) and that steady-state reads
-~100%.
+Reproduce the soak: enable the prober (liveness tier), run a proxy hot-restart
+(`kubectl rollout restart ds/aether-proxy`) and confirm the prober records
+`connection_error` on the rolling node while `aether_requests_total` shows ~0 infra
+failures — i.e., the prober sees what the mesh cannot. Confirm per-node attribution
+(only the rolling node's prober dips) and steady-state ~100%. With the reachability
+tier enabled, a service deploy should dip reachability (EDS/propagation) while
+liveness stays flat.


### PR DESCRIPTION
## What

Amends **proposal 013** (already merged): the prober probes a **proxy local-reply liveness endpoint**, not a real service.

## Why

Probing `svc-1/2/3` would fold the *application's* health back into the mesh SLI — the same app-vs-mesh confusion we removed from the dashboard. A proxy **local-reply** (`direct_response` 200, never forwarded upstream) makes a failure unambiguously the **mesh's** fault, decoupled from both the app and upstream reachability.

aether already has the primitive: `MeshLivePath = "/-/-/live"` on the inbound listener (`ingress.go`) — 200 ⇒ config loaded + listener serving + mTLS up, no app/upstream dependency. (`/-/-/ready` re-couples app health, so it's not a mesh-SLI target.)

## Changes in the amendment

- **Primary probe target → egress `/-/-/live` local-reply** (drop real-service probing).
- **Small agent xDS prerequisite**: emit a reserved liveness `direct_response: 200` route on the **egress** listener (the prober is an egress client; `/-/-/live` today is inbound-only). Nearly free — the agent already generates egress routes + uses `direct_response` (`route.go`, `healthgateway.go`).
- **Two tiers**: `liveness` (primary, headline SLO; catches the hot-restart connection-down blind spot) vs an optional **echo-upstream `reachability`** tier (routing/EDS/transport/dest-proxy, decoupled from app health) — mirrors the mesh structural-health split.
- Liveness tier needs **no** `config.aether.io/upstreams` (never leaves the proxy); metric gains a `tier` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)