### PR TITLE
docs(edge): proposal 003 (as-built) + talos e2e runbook + example EdgeRoutes

### DIFF
--- a/docs/proposals/003_edge-proxy.md
+++ b/docs/proposals/003_edge-proxy.md
@@ -1,0 +1,146 @@
+# Proposal: Edge Proxy (North-South Ingress Gateway)
+
+**Status:** Implemented — PRs #236 (control plane), #237 (EdgeRoute CRD), #238
+(chart), #239 (downstream TLS)
+**Author:** Bruno Palermo
+**Date:** 2026-06-19
+
+## Problem statement
+
+Aether is east-west only: traffic enters the mesh exclusively from mesh-managed
+pods through their netns-bound outbound listeners. There is no sanctioned way for
+external (north-south) traffic to reach mesh services, and we explicitly do not
+want to route north-south traffic through the node proxy / DaemonSet.
+
+This adds an **edge proxy**: an unprivileged Envoy Deployment behind a Service
+that terminates external traffic and forwards it **directly to destination pods'
+mesh inbound listeners** (`<pod_ip>:15008`, mTLS) — exactly the path every mesh
+client already uses. Edge pods do **not** run the agent/proxy DaemonSet.
+
+## Design principle: the edge is a single-identity mesh client
+
+The transport migration (#98–#101) already made node-proxy egress a plain
+per-source mTLS HTTP/2 client dialing `pod_ip:15008`, where the destination pod's
+own netns-bound inbound listener terminates mTLS and records the caller in
+`x-forwarded-client-cert`. The edge is **the same path with one identity instead
+of many**:
+
+| Contract element | Where it lives |
+|---|---|
+| Endpoint discovery | registrar `WatchEndpoints` stream (scoped to the exposed services) |
+| Delivery address | `pod_ip:15008` netns-bound inbound mTLS listener |
+| Endpoint readiness | EDS health (delegated liveness) + outlier detection |
+| Client identity | the edge's single SVID; the callee records it in XFCC |
+| Per-service routing | `NewServiceCluster` / `BuildOutboundClusterVirtualHost` |
+
+Consequence: **zero node data-plane changes.** Inbound listeners already accept
+any trust-domain client certificate; the edge presents its own gateway identity
+(`spiffe://<td>/ns/<ns>/sa/<edge-sa>`) and destination pods see it in XFCC —
+correct, since the external caller has no mesh identity. Because the edge has a
+single identity it does **not** need the node proxy's per-source
+`transport_socket_matcher` or `connection_pool_per_downstream_connection`: it uses
+a single transport socket and gets full upstream connection multiplexing.
+
+## Control plane: `agent edge` (subtractive sidecar)
+
+The edge runs the agent binary in a new `edge` subcommand — a subtraction of the
+node agent. It keeps the controller-runtime manager, the registrar watch client,
+the snapshot cache, the delta-xDS server + ACK tracking, and the cluster/CLA/vhost
+generators. It drops the CNI server, local pod storage, per-pod netns listeners,
+and — crucially — the SPIRE bridge:
+
+- **Envoy fetches its SVID from SPIRE directly.** The edge has one identity, so
+  the bridge's reason for being (delegated fan-out of many workload SVIDs over the
+  admin socket) does not apply. The edge Envoy bootstrap declares a static
+  `spire_agent` SDS gRPC cluster pointing at the SPIRE Agent's Workload API socket
+  (which serves the Envoy SDS API natively), and the service clusters' transport
+  sockets fetch the edge SVID + trust bundle over it. SAN pinning (#165/#166) is
+  unchanged — `match_typed_subject_alt_names` is inline; only the trust bundle
+  comes over SDS.
+- **xDS over a pod-local socket.** The agent serves xDS on an `emptyDir`
+  (`/run/aether/xds.sock`); the co-located Envoy dials it. One agent ↔ one Envoy
+  per pod, keyed on `--proxy-id=$(POD_NAME)` = Envoy `--service-node`.
+
+The edge runs no leader election (each replica is its own control plane), so a
+sick sidecar fails exactly one replica behind the Service.
+
+## Exposure: the EdgeRoute CRD
+
+Exposure is an `EdgeRoute` custom resource (`config.aether.io/v1`, **namespaced**):
+
+```yaml
+apiVersion: config.aether.io/v1
+kind: EdgeRoute
+metadata:
+  name: api
+  namespace: aether-edge
+spec:
+  hosts: [api.example.com]   # external Host/SNI; empty = the service mesh FQDN
+  service: svc-1             # mesh service = ServiceAccount = registry key
+  port: 8080                 # optional; omit = default port
+```
+
+The edge agent watches EdgeRoutes (level-based: re-lists on every change), projects
+them into the listener's route table (external host → service cluster; routes to
+the same cluster merge into one vhost), and scopes its registrar watch to exactly
+the referenced services. A custom CRD was chosen over Gateway API for v1: it names
+the mesh service directly (no `Service`-object indirection), is a tiny watch (vs a
+GatewayClass-conformance controller), and reuses the `config.aether.io` machinery
+from proposal 015. Gateway API is the v2 once the L7 vocabulary (path/header
+matching, weighted backends) is wanted — the EdgeRoute spec is shaped to migrate.
+
+`--expose <svc>` is a static seed (routed at the service FQDN), merged with the
+CRs; handy for bring-up before any EdgeRoute exists.
+
+## Data plane
+
+- **One listener** (`0.0.0.0:<edge.httpPort>`): an HCM with the `/aether/readyz`
+  readiness `health_check` filter ahead of the router (backs the pod readiness
+  probe, drain-aware) and RDS pointing at the EdgeRoute-derived route table. No
+  on-demand/ODCDS catch-all — the edge serves only its explicit exposed set; an
+  unmatched authority gets an immediate 404.
+- **Service clusters**: the existing EDS generators, with a single SPIRE-SDS
+  transport socket and `connection_pool_per_downstream_connection` off.
+- **Downstream TLS** (optional, #239): the listener terminates external TLS from a
+  mounted Kubernetes TLS Secret (`edge.tls`). No client certificate is required
+  (external callers have no mesh identity); the edge→pod hop stays mTLS. The cert
+  is mounted as files — rotating the Secret takes effect on the next edge pod roll.
+
+## Deployment
+
+The edge is part of `charts/aether`, gated on `edge.enabled` (default off): an
+unprivileged Deployment (Envoy + the `agent edge` sidecar), a Service
+(LoadBalancer/NodePort), an Envoy bootstrap ConfigMap (the `agent_xds` and
+`spire_agent` clusters), a namespaced Role/RoleBinding for the EdgeRoute watch, and
+an optional ClusterSPIFFEID so SPIRE issues the edge pod its SVID. Being
+unprivileged, the edge pod gets a private cgroup namespace, so its overload monitor
+works (unlike the privileged node DaemonSet).
+
+## Security
+
+- Exposure is opt-in and edge-local; the mesh's east-west surface is unchanged.
+- Destination pods authenticate the edge like any peer and see `URI=.../sa/<edge-sa>`
+  in XFCC. Service-level peer authorization is out of scope (the mesh has no peer
+  authz anywhere yet); when it grows one, the edge identity is just another principal.
+- The external client's identity does not enter the mesh as a certificate; propagate
+  it as headers (`x-forwarded-for`, optional JWT validation at the edge later).
+- The edge pod is unprivileged and holds only its own SVID.
+
+## Deferred
+
+- Gateway API translation; JWT / external authn at the edge; peer authz when the
+  mesh grows one; cross-cluster edge routing (until the multi-cluster registry).
+
+## End-to-end validation (talos-main)
+
+See `test/e2e/edge/README.md` for the runbook. Summary:
+
+1. `helm upgrade aether` with `edge.enabled=true`, `edge.spire.clusterSpiffeID.className`
+   set, and (optionally) `edge.tls.enabled=true` + a TLS Secret.
+2. Apply an `EdgeRoute` exposing `svc-1` (and a multi-port one for the `:3001` h2c
+   case from proposal 005).
+3. `curl` the edge Service from outside the mesh → 200; confirm the destination
+   pod's XFCC shows `URI=spiffe://…/sa/<edge-sa>`.
+4. Roll the edge Deployment under load → hitless behind the Service/readiness gate.
+5. Add/remove an EdgeRoute → the route appears/disappears with no redeploy.
+6. Confirm the edge pod runs on a node with **no** agent DaemonSet.

--- a/docs/proposals/003_edge-proxy.md
+++ b/docs/proposals/003_edge-proxy.md
@@ -75,7 +75,7 @@ metadata:
   name: api
   namespace: aether-edge
 spec:
-  hosts: [api.example.com]   # external Host/SNI; empty = the service mesh FQDN
+  hosts: [api.example.com]   # external Host/SNI (required) — at least one
   service: svc-1             # mesh service = ServiceAccount = registry key
   port: 8080                 # optional; omit = default port
 ```
@@ -89,8 +89,10 @@ GatewayClass-conformance controller), and reuses the `config.aether.io` machiner
 from proposal 015. Gateway API is the v2 once the L7 vocabulary (path/header
 matching, weighted backends) is wanted — the EdgeRoute spec is shaped to migrate.
 
-`--expose <svc>` is a static seed (routed at the service FQDN), merged with the
-CRs; handy for bring-up before any EdgeRoute exists.
+The edge routes **only** by explicit external host. The internal mesh FQDN
+(`<service>.<mesh-domain>`) is deliberately NOT routable from the edge — it is the
+mesh's east-west addressing scheme, not a north-south entrypoint. So `hosts` is
+required (≥1); a route without hosts exposes nothing.
 
 ## Data plane
 

--- a/test/e2e/edge/README.md
+++ b/test/e2e/edge/README.md
@@ -1,0 +1,78 @@
+# Edge proxy e2e (talos-main)
+
+Validates the north-south edge gateway (proposal 003): external traffic →
+edge Service → edge Envoy → destination pod's mesh inbound (`pod_ip:15008`,
+mTLS), with **no node proxy / DaemonSet in the path**.
+
+This is a manual runbook against a live cluster (talos-main); it is not a CI
+target. It assumes aether is already deployed (agent + registrar + controller)
+and SPIRE is installed with a `spire-controller-manager` class.
+
+## 1. Enable the edge
+
+Add to the `helm upgrade aether ...` values (no `--reuse-values`):
+
+```yaml
+edge:
+  enabled: true
+  expose: [svc-1]                 # optional static seed; EdgeRoutes work too
+  service:
+    type: LoadBalancer            # or NodePort for a quick test
+  spire:
+    clusterSpiffeID:
+      className: spire-mgmt-spire  # the talos-main SPIRE class
+  # Downstream TLS is optional; omit for a plain-HTTP first pass.
+  # tls:
+  #   enabled: true
+  #   secretName: edge-cert       # a kubernetes.io/tls Secret in the edge namespace
+```
+
+The edge Deployment, Service, bootstrap ConfigMap, RBAC and ClusterSPIFFEID
+render only when `edge.enabled=true`.
+
+## 2. Expose a service
+
+Apply `edgeroute.yaml` (host-based) and/or rely on the `--expose` seed:
+
+```bash
+kubectl apply -f test/e2e/edge/edgeroute.yaml
+kubectl get edgeroutes -n aether-edge
+```
+
+## 3. Drive traffic
+
+```bash
+# External entrypoint (LoadBalancer IP or NodePort).
+EDGE=$(kubectl get svc -n aether-edge aether-edge -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+# Host-routed (matches EdgeRoute.spec.hosts):
+curl -sS -H 'Host: api.example.com' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'   # 200
+
+# FQDN-routed (the --expose seed / hostless EdgeRoute):
+curl -sS -H 'Host: svc-1.aether.internal' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'  # 200
+
+# Unmatched authority -> 404 (the edge serves only its exposed set):
+curl -sS -H 'Host: nope.example.com' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'   # 404
+```
+
+With `edge.tls.enabled`, use `https://` and the cert's SNI.
+
+## 4. Assertions
+
+- **Direct-to-pod, edge identity in XFCC.** The destination app should observe
+  `x-forwarded-client-cert` with `URI=spiffe://<trust-domain>/ns/<ns>/sa/<edge-sa>`
+  (the edge SA, not a mesh workload). With the echo app:
+  `curl ... | jq '.headers["x-forwarded-client-cert"]'`.
+- **No node proxy in the path.** Schedule the edge on a node and confirm there is
+  no agent/proxy DaemonSet pod required for the request to succeed (the edge dials
+  `pod_ip:15008` directly).
+- **Hitless rollout.** `kubectl rollout restart deploy/aether-edge -n aether-edge`
+  under a load generator → no failed requests (Service + `/aether/readyz` readiness
+  gate).
+- **Live route changes.** `kubectl apply`/`delete` an EdgeRoute → the route
+  appears/disappears within a reconcile, no edge redeploy.
+
+## Rollback
+
+`helm upgrade aether ... --set edge.enabled=false` removes all edge resources;
+the EdgeRoute CRD (in the `crds` chart, `resource-policy: keep`) is left in place.

--- a/test/e2e/edge/README.md
+++ b/test/e2e/edge/README.md
@@ -15,7 +15,6 @@ Add to the `helm upgrade aether ...` values (no `--reuse-values`):
 ```yaml
 edge:
   enabled: true
-  expose: [svc-1]                 # optional static seed; EdgeRoutes work too
   service:
     type: LoadBalancer            # or NodePort for a quick test
   spire:
@@ -32,7 +31,8 @@ render only when `edge.enabled=true`.
 
 ## 2. Expose a service
 
-Apply `edgeroute.yaml` (host-based) and/or rely on the `--expose` seed:
+Apply `edgeroute.yaml` (host-based). The edge exposes a service ONLY at the
+external hostnames its EdgeRoute lists:
 
 ```bash
 kubectl apply -f test/e2e/edge/edgeroute.yaml
@@ -48,8 +48,8 @@ EDGE=$(kubectl get svc -n aether-edge aether-edge -o jsonpath='{.status.loadBala
 # Host-routed (matches EdgeRoute.spec.hosts):
 curl -sS -H 'Host: api.example.com' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'   # 200
 
-# FQDN-routed (the --expose seed / hostless EdgeRoute):
-curl -sS -H 'Host: svc-1.aether.internal' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'  # 200
+# The internal mesh FQDN is NOT routable from the edge -> 404:
+curl -sS -H 'Host: svc-1.aether.internal' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'  # 404
 
 # Unmatched authority -> 404 (the edge serves only its exposed set):
 curl -sS -H 'Host: nope.example.com' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'   # 404

--- a/test/e2e/edge/edgeroute.yaml
+++ b/test/e2e/edge/edgeroute.yaml
@@ -7,8 +7,8 @@ metadata:
   name: svc-1
   namespace: aether-edge
 spec:
-  # External hostnames routed to the mesh service. Empty would route the service
-  # at its mesh FQDN (svc-1.aether.internal) only.
+  # External hostnames routed to the mesh service (required, >=1). The internal
+  # mesh FQDN (svc-1.aether.internal) is deliberately NOT routable from the edge.
   hosts:
     - api.example.com
   # The mesh service name = its ServiceAccount = the registry key. The edge dials

--- a/test/e2e/edge/edgeroute.yaml
+++ b/test/e2e/edge/edgeroute.yaml
@@ -1,0 +1,30 @@
+# Example EdgeRoutes for the edge proxy e2e (proposal 003). Apply into the edge's
+# watched namespace (default: the edge pod's own namespace, aether-edge).
+---
+apiVersion: config.aether.io/v1
+kind: EdgeRoute
+metadata:
+  name: svc-1
+  namespace: aether-edge
+spec:
+  # External hostnames routed to the mesh service. Empty would route the service
+  # at its mesh FQDN (svc-1.aether.internal) only.
+  hosts:
+    - api.example.com
+  # The mesh service name = its ServiceAccount = the registry key. The edge dials
+  # this service's pods directly over mTLS.
+  service: svc-1
+  # Default port (omit `port`) routes to the service's primary port.
+---
+apiVersion: config.aether.io/v1
+kind: EdgeRoute
+metadata:
+  name: svc-5-grpc
+  namespace: aether-edge
+spec:
+  hosts:
+    - grpc.example.com
+  service: svc-5
+  # Multi-port routing (proposal 005): target a specific advertised port (e.g. the
+  # h2c port from the multi-port e2e). Routes to the per-port cluster.
+  port: 3001


### PR DESCRIPTION
## What

PR5 (final) of the edge proxy plan (**stacked on #239**). Documentation + e2e assets — no code or chart changes.

> Base is `feat/edge-tls` (#239); review after the stack merges.

- **`docs/proposals/003_edge-proxy.md`** — the as-built proposal reflecting what shipped across #236–#239: the single-identity `agent edge` control plane, Envoy-talks-SPIRE-SDS-directly (no bridge), the EdgeRoute CRD, the `edge.enabled` chart, and downstream TLS. This **resolves the `docs/proposals/003_edge-proxy.md` references** already present in the code/chart comments (the proto, values, and chart docstrings pointed at it).
- **`test/e2e/edge/`** — a manual talos-main runbook (enable the edge, expose a service, drive traffic, and assert: direct-to-pod delivery with the edge SA in XFCC, no node proxy in the path, hitless rollout, live EdgeRoute changes) plus example `EdgeRoute` manifests (host-based + multi-port).

The actual talos run requires cluster access and is performed manually per the runbook; this PR lands the procedure and examples.

## The full stack

| PR | Scope | Status |
|----|-------|--------|
| #236 | `agent edge` control plane (SPIRE SDS direct) | merged |
| #237 | EdgeRoute CRD + live watch | merged |
| #238 | `edge.enabled` chart | open |
| #239 | downstream TLS | open (on #238) |
| this | proposal doc + e2e runbook | open (on #239) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)