### PR TITLE
perf(registry): document + test etcd ListEndpoints cross-origin scan

### DIFF
--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -298,8 +298,20 @@ func (r *EtcdRegistry) UnregisterEndpoints(ctx context.Context, serviceName stri
 
 // ListEndpoints retrieves all endpoints for a specific service and protocol,
 // ACROSS every origin (region/cluster) — a consumer wants every endpoint of the
-// service, not just this instance's own partition. Since the origin precedes the
-// service in the key, this ranges the whole root and filters by service+protocol.
+// service, not just this instance's own partition.
+//
+// Cost: because origin precedes service in the key (proposal 006, origin-first so
+// the replicator mirrors one contiguous prefix), a single service's endpoints are
+// NOT a contiguous range — this ranges the whole root and filters in memory, i.e.
+// O(all endpoints) per call. That is acceptable and NOT worth a per-service
+// secondary index: the only caller is the agent's COLD path (an ODCDS-observed
+// service the re-filtered watch hasn't delivered yet, agent/internal/xds/cache/
+// cluster.go), gated by the service catalog (nonexistent services cost nothing),
+// hit at most once per service, and failure-tolerant (the watch catch-up repairs).
+// In the deployed topology the agent uses the registrar backend (an in-memory
+// per-service cache), so this etcd path runs only with --registry-backend=etcd
+// directly. An index would add write-amplification to every register for a rarely
+// taken read; revisit only if a hot direct-to-etcd consumer appears.
 func (r *EtcdRegistry) ListEndpoints(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
 	r.log.DebugContext(ctx, "listing endpoints", "service", service, "protocol", protocol)
 

--- a/registry/internal/etcd/etcd_test.go
+++ b/registry/internal/etcd/etcd_test.go
@@ -454,3 +454,58 @@ func TestEtcdRegistry_WatchSignalsChanges(t *testing.T) {
 		t.Fatal("watch did not signal a change after UnregisterEndpoint")
 	}
 }
+
+// crossOriginRegistry builds an etcd registry sharing the given key-prefix root
+// but owning a distinct (region, cluster) partition, so several can write
+// disjoint origin subtrees into one etcd (proposal 006).
+func crossOriginRegistry(ctx context.Context, t *testing.T, prefix, region, cluster string) *etcd.EtcdRegistry {
+	t.Helper()
+	r := etcd.NewEtcdRegistry(slog.New(slog.DiscardHandler), etcd.Config{
+		Endpoints:   []string{testEndpoint},
+		DialTimeout: 5 * time.Second,
+		KeyPrefix:   prefix,
+		Region:      region,
+		Cluster:     cluster,
+	})
+	require.NoError(t, r.Initialize(ctx))
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+// TestEtcdRegistry_ListEndpointsCrossOrigin verifies the origin-first key schema:
+// ListEndpoints returns the UNION of a service's endpoints across origins, two
+// origins sharing an IP (overlapping pod CIDRs across clusters) do NOT clobber
+// each other, and each origin's unregister touches only its own partition.
+func TestEtcdRegistry_ListEndpointsCrossOrigin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	ctx := context.Background()
+	prefix := keyPrefix(t)
+	regA := crossOriginRegistry(ctx, t, prefix, "us-east", "cluster-a")
+	regB := crossOriginRegistry(ctx, t, prefix, "us-west", "cluster-b")
+
+	// SAME IP in both origins: origin-first keys keep the partitions disjoint, so
+	// neither write clobbers the other despite the shared IP.
+	const ip = "10.244.0.5"
+	require.NoError(t, regA.RegisterEndpoint(ctx, "svc", registryv1.Service_PROTOCOL_HTTP,
+		&registryv1.ServiceEndpoint{Ip: ip, ClusterName: "cluster-a", Port: 8080}))
+	require.NoError(t, regB.RegisterEndpoint(ctx, "svc", registryv1.Service_PROTOCOL_HTTP,
+		&registryv1.ServiceEndpoint{Ip: ip, ClusterName: "cluster-b", Port: 8080}))
+
+	// ListEndpoints ranges every origin and returns the union (from either reader).
+	eps, err := regA.ListEndpoints(ctx, "svc", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, eps, 2, "both origins' endpoints are returned despite the shared IP")
+	assert.ElementsMatch(t, []string{"cluster-a", "cluster-b"},
+		[]string{eps[0].GetClusterName(), eps[1].GetClusterName()})
+
+	// Each origin writes/deletes ONLY its own partition: A's unregister leaves B's
+	// endpoint intact.
+	require.NoError(t, regA.UnregisterEndpoint(ctx, "svc", ip))
+	eps, err = regB.ListEndpoints(ctx, "svc", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "cluster-b", eps[0].GetClusterName())
+}


### PR DESCRIPTION
Follow-up to proposal 006 (origin-first etcd keys). `ListEndpoints(svc)` can no longer be a single prefix `Get` — origin (region/cluster) precedes service in the key, so it ranges the whole `/aether/v1/regions/` root and filters in memory: **O(all endpoints) per call**.

## Finding: keep-and-document, no index
The sole caller is the agent's **cold path** (`agent/internal/xds/cache/cluster.go:199` — an ODCDS-observed service the re-filtered watch hasn't delivered yet): catalog-gated (nonexistent services cost nothing), hit at most once per service, failure-tolerant (watch catch-up repairs). And in the **deployed** topology the agent uses the **registrar** backend (in-memory per-service cache, O(1)); the etcd `ListEndpoints` runs only with `--registry-backend=etcd` directly. A per-service secondary index would add write-amplification to every register for a rarely taken read — not worth it. This PR documents that reasoning on the function.

## Test: the property that matters is *correctness*, not speed
Adds an integration test (testcontainers, `Short`-skipped, matching `etcd_test.go`): two origins sharing one etcd root but distinct `(region, cluster)` partitions both register the **same service with an overlapping IP** (cross-cluster pod-CIDR overlap — exactly the collision origin-first keys exist to prevent). Asserts `ListEndpoints` returns the **union** with no clobber, and each origin's `UnregisterEndpoint` touches only its own partition.

## Validation
`bazel run //:gazelle`/`//:format`; `bazel test //registry/internal/etcd:etcd_test` green against a real etcd container. Doc + test only — **no behavior change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)