### PR TITLE
ci: bump bazel-contrib/setup-bazel 0.18.0 -> 0.19.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
           distribution: temurin
           java-version: "21"
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           repository-cache: true
@@ -114,7 +114,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
@@ -145,7 +145,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
@@ -167,7 +167,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
       - name: Build and load container images

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           repository-cache: true

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           repository-cache: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Setup Bazel
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
           repository-cache: true


### PR DESCRIPTION
Bumps `bazel-contrib/setup-bazel` from `0.18.0` to `0.19.0` across all workflows (ci, publish, proxy, proxy-release — 7 references).

`0.18.0` targets Node.js 20, which is deprecated; GitHub runners force it onto Node 24 with a warning (visible in recent `publish` runs). `0.19.0` runs on Node 24 natively, clearing the annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)