### PR TITLE
fix(controller): caBundle GET+Update; chart-render ClusterSPIFFEID behind the knob

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.5.0-{GIT_COMMIT}"
+version: "0.6.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-clusterspiffeid.yaml
+++ b/charts/aether/templates/controller-clusterspiffeid.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.controller.webhook.spire .Values.controller.webhook.clusterSpiffeID.create .Values.controller.webhook.clusterSpiffeID.className }}
+{{- /*
+  In SPIRE webhook mode the controller serves with its SPIRE SVID, which must
+  carry the webhook Service DNS name as a SAN or the apiserver's TLS hostname
+  check fails. This ClusterSPIFFEID grants exactly that. It is non-fallback, so it
+  takes precedence over the default (fallback) ClusterSPIFFEID for the controller
+  pod — the controller then gets a single SVID with the DNS SANs. The {{ }} inside
+  the templates are spire-controller-manager fields, escaped from Helm.
+*/}}
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: {{ include "aether.controller.fullname" . }}-webhook
+  labels:
+    {{- include "aether.controller.labels" . | nindent 4 }}
+spec:
+  className: {{ .Values.controller.webhook.clusterSpiffeID.className | quote }}
+  spiffeIDTemplate: "spiffe://{{ `{{ .TrustDomain }}` }}/ns/{{ `{{ .PodMeta.Namespace }}` }}/sa/{{ `{{ .PodSpec.ServiceAccountName }}` }}"
+  dnsNameTemplates:
+    - {{ printf "%s.%s.svc" (include "aether.controller.webhookServiceName" .) (include "aether.namespace" .) | quote }}
+    - {{ printf "%s.%s.svc.cluster.local" (include "aether.controller.webhookServiceName" .) (include "aether.namespace" .) | quote }}
+  podSelector:
+    matchLabels:
+      {{- include "aether.controller.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "aether.namespace" . }}
+{{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -202,11 +202,18 @@ controller:
     #   false (default): a Helm self-signed cert (genSignedCert, caBundle baked
     #     into the webhook config). Validates out of the box, no SPIRE setup.
     #   true: serve with the controller's SPIRE X.509 SVID and inject the trust
-    #     bundle into the caBundle at runtime. Requires a ClusterSPIFFEID granting
-    #     the controller the webhook Service DNS name
-    #     (<release>-controller-webhook.<ns>.svc) in its dnsNames, else the
-    #     apiserver's TLS hostname check fails.
+    #     bundle into the caBundle at runtime. Requires the ClusterSPIFFEID below
+    #     (or an equivalent) granting the controller the webhook Service DNS name
+    #     in its dnsNames, else the apiserver's TLS hostname check fails.
     spire: false
+    # When spire=true, have the chart create the controller's ClusterSPIFFEID with
+    # the webhook Service DNS SANs, so SPIRE mode works without a manual entry.
+    clusterSpiffeID:
+      create: true
+      # spire-controller-manager class name for your SPIRE install (e.g.
+      # "spire-mgmt-spire"). REQUIRED when create=true; if empty the resource is
+      # not rendered (manage the ClusterSPIFFEID yourself).
+      className: ""
   resources:
     requests:
       cpu: 50m

--- a/controller/internal/meshconfig/cabundle.go
+++ b/controller/internal/meshconfig/cabundle.go
@@ -1,13 +1,13 @@
 package meshconfig
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
 
 	"github.com/bpalermo/aether/common/spire"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -47,33 +47,35 @@ func (i *CABundleInjector) Start(ctx context.Context) error {
 	}
 }
 
+// inject sets the current SPIRE trust bundle as the caBundle on every webhook in
+// the ValidatingWebhookConfiguration via read-modify-write (Update), NOT
+// Server-Side Apply: the `webhooks` list is atomic for SSA, so a partial apply
+// would replace the whole entry and drop Helm-owned required fields
+// (sideEffects, admissionReviewVersions). This is the standard caBundle-injection
+// pattern (cf. cert-manager's cainjector).
 func (i *CABundleInjector) inject(ctx context.Context) error {
 	bundle, err := spire.TrustBundlePEM(i.Source)
 	if err != nil {
 		return err
 	}
 
-	// Read the existing webhook names so the Server-Side Apply targets the real
-	// list entries (webhooks is a list-map keyed by name) rather than creating a
-	// phantom one. The controller's field manager then owns ONLY each webhook's
-	// caBundle; Helm keeps ownership of the rest of the config.
-	var existing admissionregistrationv1.ValidatingWebhookConfiguration
-	if err := i.Client.Get(ctx, types.NamespacedName{Name: i.WebhookConfigName}, &existing); err != nil {
+	var vwc admissionregistrationv1.ValidatingWebhookConfiguration
+	if err := i.Client.Get(ctx, types.NamespacedName{Name: i.WebhookConfigName}, &vwc); err != nil {
 		return fmt.Errorf("get ValidatingWebhookConfiguration %q: %w", i.WebhookConfigName, err)
 	}
 
-	apply := &admissionregistrationv1.ValidatingWebhookConfiguration{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingWebhookConfiguration"},
-		ObjectMeta: metav1.ObjectMeta{Name: i.WebhookConfigName},
+	changed := false
+	for idx := range vwc.Webhooks {
+		if !bytes.Equal(vwc.Webhooks[idx].ClientConfig.CABundle, bundle) {
+			vwc.Webhooks[idx].ClientConfig.CABundle = bundle
+			changed = true
+		}
 	}
-	for _, w := range existing.Webhooks {
-		apply.Webhooks = append(apply.Webhooks, admissionregistrationv1.ValidatingWebhook{
-			Name:         w.Name,
-			ClientConfig: admissionregistrationv1.WebhookClientConfig{CABundle: bundle},
-		})
+	if !changed {
+		return nil
 	}
-	if err := i.Client.Patch(ctx, apply, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {
-		return fmt.Errorf("apply webhook caBundle: %w", err)
+	if err := i.Client.Update(ctx, &vwc); err != nil {
+		return fmt.Errorf("update webhook caBundle: %w", err)
 	}
 	i.Log.InfoContext(ctx, "injected SPIRE trust bundle into webhook caBundle", "webhookConfig", i.WebhookConfigName)
 	return nil


### PR DESCRIPTION
Found while validating the SPIRE webhook on talos-main.

## 1. caBundle injection: SSA → GET+Update
Enabling `controller.webhook.spire=true` made the controller's `CABundleInjector` fail:
```
webhooks[0].sideEffects: Required value ...; webhooks[0].admissionReviewVersions: Required value ...
```
`ValidatingWebhookConfiguration.webhooks` is an **atomic list** for Server-Side Apply, so a partial apply (just `name`+`caBundle`) replaces the whole entry and drops Helm-owned required fields → apiserver rejects it, webhook goes fail-open. Reverted the injector to **read-modify-write** (`GET` + set `caBundle` + `Update`) — the standard caBundle-injection pattern (cf. cert-manager's cainjector). SSA stays for the ConfigMap projection + status (correct there).

## 2. Chart-render the ClusterSPIFFEID behind the knob
SPIRE webhook mode needs the controller's SVID to carry the webhook Service DNS SAN, or the apiserver TLS hostname check fails. Rather than a manual `kubectl apply`, the chart now creates it when `controller.webhook.spire=true` and `controller.webhook.clusterSpiffeID.create` with a `className`:
- non-fallback `ClusterSPIFFEID` (takes precedence over the default fallback one, so the controller gets a single SVID with the DNS SANs),
- SA-based spiffeID, dnsNames = `<release>-controller-webhook.<ns>.svc[.cluster.local]`, podSelector = controller.
- `className` is required (the spire-controller-manager class is environment-specific, e.g. `spire-mgmt-spire`); empty → not rendered (manage it yourself).

Bumps the `aether` chart to `0.6.0`. Verified: render of the CSID in SPIRE mode (escaped spire templates, correct SANs/selectors), chart lint/template + controller tests pass.

> Validated the mechanism on talos-main: the non-fallback CSID matched the controller (1 entry, 0 failures) and the `fallback: true` default was masked for it. The injector + cert flow will be re-verified end-to-end once this merges and republishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)