### PR TITLE
fix(agent,proxy): prune stale-netns pods + supervisor crash-fast-fail

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -2,8 +2,12 @@ package server
 
 import (
 	"context"
+	"errors"
+	"io/fs"
+	"os"
 	"time"
 
+	"github.com/bpalermo/aether/agent/types"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/telemetry"
@@ -31,6 +35,14 @@ import (
 // registering pod cannot be judged a ghost mid-flight.
 
 const ghostSweepInterval = 60 * time.Second
+
+// netnsExists reports whether a pod's network-namespace path is still present.
+// Overridable in tests (which use synthetic netns paths). A stored pod whose
+// netns is gone is a stale entry from a missed CNI DEL — see sweepGhostEndpoints.
+var netnsExists = func(path string) bool {
+	_, err := os.Stat(path)
+	return !errors.Is(err, fs.ErrNotExist)
+}
 
 // runGhostSweepLoop periodically reconciles this node's registry endpoints
 // against local pod storage, and additionally runs an immediate sweep after
@@ -90,13 +102,14 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	// pipeline, so each iteration is traced with the corrections it made.
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "agent.ghost_sweep")
 	var retErr error
-	ghostsRemoved, missingRegistered, storedPods := 0, 0, 0
+	ghostsRemoved, missingRegistered, stalePruned, storedPods := 0, 0, 0, 0
 	defer func() {
 		span.SetAttributes(
 			attribute.Int("aether.sweep.ghosts_removed", ghostsRemoved),
 			attribute.Int("aether.sweep.missing_registered", missingRegistered),
+			attribute.Int("aether.sweep.stale_pruned", stalePruned),
 		)
-		s.metrics.sweepCompleted(ctx, ghostsRemoved, missingRegistered, storedPods, retErr)
+		s.metrics.sweepCompleted(ctx, ghostsRemoved, missingRegistered, stalePruned, storedPods, retErr)
 		telemetry.EndSpan(span, retErr)
 	}()
 
@@ -133,6 +146,37 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		return
 	}
 	storedPods = len(pods)
+	// Prune storage entries whose network namespace no longer exists: a missed
+	// CNI DEL left the file behind. Keeping it both re-registers a dead endpoint
+	// (the missing-direction loop would treat it as a live local pod) and makes
+	// Envoy fault opening the gone netns when the per-pod cluster is programmed
+	// (talos worker-01, 2026-06-19). Drop the storage entry and its listener; its
+	// registry endpoints then fall through to ghost deregistration below.
+	fresh := pods[:0]
+	for _, p := range pods {
+		netns := p.GetNetworkNamespace()
+		if netns == "" {
+			fresh = append(fresh, p)
+			continue
+		}
+		if netnsExists(netns) {
+			fresh = append(fresh, p)
+			continue
+		}
+		if err := s.storage.RemoveResource(ctx, types.ContainerID(p.GetContainerId())); err != nil {
+			s.log.ErrorContext(ctx, "ghost sweep: failed to prune stale pod storage", "pod", p.GetName(), "netns", netns, "error", err)
+			fresh = append(fresh, p) // keep it; retry next sweep
+			continue
+		}
+		if err := s.snapshotCache.RemovePod(ctx, netns); err != nil {
+			s.log.ErrorContext(ctx, "ghost sweep: failed to drop listener for pruned pod", "pod", p.GetName(), "netns", netns, "error", err)
+		}
+		stalePruned++
+		s.log.InfoContext(ctx, "ghost sweep: pruned stale pod (network namespace gone; CNI DEL missed)",
+			"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+	}
+	pods = fresh
+
 	// Live local pods by IP. Terminating pods are tracked separately: their
 	// endpoints are deliberately still registered (marked DRAINING by the
 	// termination watch, removed at CNI DEL) — they are neither ghosts to

--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -149,9 +149,12 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	// Prune storage entries whose network namespace no longer exists: a missed
 	// CNI DEL left the file behind. Keeping it both re-registers a dead endpoint
 	// (the missing-direction loop would treat it as a live local pod) and makes
-	// Envoy fault opening the gone netns when the per-pod cluster is programmed
-	// (talos worker-01, 2026-06-19). Drop the storage entry and its listener; its
-	// registry endpoints then fall through to ghost deregistration below.
+	// Envoy fault creating a connection in the gone netns when the per-pod app
+	// cluster is programmed (talos worker-01, 2026-06-19). RemovePod drops the
+	// whole listenerEntry — inbound/outbound listeners AND the per-pod app/health
+	// clusters (which carry the netns) — so the dead-netns cluster leaves the
+	// snapshot. The pruned pod's registry endpoints then fall through to ghost
+	// deregistration below.
 	fresh := pods[:0]
 	for _, p := range pods {
 		netns := p.GetNetworkNamespace()

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Sweep tests use synthetic netns paths that don't exist on disk; treat them as
+// present so the stale-prune step doesn't remove them. TestSweepPrunesStalePods
+// overrides this locally to exercise the prune.
+func init() { netnsExists = func(string) bool { return true } }
+
 // sweepRegistry serves a fixed endpoint listing and records UnregisterEndpoint calls.
 type sweepRegistry struct {
 	testRegistry
@@ -97,6 +102,43 @@ func TestSweepGhostEndpoints(t *testing.T) {
 		"svc-a": {"10.0.0.9"},
 	}, reg.unregistered)
 	assert.Empty(t, reg.registered, "all live pods were present in the registry")
+}
+
+// TestSweepPrunesStalePods: a stored pod whose network namespace no longer
+// exists (a missed CNI DEL) is removed from storage and its registry endpoint
+// deregistered; a live pod is untouched.
+func TestSweepPrunesStalePods(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	// Only the stale pod's netns is "missing".
+	netnsExists = func(path string) bool { return path != "/run/aether/netns/gone" }
+
+	stale := validCNIPod("pod-stale", "default", "container-stale")
+	stale.NetworkNamespace = "/run/aether/netns/gone"
+	stale.Ips = []string{"10.0.0.5"}
+	live := validCNIPod("pod-live", "default", "container-live") // 10.0.0.1, netns present
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-stale"), stale))
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-live"), live))
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{
+		"default": {
+			sweepEndpoint("10.0.0.5", "test-node", "pod-stale"), // pruned -> deregistered as ghost
+			sweepEndpoint("10.0.0.1", "test-node", "pod-live"),  // live -> kept
+		},
+	}}
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	s.sweepGhostEndpoints(ctx)
+
+	_, err := store.GetResource(ctx, types.ContainerID("container-stale"))
+	require.Error(t, err, "stale pod pruned from storage")
+	_, err = store.GetResource(ctx, types.ContainerID("container-live"))
+	require.NoError(t, err, "live pod kept")
+	assert.Equal(t, map[string][]string{"default": {"10.0.0.5"}}, reg.unregistered)
 }
 
 // TestSweepRegistersMissingEndpoint: a live local pod absent from the registry

--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -26,6 +26,7 @@ const (
 type cniMetrics struct {
 	ghostsRemoved     metric.Int64Counter
 	missingRegistered metric.Int64Counter
+	stalePruned       metric.Int64Counter
 	sweepErrors       metric.Int64Counter
 	storagePods       metric.Int64Gauge
 	healthTransitions metric.Int64Counter
@@ -44,6 +45,10 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 	if m.missingRegistered, err = meter.Int64Counter("aether.agent.ghost_sweep.missing_registered",
 		metric.WithDescription("Live local pods re-registered because the registry was missing them (missed CNI ADD registration)")); err != nil {
 		return nil, fmt.Errorf("missing registered: %w", err)
+	}
+	if m.stalePruned, err = meter.Int64Counter("aether.agent.ghost_sweep.stale_pruned",
+		metric.WithDescription("Local storage pod entries pruned because their network namespace no longer exists (missed CNI DEL); keeping them faults Envoy on the dead netns")); err != nil {
+		return nil, fmt.Errorf("stale pruned: %w", err)
 	}
 	if m.sweepErrors, err = meter.Int64Counter("aether.agent.ghost_sweep.errors",
 		metric.WithDescription("Ghost sweep cycles that failed before reconciling")); err != nil {
@@ -66,7 +71,7 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 	return m, nil
 }
 
-func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingRegistered, storedPods int, err error) {
+func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingRegistered, stalePruned, storedPods int, err error) {
 	if m == nil {
 		return
 	}
@@ -79,6 +84,9 @@ func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingR
 	}
 	if missingRegistered > 0 {
 		m.missingRegistered.Add(ctx, int64(missingRegistered))
+	}
+	if stalePruned > 0 {
+		m.stalePruned.Add(ctx, int64(stalePruned))
 	}
 	m.storagePods.Record(ctx, int64(storedPods))
 }

--- a/agent/internal/cni/server/metrics_test.go
+++ b/agent/internal/cni/server/metrics_test.go
@@ -54,8 +54,8 @@ func metricSum(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64
 func TestCNIMetrics_NilReceiverSafe(t *testing.T) {
 	var m *cniMetrics
 	ctx := context.Background()
-	m.sweepCompleted(ctx, 1, 1, 1, nil)
-	m.sweepCompleted(ctx, 0, 0, 0, errors.New("boom"))
+	m.sweepCompleted(ctx, 1, 1, 1, 1, nil)
+	m.sweepCompleted(ctx, 0, 0, 0, 0, errors.New("boom"))
 	m.healthTransition(ctx, "HEALTH_UNHEALTHY", "HEALTH_HEALTHY")
 }
 
@@ -63,7 +63,7 @@ func TestCNIMetrics_SweepCompleted(t *testing.T) {
 	m, reader := newTestCNIMetrics(t)
 	ctx := context.Background()
 
-	m.sweepCompleted(ctx, 2, 1, 7, nil)
+	m.sweepCompleted(ctx, 2, 1, 3, 7, nil)
 
 	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.ghosts_removed"); got != 2 {
 		t.Errorf("ghosts_removed = %d, want 2", got)
@@ -79,7 +79,7 @@ func TestCNIMetrics_SweepCompleted(t *testing.T) {
 func TestCNIMetrics_SweepFailed(t *testing.T) {
 	m, reader := newTestCNIMetrics(t)
 
-	m.sweepCompleted(context.Background(), 0, 0, 0, errors.New("registry down"))
+	m.sweepCompleted(context.Background(), 0, 0, 0, 0, errors.New("registry down"))
 
 	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.errors"); got != 1 {
 		t.Errorf("sweep errors = %d, want 1", got)

--- a/agent/internal/proxy/hotrestart/BUILD.bazel
+++ b/agent/internal/proxy/hotrestart/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "hotrestart",
     srcs = [
         "coordination.go",
+        "crash.go",
         "metrics.go",
         "supervisor.go",
         "telemetry.go",
@@ -26,6 +27,7 @@ go_test(
     name = "hotrestart_test",
     srcs = [
         "coordination_test.go",
+        "crash_test.go",
         "metrics_test.go",
         "supervisor_test.go",
     ],

--- a/agent/internal/proxy/hotrestart/crash.go
+++ b/agent/internal/proxy/hotrestart/crash.go
@@ -1,0 +1,30 @@
+package hotrestart
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+// isCrashSignal reports whether an *exec.Cmd Wait error is a fatal-signal crash
+// (SIGSEGV/SIGABRT/SIGBUS/SIGILL) rather than a clean non-zero exit. A base-id
+// bind collision exits non-zero (errno 98) WITHOUT a signal; a genuine Envoy
+// crash is signaled. Distinguishing them lets the supervisor give up on a
+// crashing Envoy fast instead of burning the (much larger) bind-collision retry
+// budget and looping silently for minutes (talos worker-01, 2026-06-19: a CDS
+// referencing a gone netns crashed every epoch and masqueraded as a collision).
+func isCrashSignal(err error) bool {
+	var ee *exec.ExitError
+	if !errors.As(err, &ee) {
+		return false
+	}
+	ws, ok := ee.Sys().(syscall.WaitStatus)
+	if !ok || !ws.Signaled() {
+		return false
+	}
+	switch ws.Signal() {
+	case syscall.SIGSEGV, syscall.SIGABRT, syscall.SIGBUS, syscall.SIGILL:
+		return true
+	}
+	return false
+}

--- a/agent/internal/proxy/hotrestart/crash_test.go
+++ b/agent/internal/proxy/hotrestart/crash_test.go
@@ -1,0 +1,24 @@
+package hotrestart
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCrashSignal(t *testing.T) {
+	// Killed by a fatal signal (SIGSEGV) -> crash.
+	assert.True(t, isCrashSignal(exec.Command("sh", "-c", "kill -SEGV $$").Run()),
+		"a SIGSEGV-terminated process is a crash")
+
+	// Clean non-zero exit (a base-id bind collision exits errno 98, no signal).
+	assert.False(t, isCrashSignal(exec.Command("sh", "-c", "exit 1").Run()),
+		"a non-zero exit without a signal is not a crash")
+
+	// Success and non-exec errors are not crashes.
+	assert.False(t, isCrashSignal(exec.Command("sh", "-c", "exit 0").Run()))
+	assert.False(t, isCrashSignal(errors.New("boom")))
+	assert.False(t, isCrashSignal(nil))
+}

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -76,6 +76,13 @@ const (
 	bindCollisionWindow     = 5 * time.Second
 	bindCollisionRetryPause = 3 * time.Second
 	maxBindCollisionRetries = 90
+	// maxCrashRetries bounds in-process retries of an epoch that died on a fatal
+	// SIGNAL (SIGSEGV/SIGABRT) rather than a clean bind-collision exit. A crash is
+	// not a transient socket race, so it gets a small budget: a deterministically
+	// crashing Envoy (e.g. a CDS referencing a gone netns — talos worker-01,
+	// 2026-06-19) surfaces as CrashLoopBackOff in ~15s instead of looping silently
+	// for the full 4.5-min bind-collision budget while masquerading as a collision.
+	maxCrashRetries = 5
 )
 
 // Config configures the Envoy hot-restart supervisor.
@@ -232,6 +239,7 @@ func (s *Supervisor) Run(ctx context.Context) error {
 	debounce.Stop()
 	var debounceC <-chan time.Time
 	bindRetries := 0
+	crashRetries := 0
 
 	arm := func(reason string) {
 		s.log.DebugContext(ctx, "hot restart armed", "reason", reason, "debounce", debounceDelay)
@@ -335,31 +343,47 @@ func (s *Supervisor) Run(ctx context.Context) error {
 					<-ctx.Done()
 					return nil
 				}
-				// Suspected base-id bind collision (see the bindCollision*
-				// constants): a fresh epoch that died non-LIVE within seconds of
-				// launch while a predecessor may still hold the domain socket.
-				// Retry epoch detection in-process — the predecessor keeps
-				// serving meanwhile — instead of exiting into the kubelet's
-				// CrashLoopBackOff.
-				if s.quickNonLiveExit() && bindRetries < maxBindCollisionRetries {
-					bindRetries++
-					s.metrics.childExited(exitBindCollision)
-					s.reap(exit.epoch)
-					s.log.InfoContext(ctx, "suspected base-id bind collision with a live predecessor; retrying epoch detection in-process",
-						"epoch", exit.epoch, "attempt", bindRetries, "error", exit.err.Error())
-					select {
-					case <-ctx.Done():
-						s.shutdown()
-						return nil
-					case <-time.After(bindCollisionRetryPause):
+				// A fresh epoch that died non-LIVE within seconds: either a base-id
+				// bind collision (a predecessor still holds the domain socket; exits
+				// errno 98, no signal) or a genuine Envoy crash (a fatal SIGNAL).
+				// Retry epoch detection in-process — a predecessor keeps serving
+				// meanwhile — instead of exiting into CrashLoopBackOff. A crash gets
+				// a much smaller budget so a deterministically crashing Envoy
+				// surfaces fast instead of masquerading as a collision for minutes.
+				if s.quickNonLiveExit() {
+					crash := isCrashSignal(exit.err)
+					attempt, budget := bindRetries+1, maxBindCollisionRetries
+					if crash {
+						attempt, budget = crashRetries+1, maxCrashRetries
 					}
-					s.resetEpochForRetry()
-					s.initStartEpoch(ctx)
-					s.gateReadinessIfSuccessor()
-					if err := s.hotRestart(); err != nil {
-						return fmt.Errorf("relaunching envoy after bind-collision retry: %w", err)
+					if attempt <= budget {
+						if crash {
+							crashRetries++
+						} else {
+							bindRetries++
+						}
+						s.metrics.childExited(exitBindCollision)
+						s.reap(exit.epoch)
+						kind := "suspected base-id bind collision with a live predecessor"
+						if crash {
+							kind = "envoy crashed on launch (fatal signal)"
+						}
+						s.log.InfoContext(ctx, kind+"; retrying epoch detection in-process",
+							"epoch", exit.epoch, "attempt", attempt, "budget", budget, "crashSignal", crash, "error", exit.err.Error())
+						select {
+						case <-ctx.Done():
+							s.shutdown()
+							return nil
+						case <-time.After(bindCollisionRetryPause):
+						}
+						s.resetEpochForRetry()
+						s.initStartEpoch(ctx)
+						s.gateReadinessIfSuccessor()
+						if err := s.hotRestart(); err != nil {
+							return fmt.Errorf("relaunching envoy after retry: %w", err)
+						}
+						continue
 					}
-					continue
 				}
 				// The newest epoch died unexpectedly: nothing left serving traffic.
 				// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"context"
 	"errors"
+	"io/fs"
+	"os"
 
 	agentconstants "github.com/bpalermo/aether/agent/constants"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -11,6 +13,14 @@ import (
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
+
+// netnsExists reports whether a pod's network-namespace path is still present.
+// Overridable in tests (which use synthetic netns paths). A pod whose netns is
+// gone is excluded from listener generation — see LoadListenersFromStorage.
+var netnsExists = func(path string) bool {
+	_, err := os.Stat(path)
+	return !errors.Is(err, fs.ErrNotExist)
+}
 
 // AddPod generates the inbound and outbound listeners and per-pod clusters for the
 // given pod and adds them to the cache keyed by the pod's network namespace, then
@@ -162,6 +172,16 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 	c.listenerMu.Lock()
 	for _, pod := range pods {
 		netns := pod.GetNetworkNamespace()
+
+		// Skip a pod whose network namespace no longer exists: a missed CNI DEL
+		// left the storage entry behind, and programming its per-pod cluster
+		// (NetworkNamespaceFilepath) faults Envoy opening the dead netns (talos
+		// worker-01, 2026-06-19). The ghost sweep prunes the stale entry; this
+		// keeps the bad config out of the snapshot at startup, before that runs.
+		if netns != "" && !netnsExists(netns) {
+			c.log.WarnContext(ctx, "skipping pod with missing network namespace (stale storage; CNI DEL likely missed)", "pod", pod.GetName(), "namespace", pod.GetNamespace(), "netns", netns)
+			continue
+		}
 		c.log.DebugContext(ctx, "generating listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace(), "netns", netns)
 
 		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain, c.emitStatsPod)

--- a/agent/internal/xds/cache/listener_test.go
+++ b/agent/internal/xds/cache/listener_test.go
@@ -13,6 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Tests use synthetic netns paths that don't exist on disk; treat them as
+// present so the missing-netns guard in LoadListenersFromStorage doesn't skip
+// them. TestLoadListenersFromStorage_SkipsMissingNetns overrides this locally.
+func init() { netnsExists = func(string) bool { return true } }
+
 // makeCNIPod builds a minimal CNIPod that satisfies proxy.GenerateListenersFromRegistryPod.
 // A non-empty NetworkNamespace is the only field required for listener generation.
 func makeCNIPod(name, namespace, networkNamespace string) *cniv1.CNIPod {
@@ -235,6 +240,29 @@ func TestLoadListenersFromStorage_EmptyStorage(t *testing.T) {
 	assert.Empty(t, c.listeners)
 	// Only the always-present health gateway listener remains.
 	assert.Len(t, c.Listeners(), 1)
+}
+
+// TestLoadListenersFromStorage_SkipsMissingNetns verifies that a stored pod
+// whose network namespace is gone (a missed CNI DEL) is excluded from listener
+// generation, so its dead-netns cluster never enters the snapshot.
+func TestLoadListenersFromStorage_SkipsMissingNetns(t *testing.T) {
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	netnsExists = func(path string) bool { return path != "/proc/dead/ns/net" }
+
+	c := newTestCache("node-1")
+	initListeners(c)
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(context.Background(), "live", makeCNIPod("pod-live", "default", "/proc/100/ns/net")))
+	require.NoError(t, store.AddResource(context.Background(), "dead", makeCNIPod("pod-dead", "default", "/proc/dead/ns/net")))
+
+	_ = c.LoadListenersFromStorage(context.Background(), store, "example.org")
+
+	require.Len(t, c.listeners, 1, "only the live-netns pod produces a listener entry")
+	_, ok := c.listeners["/proc/100/ns/net"]
+	assert.True(t, ok, "live pod kept")
+	_, ok = c.listeners["/proc/dead/ns/net"]
+	assert.False(t, ok, "missing-netns pod skipped")
 }
 
 // TestLoadListenersFromStorage_ValidPodsMapPopulation verifies that valid pods


### PR DESCRIPTION
## Problem (diagnosed on talos worker-01)

A missed CNI `DEL` left **7 stale pod files** in the agent's registry after the pods' netns were torn down. The agent generated each pod's per-pod cluster with `NetworkNamespaceFilepath` pointing at a **nonexistent netns**, pushed it via CDS, and Envoy **segfaulted** opening the dead netns — *every epoch*:

```
failed to open netns file /run/aether/netns/930bd2c…: No such file or directory
→ Caught Segmentation fault
```

The hot-restart supervisor mislabeled the crash as a base-id bind collision and looped **silently for ~4.5 min** (90 × 3s) before giving up; a fresh pod re-read the same stale files and crashed identically — a cross-pod wedge. (Notably **not** an orphan process: the proxy supervisor is the container's PID 1, so an Envoy can't outlive its pod.)

## Fix

**Agent — self-heal + visibility:**
- The ghost sweep now **prunes storage entries whose netns no longer exists** (`RemoveResource` + drop the listener via `snapshotCache.RemovePod`); the dead pod's registry endpoints then fall through to ghost deregistration. New metric **`aether.agent.ghost_sweep.stale_pruned`** + trace attribute surfaces these missed DELs.
- `LoadListenersFromStorage` **skips a missing-netns pod**, so a stale entry can't poison the snapshot at startup before the first sweep runs (the worker-01 window). `netnsExists` is an overridable package var for tests.

**Proxy supervisor — fail fast instead of masquerading:**
- Distinguish a **fatal signal crash** (SIGSEGV/SIGABRT/SIGBUS/SIGILL) from a clean bind-collision exit (errno 98, no signal). A crash gets a small budget (`maxCrashRetries=5`, ~15s) instead of the 90-retry bind-collision budget, so a deterministically crashing Envoy surfaces as `CrashLoopBackOff` in seconds — alertable, not silent.

## Tests

Stale-pod prune (storage entry removed + endpoint deregistered, live pod kept); `LoadListenersFromStorage` skips missing-netns; `isCrashSignal` classification (real SIGSEGV vs clean exit vs success/non-exec). Full build, agent suite (15/15), lint, format pass.

## Notes
- worker-01 was recovered manually (delete the 7 stale files + restart its agent — the agent's fsnotify doesn't cross bind mounts, so it needed a re-read). This PR makes that self-healing.
- Out of scope: the underlying missed-CNI-`DEL` cause (the sweep now cleans up after it); the Envoy NULL-deref on a missing netns (an upstream Envoy hardening matter — we now never feed it a dead netns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)