### PR TITLE
feat(prober): synthetic mesh-availability prober (proposal 013)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,3 +46,4 @@ jobs:
         run: |
           bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/agent:agent.push
           bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/registrar:registrar.push
+          bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/prober:prober.push

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -73,6 +73,20 @@ func buildOnDemandCatchAllVirtualHost(meshDomain string) *routev3.VirtualHost {
 		Name:    "on_demand_catch_all",
 		Domains: []string{"*"},
 		Routes: []*routev3.Route{
+			// Egress liveness: a local-reply 200 on MeshLivePath, answered without
+			// leaving the proxy (no upstream, no app), for the synthetic mesh
+			// availability prober (proposal 013). First so it wins for this exact
+			// path regardless of authority; the prober uses a reserved non-service
+			// authority so it lands on this catch-all vhost. A 200 proves this
+			// node's egress listener is serving + config loaded; a connection error
+			// proves it is not — the signal aether_stats (proxy-emitted) is
+			// structurally blind to during hot restarts.
+			{
+				Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Path{Path: MeshLivePath}},
+				Action: &routev3.Route_DirectResponse{
+					DirectResponse: &routev3.DirectResponseAction{Status: 200},
+				},
+			},
 			{
 				Match: &routev3.RouteMatch{
 					PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"},

--- a/agent/internal/xds/proxy/route_test.go
+++ b/agent/internal/xds/proxy/route_test.go
@@ -46,12 +46,15 @@ func TestBuildOutboundRouteConfiguration(t *testing.T) {
 			require.Len(t, routeConfig.GetVirtualHosts(), tt.expectLen+1)
 			catchAll := routeConfig.GetVirtualHosts()[tt.expectLen]
 			assert.Equal(t, []string{"*"}, catchAll.GetDomains())
-			// Route 1: mesh-shaped authority (regex) -> ODCDS cluster_header.
-			// Route 2: everything else -> instant 404.
-			require.Len(t, catchAll.GetRoutes(), 2)
-			assert.Equal(t, onDemandClusterHeader, catchAll.GetRoutes()[0].GetRoute().GetClusterHeader())
-			assert.NotEmpty(t, catchAll.GetRoutes()[0].GetMatch().GetHeaders(), "mesh-authority regex gate")
-			assert.Equal(t, uint32(404), catchAll.GetRoutes()[1].GetDirectResponse().GetStatus())
+			// Route 1: liveness local-reply 200 on MeshLivePath (proposal 013).
+			// Route 2: mesh-shaped authority (regex) -> ODCDS cluster_header.
+			// Route 3: everything else -> instant 404.
+			require.Len(t, catchAll.GetRoutes(), 3)
+			assert.Equal(t, MeshLivePath, catchAll.GetRoutes()[0].GetMatch().GetPath())
+			assert.Equal(t, uint32(200), catchAll.GetRoutes()[0].GetDirectResponse().GetStatus())
+			assert.Equal(t, onDemandClusterHeader, catchAll.GetRoutes()[1].GetRoute().GetClusterHeader())
+			assert.NotEmpty(t, catchAll.GetRoutes()[1].GetMatch().GetHeaders(), "mesh-authority regex gate")
+			assert.Equal(t, uint32(404), catchAll.GetRoutes()[2].GetDirectResponse().GetStatus())
 		})
 	}
 }
@@ -90,7 +93,15 @@ func TestOutboundRetryPolicy(t *testing.T) {
 		"cluster vhost":   BuildOutboundClusterVirtualHost("svc-1.aether.internal", []string{"svc-1.aether.internal"}),
 		"catch-all vhost": buildOnDemandCatchAllVirtualHost("aether.internal"),
 	} {
-		rp := vh.GetRoutes()[0].GetRoute().GetRetryPolicy()
+		// Find the routed (non-direct-response) route; the catch-all leads with a
+		// liveness direct_response route (see TestEgressLivenessRoute).
+		var rp *routev3.RetryPolicy
+		for _, r := range vh.GetRoutes() {
+			if r.GetRoute() != nil {
+				rp = r.GetRoute().GetRetryPolicy()
+				break
+			}
+		}
 		require.NotNil(t, rp, name)
 		assert.Equal(t, "connect-failure,refused-stream,reset-before-request,retriable-status-codes", rp.GetRetryOn(), name)
 		assert.Equal(t, []uint32{503}, rp.GetRetriableStatusCodes(), name)
@@ -98,4 +109,16 @@ func TestOutboundRetryPolicy(t *testing.T) {
 		require.Len(t, rp.GetRetryHostPredicate(), 1, name)
 		assert.Equal(t, "envoy.retry_host_predicates.previous_hosts", rp.GetRetryHostPredicate()[0].GetName(), name)
 	}
+}
+
+// TestEgressLivenessRoute: the outbound catch-all leads with a local-reply 200 on
+// MeshLivePath (proposal 013 prober), matched by exact path before the
+// authority-regex/404 routes, so it wins regardless of authority.
+func TestEgressLivenessRoute(t *testing.T) {
+	vh := buildOnDemandCatchAllVirtualHost("aether.internal")
+	require.NotEmpty(t, vh.GetRoutes())
+	live := vh.GetRoutes()[0]
+	assert.Equal(t, MeshLivePath, live.GetMatch().GetPath(), "liveness must be an exact-path match")
+	require.NotNil(t, live.GetDirectResponse(), "liveness must be a direct_response")
+	assert.Equal(t, uint32(200), live.GetDirectResponse().GetStatus())
 }

--- a/charts/prober/BUILD.bazel
+++ b/charts/prober/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_helm//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_template_test")
+
+# prober Helm chart (published as ghcr.io/bpalermo/aether/charts/prober).
+#
+# Publish targets (GitHub Container Registry, OCI):
+#   bazel run //charts/prober:prober.push           # chart + image
+#   bazel run //charts/prober:prober.push_registry  # chart only
+# Authenticate first via HELM_REGISTRY_USERNAME / HELM_REGISTRY_PASSWORD.
+helm_chart(
+    name = "prober",
+    chart = "Chart.yaml",
+    images = [
+        "//prober/cmd/prober:image_push",
+    ],
+    login_url = "ghcr.io",
+    registry_url = "oci://ghcr.io/bpalermo/aether/charts",
+    values = "values.yaml",
+    visibility = ["//visibility:public"],
+)
+
+helm_lint_test(
+    name = "prober_lint_test",
+    chart = ":prober",
+)
+
+helm_template_test(
+    name = "prober_template_test",
+    chart = ":prober",
+)

--- a/charts/prober/Chart.yaml
+++ b/charts/prober/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: prober
+description: |
+  Aether synthetic mesh-availability prober (proposal 013). Deploys a per-node
+  DaemonSet that black-box probes the mesh data plane from the client side
+  (a proxy local-reply liveness endpoint) and emits its own pass/fail SLI,
+  capturing the connection-level failures the proxy-emitted aether_stats metric
+  is structurally blind to during hot restarts.
+type: application
+# Stamped at package time when built with `--stamp` (see registrar Chart.yaml).
+version: "0.1.0-{GIT_COMMIT}"
+appVersion: "{STABLE_GIT_VERSION}"
+keywords:
+  - aether
+  - service-mesh
+  - prober
+  - sli
+sources:
+  - https://github.com/bpalermo/aether

--- a/charts/prober/templates/_helpers.tpl
+++ b/charts/prober/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Chart name, optionally overridden via nameOverride.
+*/}}
+{{- define "prober.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Fully qualified, release-prefixed name.
+*/}}
+{{- define "prober.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Namespace the chart deploys into. Defaults to the release namespace.
+*/}}
+{{- define "prober.namespace" -}}
+{{- default .Release.Namespace .Values.namespace.name -}}
+{{- end -}}
+
+{{/*
+ServiceAccount name.
+*/}}
+{{- define "prober.serviceAccountName" -}}
+{{- include "prober.fullname" . -}}
+{{- end -}}
+
+{{/*
+Chart label value (name-version).
+*/}}
+{{- define "prober.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Selector labels (immutable subset).
+*/}}
+{{- define "prober.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prober.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: prober
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "prober.labels" -}}
+helm.sh/chart: {{ include "prober.chart" . }}
+{{ include "prober.selectorLabels" . }}
+app.kubernetes.io/part-of: aether
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}

--- a/charts/prober/templates/daemonset.yaml
+++ b/charts/prober/templates/daemonset.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "prober.fullname" . }}
+  namespace: {{ include "prober.namespace" . }}
+  labels:
+    {{- include "prober.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "prober.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "prober.labels" . | nindent 8 }}
+        # Mesh injection: the CNI intercepts this pod and the agent plumbs the
+        # per-pod egress listener at {{ .Values.probe.egress }}.
+        aether.io/managed: "true"
+      {{- with .Values.probe.reachabilityTargets }}
+      annotations:
+        # Reachability tier only: authorize the echo upstream clusters (proposal 004).
+        config.aether.io/upstreams: {{ join "," . | quote }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "prober.serviceAccountName" . }}
+      containers:
+        - name: prober
+          image: {{ .Values.image.ref | quote }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--egress={{ .Values.probe.egress }}"
+            - "--liveness-path={{ .Values.probe.livenessPath }}"
+            - "--liveness-authority={{ .Values.probe.livenessAuthority }}"
+            - "--mesh-domain={{ .Values.probe.meshDomain }}"
+            - "--rate={{ .Values.probe.rate }}"
+            - "--timeout={{ .Values.probe.timeout }}"
+            {{- with .Values.probe.reachabilityTargets }}
+            - "--reachability-targets={{ join "," . }}"
+            {{- end }}
+            {{- with .Values.telemetry.otlpEndpoint }}
+            - "--otlp-endpoint={{ . }}"
+            {{- end }}
+          env:
+            # Per-node de-collapse: stamp the node onto the OTel resource so probe
+            # series are one-per-node (see PR #210 / the collector transform/promote).
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.node.name=$(NODE_NAME),k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME)"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/prober/templates/namespace.yaml
+++ b/charts/prober/templates/namespace.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "prober.namespace" . }}
+  labels:
+    {{- include "prober.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/prober/templates/serviceaccount.yaml
+++ b/charts/prober/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prober.serviceAccountName" . }}
+  namespace: {{ include "prober.namespace" . }}
+  labels:
+    {{- include "prober.labels" . | nindent 4 }}

--- a/charts/prober/values.yaml
+++ b/charts/prober/values.yaml
@@ -1,0 +1,47 @@
+# Default values for the prober chart.
+
+nameOverride: ""
+fullnameOverride: ""
+
+# Namespace the prober DaemonSet is deployed into. Must be a namespace whose pods
+# are mesh-managed so the CNI plumbs the local egress listener (e.g. aether-test).
+namespace:
+  create: false
+  name: ""
+
+image:
+  # Substituted at package time with the digest-pinned reference produced by
+  # //prober/cmd/prober:image_push.
+  ref: "{@//prober/cmd/prober:image_push}"
+  pullPolicy: Always
+
+# Probe settings (see prober flags).
+probe:
+  # Local mesh egress listener the prober dials.
+  egress: "127.0.0.1:18081"
+  # Proxy local-reply liveness route (agent emits a direct_response 200 here).
+  livenessPath: "/-/-/live"
+  # Reserved, non-service Host authority for the liveness probe.
+  livenessAuthority: "liveness.aether.internal"
+  # Probes/sec per target.
+  rate: 5
+  # Per-probe timeout.
+  timeout: "2s"
+  # Mesh authority suffix for the reachability tier.
+  meshDomain: "aether.internal"
+  # Optional reachability tier: echo upstream service names. When non-empty, the
+  # pod gets config.aether.io/upstreams so the agent programs those clusters.
+  reachabilityTargets: []
+
+# OTel: push the probe SLI to the collector (host:port, insecure). Empty disables
+# telemetry (the prober still runs but emits nothing).
+telemetry:
+  otlpEndpoint: ""
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+  limits:
+    cpu: 50m
+    memory: 64Mi

--- a/prober/cmd/prober/BUILD.bazel
+++ b/prober/cmd/prober/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/img:go_multi_arch_image.bzl", "go_multi_arch_image")
+
+go_library(
+    name = "prober_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/bpalermo/aether/prober/cmd/prober",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prober/internal/cmd",
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+    ],
+)
+
+go_binary(
+    name = "prober",
+    embed = [":prober_lib"],
+    visibility = ["//visibility:public"],
+    x_defs = {
+        "github.com/bpalermo/aether/prober/internal/cmd.Version": "{STABLE_GIT_VERSION}",
+    },
+)
+
+go_multi_arch_image(
+    name = "prober_image",
+    binary = ":prober",
+    repository = "bpalermo/aether/prober",
+)

--- a/prober/cmd/prober/main.go
+++ b/prober/cmd/prober/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"os"
+
+	"github.com/bpalermo/aether/prober/internal/cmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func main() {
+	ctx := ctrl.SetupSignalHandler()
+	if err := cmd.GetCommand().ExecuteContext(ctx); err != nil {
+		os.Exit(1)
+	}
+}

--- a/prober/cmd/prober/testdata/container_test.yaml
+++ b/prober/cmd/prober/testdata/container_test.yaml
@@ -1,0 +1,10 @@
+schemaVersion: 2.0.0
+metadataTest:
+  entrypoint: ["/prober"]
+  user: 65532 # nonroot
+fileExistenceTests:
+  - name: 'prober'
+    path: '/prober'
+    shouldExist: true
+    permissions: '-rwxr-xr-x'
+    isExecutableBy: 'other'

--- a/prober/internal/cmd/BUILD.bazel
+++ b/prober/internal/cmd/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cmd",
+    srcs = ["root.go"],
+    importpath = "github.com/bpalermo/aether/prober/internal/cmd",
+    visibility = ["//prober:__subpackages__"],
+    deps = [
+        "//prober/internal/prober",
+        "@com_github_spf13_cobra//:cobra",
+        "@io_k8s_sigs_controller_runtime//pkg/log/zap",
+    ],
+)

--- a/prober/internal/cmd/root.go
+++ b/prober/internal/cmd/root.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/bpalermo/aether/prober/internal/prober"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Version is stamped at build time (see BUILD.bazel x_defs).
+var Version = "dev"
+
+// GetCommand builds the prober root command.
+func GetCommand() *cobra.Command {
+	cfg := prober.DefaultConfig()
+	cmd := &cobra.Command{
+		Use:   "prober",
+		Short: "Synthetic mesh-availability prober (proposal 013)",
+		Long: "Black-box probes the mesh data plane from the client side and emits its own " +
+			"pass/fail SLI, capturing the connection-level failures the proxy-emitted " +
+			"aether_stats metric is structurally blind to during hot restarts.",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, _ []string) error {
+			log := zap.New()
+			p, err := prober.New(c.Context(), cfg, log, Version)
+			if err != nil {
+				return fmt.Errorf("init prober: %w", err)
+			}
+			return p.Run(c.Context())
+		},
+	}
+
+	f := cmd.Flags()
+	f.StringVar(&cfg.Egress, "egress", cfg.Egress, "local mesh egress listener host:port")
+	f.StringVar(&cfg.LivenessPath, "liveness-path", cfg.LivenessPath, "proxy local-reply liveness route path")
+	f.StringVar(&cfg.LivenessAuthority, "liveness-authority", cfg.LivenessAuthority, "reserved Host authority for the liveness probe (must not be a real service)")
+	f.StringVar(&cfg.MeshDomain, "mesh-domain", cfg.MeshDomain, "mesh authority suffix for reachability targets")
+	f.StringSliceVar(&cfg.ReachabilityTargets, "reachability-targets", cfg.ReachabilityTargets, "optional echo upstream service names for the reachability tier")
+	f.Float64Var(&cfg.Rate, "rate", cfg.Rate, "probes per second per target")
+	f.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "per-probe timeout")
+	f.IntVar(&cfg.MaxConcurrent, "max-concurrent", cfg.MaxConcurrent, "max in-flight probes per target")
+	f.StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", cfg.OTLPEndpoint, "OTLP gRPC collector endpoint host:port; empty disables telemetry")
+	return cmd
+}

--- a/prober/internal/prober/BUILD.bazel
+++ b/prober/internal/prober/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "prober",
+    srcs = ["prober.go"],
+    importpath = "github.com/bpalermo/aether/prober/internal/prober",
+    visibility = ["//prober:__subpackages__"],
+    deps = [
+        "@com_github_go_logr_logr//:logr",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel//semconv/v1.30.0:v1_30_0",
+        "@io_opentelemetry_go_otel_exporters_otlp_otlpmetric_otlpmetricgrpc//:otlpmetricgrpc",
+        "@io_opentelemetry_go_otel_metric//:metric",
+        "@io_opentelemetry_go_otel_metric//noop",
+        "@io_opentelemetry_go_otel_sdk//resource",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+    ],
+)
+
+go_test(
+    name = "prober_test",
+    srcs = ["prober_test.go"],
+    embed = [":prober"],
+    deps = ["@com_github_go_logr_logr//:logr"],
+)

--- a/prober/internal/prober/prober.go
+++ b/prober/internal/prober/prober.go
@@ -1,0 +1,262 @@
+// Package prober is a synthetic mesh-availability prober (proposal 013). It runs
+// as a per-node DaemonSet, mesh-managed like any client, and probes the mesh data
+// plane from the client side — primarily a proxy local-reply liveness endpoint
+// (direct_response, no upstream, no app) so a failure is unambiguously the mesh's
+// fault. It emits its OWN pass/fail counter, so it records the connection-level
+// failures the proxy-emitted aether_stats metric cannot (the source proxy can't
+// report its own outage).
+package prober
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+)
+
+const (
+	telemetryServiceName = "aether-prober"
+	otlpTimeout          = 10 * time.Second
+	shutdownTimeout      = 5 * time.Second
+
+	tierLiveness     = "liveness"
+	tierReachability = "reachability"
+
+	resultSuccess         = "success"
+	resultHTTPError       = "http_error"
+	resultConnectionError = "connection_error"
+	resultTimeout         = "timeout"
+	resultSaturated       = "saturated"
+)
+
+// Config configures the prober.
+type Config struct {
+	Egress              string
+	LivenessPath        string
+	LivenessAuthority   string
+	MeshDomain          string
+	ReachabilityTargets []string
+	Rate                float64
+	Timeout             time.Duration
+	MaxConcurrent       int
+	OTLPEndpoint        string
+}
+
+// DefaultConfig returns the default prober configuration.
+func DefaultConfig() Config {
+	return Config{
+		Egress:            "127.0.0.1:18081",
+		LivenessPath:      "/-/-/live",
+		LivenessAuthority: "liveness.aether.internal",
+		MeshDomain:        "aether.internal",
+		Rate:              5,
+		Timeout:           2 * time.Second,
+		MaxConcurrent:     16,
+	}
+}
+
+type target struct {
+	tier      string
+	name      string // metric "target" label
+	url       string
+	authority string
+}
+
+// Prober samples the mesh data plane and records results to OTel.
+type Prober struct {
+	cfg      Config
+	log      logr.Logger
+	client   *http.Client
+	provider *sdkmetric.MeterProvider // nil when telemetry is disabled
+	counter  metric.Int64Counter
+	duration metric.Float64Histogram
+	targets  []target
+}
+
+// New builds a Prober.
+func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Prober, error) {
+	meter, provider, err := newMeter(ctx, cfg.OTLPEndpoint, version)
+	if err != nil {
+		return nil, err
+	}
+	counter, err := meter.Int64Counter("aether_probe_requests_total",
+		metric.WithDescription("Synthetic mesh probe results by tier/target/result."))
+	if err != nil {
+		return nil, fmt.Errorf("probe counter: %w", err)
+	}
+	duration, err := meter.Float64Histogram("aether_probe_request_duration_seconds",
+		metric.WithDescription("Synthetic mesh probe duration."), metric.WithUnit("s"))
+	if err != nil {
+		return nil, fmt.Errorf("probe histogram: %w", err)
+	}
+
+	p := &Prober{
+		cfg: cfg, log: log, counter: counter, duration: duration, provider: provider,
+		client: &http.Client{
+			// No client.Timeout: the per-probe deadline is a context so we can tell
+			// timeout from connection error. Don't follow redirects.
+			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		},
+	}
+
+	// Liveness tier (always): hit the proxy's egress local-reply route. No upstream
+	// is involved, so this needs no config.aether.io/upstreams authorization.
+	p.targets = append(p.targets, target{
+		tier:      tierLiveness,
+		name:      "egress",
+		url:       "http://" + cfg.Egress + cfg.LivenessPath,
+		authority: cfg.LivenessAuthority,
+	})
+	// Reachability tier (optional): full round-trip to an echo upstream.
+	for _, svc := range cfg.ReachabilityTargets {
+		p.targets = append(p.targets, target{
+			tier:      tierReachability,
+			name:      svc,
+			url:       "http://" + cfg.Egress + "/",
+			authority: svc + "." + cfg.MeshDomain,
+		})
+	}
+	return p, nil
+}
+
+func newMeter(ctx context.Context, endpoint, version string) (metric.Meter, *sdkmetric.MeterProvider, error) {
+	if endpoint == "" {
+		return noop.NewMeterProvider().Meter(telemetryServiceName), nil, nil
+	}
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
+			semconv.ServiceName(telemetryServiceName),
+			semconv.ServiceVersion(version),
+		),
+		resource.WithFromEnv(), // picks up OTEL_RESOURCE_ATTRIBUTES (k8s.node.name)
+		resource.WithTelemetrySDK(),
+		resource.WithProcess(),
+		resource.WithHost(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create resource: %w", err)
+	}
+	exporter, err := otlpmetricgrpc.New(ctx,
+		otlpmetricgrpc.WithEndpoint(endpoint),
+		otlpmetricgrpc.WithInsecure(),
+		otlpmetricgrpc.WithTimeout(otlpTimeout),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create OTLP exporter: %w", err)
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithResource(res),
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(exporter)),
+	)
+	return mp.Meter(telemetryServiceName), mp, nil
+}
+
+// Run samples all targets until ctx is cancelled, then flushes telemetry.
+func (p *Prober) Run(ctx context.Context) error {
+	p.log.Info("prober starting", "targets", len(p.targets), "rate", p.cfg.Rate, "egress", p.cfg.Egress)
+	var wg sync.WaitGroup
+	for _, t := range p.targets {
+		wg.Add(1)
+		go func(t target) {
+			defer wg.Done()
+			p.runTarget(ctx, t)
+		}(t)
+	}
+	wg.Wait()
+	if p.provider != nil {
+		sctx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+		defer cancel()
+		if err := p.provider.Shutdown(sctx); err != nil {
+			p.log.Error(err, "telemetry shutdown")
+		}
+	}
+	return nil
+}
+
+func (p *Prober) runTarget(ctx context.Context, t target) {
+	interval := time.Second
+	if p.cfg.Rate > 0 {
+		interval = time.Duration(float64(time.Second) / p.cfg.Rate)
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	// Bound in-flight probes so a hung hop never blocks the open-loop ticker.
+	sem := make(chan struct{}, max(1, p.cfg.MaxConcurrent))
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			select {
+			case sem <- struct{}{}:
+				go func() {
+					defer func() { <-sem }()
+					p.probe(ctx, t)
+				}()
+			default:
+				p.record(t, resultSaturated, 0)
+			}
+		}
+	}
+}
+
+func (p *Prober) probe(ctx context.Context, t target) {
+	rctx, cancel := context.WithTimeout(ctx, p.cfg.Timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(rctx, http.MethodGet, t.url, nil)
+	if err != nil {
+		p.record(t, resultConnectionError, 0)
+		return
+	}
+	req.Host = t.authority
+	start := time.Now()
+	resp, err := p.client.Do(req)
+	elapsed := time.Since(start).Seconds()
+	if err != nil {
+		p.record(t, classifyErr(rctx, err), elapsed)
+		return
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		p.record(t, resultSuccess, elapsed)
+		return
+	}
+	p.record(t, resultHTTPError, elapsed)
+}
+
+// classifyErr maps a request error to a result. connection_error is the class the
+// proxy-emitted metric is blind to (no response produced / listener down).
+func classifyErr(ctx context.Context, err error) string {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		return resultTimeout
+	}
+	var ne net.Error
+	if errors.As(err, &ne) && ne.Timeout() {
+		return resultTimeout
+	}
+	return resultConnectionError
+}
+
+func (p *Prober) record(t target, result string, elapsed float64) {
+	attrs := metric.WithAttributes(
+		attribute.String("tier", t.tier),
+		attribute.String("target", t.name),
+		attribute.String("result", result),
+	)
+	p.counter.Add(context.Background(), 1, attrs)
+	if elapsed > 0 {
+		p.duration.Record(context.Background(), elapsed, attrs)
+	}
+}

--- a/prober/internal/prober/prober_test.go
+++ b/prober/internal/prober/prober_test.go
@@ -1,0 +1,45 @@
+package prober
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func TestClassifyErr(t *testing.T) {
+	t.Run("connection refused -> connection_error", func(t *testing.T) {
+		err := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+		if got := classifyErr(context.Background(), err); got != resultConnectionError {
+			t.Fatalf("got %q, want %q", got, resultConnectionError)
+		}
+	})
+	t.Run("deadline -> timeout", func(t *testing.T) {
+		if got := classifyErr(context.Background(), context.DeadlineExceeded); got != resultTimeout {
+			t.Fatalf("got %q, want %q", got, resultTimeout)
+		}
+	})
+}
+
+func TestNewTargets(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ReachabilityTargets = []string{"svc-1", "svc-2"}
+	p, err := New(context.Background(), cfg, logr.Discard(), "test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if len(p.targets) != 3 {
+		t.Fatalf("want 3 targets (1 liveness + 2 reachability), got %d", len(p.targets))
+	}
+	if p.targets[0].tier != tierLiveness {
+		t.Fatalf("first target tier = %q, want liveness", p.targets[0].tier)
+	}
+	if want := "http://127.0.0.1:18081/-/-/live"; p.targets[0].url != want {
+		t.Fatalf("liveness url = %q, want %q", p.targets[0].url, want)
+	}
+	if want := "svc-1.aether.internal"; p.targets[1].authority != want {
+		t.Fatalf("reachability authority = %q, want %q", p.targets[1].authority, want)
+	}
+}


### PR DESCRIPTION
Implements **proposal 013** — a synthetic prober that measures mesh availability from the **client side**, capturing the connection-level failures the proxy-emitted `aether_stats` metric is structurally blind to during churn (the 2026-06-17 soak: k6 saw ~501k failures, the mesh metric recorded 9).

## Changes

**Agent — egress liveness route** (`agent/internal/xds/proxy/route.go`)
- Prepends a `direct_response: 200` on `MeshLivePath` (`/-/-/live`) to the outbound catch-all vhost, answered **locally** (no upstream, no app). A 200 ⇒ this node's egress listener is serving + config loaded; a connection error ⇒ it isn't. Exact-path match so it wins regardless of authority. +unit tests.

**`prober/` — new Go component** (mirrors agent/registrar/cni)
- `cmd/prober` (cobra) + `internal/prober` open-loop sampler: `time.Ticker` at `--rate`/s, bounded in-flight workers (`saturated` if over cap), per-probe context timeout.
- Result classification: `success / http_error / connection_error / timeout / saturated` — `connection_error` is the blind-spot class.
- OTel `aether_probe_requests_total{tier,target,result}` + duration histogram; per-node resource attr via `OTEL_RESOURCE_ATTRIBUTES` (à la #210). Telemetry no-ops if `--otlp-endpoint` empty.
- **Liveness tier** (primary, hits `/-/-/live`, needs no upstreams) + optional **echo-upstream reachability tier**.

**`charts/prober`** — DaemonSet (one mesh-managed pod per node, `aether.io/managed=true`), nonroot, off by default. `publish.yaml` publishes the chart+image on merge.

## Validation
`bazel test //prober/... //charts/prober:all //agent/internal/xds/proxy:proxy_test` — all green (incl. the image structure test and new route tests).

After merge → CI publishes the prober image+chart → deploy on talos-main (enable the chart) and validate the liveness SLI tracks a manual proxy roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)