### PR TITLE
chore: hygiene bundle (xds comment drift, edge flag rename, region invariant)

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -75,9 +75,9 @@ type AgentConfig struct {
 	// binds (edge subcommand only).
 	EdgeHTTPPort uint32
 
-	// EdgeRouteNamespace is the namespace the edge watches VirtualHost CRs in
+	// RouteNamespace is the namespace the edge watches VirtualHost CRs in
 	// (edge subcommand only); empty means the edge pod's own namespace.
-	EdgeRouteNamespace string
+	RouteNamespace string
 
 	// EdgeTLS enables downstream TLS termination: the edge serves an HTTPS
 	// listener on EdgeHTTPSPort (certs per VirtualHost via SDS) and an HTTP->HTTPS

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -49,7 +49,10 @@ func init() {
 	// at a pod-local emptyDir so PreListen's load is a no-op.
 	edgeCmd.Flags().StringVar(&cfg.MountedLocalStorageDir, "mounted-registry-dir", "/var/lib/aether/registry", "Pod-local directory for the edge's (empty) local store")
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPPort, "edge-http-port", cfg.EdgeHTTPPort, "Port the edge proxy's public-facing HTTP listener binds")
-	edgeCmd.Flags().StringVar(&cfg.EdgeRouteNamespace, "edge-route-namespace", "", "Namespace to watch VirtualHost CRs in (empty = the edge pod's own namespace)")
+	edgeCmd.Flags().StringVar(&cfg.RouteNamespace, "route-namespace", "", "Namespace to watch VirtualHost CRs in (empty = the edge pod's own namespace)")
+	// Deprecated alias kept for one release (the flag predates the EdgeRoute->VirtualHost rename).
+	edgeCmd.Flags().StringVar(&cfg.RouteNamespace, "edge-route-namespace", "", "Deprecated alias for --route-namespace")
+	_ = edgeCmd.Flags().MarkDeprecated("edge-route-namespace", "use --route-namespace")
 	edgeCmd.Flags().BoolVar(&cfg.EdgeTLS, "edge-tls", false, "Terminate downstream TLS: serve an HTTPS listener (certs per VirtualHost via SDS) + an HTTP->HTTPS redirect")
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPSPort, "edge-https-port", cfg.EdgeHTTPSPort, "Port the edge TLS listener binds when --edge-tls is set")
 }
@@ -81,7 +84,7 @@ func runEdge(ctx context.Context) (retErr error) {
 	// Watch VirtualHost CRs in the edge's own namespace (or an override). Scope the
 	// manager's informer cache to that namespace so the edge needs only namespaced
 	// RBAC, not cluster-wide.
-	routeNamespace := cfg.EdgeRouteNamespace
+	routeNamespace := cfg.RouteNamespace
 	if routeNamespace == "" {
 		routeNamespace = currentNamespace()
 	}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.15.0-{GIT_COMMIT}"
+version: "0.16.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -51,7 +51,7 @@ spec:
             # otherwise win and not exist in the edge pod.
             - "--mounted-registry-dir=/var/lib/aether/registry"
             - "--edge-http-port={{ .Values.edge.httpPort }}"
-            - "--edge-route-namespace={{ $routeNamespace }}"
+            - "--route-namespace={{ $routeNamespace }}"
             {{- if .Values.edge.tls.enabled }}
             - "--edge-tls"
             - "--edge-https-port={{ .Values.edge.httpsPort }}"

--- a/common/xds/xds.go
+++ b/common/xds/xds.go
@@ -43,9 +43,9 @@ func NewXdsServer(ctx context.Context, cfg *ServerConfig, cache cachev3.Snapshot
 		grpc.KeepaliveParams(keepalive.ServerParameters{
 			MaxConnectionIdle:     15 * time.Minute, // Close idle connections after 15 minutes
 			MaxConnectionAge:      1 * time.Hour,    // Max age of connection
-			MaxConnectionAgeGrace: 10 * time.Second, // Allow 5 seconds for pending RPCs to complete
+			MaxConnectionAgeGrace: 10 * time.Second, // Allow 10 seconds for pending RPCs to complete
 			Time:                  keepAliveTime,    // Ping client if no activity for 30 seconds
-			Timeout:               5 * time.Second,  // Wait 10 seconds for ping ack before closing
+			Timeout:               5 * time.Second,  // Wait 5 seconds for ping ack before closing
 		}),
 		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
 			// Ensure we allow clients has enough time to send keep alive. If this is higher than the client's

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -57,7 +57,7 @@ func init() {
 	manager.RegisterFlags(rootCmd, &cfg.Config)
 
 	rootCmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", "", "Kubernetes cluster name (required)")
-	rootCmd.Flags().StringVar(&cfg.Region, "region", cfg.Region, "Region owning this registrar's etcd partition (etcd backend; proposal 006)")
+	rootCmd.Flags().StringVar(&cfg.Region, "region", cfg.Region, "Region owning this registrar's etcd partition (etcd backend; proposal 006). MUST be unique per regional etcd cluster: one region = one etcd. Pointing two etcds at the same region splits the registry; pointing two regions at one etcd collides their writes.")
 	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", cfg.RegistryBackend, "Registry backend (kubernetes, dynamodb, or etcd)")
 	rootCmd.Flags().StringSliceVar(&cfg.EtcdEndpoints, "etcd-endpoints", cfg.EtcdEndpoints, "Comma-separated etcd endpoints")
 	rootCmd.Flags().DurationVar(&cfg.SyncInterval, "sync-interval", cfg.SyncInterval, "How often to sync from the registry")
@@ -76,6 +76,11 @@ func runRegistrar(ctx context.Context) (retErr error) {
 	l.InfoContext(ctx, "starting aether registrar",
 		"clusterName", cfg.ClusterName,
 		"registryBackend", cfg.RegistryBackend,
+		// region names this registrar's etcd partition (proposal 006). Surfaced at
+		// startup because the region<->etcd 1:1 invariant is not locally enforceable
+		// (a registrar can't see a peer pointing a DIFFERENT etcd at the same region):
+		// an operator spots a misconfiguration by comparing this across registrars.
+		"region", cfg.Region,
 		"syncInterval", cfg.SyncInterval,
 		"grpcAddress", cfg.GRPCAddress,
 		"metricsEnabled", cfg.MetricsEnabled,


### PR DESCRIPTION
Three low-risk cleanups from a codebase review (the bigger items — CNI installer tests, etcd List perf — are in a separate effort).

**1. Fix stale keepalive comments** (`common/xds/xds.go`) — the comments contradicted their values:
- `MaxConnectionAgeGrace: 10 * time.Second` said *"5 seconds"*
- `Timeout: 5 * time.Second` said *"10 seconds"*

Copy-paste drift that would mislead anyone tuning gRPC keepalive during an incident.

**2. Rename `--edge-route-namespace` → `--route-namespace`** — it watches **VirtualHost** CRs now (post proposal 017), so the old name is misleading. The old flag is kept as a **hidden, deprecated alias** for one release; the chart passes `--route-namespace`. Config field `EdgeRouteNamespace` → `RouteNamespace`. aether chart `0.16.0`.

**3. Make the `region↔etcd` 1:1 invariant visible** (proposal 006) — the `--region` flag help now states it (*one region = one etcd*), and the value is logged at registrar startup. The split-brain case (two etcds, same region) isn't locally enforceable — a registrar can't see a peer pointing a different etcd at the same region — so operator-visible logging is the honest guard, not a fake check.

## Validation
`bazel build //...` green; gazelle + format applied; agent/registrar/common-xds tests pass; `helm template` renders `--route-namespace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)