### PR TITLE
feat(proxy): OTel access logs to the collector (proposal 014)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -126,6 +126,7 @@ use_repo(
     "io_opentelemetry_go_otel_sdk",
     "io_opentelemetry_go_otel_sdk_metric",
     "io_opentelemetry_go_otel_trace",
+    "io_opentelemetry_go_proto_otlp",
     "org_golang_google_grpc",
     "org_golang_google_protobuf",
     "org_golang_x_sys",

--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//agent/internal/spire",
         "//agent/internal/xds/ack",
         "//agent/internal/xds/cache",
+        "//agent/internal/xds/proxy",
         "//agent/internal/xds/server",
         "//agent/storage",
         "//api/aether/cni/v1:cni",

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -34,6 +34,13 @@ type AgentConfig struct {
 	// aether_stats request counter. Off by default to bound cardinality.
 	EmitStatsPod bool
 
+	// AccessLogsEnabled attaches the OTel access logger to every HCM (proposal
+	// 014), pushing per-request OTLP logs to the collector. Off by default.
+	AccessLogsEnabled bool
+	// AccessLogSuccessSampleRate is the percent (0-100) of successful requests
+	// logged; failures (any response flag / status >= 500) are always logged.
+	AccessLogSuccessSampleRate uint32
+
 	// SpireEnabled controls whether the SPIRE bridge is started
 	SpireEnabled bool
 	// SpireAdminSocketPath is the path to the SPIRE agent admin socket

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/spire"
 	"github.com/bpalermo/aether/agent/internal/xds/ack"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	xdsServer "github.com/bpalermo/aether/agent/internal/xds/server"
 	"github.com/bpalermo/aether/agent/storage"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
@@ -98,6 +99,8 @@ func init() {
 	// Mesh routing configuration
 	rootCmd.Flags().StringVar(&cfg.MeshDomain, "mesh-domain", cfg.MeshDomain, "DNS-style domain mesh authorities live under (clients call <service>.<mesh-domain>)")
 	rootCmd.Flags().BoolVar(&cfg.EmitStatsPod, "stats-emit-pod", cfg.EmitStatsPod, "emit per-pod labels (source_pod/destination_pod) on the aether_stats request counter (raises cardinality)")
+	rootCmd.Flags().BoolVar(&cfg.AccessLogsEnabled, "access-logs-enabled", cfg.AccessLogsEnabled, "attach the OTel access logger to every HCM, pushing per-request OTLP logs to the collector (proposal 014)")
+	rootCmd.Flags().Uint32Var(&cfg.AccessLogSuccessSampleRate, "access-log-success-sample-rate", 100, "percent (0-100) of successful requests logged; failures are always logged")
 
 	// SPIRE and security configuration
 	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", true, "Whether to enable SPIRE integration for X.509 SVID management and mTLS")
@@ -183,6 +186,11 @@ func runAgent(ctx context.Context) (retErr error) {
 	snapshotCache := cache.NewSnapshotCache(cfg.NodeName, l)
 	snapshotCache.SetMeshDomain(cfg.MeshDomain)
 	snapshotCache.SetEmitStatsPod(cfg.EmitStatsPod)
+	// Global access-log config, set once before the cache builds any listener.
+	proxy.SetAccessLogConfig(proxy.AccessLogConfig{
+		Enabled:           cfg.AccessLogsEnabled,
+		SuccessSampleRate: cfg.AccessLogSuccessSampleRate,
+	})
 
 	// Tracks Envoy's delta-xDS ACK/NACKs so the CNI server can confirm (and
 	// diagnose) config delivery without polling the Envoy admin interface.

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "proxy",
     srcs = [
+        "accesslog.go",
         "cluster.go",
         "egress.go",
         "endpoint.go",
@@ -30,11 +31,14 @@ go_library(
         "@com_github_cncf_xds_go//xds/core/v3:core",
         "@com_github_cncf_xds_go//xds/type/matcher/v3:matcher",
         "@com_github_cncf_xds_go//xds/type/v3:type",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/accesslog/v3:accesslog",
         "@com_github_envoyproxy_go_control_plane_envoy//config/cluster/v3:cluster",
         "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/grpc/v3:grpc",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/open_telemetry/v3:open_telemetry",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",
@@ -48,6 +52,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_envoyproxy_go_control_plane_envoy//type/matcher/v3:matcher",
         "@com_github_envoyproxy_go_control_plane_envoy//type/v3:type",
+        "@io_opentelemetry_go_proto_otlp//common/v1:common",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
@@ -59,6 +64,7 @@ go_library(
 go_test(
     name = "proxy_test",
     srcs = [
+        "accesslog_test.go",
         "egress_test.go",
         "endpoint_test.go",
         "filterchain_test.go",
@@ -88,6 +94,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/open_telemetry/v3:open_telemetry",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",

--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -1,0 +1,141 @@
+package proxy
+
+import (
+	"github.com/bpalermo/aether/agent/internal/xds/config"
+	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	grpcaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
+	otelaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/open_telemetry/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	otlpcommonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+const (
+	accessLogName        = "aether_access"
+	accessLogStatusKey   = "aether.access_log.min_status"
+	accessLogSampleKey   = "aether.access_log.sample"
+	accessLogMinStatus   = 500
+	defaultCollectorName = "otel_collector"
+
+	// ReporterSource/ReporterDestination tag an access log entry with the hop that
+	// emitted it (egress client side vs per-pod inbound server side), mirroring the
+	// aether_stats `reporter` label.
+	ReporterSource      = "source"
+	ReporterDestination = "destination"
+)
+
+// AccessLogConfig is the global access-log configuration. It is set ONCE at agent
+// startup (SetAccessLogConfig) before the snapshot cache builds any listener, then
+// read without locking — the same set-once pattern as SnapshotCache.emitStatsPod.
+type AccessLogConfig struct {
+	// Enabled turns the OTel access logger on for every HCM.
+	Enabled bool
+	// CollectorCluster is the OTLP gRPC cluster the logs are pushed to (the proxy
+	// bootstrap's "otel_collector"). Empty defaults to defaultCollectorName.
+	CollectorCluster string
+	// SuccessSampleRate is the percent (0-100) of *successful* requests logged.
+	// Failures (any response flag, or status >= 500) are always logged regardless.
+	SuccessSampleRate uint32
+}
+
+var accessLogConfig AccessLogConfig
+
+// SetAccessLogConfig sets the global access-log configuration. Call once before
+// the manager starts.
+func SetAccessLogConfig(c AccessLogConfig) { accessLogConfig = c }
+
+// buildAccessLog returns the OTel access logger for an HCM, tagged with reporter,
+// or nil when access logging is disabled. The logger pushes OTLP logs to the
+// collector cluster; the filter logs all failures plus a SuccessSampleRate sample
+// of successes.
+func buildAccessLog(reporter string) []*accesslogv3.AccessLog {
+	if !accessLogConfig.Enabled {
+		return nil
+	}
+	cluster := accessLogConfig.CollectorCluster
+	if cluster == "" {
+		cluster = defaultCollectorName
+	}
+
+	otelCfg := &otelaccesslogv3.OpenTelemetryAccessLogConfig{
+		CommonConfig: &grpcaccesslogv3.CommonGrpcAccessLogConfig{
+			LogName: accessLogName,
+			GrpcService: &corev3.GrpcService{
+				TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: cluster},
+				},
+			},
+			TransportApiVersion: corev3.ApiVersion_V3,
+		},
+		// Human-readable line; structured fields go in attributes for querying.
+		Body: stringValue("%RESPONSE_CODE% %RESPONSE_FLAGS% %REQ(:METHOD)% %REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %DURATION%ms -> %UPSTREAM_HOST%"),
+		Attributes: &otlpcommonv1.KeyValueList{Values: []*otlpcommonv1.KeyValue{
+			kv("reporter", reporter),
+			kv("response_code", "%RESPONSE_CODE%"),
+			kv("response_flags", "%RESPONSE_FLAGS%"),
+			kv("method", "%REQ(:METHOD)%"),
+			kv("authority", "%REQ(:AUTHORITY)%"),
+			kv("path", "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"),
+			kv("protocol", "%PROTOCOL%"),
+			kv("duration_ms", "%DURATION%"),
+			kv("upstream_service_time", "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"),
+			kv("bytes_sent", "%BYTES_SENT%"),
+			kv("bytes_received", "%BYTES_RECEIVED%"),
+			kv("upstream_host", "%UPSTREAM_HOST%"),
+			kv("upstream_cluster", "%UPSTREAM_CLUSTER%"),
+			kv("x_request_id", "%REQ(X-REQUEST-ID)%"),
+			kv("source_netns", "%FILTER_STATE(aether.network.network_namespace:PLAIN)%"),
+		}},
+	}
+
+	return []*accesslogv3.AccessLog{{
+		Name:       "envoy.access_loggers.open_telemetry",
+		Filter:     accessLogFilter(),
+		ConfigType: &accesslogv3.AccessLog_TypedConfig{TypedConfig: config.TypedConfig(otelCfg)},
+	}}
+}
+
+// accessLogFilter logs every failure (any response flag OR status >= 500) plus a
+// SuccessSampleRate% sample of everything else.
+func accessLogFilter() *accesslogv3.AccessLogFilter {
+	return &accesslogv3.AccessLogFilter{
+		FilterSpecifier: &accesslogv3.AccessLogFilter_OrFilter{
+			OrFilter: &accesslogv3.OrFilter{
+				Filters: []*accesslogv3.AccessLogFilter{
+					{FilterSpecifier: &accesslogv3.AccessLogFilter_ResponseFlagFilter{
+						ResponseFlagFilter: &accesslogv3.ResponseFlagFilter{},
+					}},
+					{FilterSpecifier: &accesslogv3.AccessLogFilter_StatusCodeFilter{
+						StatusCodeFilter: &accesslogv3.StatusCodeFilter{
+							Comparison: &accesslogv3.ComparisonFilter{
+								Op: accesslogv3.ComparisonFilter_GE,
+								Value: &corev3.RuntimeUInt32{
+									DefaultValue: accessLogMinStatus,
+									RuntimeKey:   accessLogStatusKey,
+								},
+							},
+						},
+					}},
+					{FilterSpecifier: &accesslogv3.AccessLogFilter_RuntimeFilter{
+						RuntimeFilter: &accesslogv3.RuntimeFilter{
+							RuntimeKey: accessLogSampleKey,
+							PercentSampled: &typev3.FractionalPercent{
+								Numerator:   accessLogConfig.SuccessSampleRate,
+								Denominator: typev3.FractionalPercent_HUNDRED,
+							},
+							UseIndependentRandomness: true,
+						},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func stringValue(s string) *otlpcommonv1.AnyValue {
+	return &otlpcommonv1.AnyValue{Value: &otlpcommonv1.AnyValue_StringValue{StringValue: s}}
+}
+
+func kv(key, val string) *otlpcommonv1.KeyValue {
+	return &otlpcommonv1.KeyValue{Key: key, Value: stringValue(val)}
+}

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	"testing"
+
+	otelaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/open_telemetry/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestBuildAccessLogDisabled(t *testing.T) {
+	t.Cleanup(func() { SetAccessLogConfig(AccessLogConfig{}) })
+	SetAccessLogConfig(AccessLogConfig{Enabled: false})
+	assert.Nil(t, buildAccessLog(ReporterSource))
+}
+
+func TestBuildAccessLogEnabled(t *testing.T) {
+	t.Cleanup(func() { SetAccessLogConfig(AccessLogConfig{}) })
+	SetAccessLogConfig(AccessLogConfig{Enabled: true, SuccessSampleRate: 100})
+
+	logs := buildAccessLog(ReporterDestination)
+	require.Len(t, logs, 1)
+	al := logs[0]
+	assert.Equal(t, "envoy.access_loggers.open_telemetry", al.GetName())
+
+	// Filter: OR(response_flag, status>=500, runtime sample) so failures always log.
+	require.NotNil(t, al.GetFilter().GetOrFilter())
+	assert.Len(t, al.GetFilter().GetOrFilter().GetFilters(), 3)
+
+	// Decode the OTel config: collector cluster default + reporter attribute.
+	var cfg otelaccesslogv3.OpenTelemetryAccessLogConfig
+	require.NoError(t, proto.Unmarshal(al.GetTypedConfig().GetValue(), &cfg))
+	assert.Equal(t, defaultCollectorName, cfg.GetCommonConfig().GetGrpcService().GetEnvoyGrpc().GetClusterName())
+
+	var reporter string
+	for _, kv := range cfg.GetAttributes().GetValues() {
+		if kv.GetKey() == "reporter" {
+			reporter = kv.GetValue().GetStringValue()
+		}
+	}
+	assert.Equal(t, ReporterDestination, reporter)
+}

--- a/agent/internal/xds/proxy/filterchain.go
+++ b/agent/internal/xds/proxy/filterchain.go
@@ -20,7 +20,7 @@ import (
 // module .so on the proxy unconditionally; Envoy rejects the listener if the
 // referenced dynamic module is absent.
 func buildDefaultOutboundHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager("outbound_http", nil)
+	hcm := buildHTTPConnectionManager("outbound_http", ReporterSource, nil)
 
 	// strip_any_host_port stays OFF: the authority port is a first-class routing
 	// selector (FQDN:port → that port's cluster, proposal 005). The default-port

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -115,7 +115,7 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 // is the default (no match criteria). chainPort selects both the app cluster
 // and the chain name suffix.
 func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager("inbound", buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
+	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
 	// Liveness/readiness are answered locally before the router; everything else
 	// passes through to the pod's application. The stats filter sits after the
 	// health-check filters (so locally-answered probe requests are not counted)

--- a/agent/internal/xds/proxy/networkfilter.go
+++ b/agent/internal/xds/proxy/networkfilter.go
@@ -72,14 +72,17 @@ const downstreamIdleTimeout = 5 * time.Minute
 
 // buildHTTPConnectionManager creates an HTTP connection manager for processing HTTP traffic.
 // It includes a router HTTP filter and uses the provided route configuration.
-// If routeConfig is nil, routes will be retrieved via RDS.
-func buildHTTPConnectionManager(name string, routeConfig *routev3.RouteConfiguration) *http_connection_managerv3.HttpConnectionManager {
+// If routeConfig is nil, routes will be retrieved via RDS. reporter tags the OTel
+// access logger (ReporterSource for egress, ReporterDestination for inbound); the
+// logger is attached only when access logging is enabled (buildAccessLog → nil).
+func buildHTTPConnectionManager(name, reporter string, routeConfig *routev3.RouteConfiguration) *http_connection_managerv3.HttpConnectionManager {
 	return &http_connection_managerv3.HttpConnectionManager{
 		StatPrefix: name,
 		CodecType:  http_connection_managerv3.HttpConnectionManager_AUTO,
 		CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
 			IdleTimeout: durationpb.New(downstreamIdleTimeout),
 		},
+		AccessLog: buildAccessLog(reporter),
 		HttpFilters: []*http_connection_managerv3.HttpFilter{
 			routerHttpFilter(),
 		},

--- a/agent/internal/xds/proxy/networkfilter_test.go
+++ b/agent/internal/xds/proxy/networkfilter_test.go
@@ -46,7 +46,7 @@ func TestBuildHTTPConnectionManager(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hcm := buildHTTPConnectionManager(tt.statPrefix, tt.routeConfig)
+			hcm := buildHTTPConnectionManager(tt.statPrefix, ReporterSource, tt.routeConfig)
 
 			require.NotNil(t, hcm)
 			assert.Equal(t, tt.statPrefix, hcm.GetStatPrefix())
@@ -58,7 +58,7 @@ func TestBuildHTTPConnectionManager(t *testing.T) {
 }
 
 func TestBuildHTTPConnectionManagerFilter(t *testing.T) {
-	hcm := buildHTTPConnectionManager("test", nil)
+	hcm := buildHTTPConnectionManager("test", ReporterSource, nil)
 	filter := buildHTTPConnectionManagerFilter(hcm)
 
 	require.NotNil(t, filter)
@@ -83,7 +83,7 @@ func TestBuildSetFilterState(t *testing.T) {
 // downstream idle timeout backstop (Envoy default is 1h, which let a peer's
 // leaked upstream connections pin thousands of inbound connections).
 func TestHCMDownstreamIdleTimeout(t *testing.T) {
-	hcm := buildHTTPConnectionManager("test", nil)
+	hcm := buildHTTPConnectionManager("test", ReporterSource, nil)
 	idle := hcm.GetCommonHttpProtocolOptions().GetIdleTimeout()
 	require.NotNil(t, idle, "downstream idle timeout must be set")
 	assert.Equal(t, downstreamIdleTimeout, idle.AsDuration())

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.2.3-{GIT_COMMIT}"
+version: "0.2.4-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -63,6 +63,10 @@ spec:
             {{- if .Values.telemetry.statsEmitPod }}
             - "--stats-emit-pod"
             {{- end }}
+            {{- if .Values.telemetry.accessLogs.enabled }}
+            - "--access-logs-enabled"
+            - "--access-log-success-sample-rate={{ .Values.telemetry.accessLogs.successSampleRate }}"
+            {{- end }}
             {{- if .Values.telemetry.tracing.enabled }}
             - "--tracing-enabled=true"
             - "--trace-sample-rate={{ .Values.telemetry.tracing.sampleRate }}"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -45,6 +45,15 @@ telemetry:
   # local pod count. The metric itself ships regardless; this only adds the pod
   # dimension.
   statsEmitPod: false
+  # Per-request access logs as OTLP logs to the collector (proposal 014). When
+  # enabled, every HCM gets an OTel access logger (reporter=source on egress,
+  # destination on inbound). Failures (any response flag / status >= 500) are
+  # always logged; successSampleRate is the percent (0-100) of successful
+  # requests logged. Requires otlpEndpoint (uses the proxy's otel_collector
+  # cluster). Off by default.
+  accessLogs:
+    enabled: false
+    successSampleRate: 100
   tracing:
     # Enables OTLP trace export on the agent (`--tracing-enabled`);
     # requires otlpEndpoint.

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.65.0 // indirect
 	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -194,6 +193,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
+	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/atomic v1.11.0
 	golang.org/x/sys v0.45.0
 	golang.org/x/time v0.15.0


### PR DESCRIPTION
Implements the **proxy side of proposal 014** — Envoy access logs as OTLP logs, pushed to the proxy's existing `otel_collector` cluster (the collector → VictoriaLogs logs pipeline is the deploy-time half).

## Changes

- **`agent/internal/xds/proxy/accesslog.go`**: `AccessLogConfig` (set-once global, same pattern as `emitStatsPod`) + `buildAccessLog(reporter)` → `envoy.access_loggers.open_telemetry` with `grpc_service → otel_collector`, OTLP body + attributes (`response_code`/`response_flags`, `authority`, `path`, `upstream_host`/`cluster`, `x_request_id`, durations, source netns).
- **Filter**: `OR(response_flag_filter, status≥500, runtime sample)` — **failures always log**, plus a `successSampleRate%` sample of successes (default **100**, tunable).
- Wired into `buildHTTPConnectionManager` via a `reporter` arg: **egress = source**, **inbound = destination**.
- Agent flags `--access-logs-enabled` / `--access-log-success-sample-rate` → `proxy.SetAccessLogConfig` at startup.
- **`charts/agent`**: `telemetry.accessLogs.{enabled,successSampleRate}` (default off) + daemonset flags; chart **0.2.3 → 0.2.4**.
- Adds `go.opentelemetry.io/proto/otlp` (the access-log body/attributes types).

## Validation
`bazel test //agent/internal/xds/proxy/... //agent/internal/cmd/... //charts/agent:all` — all green (incl. new `accesslog_test.go`: disabled→nil, enabled→OTel logger with the 3-way OR filter, default collector cluster, reporter attribute).

## Follow-up (deploy-time, per 014)
Collector `logs` pipeline → `otlphttp/victorialogs` (`http://victorialogs-...:9428/insert/opentelemetry/v1/logs`), then enable `telemetry.accessLogs.enabled` on talos at a chosen sample rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)