### PR TITLE
feat(proxy): exclude health checks from access logs; drop deprecated CommonConfig

### DIFF
--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -37,7 +37,6 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
-        "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/grpc/v3:grpc",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/open_telemetry/v3:open_telemetry",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",

--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -4,18 +4,26 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	accesslogv3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	grpcaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	otelaccesslogv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/open_telemetry/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	otlpcommonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 )
 
 const (
-	accessLogName        = "aether_access"
+	accessLogName        = "aether_access_logs"
 	accessLogStatusKey   = "aether.access_log.min_status"
 	accessLogSampleKey   = "aether.access_log.sample"
 	accessLogMinStatus   = 500
 	defaultCollectorName = "otel_collector"
+
+	// meshProbePathPrefix is the reserved path prefix for the in-mesh
+	// liveness/readiness probes (MeshLivePath, MeshReadyPath). Both the inbound
+	// health_check filters and the egress local-reply liveness route answer
+	// these; the access-log filter drops them so probe traffic never reaches
+	// VictoriaLogs. No real service path uses this prefix.
+	meshProbePathPrefix = "/-/-/"
 
 	// ReporterSource/ReporterDestination tag an access log entry with the hop that
 	// emitted it (egress client side vs per-pod inbound server side), mirroring the
@@ -58,14 +66,13 @@ func buildAccessLog(reporter string) []*accesslogv3.AccessLog {
 	}
 
 	otelCfg := &otelaccesslogv3.OpenTelemetryAccessLogConfig{
-		CommonConfig: &grpcaccesslogv3.CommonGrpcAccessLogConfig{
-			LogName: accessLogName,
-			GrpcService: &corev3.GrpcService{
-				TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
-					EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: cluster},
-				},
+		// GrpcService + LogName are the current fields; the older common_config
+		// (CommonGrpcAccessLogConfig) wrapper is deprecated. Transport is V3 only.
+		LogName: accessLogName,
+		GrpcService: &corev3.GrpcService{
+			TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+				EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: cluster},
 			},
-			TransportApiVersion: corev3.ApiVersion_V3,
 		},
 		// Human-readable line; structured fields go in attributes for querying.
 		Body: stringValue("%RESPONSE_CODE% %RESPONSE_FLAGS% %REQ(:METHOD)% %REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %DURATION%ms -> %UPSTREAM_HOST%"),
@@ -95,9 +102,59 @@ func buildAccessLog(reporter string) []*accesslogv3.AccessLog {
 	}}
 }
 
-// accessLogFilter logs every failure (any response flag OR status >= 500) plus a
-// SuccessSampleRate% sample of everything else.
+// accessLogFilter keeps a log entry only when it is NOT a health/liveness probe
+// AND it is log-worthy (a failure, or part of the success sample). Health checks
+// are dropped unconditionally — including failing ones — so probe traffic
+// (proposal 013 mesh prober + inbound live/ready) never reaches VictoriaLogs.
 func accessLogFilter() *accesslogv3.AccessLogFilter {
+	return &accesslogv3.AccessLogFilter{
+		FilterSpecifier: &accesslogv3.AccessLogFilter_AndFilter{
+			AndFilter: &accesslogv3.AndFilter{
+				Filters: []*accesslogv3.AccessLogFilter{
+					notHealthCheckFilter(),
+					notProbePathFilter(),
+					logWorthyFilter(),
+				},
+			},
+		},
+	}
+}
+
+// notHealthCheckFilter drops requests Envoy marked as health checks — the inbound
+// live/ready HTTP health_check filters and the per-pod health gateway. The egress
+// liveness route is a local-reply (not health_check-marked), so notProbePathFilter
+// covers it by path.
+func notHealthCheckFilter() *accesslogv3.AccessLogFilter {
+	return &accesslogv3.AccessLogFilter{
+		FilterSpecifier: &accesslogv3.AccessLogFilter_NotHealthCheckFilter{
+			NotHealthCheckFilter: &accesslogv3.NotHealthCheckFilter{},
+		},
+	}
+}
+
+// notProbePathFilter drops any request whose :path is under the reserved mesh
+// probe prefix (MeshLivePath/MeshReadyPath), regardless of how it was answered.
+func notProbePathFilter() *accesslogv3.AccessLogFilter {
+	return &accesslogv3.AccessLogFilter{
+		FilterSpecifier: &accesslogv3.AccessLogFilter_HeaderFilter{
+			HeaderFilter: &accesslogv3.HeaderFilter{
+				Header: &routev3.HeaderMatcher{
+					Name: ":path",
+					HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+						StringMatch: &matcherv3.StringMatcher{
+							MatchPattern: &matcherv3.StringMatcher_Prefix{Prefix: meshProbePathPrefix},
+						},
+					},
+					InvertMatch: true,
+				},
+			},
+		},
+	}
+}
+
+// logWorthyFilter logs every failure (any response flag OR status >= 500) plus a
+// SuccessSampleRate% sample of everything else.
+func logWorthyFilter() *accesslogv3.AccessLogFilter {
 	return &accesslogv3.AccessLogFilter{
 		FilterSpecifier: &accesslogv3.AccessLogFilter_OrFilter{
 			OrFilter: &accesslogv3.OrFilter{

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -24,14 +24,25 @@ func TestBuildAccessLogEnabled(t *testing.T) {
 	al := logs[0]
 	assert.Equal(t, "envoy.access_loggers.open_telemetry", al.GetName())
 
-	// Filter: OR(response_flag, status>=500, runtime sample) so failures always log.
-	require.NotNil(t, al.GetFilter().GetOrFilter())
-	assert.Len(t, al.GetFilter().GetOrFilter().GetFilters(), 3)
+	// Filter: AND(not health check, not probe path, OR(response_flag, status>=500,
+	// runtime sample)) so probes are dropped and failures always log.
+	and := al.GetFilter().GetAndFilter()
+	require.NotNil(t, and)
+	require.Len(t, and.GetFilters(), 3)
+	assert.NotNil(t, and.GetFilters()[0].GetNotHealthCheckFilter())
+	probe := and.GetFilters()[1].GetHeaderFilter()
+	require.NotNil(t, probe)
+	assert.Equal(t, ":path", probe.GetHeader().GetName())
+	assert.Equal(t, meshProbePathPrefix, probe.GetHeader().GetStringMatch().GetPrefix())
+	assert.True(t, probe.GetHeader().GetInvertMatch())
+	assert.Len(t, and.GetFilters()[2].GetOrFilter().GetFilters(), 3)
 
-	// Decode the OTel config: collector cluster default + reporter attribute.
+	// Decode the OTel config: collector cluster default (current grpc_service field,
+	// not deprecated common_config) + log name + reporter attribute.
 	var cfg otelaccesslogv3.OpenTelemetryAccessLogConfig
 	require.NoError(t, proto.Unmarshal(al.GetTypedConfig().GetValue(), &cfg))
-	assert.Equal(t, defaultCollectorName, cfg.GetCommonConfig().GetGrpcService().GetEnvoyGrpc().GetClusterName())
+	assert.Equal(t, defaultCollectorName, cfg.GetGrpcService().GetEnvoyGrpc().GetClusterName())
+	assert.Equal(t, accessLogName, cfg.GetLogName())
 
 	var reporter string
 	for _, kv := range cfg.GetAttributes().GetValues() {

--- a/docs/proposals/014_proxy-access-logs-otlp.md
+++ b/docs/proposals/014_proxy-access-logs-otlp.md
@@ -51,8 +51,10 @@ and the `otel_collector` cluster + batching + per-node resource are already wire
 
 Add an `envoy.access_loggers.open_telemetry`
 (`OpenTelemetryAccessLogConfig`) to `buildHTTPConnectionManager`, gated on a new
-value (`telemetry.accessLogs.enabled`). `common_config.grpc_service` →
-`envoy_grpc{ cluster_name: otel_collector }`. Map the rich format we already use
+value (`telemetry.accessLogs.enabled`). `grpc_service` →
+`envoy_grpc{ cluster_name: otel_collector }` (the top-level field; the older
+`common_config` wrapper is deprecated), with `log_name: aether_access_logs`. Map
+the rich format we already use
 in the e2e Envoy configs to OTLP:
 
 - **body**: the human-readable line (`%RESPONSE_CODE% %RESPONSE_FLAGS% …`).
@@ -77,6 +79,12 @@ At thousands of req/s, logging every request is untenable. Use Envoy access-log
   `status_code_filter` (>= 500) OR connect failures.
 - **sample** the rest: `runtime_filter` / `extension_filter` at a low rate
   (e.g. 1–5%), configurable.
+- **never** log health/liveness probes: AND a `not_health_check_filter` (drops the
+  inbound live/ready `health_check` filters and the per-pod health gateway) with a
+  `header_filter` that inverts a `:path` prefix match on `/-/-/` (drops the egress
+  liveness local-reply, which is not health_check-marked). Probes are dropped
+  unconditionally — including failures — so the proposal-013 prober's own
+  connection-error signal stays the source of truth, not access logs.
 
 This keeps the failure signal complete (the cases we built the prober/flag-SLI
 for) while bounding steady-state volume.


### PR DESCRIPTION
## What

Proxy access logs were emitting for in-mesh liveness/readiness probes (proposal 013 egress prober + inbound live/ready), polluting VictoriaLogs. This excludes them, and cleans up two adjacent issues in the same access-log config.

## Changes

**1. Exclude health checks** — `accessLogFilter()` is now an `AndFilter` that keeps a record only when it is NOT a probe AND log-worthy:
- `not_health_check_filter` — drops Envoy-marked health checks (inbound live/ready `health_check` filters; any future filter-based probe). Future-proof on any path.
- `header_filter` — inverted `:path` prefix match on `/-/-/` to drop the **egress liveness** local-reply, which is a `DirectResponse` route and therefore *not* health-check-marked.

The egress liveness intentionally stays a `DirectResponse` route (not a filter): its 200 requires the route config to be loaded, which is the stronger "config loaded" signal the proposal-013 prober relies on. A `health_check` filter sits before route resolution and would falsely report "live" during the hot-restart window where routes aren't loaded yet.

Probes are dropped **unconditionally** (including failures) so the prober's own connection-error signal stays the source of truth.

**2. Drop deprecated `common_config`** — `OpenTelemetryAccessLogConfig` now uses the top-level `grpc_service` + `log_name` fields (the `common_config`/`CommonGrpcAccessLogConfig` wrapper is deprecated in go-control-plane v1.37.0; transport is V3-only now).

**3. Rename** the log to `aether_access_logs`.

## ⚠️ Operational note

The `log_name` rename splits the VictoriaLogs stream (`aether_access` → `aether_access_logs`). Any saved LogsQL queries / dashboards / retention rules keyed on the old value need updating. This is a label-value change only (not a module name), so there's **no mixed-rollout outage risk**.

## Scope

Agent-side xDS only — no chart values touched, so no `Chart.yaml` bump needed.

## Test

- `accesslog_test.go` updated for the new AND-filter shape and `grpc_service`/`log_name` getters.
- `bazel build //agent/...` and `//agent/internal/xds/proxy:proxy_test` green; formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)