### PR TITLE
fix(edge): mount the MeshConfig ConfigMap so the edge honors proxy observability

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.10.0-{GIT_COMMIT}"
+version: "0.11.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -119,6 +119,11 @@ spec:
               mountPath: /run/aether
             - name: registry-dir
               mountPath: /var/lib/aether/registry
+            # MeshConfig overrides (access logs / tracing / stats-pod) so the edge
+            # honors the same proxy observability policy as the node proxies.
+            - name: mesh-config
+              mountPath: /etc/aether
+              readOnly: true
             {{- if .Values.spire.enabled }}
             - name: workload-socket
               mountPath: /run/secrets/workload-spiffe-uds
@@ -204,6 +209,11 @@ spec:
           emptyDir: {}
         - name: registry-dir
           emptyDir: {}
+        # Projected from the MeshConfig CR by the aether-controller (release-derived
+        # name; the pod waits for it, like the node agent). See proposal 015.
+        - name: mesh-config
+          configMap:
+            name: {{ include "aether.meshConfigMapName" . }}
         - name: edge-config
           configMap:
             name: {{ include "aether.edge.configMapName" . }}


### PR DESCRIPTION
## Problem

The edge ignored all MeshConfig proxy-observability overrides (access logs, tracing, stats-pod). The edge HCM is wired for the OTel access logger and the edge bootstrap has the `otel_collector` gRPC cluster, **but** the edge agent never mounted the projected `aether-mesh-config` ConfigMap — so `config.Load` found no file and `accessLogsEnabled`/`tracingEnabled` defaulted to **off**, even where `meshConfig.proxy.accessLogsEnabled=true` (the node proxies log because they mount it; the edge didn't).

Asked directly: "does the edge ship access logs via OTel?" — it didn't, because of this missing mount.

## Fix

Mount `aether-mesh-config` at `/etc/aether` on the edge agent (same as the node agent / proposal 015). The edge now inherits the same proxy observability policy. Chart `0.10.0 → 0.11.0`.

## Validated on talos-main

With `meshConfig.proxy.accessLogsEnabled=true`, a request through the edge produced its own access log in VictoriaLogs:

```
cluster_name=aether-edge  reporter=source  authority=svc-1.example.com
  path=/edge-accesslog-probe-5  response_code=200
  upstream_cluster=svc-1  upstream_host=10.244.3.106:15008
  trace_id=ad66f21f…
```

trace-correlated (same `trace_id`) with the destination pod proxy's `reporter=destination` entry — full source→dest visibility with the edge as the source. Tracing context rides along via the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)