### PR TITLE
feat(edge): edge.enabled chart — Deployment, Service, bootstrap, RBAC, SPIRE identity

### DIFF
--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -44,6 +44,9 @@ func init() {
 	manager.RegisterFlags(edgeCmd, &cfg.Config)
 	registerSharedFlags(edgeCmd)
 
+	// The edge has no CNI/pod storage; it points the (always-empty) local store
+	// at a pod-local emptyDir so PreListen's load is a no-op.
+	edgeCmd.Flags().StringVar(&cfg.MountedLocalStorageDir, "mounted-registry-dir", "/var/lib/aether/registry", "Pod-local directory for the edge's (empty) local store")
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPPort, "edge-http-port", cfg.EdgeHTTPPort, "Port the edge proxy's public-facing HTTP listener binds")
 	edgeCmd.Flags().StringSliceVar(&cfg.EdgeExposes, "expose", nil, "Mesh service names the edge always routes to at their mesh FQDN (comma-separated or repeated); merged with the EdgeRoute CRs")
 	edgeCmd.Flags().StringVar(&cfg.EdgeRouteNamespace, "edge-route-namespace", "", "Namespace to watch EdgeRoute CRs in (empty = the edge pod's own namespace)")

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.6.0-{GIT_COMMIT}"
+version: "0.7.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/_helpers.tpl
+++ b/charts/aether/templates/_helpers.tpl
@@ -119,6 +119,29 @@ app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 {{- end -}}
 
+{{/* ------------------------------------------------------------------- edge */}}
+{{- define "aether.edge.fullname" -}}
+{{- printf "%s-edge" (include "aether.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "aether.edge.serviceAccountName" -}}{{ include "aether.edge.fullname" . }}{{- end -}}
+{{- define "aether.edge.configMapName" -}}
+{{- printf "%s-config" (include "aether.edge.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- define "aether.edge.selectorLabels" -}}
+app.kubernetes.io/name: aether-edge
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: edge
+{{- end -}}
+{{- define "aether.edge.labels" -}}
+helm.sh/chart: {{ include "aether.chart" . }}
+{{ include "aether.edge.selectorLabels" . }}
+app.kubernetes.io/part-of: aether
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Chart.AppVersion }}
+app.kubernetes.io/version: {{ . | quote }}
+{{- end }}
+{{- end -}}
+
 {{/* ------------------------------------------------------------- controller */}}
 {{- define "aether.controller.fullname" -}}
 {{- printf "%s-controller" (include "aether.fullname" .) | trunc 63 | trimSuffix "-" -}}

--- a/charts/aether/templates/edge-clusterspiffeid.yaml
+++ b/charts/aether/templates/edge-clusterspiffeid.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.edge.enabled .Values.spire.enabled .Values.edge.spire.clusterSpiffeID.create .Values.edge.spire.clusterSpiffeID.className }}
+{{- /*
+  The edge presents a single SPIFFE SVID (spiffe://<td>/ns/<ns>/sa/<edge-sa>) to
+  every upstream pod. This ClusterSPIFFEID has spire-controller-manager issue it
+  to the edge pods. The {{ }} inside the template strings are
+  spire-controller-manager fields, escaped from Helm.
+*/}}
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: {{ include "aether.edge.fullname" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+spec:
+  className: {{ .Values.edge.spire.clusterSpiffeID.className | quote }}
+  spiffeIDTemplate: "spiffe://{{ `{{ .TrustDomain }}` }}/ns/{{ `{{ .PodMeta.Namespace }}` }}/sa/{{ `{{ .PodSpec.ServiceAccountName }}` }}"
+  podSelector:
+    matchLabels:
+      {{- include "aether.edge.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ include "aether.namespace" . }}
+{{- end }}

--- a/charts/aether/templates/edge-configmap.yaml
+++ b/charts/aether/templates/edge-configmap.yaml
@@ -1,0 +1,149 @@
+{{- if .Values.edge.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aether.edge.configMapName" . }}
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+data:
+  envoy.yaml: |
+    admin:
+      address:
+        socket_address:
+          address: 127.0.0.1
+          port_value: 9901
+
+{{- if .Values.proxy.jsonLogs }}
+    application_log_config:
+      log_format:
+        json_format:
+          time: "%Y-%m-%dT%T.%e%z"
+          level: "%l"
+          name: "%n"
+          thread: "%t"
+          source: "%g:%#"
+          message: "%j"
+{{- end }}
+
+{{- if .Values.otel.endpoint }}
+    # Push the edge Envoy's stats to the collector over OTLP, like the rest of
+    # the mesh telemetry (no scrape port). The edge listener carries no
+    # aether_stats filter, so no custom stat conversions are needed.
+    stats_sinks:
+      - name: envoy.stat_sinks.open_telemetry
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig
+          grpc_service:
+            envoy_grpc:
+              cluster_name: otel_collector
+          resource_detectors:
+            - name: envoy.tracers.opentelemetry.resource_detectors.environment
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.tracers.opentelemetry.resource_detectors.v3.EnvironmentResourceDetectorConfig
+          prefix: envoy
+          emit_tags_as_attributes: true
+          use_tag_extracted_name: true
+{{- end }}
+
+{{- if .Values.edge.overload.enabled }}
+    # Graceful degradation before the container memory limit OOM-kills Envoy.
+    # The edge pod is unprivileged (private cgroup namespace), so unlike the
+    # node DaemonSet it COULD use cgroup_memory; fixed_heap is used here too for
+    # parity and to stay independent of the cgroup layout. Keep maxHeapSizeBytes
+    # at ~75% of edge.resources.limits.memory.
+    overload_manager:
+      refresh_interval: 0.25s
+      resource_monitors:
+        - name: "envoy.resource_monitors.fixed_heap"
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+            max_heap_size_bytes: {{ int64 .Values.edge.overload.maxHeapSizeBytes }}
+      actions:
+        - name: "envoy.overload_actions.shrink_heap"
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              threshold:
+                value: 0.80
+        - name: "envoy.overload_actions.stop_accepting_requests"
+          triggers:
+            - name: "envoy.resource_monitors.fixed_heap"
+              threshold:
+                value: 0.95
+{{- end }}
+
+    dynamic_resources:
+      ads_config:
+        api_type: DELTA_GRPC
+        grpc_services:
+          - envoy_grpc:
+              cluster_name: agent_xds
+      cds_config:
+        ads: {}
+      lds_config:
+        ads: {}
+
+    static_resources:
+      clusters:
+      # The edge agent sidecar serves LDS/CDS/EDS/RDS over this pod-local socket.
+      - name: agent_xds
+        type: STATIC
+        load_assignment:
+          cluster_name: agent_xds
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      pipe:
+                        path: /run/aether/xds.sock
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options:
+                connection_keepalive:
+                  interval: 15s
+                  timeout: 5s
+{{- if .Values.spire.enabled }}
+      # SPIRE Agent's native Envoy SDS API (served on the Workload API socket):
+      # the edge fetches its single SVID + trust bundle straight from SPIRE. The
+      # service clusters' SDS config sources reference this cluster by name
+      # (proxy.SpireAgentSDSClusterName = "spire_agent").
+      - name: spire_agent
+        type: STATIC
+        connect_timeout: 2s
+        load_assignment:
+          cluster_name: spire_agent
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      pipe:
+                        path: {{ .Values.spire.workloadSocketPath }}
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
+{{- end }}
+{{- if .Values.otel.endpoint }}
+{{- $otlp := splitList ":" .Values.otel.endpoint }}
+      - name: otel_collector
+        type: STRICT_DNS
+        connect_timeout: 2s
+        load_assignment:
+          cluster_name: otel_collector
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: {{ index $otlp 0 }}
+                        port_value: {{ index $otlp 1 }}
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
+{{- end }}
+{{- end }}

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -1,0 +1,199 @@
+{{- if .Values.edge.enabled }}
+{{- $routeNamespace := default (include "aether.namespace" .) .Values.edge.routeNamespace }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "aether.edge.fullname" . }}
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.edge.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "aether.edge.selectorLabels" . | nindent 6 }}
+  # Standard rolling update behind the Service: the readiness probe (Envoy's
+  # /aether/readyz health_check filter, drain-aware) gates each replica, so no
+  # hot-restart supervisor is needed — nothing node-local to preserve.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "aether.edge.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "aether.edge.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        # Edge control plane: serves xDS to the co-located Envoy over a pod-local
+        # socket. Subtractive agent mode — no CNI, no per-pod listeners, no SPIRE
+        # bridge (Envoy talks to SPIRE SDS directly).
+        - name: agent
+          image: {{ include "aether.image" .Values.agent.image | quote }}
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          args:
+            - "edge"
+            - "--debug={{ .Values.debug }}"
+            - "--proxy-id=$(POD_NAME)"
+            - "--cluster-name={{ .Values.clusterName }}"
+            - "--node-name=$(POD_NAME)"
+            - "--mesh-domain={{ .Values.meshDomain }}"
+            - "--edge-http-port={{ .Values.edge.httpPort }}"
+            - "--edge-route-namespace={{ $routeNamespace }}"
+            {{- range .Values.edge.expose }}
+            - "--expose={{ . }}"
+            {{- end }}
+            {{- if .Values.otel.enabled }}
+            - "--otel-enabled=true"
+            {{- end }}
+            {{- with .Values.otel.endpoint }}
+            - "--otlp-endpoint={{ . }}"
+            {{- end }}
+            {{- if .Values.otel.logs }}
+            - "--logs-enabled=true"
+            {{- end }}
+            - "--trace-sample-rate={{ .Values.otel.traceSampleRate }}"
+            {{- if .Values.otel.traceExport }}
+            - "--trace-export=true"
+            {{- end }}
+            - "--spire-enabled={{ .Values.spire.enabled }}"
+            {{- if .Values.spire.enabled }}
+            - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
+            {{- end }}
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(POD_NAMESPACE)"
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  resource: limits.memory
+                  divisor: "1"
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: xds-sock
+              mountPath: /run/aether
+            - name: registry-dir
+              mountPath: /var/lib/aether/registry
+            {{- if .Values.spire.enabled }}
+            - name: workload-socket
+              mountPath: /run/secrets/workload-spiffe-uds
+              readOnly: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.edge.resources | nindent 12 }}
+        # Public-facing Envoy. Plain entrypoint (no supervisor): the edge has no
+        # node-local state to preserve across restarts.
+        - name: envoy
+          image: {{ include "aether.image" .Values.proxy.image | quote }}
+          imagePullPolicy: {{ .Values.proxy.image.pullPolicy }}
+          command:
+            - "/usr/local/bin/envoy"
+            - "-c"
+            - "/etc/envoy/envoy.yaml"
+            - "-l"
+            - "{{ .Values.proxy.logLevel }}"
+            - "--service-cluster"
+            - "aether-edge"
+            - "--service-node"
+            - "$(POD_NAME)"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.namespace.name=$(POD_NAMESPACE),k8s.pod.name=$(POD_NAME)"
+          ports:
+            - name: http
+              containerPort: {{ .Values.edge.httpPort }}
+              protocol: TCP
+          readinessProbe:
+            # Envoy's /aether/readyz health_check filter (on the edge listener):
+            # 200 while serving, 503 while draining. Probed over the listener port.
+            httpGet:
+              path: /aether/readyz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            failureThreshold: 3
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: xds-sock
+              mountPath: /run/aether
+            - name: edge-config
+              mountPath: /etc/envoy
+              readOnly: true
+            {{- if .Values.spire.enabled }}
+            - name: workload-socket
+              mountPath: /run/secrets/workload-spiffe-uds
+              readOnly: true
+            {{- end }}
+          resources:
+            {{- toYaml .Values.edge.resources | nindent 12 }}
+      volumes:
+        # Pod-local: the agent serves xDS on /run/aether/xds.sock, Envoy dials it.
+        - name: xds-sock
+          emptyDir: {}
+        - name: registry-dir
+          emptyDir: {}
+        - name: edge-config
+          configMap:
+            name: {{ include "aether.edge.configMapName" . }}
+            items:
+              - key: envoy.yaml
+                path: envoy.yaml
+        {{- if .Values.spire.enabled }}
+        - name: workload-socket
+          csi:
+            driver: "csi.spiffe.io"
+            readOnly: true
+        {{- end }}
+{{- end }}

--- a/charts/aether/templates/edge-rbac.yaml
+++ b/charts/aether/templates/edge-rbac.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.edge.enabled }}
+{{- $routeNamespace := default (include "aether.namespace" .) .Values.edge.routeNamespace }}
+# Namespaced: the edge only reads EdgeRoutes (and their status) in the namespace
+# it watches. No cluster-wide access — exposure is delegable per namespace.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aether.edge.fullname" . }}
+  namespace: {{ $routeNamespace }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["config.aether.io"]
+    resources: ["edgeroutes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["config.aether.io"]
+    resources: ["edgeroutes/status"]
+    verbs: ["get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aether.edge.fullname" . }}
+  namespace: {{ $routeNamespace }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "aether.edge.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aether.edge.serviceAccountName" . }}
+    namespace: {{ include "aether.namespace" . }}
+{{- end }}

--- a/charts/aether/templates/edge-service.yaml
+++ b/charts/aether/templates/edge-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.edge.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "aether.edge.fullname" . }}
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+  {{- with .Values.edge.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.edge.service.type }}
+  selector:
+    {{- include "aether.edge.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.edge.service.port }}
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/aether/templates/edge-serviceaccount.yaml
+++ b/charts/aether/templates/edge-serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.edge.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "aether.edge.serviceAccountName" . }}
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -158,6 +158,51 @@ proxy:
     enabled: true
     maxHeapSizeBytes: 402653184 # 384Mi = 75% of 512Mi
 
+# ----------------------------------------------------------------------- edge
+# North-south ingress gateway (proposal 003): an unprivileged Deployment running
+# Envoy + an `agent edge` sidecar that serves it xDS. The edge dials mesh pods
+# DIRECTLY over mTLS (no node DaemonSet in the path) and routes external traffic
+# by EdgeRoute CRs (config.aether.io/v1). Envoy fetches its single SVID straight
+# from SPIRE over the workload socket (no agent SPIRE bridge). Disabled by default.
+edge:
+  enabled: false
+  # Gateway replicas behind the Service; rolled with the standard RollingUpdate
+  # + readiness gate (no hot-restart supervisor — nothing node-local to preserve).
+  replicaCount: 2
+  # The edge reuses the agent image (run as `agent edge`) and the proxy image
+  # (plain Envoy entrypoint). Override agent.image / proxy.image to mirror.
+  # Port the edge's public-facing HTTP listener binds (north-south). TLS
+  # termination is a separate, later addition.
+  httpPort: 8080
+  # Namespace the edge watches EdgeRoute CRs in. Empty = the edge's own namespace.
+  routeNamespace: ""
+  # Static services always routed at their mesh FQDN (merged with the EdgeRoute
+  # CRs); handy for bring-up before any EdgeRoute exists.
+  expose: []
+  service:
+    type: LoadBalancer
+    port: 80
+    annotations: {}
+  resources:
+    requests:
+      cpu: 200m
+      memory: 128Mi
+    limits:
+      memory: 256Mi
+  # The edge pod is unprivileged (private cgroup namespace), so the cgroup_memory
+  # overload monitor — fatal in the privileged node DaemonSet — works here.
+  overload:
+    enabled: true
+    maxHeapSizeBytes: 201326592 # 192Mi = 75% of 256Mi
+  # SPIRE identity for the edge (when spire.enabled): create a ClusterSPIFFEID so
+  # SPIRE issues the edge pod its SVID. Mirrors controller.webhook.clusterSpiffeID.
+  spire:
+    clusterSpiffeID:
+      create: true
+      # spire-controller-manager class name (e.g. "spire-mgmt-spire"). REQUIRED
+      # when create=true; empty = not rendered (manage the ClusterSPIFFEID yourself).
+      className: ""
+
 # ----------------------------------------------------------------- registrar
 registrar:
   image:


### PR DESCRIPTION
## What

PR3 of the edge proxy plan (on merged #236 + #237). Adds the **edge (north-south ingress) gateway to `charts/aether`** behind `edge.enabled` (default **off**): an unprivileged Deployment running plain Envoy + an `agent edge` sidecar that serves it xDS over a pod-local socket. The edge dials mesh pods directly over mTLS and routes by EdgeRoute CRs.

## Resources (all gated on `edge.enabled`)

- **`edge-deployment.yaml`** — two containers (`agent edge` + Envoy), unprivileged (`runAsNonRoot`, drop ALL caps, `readOnlyRootFilesystem`), a shared `emptyDir` xDS socket, the `csi.spiffe.io` workload socket mounted in **both** (registrar mTLS + identity for the agent; SDS for Envoy), and a pod-local empty store. Envoy readiness rides the `/aether/readyz` health_check filter; standard `RollingUpdate` + readiness gate (no hot-restart supervisor — nothing node-local to preserve).
- **`edge-configmap.yaml`** — Envoy bootstrap: ADS over the `agent_xds` UDS, a static **`spire_agent` SDS cluster** (the SPIRE Workload API socket — `proxy.SpireAgentSDSClusterName`), optional `otel_collector` sink, and a `fixed_heap` overload ladder (the unprivileged edge could use `cgroup_memory`, but `fixed_heap` keeps parity and avoids cgroup-layout assumptions).
- **`edge-service.yaml`** — `LoadBalancer` (configurable type/port/annotations) on the edge HTTP port.
- **`edge-rbac.yaml`** — **namespaced** Role/RoleBinding for the EdgeRoute watch (`get/list/watch` edgeroutes + status), scoped to the watched namespace.
- **`edge-clusterspiffeid.yaml`** — optional `ClusterSPIFFEID` so SPIRE issues the edge pod its SVID (gated on `spire.enabled` + `className`), mirroring the controller.
- Edge ServiceAccount, `_helpers.tpl` entries, and an `edge:` values block. `agent edge` gains `--mounted-registry-dir` (pod-local `emptyDir` default). Chart `0.6.0 → 0.7.0`.

## Notes

- The edge keys its xDS node id on `--proxy-id=$(POD_NAME)`, matching Envoy `--service-node $(POD_NAME)` (one agent ↔ one Envoy per pod).
- No leader election (each edge pod runs its own control plane), so no Lease RBAC.

## Verification

`helm template` renders cleanly with `edge.enabled` on and off; the bootstrap carries `agent_xds` + `spire_agent` (+ `otel_collector`) clusters; the ClusterSPIFFEID template unescapes correctly. Agent builds; `make format` and `scripts/check-chart-version-bump.sh` pass.

## Follow-ups (stacked)

- PR4: downstream TLS termination (k8s TLS Secret, file SDS).
- PR5: talos e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)