### PR TITLE
fix(telemetry): always-on TracerProvider, opt-in span export (trace_id without stderr flood)

### DIFF
--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -95,7 +95,8 @@ func NewCNIServer(clusterName string, nodeName string, proxyID string, trustDoma
 
 	grpcServer := grpc.NewServer(
 		grpc.UnaryInterceptor(protovalidate_middleware.UnaryServerInterceptor(validator)),
-		// No-op until OTel providers are registered (--otel-enabled / --tracing-enabled).
+		// The TracerProvider is always installed, so this records real RPC spans (whose
+		// trace_id flows to logs); spans export only with --trace-export.
 		grpc.StatsHandler(telemetry.ServerStatsHandler()),
 	)
 

--- a/charts/agent/Chart.yaml
+++ b/charts/agent/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.2.5-{GIT_COMMIT}"
+version: "0.2.6-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -67,12 +67,11 @@ spec:
             - "--access-logs-enabled"
             - "--access-log-success-sample-rate={{ .Values.telemetry.accessLogs.successSampleRate }}"
             {{- end }}
-            {{- if .Values.telemetry.tracing.enabled }}
-            - "--tracing-enabled=true"
+            # Tracing (the TracerProvider for trace_id on logs) is always on in the
+            # binary; only the sample rate and span export are configurable.
             - "--trace-sample-rate={{ .Values.telemetry.tracing.sampleRate }}"
             {{- if .Values.telemetry.tracing.export }}
             - "--trace-export=true"
-            {{- end }}
             {{- end }}
             {{- if .Values.telemetry.logs.enabled }}
             - "--logs-enabled=true"

--- a/charts/agent/templates/daemonset.yaml
+++ b/charts/agent/templates/daemonset.yaml
@@ -70,6 +70,9 @@ spec:
             {{- if .Values.telemetry.tracing.enabled }}
             - "--tracing-enabled=true"
             - "--trace-sample-rate={{ .Values.telemetry.tracing.sampleRate }}"
+            {{- if .Values.telemetry.tracing.export }}
+            - "--trace-export=true"
+            {{- end }}
             {{- end }}
             {{- if .Values.telemetry.logs.enabled }}
             - "--logs-enabled=true"

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -55,11 +55,16 @@ telemetry:
     enabled: false
     successSampleRate: 100
   tracing:
-    # Enables OTLP trace export on the agent (`--tracing-enabled`);
-    # requires otlpEndpoint.
+    # Installs the OTel TracerProvider (`--tracing-enabled`) so spans exist and
+    # logs emitted within them carry trace_id/span_id. Does NOT export spans on
+    # its own.
     enabled: false
     # Head-sampling ratio for traces (`--trace-sample-rate`).
     sampleRate: 0.1
+    # Export spans over OTLP (`--trace-export`). Leave false unless the collector
+    # has a traces pipeline/backend — otherwise the SDK floods stderr with
+    # "Unimplemented TraceService" errors. trace_id on logs works without it.
+    export: false
   logs:
     # Export the agent's own application logs over OTLP to the collector
     # (`--logs-enabled`), tee'd into stderr (kubectl logs is unchanged).

--- a/charts/agent/values.yaml
+++ b/charts/agent/values.yaml
@@ -55,11 +55,10 @@ telemetry:
     enabled: false
     successSampleRate: 100
   tracing:
-    # Installs the OTel TracerProvider (`--tracing-enabled`) so spans exist and
-    # logs emitted within them carry trace_id/span_id. Does NOT export spans on
-    # its own.
-    enabled: false
-    # Head-sampling ratio for traces (`--trace-sample-rate`).
+    # The OTel TracerProvider is always installed in the binary so spans exist and
+    # logs emitted within them carry trace_id/span_id — there is no enable flag.
+    # Head-sampling ratio for traces (`--trace-sample-rate`); only bounds exported
+    # spans (trace_id on logs is unaffected by the rate).
     sampleRate: 0.1
     # Export spans over OTLP (`--trace-export`). Leave false unless the collector
     # has a traces pipeline/backend — otherwise the SDK floods stderr with

--- a/charts/registrar/Chart.yaml
+++ b/charts/registrar/Chart.yaml
@@ -10,7 +10,7 @@ type: application
 #                 OCI tag, unlike `+build` metadata which helm rewrites to `_`)
 #   appVersion -> the `git describe` version, matching the binary's embedded Version
 # Without `--stamp` the braces are stripped, yielding literal placeholder text.
-version: "0.2.1-{GIT_COMMIT}"
+version: "0.2.2-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/registrar/templates/deployment.yaml
+++ b/charts/registrar/templates/deployment.yaml
@@ -29,12 +29,11 @@ spec:
             {{- with .Values.telemetry.otlpEndpoint }}
             - "--otlp-endpoint={{ . }}"
             {{- end }}
-            {{- if .Values.telemetry.tracing.enabled }}
-            - "--tracing-enabled=true"
+            # Tracing (the TracerProvider for trace_id on logs) is always on in the
+            # binary; only the sample rate and span export are configurable.
             - "--trace-sample-rate={{ .Values.telemetry.tracing.sampleRate }}"
             {{- if .Values.telemetry.tracing.export }}
             - "--trace-export=true"
-            {{- end }}
             {{- end }}
             {{- if .Values.telemetry.logs.enabled }}
             - "--logs-enabled=true"

--- a/charts/registrar/templates/deployment.yaml
+++ b/charts/registrar/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
             {{- if .Values.telemetry.tracing.enabled }}
             - "--tracing-enabled=true"
             - "--trace-sample-rate={{ .Values.telemetry.tracing.sampleRate }}"
+            {{- if .Values.telemetry.tracing.export }}
+            - "--trace-export=true"
+            {{- end }}
             {{- end }}
             {{- if .Values.telemetry.logs.enabled }}
             - "--logs-enabled=true"

--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -23,10 +23,15 @@ telemetry:
   # OTLP gRPC collector endpoint (host:port, insecure). Empty disables push.
   otlpEndpoint: ""
   tracing:
-    # Enables OTLP trace export (`--tracing-enabled`); requires otlpEndpoint.
+    # Installs the OTel TracerProvider (`--tracing-enabled`) so logs emitted in a
+    # span carry trace_id/span_id. Does NOT export spans on its own.
     enabled: false
     # Head-sampling ratio for traces (`--trace-sample-rate`).
     sampleRate: 0.1
+    # Export spans over OTLP (`--trace-export`). Leave false unless the collector
+    # has a traces pipeline/backend, else the SDK floods stderr with
+    # "Unimplemented TraceService" errors. trace_id on logs works without it.
+    export: false
   logs:
     # Export the registrar's own application logs over OTLP to the collector
     # (`--logs-enabled`), tee'd into stderr (kubectl logs is unchanged).

--- a/charts/registrar/values.yaml
+++ b/charts/registrar/values.yaml
@@ -16,17 +16,16 @@ namespace:
 clusterName: talos-main
 
 # OTel telemetry, push-first: when otlpEndpoint is set, the registrar pushes
-# metrics (and traces when tracing.enabled) to the collector.
+# metrics (and logs/traces when their export is enabled) to the collector.
 telemetry:
   # Enables the OTel MeterProvider (`--otel-enabled`).
   enabled: false
   # OTLP gRPC collector endpoint (host:port, insecure). Empty disables push.
   otlpEndpoint: ""
   tracing:
-    # Installs the OTel TracerProvider (`--tracing-enabled`) so logs emitted in a
-    # span carry trace_id/span_id. Does NOT export spans on its own.
-    enabled: false
-    # Head-sampling ratio for traces (`--trace-sample-rate`).
+    # The OTel TracerProvider is always installed in the binary so logs emitted in
+    # a span carry trace_id/span_id — there is no enable flag. Head-sampling ratio
+    # (`--trace-sample-rate`); only bounds exported spans (trace_id is unaffected).
     sampleRate: 0.1
     # Export spans over OTLP (`--trace-export`). Leave false unless the collector
     # has a traces pipeline/backend, else the SDK floods stderr with

--- a/common/manager/config.go
+++ b/common/manager/config.go
@@ -28,4 +28,7 @@ type Config struct {
 	LogsEnabled bool
 	// TraceSampleRate is the head-sampling ratio for traces (0.0–1.0)
 	TraceSampleRate float64
+	// TracingExport attaches the OTLP span exporter; without it tracing still
+	// gives logs their trace_id but exports no spans (no trace backend needed)
+	TracingExport bool
 }

--- a/common/manager/config.go
+++ b/common/manager/config.go
@@ -21,14 +21,15 @@ type Config struct {
 	OTelEnabled bool
 	// OTLPEndpoint is the OTLP gRPC collector endpoint (e.g. "localhost:4317"); empty disables OTLP export
 	OTLPEndpoint string
-	// TracingEnabled enables the OTel TracerProvider with OTLP trace export (requires OTLPEndpoint)
-	TracingEnabled bool
 	// LogsEnabled enables the OTel LoggerProvider with OTLP log export, tee'd into
-	// the component's zap logger (requires OTLPEndpoint); stderr logging is unaffected
+	// the component's slog logger (requires OTLPEndpoint); stderr logging is unaffected
 	LogsEnabled bool
-	// TraceSampleRate is the head-sampling ratio for traces (0.0–1.0)
+	// TraceSampleRate is the head-sampling ratio for traces (0.0–1.0). The
+	// TracerProvider is always installed (for trace_id on logs); this only bounds
+	// what gets exported when TracingExport is set.
 	TraceSampleRate float64
-	// TracingExport attaches the OTLP span exporter; without it tracing still
-	// gives logs their trace_id but exports no spans (no trace backend needed)
+	// TracingExport attaches the OTLP span exporter; without it the always-on
+	// TracerProvider still gives logs their trace_id but exports no spans (no
+	// trace backend needed)
 	TracingExport bool
 }

--- a/common/manager/flags.go
+++ b/common/manager/flags.go
@@ -12,4 +12,5 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config) {
 	cmd.Flags().BoolVar(&cfg.TracingEnabled, "tracing-enabled", cfg.TracingEnabled, "Enable OTel tracing with OTLP export (requires --otlp-endpoint)")
 	cmd.Flags().BoolVar(&cfg.LogsEnabled, "logs-enabled", cfg.LogsEnabled, "Enable OTel log export over OTLP, tee'd into stderr logging (requires --otlp-endpoint)")
 	cmd.Flags().Float64Var(&cfg.TraceSampleRate, "trace-sample-rate", defaultTraceSampleRate, "Head-sampling ratio for traces (0.0-1.0)")
+	cmd.Flags().BoolVar(&cfg.TracingExport, "trace-export", cfg.TracingExport, "Export spans over OTLP (requires a collector traces pipeline); off keeps trace_id on logs without exporting")
 }

--- a/common/manager/flags.go
+++ b/common/manager/flags.go
@@ -9,8 +9,7 @@ func RegisterFlags(cmd *cobra.Command, cfg *Config) {
 	cmd.Flags().StringVar(&cfg.MetricsBindAddress, "metrics-bind-address", cfg.MetricsBindAddress, "Address for the metrics HTTP server")
 	cmd.Flags().BoolVar(&cfg.OTelEnabled, "otel-enabled", cfg.OTelEnabled, "Enable OTel MeterProvider with Prometheus exporter bridge (requires --metrics-enabled)")
 	cmd.Flags().StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", cfg.OTLPEndpoint, "OTLP gRPC collector endpoint (e.g. localhost:4317); empty disables OTLP export")
-	cmd.Flags().BoolVar(&cfg.TracingEnabled, "tracing-enabled", cfg.TracingEnabled, "Enable OTel tracing with OTLP export (requires --otlp-endpoint)")
 	cmd.Flags().BoolVar(&cfg.LogsEnabled, "logs-enabled", cfg.LogsEnabled, "Enable OTel log export over OTLP, tee'd into stderr logging (requires --otlp-endpoint)")
-	cmd.Flags().Float64Var(&cfg.TraceSampleRate, "trace-sample-rate", defaultTraceSampleRate, "Head-sampling ratio for traces (0.0-1.0)")
+	cmd.Flags().Float64Var(&cfg.TraceSampleRate, "trace-sample-rate", defaultTraceSampleRate, "Head-sampling ratio for traces (0.0-1.0); only bounds exported spans (the provider is always on for trace_id)")
 	cmd.Flags().BoolVar(&cfg.TracingExport, "trace-export", cfg.TracingExport, "Export spans over OTLP (requires a collector traces pipeline); off keeps trace_id on logs without exporting")
 }

--- a/common/manager/manager.go
+++ b/common/manager/manager.go
@@ -27,6 +27,7 @@ func Bootstrap(ctx context.Context, cfg Config, serviceName, serviceVersion stri
 		ServiceVersion:  serviceVersion,
 		OTLPEndpoint:    cfg.OTLPEndpoint,
 		TraceSampleRate: cfg.TraceSampleRate,
+		TraceExport:     cfg.TracingExport,
 	}
 
 	var shutdowns []func(context.Context) error

--- a/common/manager/manager.go
+++ b/common/manager/manager.go
@@ -38,13 +38,15 @@ func Bootstrap(ctx context.Context, cfg Config, serviceName, serviceVersion stri
 		}
 		shutdowns = append(shutdowns, metricsShutdown)
 	}
-	if cfg.TracingEnabled {
-		tracingShutdown, err := telemetry.SetupTracing(ctx, telemetryCfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to setup tracing: %w", err)
-		}
-		shutdowns = append(shutdowns, tracingShutdown)
+	// Tracing is always installed: a TracerProvider issues the span contexts that
+	// give logs their trace_id/span_id (the slog/otelslog correlation), which is
+	// useful regardless of other telemetry. Span EXPORT stays opt-in (TraceExport)
+	// — see SetupTracing.
+	tracingShutdown, err := telemetry.SetupTracing(ctx, telemetryCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup tracing: %w", err)
 	}
+	shutdowns = append(shutdowns, tracingShutdown)
 
 	var shutdown func(context.Context) error
 	if len(shutdowns) > 0 {

--- a/common/telemetry/telemetry.go
+++ b/common/telemetry/telemetry.go
@@ -33,6 +33,9 @@ type Config struct {
 	// TraceSampleRate is the head-sampling ratio for traces (0.0–1.0). Only
 	// used by SetupTracing.
 	TraceSampleRate float64
+	// TraceExport attaches the OTLP span exporter. When false, SetupTracing still
+	// installs a TracerProvider (so logs get trace_id) but exports no spans.
+	TraceExport bool
 }
 
 // newResource builds the OTel Resource shared by the meter and tracer

--- a/common/telemetry/tracing.go
+++ b/common/telemetry/tracing.go
@@ -15,39 +15,44 @@ import (
 // collector cannot block the batch span processor's export goroutine.
 const otlpTraceTimeout = 5 * time.Second
 
-// SetupTracing creates an OTel TracerProvider exporting spans to the OTLP gRPC
-// collector at cfg.OTLPEndpoint via a batching span processor, using parent-based
-// head sampling at cfg.TraceSampleRate. It sets the provider as the global OTel
-// TracerProvider and installs the W3C TraceContext + Baggage propagators, so
-// instrumentation anywhere (e.g. otelgrpc stats handlers) picks it up via
-// otel.Tracer(). The returned shutdown function flushes and stops the provider.
+// SetupTracing installs a global OTel TracerProvider (parent-based head sampling
+// at cfg.TraceSampleRate) plus the W3C TraceContext + Baggage propagators, so
+// instrumentation anywhere (e.g. otelgrpc stats handlers) issues valid span
+// contexts. That alone is what lets otelslog stamp trace_id/span_id onto logs
+// emitted within a span — log↔request correlation needs no trace backend.
 //
-// cfg.OTLPEndpoint must be non-empty: unlike metrics (which fall back to the
-// Prometheus bridge), traces have no export path without a collector.
+// Span EXPORT is opt-in (cfg.TraceExport): only then is an OTLP batch exporter
+// attached. Exporting to a collector with no traces pipeline just floods stderr
+// with "Unimplemented TraceService" errors, so export stays off until a real
+// trace backend (Tempo/VictoriaTraces) exists. The returned shutdown flushes and
+// stops the provider.
 func SetupTracing(ctx context.Context, cfg Config) (shutdown func(context.Context) error, err error) {
-	if cfg.OTLPEndpoint == "" {
-		return nil, fmt.Errorf("tracing requires an OTLP endpoint")
-	}
-
 	res, err := newResource(ctx, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create resource: %w", err)
 	}
 
-	exporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
-		otlptracegrpc.WithInsecure(),
-		otlptracegrpc.WithTimeout(otlpTraceTimeout),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", err)
+	opts := []sdktrace.TracerProviderOption{
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(cfg.TraceSampleRate))),
 	}
 
-	provider := sdktrace.NewTracerProvider(
-		sdktrace.WithResource(res),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(cfg.TraceSampleRate))),
-	)
+	if cfg.TraceExport {
+		if cfg.OTLPEndpoint == "" {
+			return nil, fmt.Errorf("trace export requires an OTLP endpoint")
+		}
+		exporter, expErr := otlptracegrpc.New(ctx,
+			otlptracegrpc.WithEndpoint(cfg.OTLPEndpoint),
+			otlptracegrpc.WithInsecure(),
+			otlptracegrpc.WithTimeout(otlpTraceTimeout),
+		)
+		if expErr != nil {
+			return nil, fmt.Errorf("failed to create OTLP trace exporter: %w", expErr)
+		}
+		opts = append(opts, sdktrace.WithBatcher(exporter))
+	}
+
+	provider := sdktrace.NewTracerProvider(opts...)
 	otel.SetTracerProvider(provider)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},

--- a/common/telemetry/tracing_test.go
+++ b/common/telemetry/tracing_test.go
@@ -13,10 +13,17 @@ import (
 	"google.golang.org/grpc/stats"
 )
 
-func TestSetupTracing_RequiresEndpoint(t *testing.T) {
-	if _, err := SetupTracing(context.Background(), Config{ServiceName: "test"}); err == nil {
-		t.Fatal("SetupTracing() with empty OTLPEndpoint should fail")
+func TestSetupTracing_ExportRequiresEndpoint(t *testing.T) {
+	// Export on + no endpoint -> error.
+	if _, err := SetupTracing(context.Background(), Config{ServiceName: "test", TraceExport: true}); err == nil {
+		t.Fatal("SetupTracing() with TraceExport and empty OTLPEndpoint should fail")
 	}
+	// No export + no endpoint -> fine (provider installed for trace_id, no exporter).
+	shutdown, err := SetupTracing(context.Background(), Config{ServiceName: "test"})
+	if err != nil {
+		t.Fatalf("SetupTracing() without export should not require an endpoint: %v", err)
+	}
+	_ = shutdown(context.Background())
 }
 
 func TestSetupTracing_SetsGlobals(t *testing.T) {

--- a/common/xds/xds.go
+++ b/common/xds/xds.go
@@ -54,7 +54,8 @@ func NewXdsServer(ctx context.Context, cfg *ServerConfig, cache cachev3.Snapshot
 			PermitWithoutStream: true,              // Allow pings even without active streams
 		}),
 		grpc.MaxConcurrentStreams(1000),
-		// No-op until OTel providers are registered (--otel-enabled / --tracing-enabled).
+		// The TracerProvider is always installed, so this records real RPC spans (whose
+		// trace_id flows to logs); spans export only with --trace-export.
 		grpc.StatsHandler(telemetry.ServerStatsHandler()),
 	)
 	xdsSrv := serverv3.NewServer(ctx, cache, callbacks)

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -80,7 +80,8 @@ func NewRegistrarServer(
 	cfg.Network = "tcp"
 	cfg.Address = address
 
-	// No-op until OTel providers are registered (--otel-enabled / --tracing-enabled).
+	// The TracerProvider is always installed, so this records real RPC spans (whose
+	// trace_id flows to logs); spans export only with --trace-export.
 	grpcOpts = append(grpcOpts, grpc.StatsHandler(telemetry.ServerStatsHandler()))
 	grpcSrv := grpc.NewServer(grpcOpts...)
 


### PR DESCRIPTION
## What

Make `trace_id`/`span_id` reliably land on logs (the slog/otelslog payoff) **without** flooding stderr, by always installing the TracerProvider and making span *export* the only knob.

## Background

- A `TracerProvider` is what issues the span contexts that give logs their `trace_id`. It does **not** need to export spans for that — a valid span context is enough for otelslog to stamp the log record.
- Trace **export**, on the other hand, sends spans over OTLP. The `o11y` collector has no traces pipeline, so exporting floods every agent/registrar stderr with `traces export: rpc error: Unimplemented ... TraceService`.
- Previously the provider was gated behind an enable flag, so trace export was tied to having the provider at all — you couldn't get `trace_id` on logs without also triggering the export flood, and forgetting the flag silently lost all correlation.

## Fix

- **The TracerProvider is always installed** (`manager.Bootstrap` always calls `SetupTracing`) — no enable flag. Logs emitted within a span always carry `trace_id`/`span_id`.
- **Span export is opt-in** via `--trace-export` / `telemetry.tracing.export` (**default off**). Correlation needs no exporter and no collector traces pipeline; flip export on once a real backend (Tempo/VictoriaTraces) + traces pipeline exist.
- Removed `--tracing-enabled` / `Config.TracingEnabled` / `telemetry.tracing.enabled`. Remaining knobs: `--trace-sample-rate` (always passed; only bounds *exported* spans) and `--trace-export`.
- Dropped the old "tracing requires an OTLP endpoint" error — only *export* needs an endpoint now.

Net on talos-main (export off): `trace_id`/`span_id` keep landing on spanned logs in VictoriaLogs; the `Unimplemented` stderr spam is gone.

Charts: agent `0.2.5`→`0.2.6`, registrar `0.2.1`→`0.2.2`.

## Test

- `bazel test //common/... //charts/... //agent/... //registrar/...` green; `TestSetupTracing_ExportRequiresEndpoint` covers the export-on (endpoint required) and export-off (provider only) paths.
- `helm template`: default emits only `--trace-sample-rate`; `--trace-export` appears only with `tracing.export=true`; no `--tracing-enabled` anywhere.

> The `proxy` check may be red from the unrelated BuildBuddy Envoy CAS-eviction flake (#225); control-plane `ci` is the relevant signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)