### PR TITLE
refactor(config): MeshConfig proto to edition 2024 (opaque API)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -140,7 +140,7 @@ use_repo(
 )
 
 buf = use_extension("@rules_buf//buf:extensions.bzl", "buf")
-buf.toolchains(version = "v1.67.0")
+buf.toolchains(version = "v1.71.0")
 use_repo(buf, "rules_buf_toolchains")
 
 # Hermetic Helm toolchain (downloads helm) plus a @helm//:helm host alias for

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1053,7 +1053,7 @@
     "@@rules_buf+//buf:extensions.bzl%buf": {
       "general": {
         "bzlTransitiveDigest": "IjW2he5lp+L/zEfsBKIilXijyHH6PC4Lf3y19MA6G4c=",
-        "usagesDigest": "31Ru5arfzP1o2+OGymbL/dROP3ZgMtAsH61E9u+08Qc=",
+        "usagesDigest": "e89v1srq+M2sfbB2oHPTlq74UTCiuwdACnUTVfCABQo=",
         "recordedInputs": [
           "REPO_MAPPING:rules_buf+,bazel_tools bazel_tools"
         ],
@@ -1061,7 +1061,7 @@
           "rules_buf_toolchains": {
             "repoRuleId": "@@rules_buf+//buf/internal:toolchain.bzl%buf_download_releases",
             "attributes": {
-              "version": "v1.67.0",
+              "version": "v1.71.0",
               "sha256": ""
             }
           }

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -137,13 +137,13 @@ func applyMeshConfig(mc *configv1.MeshConfigSpec) {
 
 	cfg.AccessLogsEnabled = p.GetAccessLogsEnabled()
 	cfg.AccessLogSuccessSampleRate = 100
-	if p != nil && p.AccessLogSuccessSampleRate != nil {
+	if p != nil && p.HasAccessLogSuccessSampleRate() {
 		cfg.AccessLogSuccessSampleRate = p.GetAccessLogSuccessSampleRate()
 	}
 
 	cfg.ProxyTracingEnabled = p.GetTracingEnabled()
 	cfg.ProxyTraceSampleRate = cfg.TraceSampleRate // inherit the aether trace rate
-	if p != nil && p.TraceSampleRate != nil {
+	if p != nil && p.HasTraceSampleRate() {
 		cfg.ProxyTraceSampleRate = p.GetTraceSampleRate()
 	}
 

--- a/api/aether/config/v1/BUILD.bazel
+++ b/api/aether/config/v1/BUILD.bazel
@@ -13,10 +13,7 @@ proto_library(
     name = "configv1_proto",
     srcs = ["mesh_config.proto"],
     visibility = ["//visibility:public"],
-    deps = [
-        "@protobuf//:go_features_proto",
-        "@protovalidate//proto/protovalidate/buf/validate:validate_proto",
-    ],
+    deps = ["@protovalidate//proto/protovalidate/buf/validate:validate_proto"],
 )
 
 go_proto_library(
@@ -25,10 +22,7 @@ go_proto_library(
     importpath = "github.com/bpalermo/aether/api/aether/config/v1",
     proto = ":configv1_proto",
     visibility = ["//visibility:public"],
-    deps = [
-        "@build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate",
-        "@org_golang_google_protobuf//types/gofeaturespb",
-    ],
+    deps = ["@build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate"],
 )
 
 go_library(

--- a/api/aether/config/v1/BUILD.bazel
+++ b/api/aether/config/v1/BUILD.bazel
@@ -3,23 +3,32 @@ load("@rules_go//go:def.bzl", "go_library")
 load("@rules_go//proto:def.bzl", "go_proto_library")
 load("//bazel/lint:linters.bzl", "buf_test")
 
+# The config proto carries no protoc-gen-dynamo annotations and uses Protobuf
+# Editions 2024 (opaque API). protoc-gen-dynamo (a protoc-gen-star fork) does not
+# understand edition descriptors, so scope this package to the standard Go
+# compiler only and keep gazelle from re-adding //bazel/go:go_dynamo.
+# gazelle:go_proto_compilers @rules_go//proto:go_proto
+
 proto_library(
     name = "configv1_proto",
     srcs = ["mesh_config.proto"],
     visibility = ["//visibility:public"],
-    deps = ["@protovalidate//proto/protovalidate/buf/validate:validate_proto"],
+    deps = [
+        "@protobuf//:go_features_proto",
+        "@protovalidate//proto/protovalidate/buf/validate:validate_proto",
+    ],
 )
 
 go_proto_library(
     name = "configv1_go_proto",
-    compilers = [
-        "@rules_go//proto:go_proto",
-        "//bazel/go:go_dynamo",
-    ],
+    compilers = ["@rules_go//proto:go_proto"],
     importpath = "github.com/bpalermo/aether/api/aether/config/v1",
     proto = ":configv1_proto",
     visibility = ["//visibility:public"],
-    deps = ["@build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate"],
+    deps = [
+        "@build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate",
+        "@org_golang_google_protobuf//types/gofeaturespb",
+    ],
 )
 
 go_library(

--- a/api/aether/config/v1/mesh_config.proto
+++ b/api/aether/config/v1/mesh_config.proto
@@ -1,11 +1,9 @@
-edition = "2023";
+edition = "2024";
 
 package aether.config.v1;
 
 import "buf/validate/validate.proto";
-import "google/protobuf/go_features.proto";
 
-option features.(pb.go).api_level = API_OPAQUE;
 option go_package = "github.com/bpalermo/aether/api/aether/config/v1;configv1";
 
 // MeshConfigSpec is the `.spec` of the MeshConfig custom resource — the proxy

--- a/api/aether/config/v1/mesh_config.proto
+++ b/api/aether/config/v1/mesh_config.proto
@@ -1,9 +1,11 @@
-syntax = "proto3";
+edition = "2023";
 
 package aether.config.v1;
 
 import "buf/validate/validate.proto";
+import "google/protobuf/go_features.proto";
 
+option features.(pb.go).api_level = API_OPAQUE;
 option go_package = "github.com/bpalermo/aether/api/aether/config/v1;configv1";
 
 // MeshConfigSpec is the `.spec` of the MeshConfig custom resource — the proxy
@@ -28,22 +30,22 @@ message MeshConfigSpec {
 message ProxyTelemetry {
   // Attach the OTel access logger to every HCM (proposal 014). Unset inherits the
   // aether default (off).
-  optional bool access_logs_enabled = 1;
+  bool access_logs_enabled = 1;
   // Percent (0-100) of successful requests logged; failures are always logged.
   // Unset defaults to 100.
-  optional uint32 access_log_success_sample_rate = 2 [(buf.validate.field).uint32.lte = 100];
+  uint32 access_log_success_sample_rate = 2 [(buf.validate.field).uint32.lte = 100];
 
   // Generate/propagate W3C trace context and export proxy request spans. Unset
   // inherits the aether default (off).
-  optional bool tracing_enabled = 3;
+  bool tracing_enabled = 3;
   // Fraction (0.0-1.0) of requests traced by the proxy. Unset inherits the aether
   // control-plane trace sample rate.
-  optional double trace_sample_rate = 4 [(buf.validate.field).double = {
+  double trace_sample_rate = 4 [(buf.validate.field).double = {
     gte: 0.0
     lte: 1.0
   }];
 
   // Emit per-pod labels (source_pod/destination_pod) on the aether_stats request
   // counter (raises cardinality). Unset inherits the aether default (off).
-  optional bool emit_stats_pod = 5;
+  bool emit_stats_pod = 5;
 }

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -51,7 +51,7 @@ func TestParse_PresenceDistinguished(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if cfg.GetProxy().TracingEnabled == nil {
+	if !cfg.GetProxy().HasTracingEnabled() {
 		t.Fatal("tracingEnabled should be present (explicit false), got nil")
 	}
 	if cfg.GetProxy().GetTracingEnabled() {

--- a/controller/internal/meshconfig/meshconfig_test.go
+++ b/controller/internal/meshconfig/meshconfig_test.go
@@ -17,22 +17,22 @@ func TestValidate(t *testing.T) {
 		t.Errorf("Validate(nil) = %v, want nil", err)
 	}
 	// in-range values are valid.
-	ok := &configv1.MeshConfigSpec{Proxy: &configv1.ProxyTelemetry{TraceSampleRate: proto.Float64(0.5)}}
+	ok := configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{TraceSampleRate: proto.Float64(0.5)}.Build()}.Build()
 	if err := Validate(ok); err != nil {
 		t.Errorf("Validate(valid) = %v, want nil", err)
 	}
 	// out-of-range trace rate is rejected.
-	bad := &configv1.MeshConfigSpec{Proxy: &configv1.ProxyTelemetry{TraceSampleRate: proto.Float64(1.5)}}
+	bad := configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{TraceSampleRate: proto.Float64(1.5)}.Build()}.Build()
 	if err := Validate(bad); err == nil {
 		t.Error("Validate(traceSampleRate=1.5) = nil, want error")
 	}
 }
 
 func TestRenderConfigMapData_RoundTrips(t *testing.T) {
-	spec := &configv1.MeshConfigSpec{Proxy: &configv1.ProxyTelemetry{
+	spec := configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{
 		TracingEnabled:  proto.Bool(true),
 		TraceSampleRate: proto.Float64(0.25),
-	}}
+	}.Build()}.Build()
 	data, err := RenderConfigMapData(spec)
 	if err != nil {
 		t.Fatalf("RenderConfigMapData: %v", err)
@@ -64,10 +64,10 @@ func TestRenderConfigMapData_NilSpec(t *testing.T) {
 // The typed MeshConfig jsonshim must round-trip the proto spec through protojson
 // (camelCase field names, optional presence), not encoding/json.
 func TestMeshConfigJSONShim(t *testing.T) {
-	mc := &crdv1.MeshConfig{Spec: &configv1.MeshConfigSpec{Proxy: &configv1.ProxyTelemetry{
+	mc := &crdv1.MeshConfig{Spec: configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{
 		AccessLogsEnabled: proto.Bool(true),
 		TraceSampleRate:   proto.Float64(0.1),
-	}}}
+	}.Build()}.Build()}
 	raw, err := json.Marshal(mc)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)


### PR DESCRIPTION
Migrate `api/aether/config/v1/mesh_config.proto` to **Protobuf Editions 2024** with the **Opaque Go API** (getters/setters/`Has`/builders). Wire- and JSON-compatible — no field-number/name/semantic change.

## Changes
- `syntax = "proto3"` → `edition = "2024"`; dropped `optional` (edition default field presence is EXPLICIT, so the 5 `ProxyTelemetry` fields keep `Has*`/pointer accessors). `buf/validate` annotations unchanged.
- Edition 2024 defaults protoc-gen-go to the **Opaque API**, so no explicit `api_level` option / `go_features` import is needed.
- **buf bumped `v1.67.0` → `v1.71.0`** (1.67 rejected `EDITION_2024`; 1.71 supports it).
- Scoped this package off the `protoc-gen-dynamo` (`go_dynamo`) compiler via a gazelle directive — that plugin doesn't grok edition descriptors and the config proto has no dynamo annotations.
- Consumer fixes for opaque: `agent/internal/cmd/root.go` presence checks → `Has*()`; `controller/internal/meshconfig/meshconfig_test.go` + `common/config/config_test.go` literals → builders / `Has*()`. Empty literals, `proto.Clone`, protojson, and the typed `crdv1.MeshConfig` wrapper are unchanged.

## Verified
`bazel test //...` (45 tests) green incl. `configv1_buf_lint_test` (edition 2024 accepted by buf 1.71); `make format-check` clean. Generated API confirmed opaque (`*_builder`, `Has*`/`Set*`), same type names/getters, protovalidate still enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)