### PR TITLE
fix(log): emit a single hierarchical "logger" key (no duplicate JSON keys)

### DIFF
--- a/common/log/BUILD.bazel
+++ b/common/log/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "fanout.go",
         "log.go",
+        "named.go",
     ],
     importpath = "github.com/bpalermo/aether/common/log",
     visibility = ["//visibility:public"],

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -93,7 +93,13 @@ func NewLoggerWithHandler(debug bool, extra slog.Handler) *slog.Logger {
 }
 
 // Named returns a child logger tagged with a component name under the "logger"
-// field, replacing logr's WithName. Nested naming keeps the most recent name.
+// field, replacing logr's WithName. Naming is hierarchical and dot-joined
+// (e.g. "aether-agent" then "cache" -> "aether-agent.cache"), and always emits a
+// single "logger" key — unlike a plain With(loggerKey, …), which would append a
+// second "logger" attribute on every re-name and produce duplicate JSON keys.
 func Named(l *slog.Logger, name string) *slog.Logger {
-	return l.With(loggerKey, name)
+	if nh, ok := l.Handler().(*nameHandler); ok {
+		return slog.New(&nameHandler{inner: nh.inner, name: nh.name + "." + name})
+	}
+	return slog.New(&nameHandler{inner: l.Handler(), name: name})
 }

--- a/common/log/log_test.go
+++ b/common/log/log_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -64,6 +65,19 @@ func TestNamed(t *testing.T) {
 	var m map[string]any
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
 	assert.Equal(t, "syncer", m["logger"])
+}
+
+func TestNamed_NestedDotJoinsSingleKey(t *testing.T) {
+	var buf bytes.Buffer
+	base := slog.New(slog.NewJSONHandler(&buf, options(slog.LevelInfo)))
+	l := Named(Named(base, "aether-agent"), "cache")
+	l.InfoContext(context.Background(), "msg")
+
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &m))
+	assert.Equal(t, "aether-agent.cache", m["logger"])
+	// Exactly one "logger" key in the raw JSON (json.Unmarshal would hide dupes).
+	assert.Equal(t, 1, strings.Count(buf.String(), `"logger":`))
 }
 
 func TestLevelGate(t *testing.T) {

--- a/common/log/named.go
+++ b/common/log/named.go
@@ -1,0 +1,33 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+)
+
+// nameHandler injects exactly one "logger" attribute (the component name) into
+// every record, delegating everything else to the wrapped handler. Named() unwraps
+// and re-wraps it so re-naming dot-joins into a single name rather than stacking
+// duplicate "logger" attributes.
+type nameHandler struct {
+	inner slog.Handler
+	name  string
+}
+
+func (h *nameHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *nameHandler) Handle(ctx context.Context, r slog.Record) error {
+	r = r.Clone()
+	r.AddAttrs(slog.String(loggerKey, h.name))
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *nameHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &nameHandler{inner: h.inner.WithAttrs(attrs), name: h.name}
+}
+
+func (h *nameHandler) WithGroup(name string) slog.Handler {
+	return &nameHandler{inner: h.inner.WithGroup(name), name: h.name}
+}


### PR DESCRIPTION
## What

Follow-up to #223. The slog migration's `Named()` used `l.With("logger", name)`, which **appends** a second `logger` attribute on every re-name. A component logger over a named base therefore produced **duplicate keys** in the stderr JSON:

```json
"logger":"aether-agent","logger":"cache"
```

OTLP/VictoriaLogs deduped to the last value (so VL was unaffected), but `kubectl logs` showed both — surfaced during the talos-main validation of #223.

## Fix

Replace the `With`-based `Named` with a small `nameHandler` that injects **exactly one** `logger` attribute and **dot-joins on re-name**, restoring logr's hierarchical `WithName` semantics:

- `Named(base, "aether-agent")` → `logger=aether-agent`
- `Named(that, "cache")` → `logger=aether-agent.cache` (single key)

`Named`'s signature is unchanged, so **no call sites are touched**.

## Test

- New `TestNamed_NestedDotJoinsSingleKey` asserts the dot-joined value **and** exactly one `"logger":` in the raw JSON (since `json.Unmarshal` silently hides duplicate keys).
- `bazel test //...` green (41/41); formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)