### PR TITLE
chore(edge): sensible flag defaults + derive identity from POD_NAME, trim chart args

### DIFF
--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/bpalermo/aether/agent/constants"
 	"github.com/bpalermo/aether/agent/internal/edge"
 	"github.com/bpalermo/aether/agent/internal/edge/secret"
 	"github.com/bpalermo/aether/agent/internal/xds/ack"
@@ -43,7 +44,7 @@ func init() {
 	// The edge needs the manager flags (logging, metrics, health probe, OTEL)
 	// and the shared identity/registrar/SPIRE flags, bound onto the same cfg.
 	manager.RegisterFlags(edgeCmd, &cfg.Config)
-	registerSharedFlags(edgeCmd)
+	registerSharedFlags(edgeCmd, false)
 
 	// The edge has no CNI/pod storage; it points the (always-empty) local store
 	// at a pod-local emptyDir so PreListen's load is a no-op.
@@ -66,6 +67,22 @@ func init() {
 // the statically exposed services so the registrar watch is scoped to exactly
 // those.
 func runEdge(ctx context.Context) (retErr error) {
+	// The edge's identity is its pod name: derive proxy-id / node-name from the
+	// POD_NAME downward-API env (set by the chart) unless explicitly overridden,
+	// so the deployment needn't wire them. node-name == proxy-id (the edge has no
+	// distinct K8s node identity).
+	if name := currentPodName(); name != "" {
+		if cfg.ProxyServiceNodeID == "" || cfg.ProxyServiceNodeID == constants.DefaultProxyID {
+			cfg.ProxyServiceNodeID = name
+		}
+		if cfg.NodeName == "" {
+			cfg.NodeName = cfg.ProxyServiceNodeID
+		}
+	}
+	if cfg.ProxyServiceNodeID == "" || cfg.NodeName == "" {
+		return fmt.Errorf("edge identity unresolved: set POD_NAME (downward API) or pass --proxy-id/--node-name")
+	}
+
 	l.InfoContext(ctx, "starting aether edge proxy control plane",
 		"proxy-id", cfg.ProxyServiceNodeID,
 		"debug", cfg.Debug,
@@ -218,8 +235,14 @@ func runEdge(ctx context.Context) (retErr error) {
 	return m.Start(ctx)
 }
 
+// currentPodName returns the edge pod's name from the POD_NAME downward-API env
+// (set by the chart); empty if unset. Used as the edge's xDS/watch identity.
+func currentPodName() string {
+	return os.Getenv("POD_NAME")
+}
+
 // currentNamespace returns the namespace the edge pod runs in (the default
-// namespace to watch EdgeRoutes in). It reads POD_NAMESPACE (set via the
+// namespace to watch VirtualHosts in). It reads POD_NAMESPACE (set via the
 // downward API by the chart) and falls back to the service-account namespace
 // file.
 func currentNamespace() string {

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -97,7 +97,7 @@ func GetCommand() *cobra.Command {
 
 func init() {
 	manager.RegisterFlags(rootCmd, &cfg.Config)
-	registerSharedFlags(rootCmd)
+	registerSharedFlags(rootCmd, true)
 
 	// Local storage configuration (node proxy only — the edge runs no CNI/storage).
 	rootCmd.Flags().StringVar(&cfg.MountedLocalStorageDir, "mounted-registry-dir", constants.DefaultHostCNIRegistryDir, "Directory where pod data is stored locally for the CNI plugin")
@@ -112,7 +112,11 @@ func init() {
 // system config inherited from the umbrella chart, and the SPIRE workload
 // socket. Each command binds them onto the shared cfg; cobra runs the root's
 // PersistentPreRunE (mesh-config load + logging) for the subcommand too.
-func registerSharedFlags(cmd *cobra.Command) {
+// registerSharedFlags binds the identity/registrar/SPIRE/system flags shared by
+// the node agent and the edge. requirePodIdentity marks node-name and proxy-id
+// required (the node agent — node-name is the K8s node, not derivable); the edge
+// passes false and derives both from the POD_NAME downward-API env instead.
+func registerSharedFlags(cmd *cobra.Command, requirePodIdentity bool) {
 	// Aether system config (OTEL enable/endpoint via manager.RegisterFlags, mesh
 	// domain, SPIRE on/off) is inherited from the aether umbrella chart's globals
 	// as flags. The proxy data plane can override its own observability via the
@@ -134,8 +138,10 @@ func registerSharedFlags(cmd *cobra.Command) {
 
 	// These calls only fail if the flag name is not registered, which would be a programming error.
 	must.NoError(cmd.MarkFlagRequired("cluster-name"))
-	must.NoError(cmd.MarkFlagRequired("node-name"))
-	must.NoError(cmd.MarkFlagRequired("proxy-id"))
+	if requirePodIdentity {
+		must.NoError(cmd.MarkFlagRequired("node-name"))
+		must.NoError(cmd.MarkFlagRequired("proxy-id"))
+	}
 }
 
 // applyMeshConfig applies the proxy observability overrides from the MeshConfig

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -30,12 +30,13 @@ const (
 	EdgeRedirectListenerName = "edge_redirect"
 
 	// DefaultEdgeHTTPPort is the port the edge plain-HTTP / redirect listener
-	// binds for external (north-south) traffic.
-	DefaultEdgeHTTPPort = 8080
+	// binds for external (north-south) traffic. Privileged (the edge is an ingress
+	// gateway); the pod is granted NET_BIND_SERVICE, so it binds unprivileged.
+	DefaultEdgeHTTPPort = 80
 
 	// DefaultEdgeHTTPSPort is the port the edge TLS-terminating listener binds
 	// when downstream TLS is enabled.
-	DefaultEdgeHTTPSPort = 8443
+	DefaultEdgeHTTPSPort = 443
 
 	// defaultEdgeAddress binds the edge listener on all interfaces (it fronts
 	// external traffic, unlike the node proxy's loopback-only outbound listener).

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.17.0-{GIT_COMMIT}"
+version: "0.18.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.edge.enabled }}
-{{- $routeNamespace := default (include "aether.namespace" .) .Values.edge.routeNamespace }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,20 +40,24 @@ spec:
           args:
             - "edge"
             - "--debug={{ .Values.debug }}"
-            - "--proxy-id=$(POD_NAME)"
             - "--cluster-name={{ .Values.clusterName }}"
-            - "--node-name=$(POD_NAME)"
+            # proxy-id / node-name derive from POD_NAME (downward API, below); the
+            # registry dir, ports, mesh domain, route namespace and SPIRE socket all
+            # use the binary defaults — passed below only when overridden.
+            {{- if ne .Values.meshDomain "aether.internal" }}
             - "--mesh-domain={{ .Values.meshDomain }}"
-            # Point the (always-empty) local store at the pod-local emptyDir below.
-            # Passed explicitly: the edge subcommand shares --mounted-registry-dir
-            # with the root command, whose default (the node hostPath) would
-            # otherwise win and not exist in the edge pod.
-            - "--mounted-registry-dir=/var/lib/aether/registry"
+            {{- end }}
+            {{- if ne (int .Values.edge.httpPort) 80 }}
             - "--edge-http-port={{ .Values.edge.httpPort }}"
-            - "--route-namespace={{ $routeNamespace }}"
+            {{- end }}
+            {{- with .Values.edge.routeNamespace }}
+            - "--route-namespace={{ . }}"
+            {{- end }}
             {{- if .Values.edge.tls.enabled }}
             - "--edge-tls"
+            {{- if ne (int .Values.edge.httpsPort) 443 }}
             - "--edge-https-port={{ .Values.edge.httpsPort }}"
+            {{- end }}
             {{- end }}
             {{- if .Values.otel.enabled }}
             - "--otel-enabled=true"
@@ -70,7 +73,7 @@ spec:
             - "--trace-export=true"
             {{- end }}
             - "--spire-enabled={{ .Values.spire.enabled }}"
-            {{- if .Values.spire.enabled }}
+            {{- if and .Values.spire.enabled (ne .Values.spire.workloadSocketPath "/run/secrets/workload-spiffe-uds/socket") }}
             - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
             {{- end }}
           env:


### PR DESCRIPTION
Slims the edge agent's deploy-time flag surface so the chart passes only the genuinely deploy-specific flags — overrides preserved.

## Code
- **Edge ports default `80`/`443`** (were `8080`/`8443`). The edge is an ingress gateway and always runs with `NET_BIND_SERVICE`, so privileged ports are the right default; local runs without the cap can still pass `--edge-http-port`/`--edge-https-port`.
- **Identity from `POD_NAME`**: the edge derives `proxy-id`/`node-name` from the `POD_NAME` downward-API env (its identity *is* its pod name). `registerSharedFlags` gains a `requirePodIdentity` param — the **node agent** keeps them required (node-name is the K8s node, not derivable); the **edge** falls back to `POD_NAME` and errors only if unresolved. Node-agent behavior unchanged.

## Chart (`edge-deployment`)
- **Dropped** `--proxy-id` / `--node-name` (POD_NAME fallback) and `--mounted-registry-dir` (edge subcommand already defaults it).
- **Conditionalized** `--mesh-domain` / `--edge-http-port` / `--edge-https-port` / `--route-namespace` / `--spire-workload-socket` — passed **only when overridden** from the (binary-matching) default. Common case is clean; overrides still propagate.
- aether chart **0.18.0**.

**Result:** the default talos edge command drops from ~18 flags to the ~10 deploy-specific ones (`--cluster-name`, `--edge-tls`, `--otel-*`, `--spire-enabled`, `--debug`).

## MeshConfig (the other half of the question)
Proxy **data-plane** observability (access logs / tracing / stats) **already** comes from the mounted MeshConfig CR — that's why there are no `--access-logs`/`--proxy-tracing` flags. The agent's **own** OTel + identity + SPIRE stay deploy-time flags **by design** (proposal 015): control-plane system config that must not be runtime-mutable (atomic fleet roll; a bad CR can't break the control plane's telemetry/identity). So nothing more should move to MeshConfig.

## Validation
`bazel build //...` green; agent/proxy/cmd tests pass. `helm template` confirmed: **default** render = minimal flags (no pod-identity/registry-dir/ports/domain/route-ns/socket); **overridden** values bring each flag back. Node agent still passes `$(NODE_NAME)` + requires identity (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)