### PR TITLE
fix(edge): make the edge chart deployable — pod-local registry dir + listen on :80

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.9.0-{GIT_COMMIT}"
+version: "0.10.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -45,6 +45,14 @@ spec:
             - "--cluster-name={{ .Values.clusterName }}"
             - "--node-name=$(POD_NAME)"
             - "--mesh-domain={{ .Values.meshDomain }}"
+            # Point the (always-empty) local store at the pod-local emptyDir below.
+            # Passed explicitly: the edge subcommand shares --mounted-registry-dir
+            # with the root command, whose default (the node hostPath) would
+            # otherwise win and not exist in the edge pod.
+            - "--mounted-registry-dir=/var/lib/aether/registry"
+            # The agent sidecar shares the pod netns with Envoy; keep its metrics
+            # server off the edge HTTP listener port (default 8080).
+            - "--metrics-bind-address=:8081"
             - "--edge-http-port={{ .Values.edge.httpPort }}"
             - "--edge-route-namespace={{ $routeNamespace }}"
             {{- if .Values.edge.tls.enabled }}
@@ -86,7 +94,7 @@ spec:
                   divisor: "1"
           ports:
             - name: metrics
-              containerPort: 8080
+              containerPort: 8081
               protocol: TCP
             - name: health
               containerPort: 8082

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -177,6 +177,12 @@ spec:
             capabilities:
               drop:
                 - ALL
+              {{- if lt (int .Values.edge.httpPort) 1024 }}
+              # Bind the privileged listener port as non-root. NET_BIND_SERVICE
+              # is the only added cap; the pod still runs unprivileged.
+              add:
+                - NET_BIND_SERVICE
+              {{- end }}
           volumeMounts:
             - name: xds-sock
               mountPath: /run/aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -50,9 +50,6 @@ spec:
             # with the root command, whose default (the node hostPath) would
             # otherwise win and not exist in the edge pod.
             - "--mounted-registry-dir=/var/lib/aether/registry"
-            # The agent sidecar shares the pod netns with Envoy; keep its metrics
-            # server off the edge HTTP listener port (default 8080).
-            - "--metrics-bind-address=:8081"
             - "--edge-http-port={{ .Values.edge.httpPort }}"
             - "--edge-route-namespace={{ $routeNamespace }}"
             {{- if .Values.edge.tls.enabled }}
@@ -94,7 +91,7 @@ spec:
                   divisor: "1"
           ports:
             - name: metrics
-              containerPort: 8081
+              containerPort: 8080
               protocol: TCP
             - name: health
               containerPort: 8082

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -171,9 +171,11 @@ edge:
   replicaCount: 2
   # The edge reuses the agent image (run as `agent edge`) and the proxy image
   # (plain Envoy entrypoint). Override agent.image / proxy.image to mirror.
-  # Port the edge's public-facing HTTP listener binds (north-south). TLS
-  # termination is a separate, later addition.
-  httpPort: 8080
+  # Port the edge's public-facing HTTP listener binds (north-south). Privileged
+  # ports (<1024, e.g. 80) are bound by granting the Envoy container
+  # NET_BIND_SERVICE — the pod still runs unprivileged. TLS termination is a
+  # separate, later addition.
+  httpPort: 80
   # Namespace the edge watches EdgeRoute CRs in. Empty = the edge's own namespace.
   routeNamespace: ""
   # Downstream (external-facing) TLS termination from a Kubernetes TLS Secret


### PR DESCRIPTION
Two edge-chart deployment fixes found while validating the edge on **talos-main** (the published 0.9.0 edge would not start). Chart-only — work with the already-published agent image.

## 1. `--mounted-registry-dir` clobber
The `agent edge` subcommand shares `--mounted-registry-dir` with the root command, whose default (node hostPath `/host/var/lib/aether/registry`) wins the `init` ordering and doesn't exist in the unprivileged edge pod → agent died with `no such file or directory`. Pass `--mounted-registry-dir=/var/lib/aether/registry` explicitly (the pod-local emptyDir).

## 2. Listen on privileged port :80
Default `edge.httpPort` to **80** (conventional ingress). The Envoy container stays unprivileged (runAsNonRoot, no escalation) and is granted **only** `NET_BIND_SERVICE` when `httpPort < 1024`, so it binds the privileged port without root. Listening on :80 also keeps the listener off the agent sidecar's metrics port (:8080), which stays at its default.

Chart `0.9.0 → 0.10.0`.

## Validated end-to-end on talos-main (Envoy bound 0.0.0.0:80)

```
EdgeRoute svc-1  ->  Host: svc-1.example.com      => 200  (svc-1 pod, direct, port 80)
                     Host: svc-1.aether.internal  => 404  (mesh FQDN not routable — #241)
                     Host: nope.example.com       => 404
```
Destination XFCC: `By=…/sa/svc-1; URI=…/ns/aether-system/sa/aether-edge` — the edge's single identity reaches the pod's own inbound mTLS, no node proxy in the path. Node mesh stayed healthy through the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)