### PR TITLE
fix(prober): suppress per-probe spans via not-sampled traceparent

### DIFF
--- a/prober/internal/prober/prober.go
+++ b/prober/internal/prober/prober.go
@@ -9,6 +9,8 @@ package prober
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -221,6 +223,14 @@ func (p *Prober) probe(ctx context.Context, t target) {
 		return
 	}
 	req.Host = t.authority
+	// Mark the probe not-sampled so the mesh proxy's HCM doesn't create and export
+	// a span per probe. The proxy's tracing is parent-based: a request that already
+	// carries a trace context honors its sampled decision instead of rolling
+	// random_sampling, so a cleared flag suppresses the span. Without this, at the
+	// probe rate with proxy tracing enabled every probe becomes a synthetic
+	// liveness-probe trace in Tempo (the access-log health-check exclusion has no
+	// tracing equivalent for the direct_response liveness route).
+	req.Header.Set("traceparent", notSampledTraceparent())
 	start := time.Now()
 	resp, err := p.client.Do(req)
 	elapsed := time.Since(start).Seconds()
@@ -234,6 +244,21 @@ func (p *Prober) probe(ctx context.Context, t target) {
 		return
 	}
 	p.record(t, resultHTTPError, elapsed)
+}
+
+// notSampledTraceparent builds a W3C traceparent with the sampled flag clear
+// ("-00"). Because the proxy honors a propagated decision over its own
+// random_sampling, this keeps every probe out of the proxy's exported spans. The
+// trace-id and parent-id are random: an all-zero trace-id is invalid per W3C and
+// would be rejected, re-enabling sampling and defeating the suppression.
+func notSampledTraceparent() string {
+	var buf [24]byte // 16-byte trace-id followed by 8-byte parent-id
+	if _, err := rand.Read(buf[:]); err != nil {
+		// crypto/rand.Read does not fail on supported platforms; fall back to a
+		// fixed nonzero id so the cleared flag is still honored.
+		return "00-0000000000000000000000000000ace0-00000000000000a1-00"
+	}
+	return "00-" + hex.EncodeToString(buf[0:16]) + "-" + hex.EncodeToString(buf[16:24]) + "-00"
 }
 
 // classifyErr maps a request error to a result. connection_error is the class the

--- a/prober/internal/prober/prober_test.go
+++ b/prober/internal/prober/prober_test.go
@@ -4,10 +4,29 @@ import (
 	"context"
 	"errors"
 	"net"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
 )
+
+var traceparentRe = regexp.MustCompile(`^00-[0-9a-f]{32}-[0-9a-f]{16}-00$`)
+
+func TestNotSampledTraceparent(t *testing.T) {
+	tp := notSampledTraceparent()
+	if !traceparentRe.MatchString(tp) {
+		t.Fatalf("traceparent %q does not match the W3C not-sampled form", tp)
+	}
+	// The trace-id must be nonzero or Envoy rejects it and re-enables sampling.
+	if strings.HasPrefix(tp, "00-00000000000000000000000000000000-") {
+		t.Fatalf("traceparent has an all-zero trace-id: %q", tp)
+	}
+	// Two calls should differ (random ids), not a constant.
+	if tp == notSampledTraceparent() {
+		t.Fatalf("traceparent is not randomized: %q", tp)
+	}
+}
 
 func TestClassifyErr(t *testing.T) {
 	t.Run("connection refused -> connection_error", func(t *testing.T) {


### PR DESCRIPTION
## Problem

The prober dials the proxy's **egress HCM**, which has tracing enabled (`meshConfig.proxy.tracingEnabled`, `traceSampleRate: 1` → **100% random_sampling** on talos-main). The probe request carried **no trace context**, so Envoy started a fresh **root span per probe** — at the probe rate (`probe.rate: 5`/s per target, per node) that's ~5 synthetic liveness-probe traces/s/node flooding Tempo, pure noise/cost.

The access-log health-check exclusion (#221) has **no tracing equivalent** here: the prober's `/-/-/live` is a `direct_response` **route**, not the `health_check` *filter* that sets `is_health_check`, so nothing marks the probe — and stock Envoy has no per-route sampling/disable knob (only the HCM-global `random_sampling` and the `decorator`, which controls operation-name propagation, not span creation).

## Fix

Inject a **W3C `traceparent` with the sampled flag clear** (`00-<random>-<random>-00`) on each probe request. The proxy is **parent-based**: a request that already carries a trace context honors its propagated sampled decision instead of rolling `random_sampling` → **no span created/exported** for the probe, even at 100% sample rate. Contained entirely to the prober — no proxy/route/chart change.

- `trace-id`/`parent-id` are random via `crypto/rand` (an all-zero trace-id is invalid per W3C and would be rejected, re-enabling sampling); fixed-nonzero fallback if `rand.Read` ever errors.
- The prober's pass/fail **metrics** (`aether_probe_requests_total`, `..._duration_seconds`) are unaffected.

## Test

`TestNotSampledTraceparent` asserts the W3C not-sampled form, a nonzero trace-id, and randomization across calls. Stdlib-only imports — no Gazelle/dep changes.

## Deploy note

Picking this up on talos needs a prober image build + redeploy of the `prober` chart from the published image (per [[feedback_no_manual_publish]]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)