### PR TITLE
fix(edge): route only by explicit external host, never the mesh FQDN

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -75,11 +75,6 @@ type AgentConfig struct {
 	// binds (edge subcommand only).
 	EdgeHTTPPort uint32
 
-	// EdgeExposes is a static list of mesh service names the edge proxy always
-	// routes to at their mesh FQDN (edge subcommand only); merged with the
-	// EdgeRoute CRs.
-	EdgeExposes []string
-
 	// EdgeRouteNamespace is the namespace the edge watches EdgeRoute CRs in
 	// (edge subcommand only); empty means the edge pod's own namespace.
 	EdgeRouteNamespace string

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -48,7 +48,6 @@ func init() {
 	// at a pod-local emptyDir so PreListen's load is a no-op.
 	edgeCmd.Flags().StringVar(&cfg.MountedLocalStorageDir, "mounted-registry-dir", "/var/lib/aether/registry", "Pod-local directory for the edge's (empty) local store")
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPPort, "edge-http-port", cfg.EdgeHTTPPort, "Port the edge proxy's public-facing HTTP listener binds")
-	edgeCmd.Flags().StringSliceVar(&cfg.EdgeExposes, "expose", nil, "Mesh service names the edge always routes to at their mesh FQDN (comma-separated or repeated); merged with the EdgeRoute CRs")
 	edgeCmd.Flags().StringVar(&cfg.EdgeRouteNamespace, "edge-route-namespace", "", "Namespace to watch EdgeRoute CRs in (empty = the edge pod's own namespace)")
 	edgeCmd.Flags().StringVar(&cfg.EdgeTLSCertFile, "edge-tls-cert-file", "", "Path to the mounted TLS certificate chain; with --edge-tls-key-file, the edge listener terminates downstream TLS (else plain HTTP)")
 	edgeCmd.Flags().StringVar(&cfg.EdgeTLSKeyFile, "edge-tls-key-file", "", "Path to the mounted TLS private key (pairs with --edge-tls-cert-file)")
@@ -68,7 +67,6 @@ func runEdge(ctx context.Context) (retErr error) {
 		"debug", cfg.Debug,
 		"clusterName", cfg.ClusterName,
 		"edgeHTTPPort", cfg.EdgeHTTPPort,
-		"exposes", cfg.EdgeExposes,
 	)
 
 	if logShutdown != nil {
@@ -151,15 +149,9 @@ func runEdge(ctx context.Context) (retErr error) {
 	snapshotCache.SetEdgeMode(cfg.EdgeHTTPPort)
 	snapshotCache.SetEdgeTLS(cfg.EdgeTLSCertFile, cfg.EdgeTLSKeyFile)
 	snapshotCache.SetEdgeIdentity(edgeSpiffeID, identityTrustDomain)
-	// Static seed: --expose services routed at their mesh FQDN. The EdgeRoute
-	// reconciler merges these with the CRs and re-applies on every change; seed
-	// them once up front so the edge exposes them before the first reconcile (and
-	// with zero EdgeRoute CRs, when no reconcile fires).
-	seedRoutes := make([]cache.EdgeRoute, 0, len(cfg.EdgeExposes))
-	for _, svc := range cfg.EdgeExposes {
-		seedRoutes = append(seedRoutes, cache.EdgeRoute{Service: svc})
-	}
-	snapshotCache.SetEdgeRoutes(seedRoutes)
+	// Routes come exclusively from EdgeRoute CRs via the reconciler below; the
+	// initial snapshot (PreListen) serves a 404-only edge route table until the
+	// first reconcile. The edge exposes ONLY explicitly-routed services.
 
 	proxy.SetAccessLogConfig(proxy.AccessLogConfig{
 		Enabled:           cfg.AccessLogsEnabled,
@@ -199,7 +191,6 @@ func runEdge(ctx context.Context) (retErr error) {
 		Client:    m.GetClient(),
 		Sink:      snapshotCache,
 		Namespace: routeNamespace,
-		Seed:      seedRoutes,
 		Log:       l,
 	}
 	if err = edgeReconciler.SetupWithManager(m); err != nil {

--- a/agent/internal/edge/reconciler.go
+++ b/agent/internal/edge/reconciler.go
@@ -21,9 +21,9 @@ type RouteSink interface {
 }
 
 // Reconciler watches EdgeRoute CRs in a namespace and pushes the complete route
-// set (every CR plus the static seed) into the cache on any change. It is
-// level-based: each reconcile re-lists, so adds, updates and deletes all
-// converge to the same projection without tracking deltas.
+// set into the cache on any change. It is level-based: each reconcile re-lists,
+// so adds, updates and deletes all converge to the same projection without
+// tracking deltas.
 type Reconciler struct {
 	client.Client
 
@@ -31,10 +31,7 @@ type Reconciler struct {
 	Sink RouteSink
 	// Namespace is the namespace EdgeRoutes are read from.
 	Namespace string
-	// Seed is always included in the projection (the --expose static routes),
-	// so the edge exposes them even with zero EdgeRoute CRs.
-	Seed []cache.EdgeRoute
-	Log  *slog.Logger
+	Log       *slog.Logger
 }
 
 // SetupWithManager registers the reconciler to watch EdgeRoute CRs.
@@ -54,12 +51,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
-	routes := make([]cache.EdgeRoute, 0, len(r.Seed)+len(list.Items))
-	routes = append(routes, r.Seed...)
+	routes := make([]cache.EdgeRoute, 0, len(list.Items))
 	for i := range list.Items {
 		spec := list.Items[i].Spec
-		if spec == nil || spec.GetService() == "" {
-			// An inert/invalid route (no service) routes nowhere; skip it.
+		// A route routes nowhere without a service or without an explicit
+		// external host — the edge never exposes a service at its mesh FQDN.
+		if spec == nil || spec.GetService() == "" || len(spec.GetHosts()) == 0 {
 			continue
 		}
 		routes = append(routes, cache.EdgeRoute{

--- a/agent/internal/edge/reconciler_test.go
+++ b/agent/internal/edge/reconciler_test.go
@@ -34,14 +34,14 @@ func edgeRoute(name, ns, service string, port uint32, hosts ...string) *crdv1.Ed
 	return er
 }
 
-func TestReconcileProjectsRoutesAndSeed(t *testing.T) {
+func TestReconcileProjectsRoutes(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, crdv1.AddToScheme(scheme))
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
 		edgeRoute("api", "aether-edge", "svc-1", 0, "api.example.com"),
-		edgeRoute("grpc", "aether-edge", "svc-2", 9090),
-		edgeRoute("elsewhere", "other-ns", "svc-9", 0), // different namespace, excluded
+		edgeRoute("grpc", "aether-edge", "svc-2", 9090, "grpc.example.com"),
+		edgeRoute("elsewhere", "other-ns", "svc-9", 0, "x.example.com"), // different namespace, excluded
 	).Build()
 
 	sink := &fakeSink{}
@@ -49,39 +49,41 @@ func TestReconcileProjectsRoutesAndSeed(t *testing.T) {
 		Client:    cl,
 		Sink:      sink,
 		Namespace: "aether-edge",
-		Seed:      []cache.EdgeRoute{{Service: "seed-svc"}},
 		Log:       slog.New(slog.DiscardHandler),
 	}
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})
 	require.NoError(t, err)
 
-	// Seed first, then the two in-namespace EdgeRoutes; the other-namespace one
-	// is excluded.
-	require.Len(t, sink.routes, 3)
-	assert.Equal(t, "seed-svc", sink.routes[0].Service)
-
+	// Both in-namespace EdgeRoutes; the other-namespace one is excluded.
+	require.Len(t, sink.routes, 2)
 	got := map[string]cache.EdgeRoute{}
 	for _, rt := range sink.routes {
 		got[rt.Service] = rt
 	}
 	assert.Equal(t, []string{"api.example.com"}, got["svc-1"].Hosts)
 	assert.Equal(t, uint32(9090), got["svc-2"].Port)
+	assert.Equal(t, []string{"grpc.example.com"}, got["svc-2"].Hosts)
 	assert.NotContains(t, got, "svc-9")
 }
 
-// TestReconcileSkipsInertRoutes verifies an EdgeRoute with no service is skipped
-// (it routes nowhere), while the seed still applies.
+// TestReconcileSkipsInertRoutes verifies routes that expose nothing are skipped:
+// no service, or no external host (the edge never routes a service at its mesh
+// FQDN).
 func TestReconcileSkipsInertRoutes(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, crdv1.AddToScheme(scheme))
 
-	inert := &crdv1.EdgeRoute{}
-	inert.Name = "inert"
-	inert.Namespace = "aether-edge"
-	inert.Spec = &configv1.EdgeRouteSpec{} // no service
+	noService := &crdv1.EdgeRoute{}
+	noService.Name = "no-service"
+	noService.Namespace = "aether-edge"
+	noService.Spec = &configv1.EdgeRouteSpec{}
+	noService.Spec.SetHosts([]string{"x.example.com"})
 
-	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(inert).Build()
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(
+		noService,
+		edgeRoute("no-hosts", "aether-edge", "svc-1", 0), // service but no hosts
+	).Build()
 	sink := &fakeSink{}
 	r := &Reconciler{Client: cl, Sink: sink, Namespace: "aether-edge", Log: slog.New(slog.DiscardHandler)}
 

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -29,12 +29,14 @@ func (c *SnapshotCache) SetEdgeRoutes(routes []EdgeRoute) {
 	c.edgeRoutes = routes
 	c.edgeMu.Unlock()
 
-	// Dependency set = the distinct referenced services (signals a reload when
-	// the set changed).
+	// Dependency set = the distinct services of ROUTABLE routes (those with at
+	// least one external host). A route without hosts exposes nothing — it must
+	// not pull its service into scope, and it never becomes routable at the mesh
+	// FQDN. Signals a reload when the set changed.
 	seen := make(map[string]struct{}, len(routes))
 	services := make([]string, 0, len(routes))
 	for _, r := range routes {
-		if r.Service == "" {
+		if r.Service == "" || len(r.Hosts) == 0 {
 			continue
 		}
 		if _, ok := seen[r.Service]; ok {
@@ -55,10 +57,11 @@ func (c *SnapshotCache) SetEdgeRoutes(routes []EdgeRoute) {
 
 // edgeRouteVhosts builds the edge listener's virtual hosts from the configured
 // routes: one vhost per target cluster, with the union of its routes' external
-// hostnames as domains (a route without hosts is reachable at the service FQDN).
-// Routes targeting the same cluster are merged so the vhost name (the cluster
-// name) and the domain set stay unique — Envoy NACKs duplicate vhost names or
-// domains.
+// hostnames as domains. The edge routes ONLY by explicit external host — a route
+// without hosts is skipped (the internal mesh FQDN is never routable from the
+// edge). Routes targeting the same cluster are merged so the vhost name (the
+// cluster name) and the domain set stay unique — Envoy NACKs duplicate vhost
+// names or domains.
 func (c *SnapshotCache) edgeRouteVhosts() []*routev3.VirtualHost {
 	c.edgeMu.RLock()
 	routes := slices.Clone(c.edgeRoutes)
@@ -70,18 +73,14 @@ func (c *SnapshotCache) edgeRouteVhosts() []*routev3.VirtualHost {
 	byCluster := make(map[string][]string)
 	order := make([]string, 0, len(routes))
 	for _, r := range routes {
-		if r.Service == "" {
+		if r.Service == "" || len(r.Hosts) == 0 {
 			continue
 		}
 		clusterName := c.edgeClusterNameLocked(r)
-		domains := r.Hosts
-		if len(domains) == 0 {
-			domains = []string{proxy.ServiceClusterName(r.Service, c.meshDomain)}
-		}
 		if _, ok := byCluster[clusterName]; !ok {
 			order = append(order, clusterName)
 		}
-		byCluster[clusterName] = append(byCluster[clusterName], domains...)
+		byCluster[clusterName] = append(byCluster[clusterName], r.Hosts...)
 	}
 
 	vhosts := make([]*routev3.VirtualHost, 0, len(order))

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -44,19 +44,21 @@ func TestSetEdgeRoutesDependencySet(t *testing.T) {
 
 	c.SetEdgeRoutes([]EdgeRoute{
 		{Hosts: []string{"api.example.com"}, Service: "svc-1"},
-		{Service: "svc-2", Port: 9090},
-		{Service: ""}, // inert, ignored
+		{Hosts: []string{"grpc.example.com"}, Service: "svc-2", Port: 9090},
+		{Service: "svc-3"}, // no hosts -> inert, never pulled into scope
+		{Service: ""},      // inert, ignored
 	})
 
 	deps := c.DependencySet()
 	assert.Len(t, deps, 2)
 	assert.Contains(t, deps, "svc-1")
 	assert.Contains(t, deps, "svc-2")
+	assert.NotContains(t, deps, "svc-3", "a hostless route exposes nothing and must not scope its service")
 }
 
 // TestEdgeRouteVhosts checks host->cluster resolution: external hosts map to the
-// default cluster, a route without hosts falls back to the service FQDN, and a
-// non-default port targets the per-port cluster.
+// default cluster and a non-default port targets the per-port cluster. A route
+// without hosts is NOT routable — the mesh FQDN is never an edge entrypoint.
 func TestEdgeRouteVhosts(t *testing.T) {
 	c := newTestCache("edge-1")
 
@@ -67,20 +69,25 @@ func TestEdgeRouteVhosts(t *testing.T) {
 
 	c.SetEdgeRoutes([]EdgeRoute{
 		{Hosts: []string{"api.example.com", "api2.example.com"}, Service: "svc-1"},
-		{Service: "svc-3"}, // no hosts -> FQDN
-		{Service: "svc-2", Port: 9090},
+		{Service: "svc-3"}, // no hosts -> NOT routable (no vhost)
+		{Hosts: []string{"grpc.example.com"}, Service: "svc-2", Port: 9090},
 	})
 
 	vhosts := c.edgeRouteVhosts()
-	require.Len(t, vhosts, 3)
+	require.Len(t, vhosts, 2)
 
 	assert.Equal(t, "svc-1.aether.internal", vhosts[0].GetName())
 	assert.Equal(t, []string{"api.example.com", "api2.example.com"}, vhosts[0].GetDomains())
 
-	assert.Equal(t, "svc-3.aether.internal", vhosts[1].GetName())
-	assert.Equal(t, []string{"svc-3.aether.internal"}, vhosts[1].GetDomains())
+	assert.Equal(t, "svc-2.aether.internal:9090", vhosts[1].GetName())
+	assert.Equal(t, []string{"grpc.example.com"}, vhosts[1].GetDomains())
 
-	assert.Equal(t, "svc-2.aether.internal:9090", vhosts[2].GetName())
+	// No vhost exposes a mesh FQDN as a routable domain.
+	for _, vh := range vhosts {
+		for _, d := range vh.GetDomains() {
+			assert.NotContains(t, d, ".aether.internal", "the mesh FQDN must not be routable from the edge")
+		}
+	}
 }
 
 // TestEdgeRouteVhostsMergeByCluster verifies multiple routes to the same service

--- a/api/aether/config/v1/edge_route.proto
+++ b/api/aether/config/v1/edge_route.proto
@@ -18,9 +18,14 @@ option go_package = "github.com/bpalermo/aether/api/aether/config/v1;configv1";
 // (TypeMeta/ObjectMeta/Spec/Status) is hand-written in edgeroute_types.go. See
 // docs/proposals/003_edge-proxy.md.
 message EdgeRouteSpec {
-  // External hostnames (Host/SNI) routed to the service. Empty means the route is
-  // reachable at the service's mesh FQDN (<service>.<mesh-domain>) only.
-  repeated string hosts = 1 [(buf.validate.field).repeated.items.string.hostname = true];
+  // External hostnames (Host/SNI) routed to the service. At least one is
+  // required: the edge routes ONLY by explicit external host. The internal mesh
+  // FQDN (<service>.<mesh-domain>) is deliberately NOT routable from the edge —
+  // it is the mesh's east-west addressing scheme, not a north-south entrypoint.
+  repeated string hosts = 1 [(buf.validate.field).repeated = {
+    min_items: 1
+    items: {string: {hostname: true}}
+  }];
 
   // Mesh service name (= ServiceAccount = registry key) this route exposes.
   string service = 2 [(buf.validate.field).string = {

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.8.0-{GIT_COMMIT}"
+version: "0.9.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -51,9 +51,6 @@ spec:
             - "--edge-tls-cert-file={{ .Values.edge.tls.mountPath }}/tls.crt"
             - "--edge-tls-key-file={{ .Values.edge.tls.mountPath }}/tls.key"
             {{- end }}
-            {{- range .Values.edge.expose }}
-            - "--expose={{ . }}"
-            {{- end }}
             {{- if .Values.otel.enabled }}
             - "--otel-enabled=true"
             {{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -176,9 +176,6 @@ edge:
   httpPort: 8080
   # Namespace the edge watches EdgeRoute CRs in. Empty = the edge's own namespace.
   routeNamespace: ""
-  # Static services always routed at their mesh FQDN (merged with the EdgeRoute
-  # CRs); handy for bring-up before any EdgeRoute exists.
-  expose: []
   # Downstream (external-facing) TLS termination from a Kubernetes TLS Secret
   # (type kubernetes.io/tls: tls.crt + tls.key). Disabled = plain HTTP. The edge
   # ->pod upstream hop stays mTLS either way. Rotating the Secret takes effect on


### PR DESCRIPTION
## Problem

The edge was routing an exposed service at its **internal mesh FQDN** (`<service>.<mesh-domain>`, e.g. `svc-1.aether.internal`) whenever an EdgeRoute had no `hosts` — and the `--expose` seed produced exactly those FQDN routes. That leaks the mesh's east-west addressing scheme as a north-south entrypoint. The edge must route **only by explicit external hostnames**; the mesh FQDN must not be reachable from the edge.

## Fix

- **proto** — `EdgeRouteSpec.hosts` is now required (`min_items=1`); documented that the mesh FQDN is deliberately not an edge entrypoint.
- **cache** — `edgeRouteVhosts` drops the mesh-FQDN fallback and skips hostless routes; `SetEdgeRoutes` scopes the dependency set to services of routes **with** hosts only, so a hostless route is fully inert (no cluster, no vhost).
- **agent / reconciler** — skip routes with no service **or** no hosts.
- Removed the `--expose` flag / `EdgeExposes` / static FQDN seed and the chart's `edge.expose` value — exposure is EdgeRoute-only. Chart `0.8.0 → 0.9.0`.

## Tests

Assert no vhost domain is a mesh FQDN, hostless routes produce no vhost and don't scope their service, and the reconciler skips no-service / no-host routes. `bazel build //...`, the edge/cache/cmd/config tests, lint, format, and version-bump all pass.

> Doc/example wording in #240 (proposal 003 + `test/e2e/edge`) is corrected on that branch to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)