### PR TITLE
chore(bazel): ignore .claude/worktrees in .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,1 +1,2 @@
 proxy
+.claude/worktrees


### PR DESCRIPTION
Background worktree agents (`Agent` tool with `isolation: worktree`) create a nested repo copy under `.claude/worktrees/`. Gazelle and bazel walk into it, hitting duplicate-package rule conflicts (`imports ... which matches multiple rules: @aether//.claude/worktrees/.../X and @aether//X`) — which silently corrupted a batch of BUILD.bazel files during a `make gazelle` this week.

Add `.claude/worktrees` to `.bazelignore` so the main workspace ignores worktree copies. Verified `make gazelle` and `bazel query //...` are clean after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)