### PR TITLE
feat(controller): VirtualHost duplicate-FQDN validating webhook (proposal 017 PR2)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.14.0-{GIT_COMMIT}"
+version: "0.15.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-rbac.yaml
+++ b/charts/aether/templates/controller-rbac.yaml
@@ -12,6 +12,10 @@ rules:
   - apiGroups: ["config.aether.io"]
     resources: ["meshconfigs/status"]
     verbs: ["get", "update", "patch"]
+  # List VirtualHosts cluster-wide for the duplicate-FQDN validating webhook.
+  - apiGroups: ["config.aether.io"]
+    resources: ["virtualhosts"]
+    verbs: ["get", "list", "watch"]
   {{- if .Values.controller.webhook.spire }}
   # Inject the SPIRE trust bundle into the webhook's caBundle (by name).
   - apiGroups: ["admissionregistration.k8s.io"]

--- a/charts/aether/templates/controller-webhook.yaml
+++ b/charts/aether/templates/controller-webhook.yaml
@@ -52,12 +52,17 @@ metadata:
   labels:
     {{- include "aether.controller.labels" . | nindent 4 }}
 webhooks:
-  - name: meshconfig.config.aether.io
+  # One webhook entry, one /validate endpoint for every config.aether.io CRD: the
+  # controller dispatches by Kind (see controller/internal/webhook). Per-resource
+  # rules carry their own scope (MeshConfig is the cluster-scoped singleton;
+  # VirtualHost is namespaced).
+  - name: validate.config.aether.io
     admissionReviewVersions: ["v1"]
     sideEffects: None
     # Ignore so a down/un-injected webhook (e.g. during the controller's own
-    # rollout, or before the SPIRE caBundle is injected) never wedges MeshConfig
-    # writes; the reconciler re-validates before projecting.
+    # rollout, or before the SPIRE caBundle is injected) never wedges writes; the
+    # consumers re-validate (the reconciler for MeshConfig; the edge, which also
+    # runtime-dedups duplicate hosts, for VirtualHost).
     failurePolicy: Ignore
     timeoutSeconds: 5
     clientConfig:
@@ -75,3 +80,8 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["meshconfigs"]
         scope: "Cluster"
+      - apiGroups: ["config.aether.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["virtualhosts"]
+        scope: "Namespaced"

--- a/controller/internal/cmd/BUILD.bazel
+++ b/controller/internal/cmd/BUILD.bazel
@@ -13,10 +13,13 @@ go_library(
         "//common/manager",
         "//common/spire",
         "//controller/internal/meshconfig",
+        "//controller/internal/virtualhost",
+        "//controller/internal/webhook",
         "@com_github_spf13_cobra//:cobra",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/webhook",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
     ],
 )

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -25,11 +25,14 @@ import (
 	"github.com/bpalermo/aether/common/manager"
 	"github.com/bpalermo/aether/common/spire"
 	"github.com/bpalermo/aether/controller/internal/meshconfig"
+	"github.com/bpalermo/aether/controller/internal/virtualhost"
+	cwebhook "github.com/bpalermo/aether/controller/internal/webhook"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 const name = "aether-controller"
@@ -149,7 +152,13 @@ func runController(ctx context.Context) (retErr error) {
 		return fmt.Errorf("failed to set up MeshConfig reconciler: %w", err)
 	}
 
-	(&meshconfig.Validator{Log: l}).SetupWithManager(m)
+	// All CRD validation is served on one /validate endpoint, dispatched by Kind.
+	// The VirtualHost validator uses the API reader for a cluster-wide
+	// duplicate-FQDN list (uncached, correct regardless of the manager cache scope).
+	cwebhook.NewHandler(l, map[string]admission.Handler{
+		crdv1.MeshConfigKind:  &meshconfig.Validator{Log: l},
+		crdv1.VirtualHostKind: &virtualhost.Validator{Reader: m.GetAPIReader(), Log: l},
+	}).SetupWithManager(m)
 
 	// In SPIRE mode the webhook presents an SVID, so the apiserver must trust the
 	// SPIRE CA: keep the ValidatingWebhookConfiguration caBundle in sync with the
@@ -168,7 +177,7 @@ func runController(ctx context.Context) (retErr error) {
 
 	l.InfoContext(ctx, "MeshConfig controller configured",
 		"configMap", cmNamespace+"/"+cfg.MeshConfigMapName,
-		"webhookPath", meshconfig.WebhookPath,
+		"webhookPath", cwebhook.Path,
 	)
 	return m.Start(ctx)
 }

--- a/controller/internal/meshconfig/webhook.go
+++ b/controller/internal/meshconfig/webhook.go
@@ -7,26 +7,16 @@ import (
 	"log/slog"
 
 	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// WebhookPath is the URL path the ValidatingWebhookConfiguration points at.
-// Unversioned: the proto spec's field-number evolution guarantees compatibility,
-// so the endpoint never needs a version suffix.
-const WebhookPath = "/validate"
-
 // Validator is an admission webhook that rejects MeshConfig resources whose spec
 // fails protovalidate — the same check the agent's file loader and the reconciler
-// run, so a CR can never describe a config the binaries would refuse to load.
+// run, so a CR can never describe a config the binaries would refuse to load. It
+// is served by the controller's shared /validate dispatcher (see
+// controller/internal/webhook), keyed by the MeshConfig Kind.
 type Validator struct {
 	Log *slog.Logger
-}
-
-// SetupWithManager registers the validating webhook on the manager's webhook
-// server.
-func (v *Validator) SetupWithManager(mgr ctrl.Manager) {
-	mgr.GetWebhookServer().Register(WebhookPath, &admission.Webhook{Handler: v})
 }
 
 // Handle validates the incoming MeshConfig's spec.

--- a/controller/internal/virtualhost/BUILD.bazel
+++ b/controller/internal/virtualhost/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "virtualhost",
+    srcs = ["webhook.go"],
+    importpath = "github.com/bpalermo/aether/controller/internal/virtualhost",
+    visibility = ["//controller:__subpackages__"],
+    deps = [
+        "//common/apis/config/v1:config",
+        "@build_buf_go_protovalidate//:protovalidate",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)
+
+go_test(
+    name = "virtualhost_test",
+    srcs = ["webhook_test.go"],
+    embed = [":virtualhost"],
+    deps = [
+        "//api/aether/config/v1:config",
+        "//common/apis/config/v1:config",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//admission/v1:admission",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)

--- a/controller/internal/virtualhost/webhook.go
+++ b/controller/internal/virtualhost/webhook.go
@@ -1,0 +1,84 @@
+// Package virtualhost provides the aether-controller's VirtualHost validating
+// admission webhook: it runs protovalidate on the spec and rejects a CREATE/
+// UPDATE whose hostnames collide with another VirtualHost (duplicate FQDN), so a
+// collision never reaches the edge's data plane. See
+// docs/proposals/017_virtual-host-l7-routing.md.
+package virtualhost
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"buf.build/go/protovalidate"
+	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validator is an admission webhook that rejects a VirtualHost whose spec fails
+// protovalidate, or any of whose hostnames is already claimed by another
+// VirtualHost cluster-wide (each external FQDN may be served by exactly one). It
+// is served by the controller's shared /validate dispatcher (see
+// controller/internal/webhook), keyed by the VirtualHost Kind.
+type Validator struct {
+	// Reader lists existing VirtualHosts cluster-wide for the duplicate-FQDN
+	// check. The API reader (uncached) is used so the check is correct regardless
+	// of the manager cache's scope, at the cost of one List per admission — fine,
+	// VirtualHost writes are infrequent.
+	Reader client.Reader
+	Log    *slog.Logger
+}
+
+// Handle validates the incoming VirtualHost's spec and host uniqueness.
+func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	vh := &crdv1.VirtualHost{}
+	// Decode via the typed object's jsonshim (protojson on .spec), so an unknown
+	// or malformed spec field is rejected here rather than reaching the edge.
+	if err := json.Unmarshal(req.Object.Raw, vh); err != nil {
+		return admission.Denied(fmt.Sprintf("VirtualHost spec is invalid: %v", err))
+	}
+
+	// Structural/semantic validation: hosts pattern + uniqueness within the
+	// manifest, >=1 route, the path oneof, backend service, ... (CEL constraints
+	// that the permissive CRD openAPI can't express).
+	if vh.Spec != nil {
+		if err := protovalidate.Validate(vh.Spec); err != nil {
+			v.Log.InfoContext(ctx, "rejected invalid VirtualHost", "name", vh.GetName(), "error", err)
+			return admission.Denied(err.Error())
+		}
+	}
+
+	incoming := vh.Spec.GetHosts()
+	if len(incoming) == 0 {
+		return admission.Allowed("")
+	}
+
+	// Duplicate-FQDN across manifests: no host may be claimed by ANOTHER
+	// VirtualHost cluster-wide (exact-string match; *.suffix vs a specific host is
+	// not a conflict — Envoy resolves most-specific-first).
+	list := &crdv1.VirtualHostList{}
+	if err := v.Reader.List(ctx, list); err != nil {
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("list VirtualHosts: %w", err))
+	}
+	claimed := make(map[string]string, len(list.Items)) // host -> "namespace/name"
+	for i := range list.Items {
+		other := &list.Items[i]
+		if other.Namespace == vh.Namespace && other.Name == vh.Name {
+			continue // self (the UPDATE case)
+		}
+		for _, h := range other.Spec.GetHosts() {
+			claimed[h] = other.Namespace + "/" + other.Name
+		}
+	}
+	for _, h := range incoming {
+		if owner, ok := claimed[h]; ok {
+			v.Log.InfoContext(ctx, "rejected duplicate VirtualHost host", "name", vh.GetName(), "host", h, "owner", owner)
+			return admission.Denied(fmt.Sprintf(
+				"host %q is already claimed by VirtualHost %s; each external FQDN may be served by only one VirtualHost", h, owner))
+		}
+	}
+	return admission.Allowed("")
+}

--- a/controller/internal/virtualhost/webhook_test.go
+++ b/controller/internal/virtualhost/webhook_test.go
@@ -1,0 +1,97 @@
+package virtualhost
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func vhSpec(hosts []string, withRoute bool) *configv1.VirtualHostSpec {
+	spec := &configv1.VirtualHostSpec{}
+	if len(hosts) > 0 {
+		spec.SetHosts(hosts)
+	}
+	if withRoute {
+		m := &configv1.RouteMatch{}
+		m.SetPrefix("/")
+		b := &configv1.RouteBackend{}
+		b.SetService("svc-1")
+		hr := &configv1.HTTPRoute{}
+		hr.SetMatch(m)
+		hr.SetBackend(b)
+		spec.SetRoutes([]*configv1.HTTPRoute{hr})
+	}
+	return spec
+}
+
+func existingVH(name, ns string, hosts ...string) *crdv1.VirtualHost {
+	vh := &crdv1.VirtualHost{Spec: vhSpec(hosts, true)}
+	vh.Name = name
+	vh.Namespace = ns
+	return vh
+}
+
+func newValidator(objs ...client.Object) *Validator {
+	scheme := runtime.NewScheme()
+	_ = crdv1.AddToScheme(scheme)
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &Validator{Reader: cl, Log: slog.New(slog.DiscardHandler)}
+}
+
+func handle(t *testing.T, v *Validator, name, ns string, hosts []string, withRoute bool) admission.Response {
+	vh := &crdv1.VirtualHost{Spec: vhSpec(hosts, withRoute)}
+	vh.Name = name
+	vh.Namespace = ns
+	raw, err := json.Marshal(vh)
+	require.NoError(t, err)
+	return v.Handle(context.Background(), admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}},
+	})
+}
+
+func TestAllowsUniqueHost(t *testing.T) {
+	v := newValidator(existingVH("other", "aether-edge", "b.example.com"))
+	resp := handle(t, v, "api", "aether-edge", []string{"a.example.com"}, true)
+	assert.True(t, resp.Allowed, "a host claimed by nobody else is admitted")
+}
+
+func TestRejectsDuplicateHost(t *testing.T) {
+	v := newValidator(existingVH("owner", "team-a", "api.example.com"))
+	resp := handle(t, v, "intruder", "team-b", []string{"api.example.com"}, true)
+	require.False(t, resp.Allowed, "a host claimed by another VirtualHost is rejected")
+	assert.Contains(t, resp.Result.Message, "team-a/owner")
+}
+
+func TestAllowsSelfUpdate(t *testing.T) {
+	// The same object (name+namespace) re-claiming its own host is an update, not
+	// a collision.
+	v := newValidator(existingVH("api", "aether-edge", "api.example.com"))
+	resp := handle(t, v, "api", "aether-edge", []string{"api.example.com"}, true)
+	assert.True(t, resp.Allowed, "a VirtualHost may keep its own host on update")
+}
+
+func TestAllowsWildcardAndSpecific(t *testing.T) {
+	// *.example.com and api.example.com are NOT a conflict — Envoy resolves
+	// most-specific-first; only exact-string duplicates are rejected.
+	v := newValidator(existingVH("wild", "aether-edge", "*.example.com"))
+	resp := handle(t, v, "api", "aether-edge", []string{"api.example.com"}, true)
+	assert.True(t, resp.Allowed, "a specific host may coexist with a wildcard host")
+}
+
+func TestRejectsInvalidSpec(t *testing.T) {
+	// No routes -> protovalidate (routes min_items=1) fails before the dup check.
+	v := newValidator()
+	resp := handle(t, v, "api", "aether-edge", []string{"api.example.com"}, false)
+	assert.False(t, resp.Allowed, "a spec failing protovalidate is rejected")
+}

--- a/controller/internal/webhook/BUILD.bazel
+++ b/controller/internal/webhook/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "webhook",
+    srcs = ["webhook.go"],
+    importpath = "github.com/bpalermo/aether/controller/internal/webhook",
+    visibility = ["//controller:__subpackages__"],
+    deps = [
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)
+
+go_test(
+    name = "webhook_test",
+    srcs = ["webhook_test.go"],
+    embed = [":webhook"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@io_k8s_api//admission/v1:admission",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)

--- a/controller/internal/webhook/webhook.go
+++ b/controller/internal/webhook/webhook.go
@@ -1,0 +1,44 @@
+// Package webhook provides the aether-controller's single validating admission
+// endpoint (/validate). The apiserver routes each CRD's CREATE/UPDATE to this one
+// path (the webhook rules select the resources); the handler dispatches to a
+// per-kind validator by the request Kind. One endpoint keeps the
+// ValidatingWebhookConfiguration and its serving cert simple.
+package webhook
+
+import (
+	"context"
+	"log/slog"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Path is the single URL path every CRD validating rule points at.
+const Path = "/validate"
+
+// Handler dispatches an admission request to the validator registered for its
+// Kind. An unknown Kind is admitted (fail-open) — it should never arrive, since
+// the webhook rules scope the endpoint to known resources.
+type Handler struct {
+	log    *slog.Logger
+	byKind map[string]admission.Handler
+}
+
+// NewHandler builds a dispatcher routing each Kind to its validator.
+func NewHandler(log *slog.Logger, byKind map[string]admission.Handler) *Handler {
+	return &Handler{log: log, byKind: byKind}
+}
+
+// Handle routes by the request's Kind.
+func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if v, ok := h.byKind[req.Kind.Kind]; ok {
+		return v.Handle(ctx, req)
+	}
+	h.log.WarnContext(ctx, "no validator for admission kind; admitting", "kind", req.Kind.Kind)
+	return admission.Allowed("")
+}
+
+// SetupWithManager registers the dispatcher at Path on the manager's webhook server.
+func (h *Handler) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register(Path, &admission.Webhook{Handler: h})
+}

--- a/controller/internal/webhook/webhook_test.go
+++ b/controller/internal/webhook/webhook_test.go
@@ -1,0 +1,38 @@
+package webhook
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+type stub struct{ resp admission.Response }
+
+func (s stub) Handle(context.Context, admission.Request) admission.Response { return s.resp }
+
+func req(kind string) admission.Request {
+	return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+		Kind: metav1.GroupVersionKind{Group: "config.aether.io", Version: "v1", Kind: kind},
+	}}
+}
+
+func TestDispatchByKind(t *testing.T) {
+	h := NewHandler(slog.New(slog.DiscardHandler), map[string]admission.Handler{
+		"MeshConfig":  stub{admission.Denied("mc")},
+		"VirtualHost": stub{admission.Denied("vh")},
+	})
+	assert.Equal(t, "mc", h.Handle(context.Background(), req("MeshConfig")).Result.Message)
+	assert.Equal(t, "vh", h.Handle(context.Background(), req("VirtualHost")).Result.Message)
+}
+
+// TestUnknownKindAdmitted verifies an unrouted Kind is admitted (fail-open) — it
+// should never arrive, since the webhook rules scope the endpoint.
+func TestUnknownKindAdmitted(t *testing.T) {
+	h := NewHandler(slog.New(slog.DiscardHandler), map[string]admission.Handler{})
+	assert.True(t, h.Handle(context.Background(), req("Other")).Allowed)
+}


### PR DESCRIPTION
**PR2** of proposal 017 (#251). Builds on **#252** (the VirtualHost CRD, merged).

Adds **VirtualHost admission validation** to `aether-controller`: protovalidate the spec, then reject a CREATE/UPDATE whose hostnames collide with another VirtualHost cluster-wide — so a duplicate FQDN never reaches the edge's data plane.

## One shared `/validate` endpoint (per feedback)
Validation is served on the controller's **single `/validate`** endpoint — **not** a per-CRD path. A thin dispatcher (`controller/internal/webhook`) routes each `AdmissionReview` to a per-kind validator by the request `Kind`. MeshConfig and VirtualHost are **two rules on one `ValidatingWebhookConfiguration` entry** (`validate.config.aether.io`), keeping one endpoint and one serving cert.

## What it does
- `controller/internal/webhook` — `/validate` dispatcher (`Kind` → `admission.Handler`; unknown Kind fails open).
- `controller/internal/virtualhost` — `Validator`: protovalidate the spec, then list VirtualHosts via the **API reader** (uncached, cluster-wide) and deny if any `spec.hosts` entry is already claimed by **another** object. Exact-string — `*.example.com` vs `api.example.com` is *not* a conflict (Envoy resolves most-specific-first). Self (same ns/name) excluded for updates.
- `meshconfig.Validator` keeps its `Handle`; its path/registration moves to the dispatcher.
- chart — one webhook entry with the `meshconfigs` (Cluster) + `virtualhosts` (Namespaced) rules; controller RBAC `virtualhosts: get/list/watch`; aether `0.15.0`.

`failurePolicy: Ignore` (never wedges writes mid-rollout); the edge's **runtime keep-first dedup** (#252) is the TOCTOU backstop.

## Validation
Controller builds; dispatcher + per-kind webhook unit tests pass (route-by-kind, unknown-kind-admitted, unique / duplicate-rejected-with-owner / self-update / wildcard-vs-specific / invalid-spec); `helm template` renders **one** `/validate` webhook with **both** rules.

## Next
e2e on talos: `*.palermo.dev` wildcard cert + path routing + a duplicate-FQDN rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)