### PR TITLE
feat(edge): downstream TLS termination from a Kubernetes TLS Secret

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -83,6 +83,12 @@ type AgentConfig struct {
 	// EdgeRouteNamespace is the namespace the edge watches EdgeRoute CRs in
 	// (edge subcommand only); empty means the edge pod's own namespace.
 	EdgeRouteNamespace string
+
+	// EdgeTLSCertFile / EdgeTLSKeyFile, when both set, make the edge listener
+	// terminate downstream TLS from those mounted files (a k8s TLS Secret);
+	// empty = plain HTTP (edge subcommand only).
+	EdgeTLSCertFile string
+	EdgeTLSKeyFile  string
 }
 
 // NewAgentConfig creates a new AgentConfig with default values.

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -50,6 +50,8 @@ func init() {
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPPort, "edge-http-port", cfg.EdgeHTTPPort, "Port the edge proxy's public-facing HTTP listener binds")
 	edgeCmd.Flags().StringSliceVar(&cfg.EdgeExposes, "expose", nil, "Mesh service names the edge always routes to at their mesh FQDN (comma-separated or repeated); merged with the EdgeRoute CRs")
 	edgeCmd.Flags().StringVar(&cfg.EdgeRouteNamespace, "edge-route-namespace", "", "Namespace to watch EdgeRoute CRs in (empty = the edge pod's own namespace)")
+	edgeCmd.Flags().StringVar(&cfg.EdgeTLSCertFile, "edge-tls-cert-file", "", "Path to the mounted TLS certificate chain; with --edge-tls-key-file, the edge listener terminates downstream TLS (else plain HTTP)")
+	edgeCmd.Flags().StringVar(&cfg.EdgeTLSKeyFile, "edge-tls-key-file", "", "Path to the mounted TLS private key (pairs with --edge-tls-cert-file)")
 }
 
 // runEdge initializes and runs the Aether edge proxy control plane. It is a
@@ -147,6 +149,7 @@ func runEdge(ctx context.Context) (retErr error) {
 	snapshotCache.SetMeshDomain(cfg.MeshDomain)
 	snapshotCache.SetEmitStatsPod(cfg.EmitStatsPod)
 	snapshotCache.SetEdgeMode(cfg.EdgeHTTPPort)
+	snapshotCache.SetEdgeTLS(cfg.EdgeTLSCertFile, cfg.EdgeTLSKeyFile)
 	snapshotCache.SetEdgeIdentity(edgeSpiffeID, identityTrustDomain)
 	// Static seed: --expose services routed at their mesh FQDN. The EdgeRoute
 	// reconciler merges these with the CRs and re-applies on every change; seed

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -88,6 +88,11 @@ type SnapshotCache struct {
 	edge bool
 	// edgeHTTPPort is the port the edge listener binds (edge mode only).
 	edgeHTTPPort uint32
+	// edgeTLSCert/edgeTLSKey, when both set, terminate downstream TLS on the edge
+	// listener from those mounted cert/key files (edge mode only); empty = plain
+	// HTTP.
+	edgeTLSCert string
+	edgeTLSKey  string
 
 	// edgeMu guards edgeRoutes: the external-host -> mesh-service mappings the
 	// edge serves (derived from EdgeRoute CRs). The edge route config is built
@@ -283,6 +288,14 @@ func (c *SnapshotCache) SetEmitStatsPod(enabled bool) {
 func (c *SnapshotCache) SetEdgeMode(httpPort uint32) {
 	c.edge = true
 	c.edgeHTTPPort = httpPort
+}
+
+// SetEdgeTLS enables downstream TLS termination on the edge listener from the
+// given mounted cert/key files. Both empty = plain HTTP. Must be called before
+// the manager starts.
+func (c *SnapshotCache) SetEdgeTLS(certPath, keyPath string) {
+	c.edgeTLSCert = certPath
+	c.edgeTLSKey = keyPath
 }
 
 // SetEdgeIdentity records the edge proxy's single SVID name and trust domain so

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -78,10 +78,15 @@ func (c *SnapshotCache) RemovePod(ctx context.Context, netns string) error {
 // health_<pod> clusters, probed by the liveness loop) as a flat slice.
 // Thread-safe.
 func (c *SnapshotCache) Listeners() []types.Resource {
-	// Edge mode: a single public-facing HTTP listener (no per-pod inbound/
-	// outbound listeners, no health gateway — the edge runs no local workloads).
+	// Edge mode: a single public-facing listener (no per-pod inbound/outbound
+	// listeners, no health gateway — the edge runs no local workloads). It
+	// terminates downstream TLS when a cert/key pair is configured.
 	if c.edge {
-		return []types.Resource{proxy.BuildEdgeListener(c.edgeHTTPPort)}
+		var tls *proxy.EdgeTLS
+		if c.edgeTLSCert != "" && c.edgeTLSKey != "" {
+			tls = &proxy.EdgeTLS{CertPath: c.edgeTLSCert, KeyPath: c.edgeTLSKey}
+		}
+		return []types.Resource{proxy.BuildEdgeListener(c.edgeHTTPPort, tls)}
 	}
 
 	c.listenerMu.RLock()

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -42,7 +42,11 @@ const (
 // destination pods directly over single-identity mTLS. No on_demand/subset
 // filters: the edge's routable set is its explicit exposed services, not the
 // whole mesh.
-func BuildEdgeListener(port uint32) *listenerv3.Listener {
+//
+// When tls is non-nil the filter chain terminates downstream TLS from the
+// mounted certificate (a Kubernetes TLS Secret); otherwise the edge serves plain
+// HTTP. Either way the upstream (edge -> pod) hop stays mTLS.
+func BuildEdgeListener(port uint32, tls *EdgeTLS) *listenerv3.Listener {
 	hcm := buildHTTPConnectionManager(EdgeListenerName, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
@@ -50,6 +54,14 @@ func BuildEdgeListener(port uint32) *listenerv3.Listener {
 			RouteConfigName: EdgeHTTPRouteName,
 			ConfigSource:    config.XDSConfigSourceADS(),
 		},
+	}
+
+	filterChain := &listenerv3.FilterChain{
+		Name:    EdgeListenerName,
+		Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
+	}
+	if tls != nil {
+		filterChain.TransportSocket = edgeDownstreamTLS(tls.CertPath, tls.KeyPath)
 	}
 
 	return &listenerv3.Listener{
@@ -68,13 +80,15 @@ func BuildEdgeListener(port uint32) *listenerv3.Listener {
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		StatPrefix:                    EdgeListenerName,
 		TrafficDirection:              corev3.TrafficDirection_INBOUND,
-		FilterChains: []*listenerv3.FilterChain{
-			{
-				Name:    EdgeListenerName,
-				Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
-			},
-		},
+		FilterChains:                  []*listenerv3.FilterChain{filterChain},
 	}
+}
+
+// EdgeTLS holds the mounted certificate/key file paths for terminating external
+// TLS at the edge (a Kubernetes TLS Secret projected into the Envoy container).
+type EdgeTLS struct {
+	CertPath string
+	KeyPath  string
 }
 
 // BuildEdgeRouteConfiguration builds the edge listener's route table from the

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -53,7 +53,7 @@ func TestNewServiceCluster_EdgePoolingOff(t *testing.T) {
 // interfaces at the configured port, RDS-driven, with the readiness filter
 // ahead of the router.
 func TestBuildEdgeListener(t *testing.T) {
-	l := BuildEdgeListener(8080)
+	l := BuildEdgeListener(8080, nil)
 
 	assert.Equal(t, EdgeListenerName, l.GetName())
 	assert.Equal(t, corev3.TrafficDirection_INBOUND, l.GetTrafficDirection())
@@ -73,6 +73,33 @@ func TestBuildEdgeListener(t *testing.T) {
 	require.GreaterOrEqual(t, len(hcm.GetHttpFilters()), 2)
 	assert.Equal(t, httpHealthCheckFilterName, hcm.GetHttpFilters()[0].GetName())
 	assert.Equal(t, httpRouterFilterName, hcm.GetHttpFilters()[len(hcm.GetHttpFilters())-1].GetName())
+}
+
+// TestBuildEdgeListenerTLS verifies downstream TLS termination: the filter chain
+// gets a TLS transport socket serving the mounted cert/key, and it does NOT
+// require a client certificate (external callers have no mesh identity).
+func TestBuildEdgeListenerTLS(t *testing.T) {
+	l := BuildEdgeListener(8443, &EdgeTLS{CertPath: "/etc/aether/edge-tls/tls.crt", KeyPath: "/etc/aether/edge-tls/tls.key"})
+
+	ts := l.GetFilterChains()[0].GetTransportSocket()
+	require.NotNil(t, ts, "TLS filter chain has a transport socket")
+	assert.Equal(t, tlsTransportSocketName, ts.GetName())
+
+	dtc := &transport_sockets_v3.DownstreamTlsContext{}
+	require.NoError(t, ts.GetTypedConfig().UnmarshalTo(dtc))
+	assert.False(t, dtc.GetRequireClientCertificate().GetValue(), "external clients present no cert")
+
+	certs := dtc.GetCommonTlsContext().GetTlsCertificates()
+	require.Len(t, certs, 1)
+	assert.Equal(t, "/etc/aether/edge-tls/tls.crt", certs[0].GetCertificateChain().GetFilename())
+	assert.Equal(t, "/etc/aether/edge-tls/tls.key", certs[0].GetPrivateKey().GetFilename())
+}
+
+// TestBuildEdgeListenerNoTLS verifies the plain-HTTP edge listener has no
+// transport socket.
+func TestBuildEdgeListenerNoTLS(t *testing.T) {
+	l := BuildEdgeListener(8080, nil)
+	assert.Nil(t, l.GetFilterChains()[0].GetTransportSocket())
 }
 
 // TestBuildEdgeRouteConfiguration verifies the edge route table: the exposed

--- a/agent/internal/xds/proxy/transportsocket.go
+++ b/agent/internal/xds/proxy/transportsocket.go
@@ -112,6 +112,29 @@ func upstreamTransportSocket(tlsCertificateSecretName string, validationContextN
 	return transportSocket(&transport_sockets_v3.UpstreamTlsContext{CommonTlsContext: common, Sni: sni})
 }
 
+// edgeDownstreamTLS terminates external (north-south) TLS at the edge listener
+// from a mounted certificate/key (a Kubernetes TLS Secret). It does NOT require a
+// client certificate — external callers have no mesh identity; the edge presents
+// its own SVID on the separate upstream (edge -> pod) mTLS hop. The cert/key are
+// inline file data sources; rotating the Secret takes effect on the next edge pod
+// roll (no SDS dependency for the downstream cert).
+func edgeDownstreamTLS(certPath, keyPath string) *corev3.TransportSocket {
+	return transportSocket(&transport_sockets_v3.DownstreamTlsContext{
+		CommonTlsContext: &transport_sockets_v3.CommonTlsContext{
+			TlsCertificates: []*transport_sockets_v3.TlsCertificate{
+				{
+					CertificateChain: &corev3.DataSource{
+						Specifier: &corev3.DataSource_Filename{Filename: certPath},
+					},
+					PrivateKey: &corev3.DataSource{
+						Specifier: &corev3.DataSource_Filename{Filename: keyPath},
+					},
+				},
+			},
+		},
+	})
+}
+
 // transportSocket creates a TLS transport socket from the given TLS context message.
 func transportSocket(msg proto.Message) *corev3.TransportSocket {
 	return &corev3.TransportSocket{

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.7.0-{GIT_COMMIT}"
+version: "0.8.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -47,6 +47,10 @@ spec:
             - "--mesh-domain={{ .Values.meshDomain }}"
             - "--edge-http-port={{ .Values.edge.httpPort }}"
             - "--edge-route-namespace={{ $routeNamespace }}"
+            {{- if .Values.edge.tls.enabled }}
+            - "--edge-tls-cert-file={{ .Values.edge.tls.mountPath }}/tls.crt"
+            - "--edge-tls-key-file={{ .Values.edge.tls.mountPath }}/tls.key"
+            {{- end }}
             {{- range .Values.edge.expose }}
             - "--expose={{ . }}"
             {{- end }}
@@ -156,6 +160,9 @@ spec:
             httpGet:
               path: /aether/readyz
               port: http
+              {{- if .Values.edge.tls.enabled }}
+              scheme: HTTPS
+              {{- end }}
             initialDelaySeconds: 2
             periodSeconds: 2
             failureThreshold: 3
@@ -171,6 +178,11 @@ spec:
             - name: edge-config
               mountPath: /etc/envoy
               readOnly: true
+            {{- if .Values.edge.tls.enabled }}
+            - name: edge-tls
+              mountPath: {{ .Values.edge.tls.mountPath }}
+              readOnly: true
+            {{- end }}
             {{- if .Values.spire.enabled }}
             - name: workload-socket
               mountPath: /run/secrets/workload-spiffe-uds
@@ -190,6 +202,11 @@ spec:
             items:
               - key: envoy.yaml
                 path: envoy.yaml
+        {{- if .Values.edge.tls.enabled }}
+        - name: edge-tls
+          secret:
+            secretName: {{ required "edge.tls.secretName is required when edge.tls.enabled" .Values.edge.tls.secretName }}
+        {{- end }}
         {{- if .Values.spire.enabled }}
         - name: workload-socket
           csi:

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -179,6 +179,14 @@ edge:
   # Static services always routed at their mesh FQDN (merged with the EdgeRoute
   # CRs); handy for bring-up before any EdgeRoute exists.
   expose: []
+  # Downstream (external-facing) TLS termination from a Kubernetes TLS Secret
+  # (type kubernetes.io/tls: tls.crt + tls.key). Disabled = plain HTTP. The edge
+  # ->pod upstream hop stays mTLS either way. Rotating the Secret takes effect on
+  # the next edge pod roll (the cert is mounted as files, no SDS).
+  tls:
+    enabled: false
+    secretName: ""
+    mountPath: /etc/aether/edge-tls
   service:
     type: LoadBalancer
     port: 80


### PR DESCRIPTION
## What

PR4 of the edge proxy plan (**stacked on #238**). Lets the edge listener terminate external (north-south) TLS from a mounted Kubernetes TLS Secret. The edge→pod upstream hop stays mTLS either way — only the external client→edge leg gains TLS.

> Base is `feat/edge-chart` (#238); review after that merges. The diff here is just the TLS delta.

## Changes

- **proxy** — `BuildEdgeListener` takes an optional `*EdgeTLS{CertPath, KeyPath}`. When set, the filter chain gets a `DownstreamTlsContext` serving those files and does **not** require a client certificate (external callers have no mesh identity). The cert is mounted as files (no SDS); rotating the Secret takes effect on the next edge pod roll.
- **cache** — `SetEdgeTLS` stores the cert/key paths; `Listeners()` passes them through in edge mode.
- **agent** — `agent edge` gains `--edge-tls-cert-file` / `--edge-tls-key-file`.
- **chart** — `edge.tls.{enabled,secretName,mountPath}` mounts the Secret into the Envoy container, passes the flags, switches the readiness probe to `scheme: HTTPS`, and `required`s `secretName` when enabled. Chart `0.7.0 → 0.8.0`.

## Tests

Unit tests cover the TLS and plain-HTTP listener variants (transport socket present/absent, no client-cert requirement, file paths). `helm template` renders both ways; the `secretName` guard errors when missing. Build, full proxy/cache/cmd tests, lint, and format pass.

## Follow-up

- PR5: talos e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)