### PR TITLE
feat(proxy): Istio default access-log field set + traceparent + pod identity

### DIFF
--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -75,14 +75,12 @@ func buildAccessLog(reporter, podName, podNamespace string) []*accesslogv3.Acces
 				EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: cluster},
 			},
 		},
-		// Human-readable line: Envoy/Istio's default access-log text format, so the
-		// _msg is the familiar one-liner. Structured fields go in attributes for
-		// querying. Absent operators render as "-" (the OTel logger has no
-		// omit-empty), matching Istio.
-		Body: stringValue(`[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_CLUSTER_RAW% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%`),
+		// Concise human-readable _msg for eyeballing; the full queryable field set
+		// (Istio's defaults + more) lives in attributes, not duplicated in the body.
+		Body: stringValue("%RESPONSE_CODE% %RESPONSE_FLAGS% %REQ(:METHOD)% %REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %DURATION%ms -> %UPSTREAM_HOST%"),
 		// Full Istio default field set as structured attributes, plus aether's
-		// reporter/source_netns and the W3C traceparent (populates once the mesh
-		// propagates trace context; "-" until then).
+		// reporter/pod identity/source_netns and the W3C traceparent (populates once
+		// the mesh propagates trace context; "-" until then).
 		Attributes: &otlpcommonv1.KeyValueList{Values: []*otlpcommonv1.KeyValue{
 			kv("reporter", reporter),
 			// Literal pod identity baked in per-pod listener: the local pod this hop

--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -74,23 +74,41 @@ func buildAccessLog(reporter string) []*accesslogv3.AccessLog {
 				EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: cluster},
 			},
 		},
-		// Human-readable line; structured fields go in attributes for querying.
-		Body: stringValue("%RESPONSE_CODE% %RESPONSE_FLAGS% %REQ(:METHOD)% %REQ(:AUTHORITY)%%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %DURATION%ms -> %UPSTREAM_HOST%"),
+		// Human-readable line: Envoy/Istio's default access-log text format, so the
+		// _msg is the familiar one-liner. Structured fields go in attributes for
+		// querying. Absent operators render as "-" (the OTel logger has no
+		// omit-empty), matching Istio.
+		Body: stringValue(`[%START_TIME%] "%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%" %RESPONSE_CODE% %RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS% %CONNECTION_TERMINATION_DETAILS% "%UPSTREAM_TRANSPORT_FAILURE_REASON%" %BYTES_RECEIVED% %BYTES_SENT% %DURATION% %RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)% "%REQ(X-FORWARDED-FOR)%" "%REQ(USER-AGENT)%" "%REQ(X-REQUEST-ID)%" "%REQ(:AUTHORITY)%" "%UPSTREAM_HOST%" %UPSTREAM_CLUSTER_RAW% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%`),
+		// Full Istio default field set as structured attributes, plus aether's
+		// reporter/source_netns and the W3C traceparent (populates once the mesh
+		// propagates trace context; "-" until then).
 		Attributes: &otlpcommonv1.KeyValueList{Values: []*otlpcommonv1.KeyValue{
 			kv("reporter", reporter),
-			kv("response_code", "%RESPONSE_CODE%"),
-			kv("response_flags", "%RESPONSE_FLAGS%"),
+			kv("start_time", "%START_TIME%"),
 			kv("method", "%REQ(:METHOD)%"),
-			kv("authority", "%REQ(:AUTHORITY)%"),
 			kv("path", "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"),
 			kv("protocol", "%PROTOCOL%"),
+			kv("response_code", "%RESPONSE_CODE%"),
+			kv("response_flags", "%RESPONSE_FLAGS%"),
+			kv("response_code_details", "%RESPONSE_CODE_DETAILS%"),
+			kv("connection_termination_details", "%CONNECTION_TERMINATION_DETAILS%"),
+			kv("upstream_transport_failure_reason", "%UPSTREAM_TRANSPORT_FAILURE_REASON%"),
+			kv("bytes_received", "%BYTES_RECEIVED%"),
+			kv("bytes_sent", "%BYTES_SENT%"),
 			kv("duration_ms", "%DURATION%"),
 			kv("upstream_service_time", "%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"),
-			kv("bytes_sent", "%BYTES_SENT%"),
-			kv("bytes_received", "%BYTES_RECEIVED%"),
+			kv("x_forwarded_for", "%REQ(X-FORWARDED-FOR)%"),
+			kv("user_agent", "%REQ(USER-AGENT)%"),
+			kv("x_request_id", "%REQ(X-REQUEST-ID)%"),
+			kv("authority", "%REQ(:AUTHORITY)%"),
 			kv("upstream_host", "%UPSTREAM_HOST%"),
 			kv("upstream_cluster", "%UPSTREAM_CLUSTER%"),
-			kv("x_request_id", "%REQ(X-REQUEST-ID)%"),
+			kv("upstream_local_address", "%UPSTREAM_LOCAL_ADDRESS%"),
+			kv("downstream_local_address", "%DOWNSTREAM_LOCAL_ADDRESS%"),
+			kv("downstream_remote_address", "%DOWNSTREAM_REMOTE_ADDRESS%"),
+			kv("requested_server_name", "%REQUESTED_SERVER_NAME%"),
+			kv("route_name", "%ROUTE_NAME%"),
+			kv("traceparent", "%REQ(TRACEPARENT)%"),
 			kv("source_netns", "%FILTER_STATE(aether.network.network_namespace:PLAIN)%"),
 		}},
 	}

--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -52,11 +52,12 @@ var accessLogConfig AccessLogConfig
 // the manager starts.
 func SetAccessLogConfig(c AccessLogConfig) { accessLogConfig = c }
 
-// buildAccessLog returns the OTel access logger for an HCM, tagged with reporter,
-// or nil when access logging is disabled. The logger pushes OTLP logs to the
-// collector cluster; the filter logs all failures plus a SuccessSampleRate sample
-// of successes.
-func buildAccessLog(reporter string) []*accesslogv3.AccessLog {
+// buildAccessLog returns the OTel access logger for an HCM, tagged with reporter
+// and the local pod this listener serves (the source pod on egress, the
+// destination pod on inbound — disambiguate via reporter), or nil when access
+// logging is disabled. The logger pushes OTLP logs to the collector cluster; the
+// filter logs all failures plus a SuccessSampleRate sample of successes.
+func buildAccessLog(reporter, podName, podNamespace string) []*accesslogv3.AccessLog {
 	if !accessLogConfig.Enabled {
 		return nil
 	}
@@ -84,6 +85,10 @@ func buildAccessLog(reporter string) []*accesslogv3.AccessLog {
 		// propagates trace context; "-" until then).
 		Attributes: &otlpcommonv1.KeyValueList{Values: []*otlpcommonv1.KeyValue{
 			kv("reporter", reporter),
+			// Literal pod identity baked in per-pod listener: the local pod this hop
+			// serves (source pod on egress, destination pod on inbound).
+			kv("pod_name", podName),
+			kv("pod_namespace", podNamespace),
 			kv("start_time", "%START_TIME%"),
 			kv("method", "%REQ(:METHOD)%"),
 			kv("path", "%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%"),

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -12,14 +12,14 @@ import (
 func TestBuildAccessLogDisabled(t *testing.T) {
 	t.Cleanup(func() { SetAccessLogConfig(AccessLogConfig{}) })
 	SetAccessLogConfig(AccessLogConfig{Enabled: false})
-	assert.Nil(t, buildAccessLog(ReporterSource))
+	assert.Nil(t, buildAccessLog(ReporterSource, "svc-1-abc", "aether-test"))
 }
 
 func TestBuildAccessLogEnabled(t *testing.T) {
 	t.Cleanup(func() { SetAccessLogConfig(AccessLogConfig{}) })
 	SetAccessLogConfig(AccessLogConfig{Enabled: true, SuccessSampleRate: 100})
 
-	logs := buildAccessLog(ReporterDestination)
+	logs := buildAccessLog(ReporterDestination, "svc-2-xyz", "aether-test")
 	require.Len(t, logs, 1)
 	al := logs[0]
 	assert.Equal(t, "envoy.access_loggers.open_telemetry", al.GetName())
@@ -49,6 +49,9 @@ func TestBuildAccessLogEnabled(t *testing.T) {
 		attrs[kv.GetKey()] = kv.GetValue().GetStringValue()
 	}
 	assert.Equal(t, ReporterDestination, attrs["reporter"])
+	// Literal pod identity for the listener's local pod.
+	assert.Equal(t, "svc-2-xyz", attrs["pod_name"])
+	assert.Equal(t, "aether-test", attrs["pod_namespace"])
 
 	// The full Istio default field set plus the W3C traceparent must be present as
 	// structured attributes.

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -44,11 +44,24 @@ func TestBuildAccessLogEnabled(t *testing.T) {
 	assert.Equal(t, defaultCollectorName, cfg.GetGrpcService().GetEnvoyGrpc().GetClusterName())
 	assert.Equal(t, accessLogName, cfg.GetLogName())
 
-	var reporter string
+	attrs := map[string]string{}
 	for _, kv := range cfg.GetAttributes().GetValues() {
-		if kv.GetKey() == "reporter" {
-			reporter = kv.GetValue().GetStringValue()
-		}
+		attrs[kv.GetKey()] = kv.GetValue().GetStringValue()
 	}
-	assert.Equal(t, ReporterDestination, reporter)
+	assert.Equal(t, ReporterDestination, attrs["reporter"])
+
+	// The full Istio default field set plus the W3C traceparent must be present as
+	// structured attributes.
+	for _, key := range []string{
+		"start_time", "method", "path", "protocol", "response_code", "response_flags",
+		"response_code_details", "connection_termination_details",
+		"upstream_transport_failure_reason", "bytes_received", "bytes_sent", "duration_ms",
+		"upstream_service_time", "x_forwarded_for", "user_agent", "x_request_id",
+		"authority", "upstream_host", "upstream_cluster", "upstream_local_address",
+		"downstream_local_address", "downstream_remote_address", "requested_server_name",
+		"route_name", "traceparent", "source_netns",
+	} {
+		assert.Contains(t, attrs, key, "missing access-log attribute %q", key)
+	}
+	assert.Equal(t, "%REQ(TRACEPARENT)%", attrs["traceparent"])
 }

--- a/agent/internal/xds/proxy/filterchain.go
+++ b/agent/internal/xds/proxy/filterchain.go
@@ -20,7 +20,7 @@ import (
 // module .so on the proxy unconditionally; Envoy rejects the listener if the
 // referenced dynamic module is absent.
 func buildDefaultOutboundHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager("outbound_http", ReporterSource, nil)
+	hcm := buildHTTPConnectionManager("outbound_http", ReporterSource, cniPod.GetName(), cniPod.GetNamespace(), nil)
 
 	// strip_any_host_port stays OFF: the authority port is a first-class routing
 	// selector (FQDN:port → that port's cluster, proposal 005). The default-port

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -115,7 +115,7 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 // is the default (no match criteria). chainPort selects both the app cluster
 // and the chain name suffix.
 func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
+	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, cniPod.GetName(), cniPod.GetNamespace(), buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
 	// Liveness/readiness are answered locally before the router; everything else
 	// passes through to the pod's application. The stats filter sits after the
 	// health-check filters (so locally-answered probe requests are not counted)

--- a/agent/internal/xds/proxy/networkfilter.go
+++ b/agent/internal/xds/proxy/networkfilter.go
@@ -75,14 +75,14 @@ const downstreamIdleTimeout = 5 * time.Minute
 // If routeConfig is nil, routes will be retrieved via RDS. reporter tags the OTel
 // access logger (ReporterSource for egress, ReporterDestination for inbound); the
 // logger is attached only when access logging is enabled (buildAccessLog → nil).
-func buildHTTPConnectionManager(name, reporter string, routeConfig *routev3.RouteConfiguration) *http_connection_managerv3.HttpConnectionManager {
+func buildHTTPConnectionManager(name, reporter, podName, podNamespace string, routeConfig *routev3.RouteConfiguration) *http_connection_managerv3.HttpConnectionManager {
 	return &http_connection_managerv3.HttpConnectionManager{
 		StatPrefix: name,
 		CodecType:  http_connection_managerv3.HttpConnectionManager_AUTO,
 		CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
 			IdleTimeout: durationpb.New(downstreamIdleTimeout),
 		},
-		AccessLog: buildAccessLog(reporter),
+		AccessLog: buildAccessLog(reporter, podName, podNamespace),
 		HttpFilters: []*http_connection_managerv3.HttpFilter{
 			routerHttpFilter(),
 		},

--- a/agent/internal/xds/proxy/networkfilter_test.go
+++ b/agent/internal/xds/proxy/networkfilter_test.go
@@ -46,7 +46,7 @@ func TestBuildHTTPConnectionManager(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hcm := buildHTTPConnectionManager(tt.statPrefix, ReporterSource, tt.routeConfig)
+			hcm := buildHTTPConnectionManager(tt.statPrefix, ReporterSource, "pod", "ns", tt.routeConfig)
 
 			require.NotNil(t, hcm)
 			assert.Equal(t, tt.statPrefix, hcm.GetStatPrefix())
@@ -58,7 +58,7 @@ func TestBuildHTTPConnectionManager(t *testing.T) {
 }
 
 func TestBuildHTTPConnectionManagerFilter(t *testing.T) {
-	hcm := buildHTTPConnectionManager("test", ReporterSource, nil)
+	hcm := buildHTTPConnectionManager("test", ReporterSource, "pod", "ns", nil)
 	filter := buildHTTPConnectionManagerFilter(hcm)
 
 	require.NotNil(t, filter)
@@ -83,7 +83,7 @@ func TestBuildSetFilterState(t *testing.T) {
 // downstream idle timeout backstop (Envoy default is 1h, which let a peer's
 // leaked upstream connections pin thousands of inbound connections).
 func TestHCMDownstreamIdleTimeout(t *testing.T) {
-	hcm := buildHTTPConnectionManager("test", ReporterSource, nil)
+	hcm := buildHTTPConnectionManager("test", ReporterSource, "pod", "ns", nil)
 	idle := hcm.GetCommonHttpProtocolOptions().GetIdleTimeout()
 	require.NotNil(t, idle, "downstream idle timeout must be set")
 	assert.Equal(t, downstreamIdleTimeout, idle.AsDuration())


### PR DESCRIPTION
## What

Brings the proxy OTel access-log entry to parity with **Istio's default access-log field set**, and adds `traceparent` plus **pod-level identity** — as structured **attributes** for querying.

- **All Istio fields as structured attributes.** New: `start_time`, `response_code_details`, `connection_termination_details`, `upstream_transport_failure_reason`, `x_forwarded_for`, `user_agent`, `upstream_local_address`, `downstream_local_address`, `downstream_remote_address`, `requested_server_name`, `route_name` (on top of the existing method/path/protocol/response_code/flags/bytes/duration/upstream_service_time/authority/upstream_host/upstream_cluster/x_request_id).
- **`traceparent`** attribute (`%REQ(TRACEPARENT)%`) for the W3C trace context.
- **`pod_name` / `pod_namespace`** — each listener is per-pod, so the local pod it serves is baked in as literal attributes. With `reporter` this gives direct pod-level correlation: egress (`reporter=source`) → source pod; inbound (`reporter=destination`) → destination pod. Previously only inferable from `source_netns` / `upstream_host` IP.
- **Body stays a concise one-liner** (`%RESPONSE_CODE% %RESPONSE_FLAGS% %REQ(:METHOD)% %REQ(:AUTHORITY)%%PATH% %DURATION%ms -> %UPSTREAM_HOST%`) for human eyeballing — the dimensions are not duplicated into `_msg`. Istio's format served as the field checklist, not the literal body.
- aether-specific `reporter` / `source_netns` retained.

## Why attributes, not the body line

VictoriaLogs/LogsQL filters and aggregations are first-class on **fields**, not body substrings; Grafana binds to fields. The body is for human eyeballing. Duplicating every dimension into a full Istio-format line would ~2× the field data (mostly `-` placeholders), so the body is kept concise.

## Notes

- **Empty fields render as `"-"`** — the OTel access logger has no per-key omit (`omit_empty_values` is only on `SubstitutionFormatString`). Dropping empties would need a collector-side OTTL transform (deferred per discussion).
- **`traceparent` is `"-"` today** — the proxy HCM has no tracing and clients don't send `traceparent`; it populates once W3C tracing is enabled on the proxy. Cross-hop request correlation already works via `x_request_id`; pod correlation now via `pod_name`.

## Test

- `proxy_test` asserts the full Istio field set, `traceparent`, and `pod_name`/`pod_namespace`; `bazel test //agent/...` green. Agent-side only (no chart change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)