### PR TITLE
fix(edge): resolve pod-local registry dir (flag-clobber regression from #259)

### DIFF
--- a/agent/constants/constants.go
+++ b/agent/constants/constants.go
@@ -10,6 +10,13 @@ const (
 	// DefaultHostCNIRegistryDir is the default directory for storing CNI registry data on the host
 	DefaultHostCNIRegistryDir = "/host" + constants.CNIDefaultRegistryPath
 
+	// DefaultEdgeRegistryDir is the edge's pod-local (always-empty) registry dir.
+	// The edge has no host CNI mount, but the shared --mounted-registry-dir flag
+	// defaults to the node hostPath (DefaultHostCNIRegistryDir) via the root
+	// command, so runEdge resolves to this pod-local path unless explicitly
+	// overridden — otherwise the edge would read a path that doesn't exist.
+	DefaultEdgeRegistryDir = constants.CNIDefaultRegistryPath
+
 	// DefaultXdsSocketPath is the default Unix domain socket path for the xDS server
 	DefaultXdsSocketPath = "/run/aether/xds.sock"
 	// DefaultCNISocketPath is the default Unix domain socket path for the CNI server

--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -46,7 +46,10 @@ go_library(
 
 go_test(
     name = "cmd_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "edge_test.go",
+    ],
     embed = [":cmd"],
     deps = [
         "//agent/constants",

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -83,6 +83,8 @@ func runEdge(ctx context.Context) (retErr error) {
 		return fmt.Errorf("edge identity unresolved: set POD_NAME (downward API) or pass --proxy-id/--node-name")
 	}
 
+	cfg.MountedLocalStorageDir = edgeStorageDir(cfg.MountedLocalStorageDir)
+
 	l.InfoContext(ctx, "starting aether edge proxy control plane",
 		"proxy-id", cfg.ProxyServiceNodeID,
 		"debug", cfg.Debug,
@@ -233,6 +235,19 @@ func runEdge(ctx context.Context) (retErr error) {
 
 	l.DebugContext(ctx, "starting edge manager")
 	return m.Start(ctx)
+}
+
+// edgeStorageDir resolves the edge's (always-empty) pod-local registry dir. The
+// shared --mounted-registry-dir flag is registered by BOTH the root and edge
+// commands on one cfg field; the root's hostPath default wins the init ordering,
+// so an un-overridden edge would inherit the node hostPath that doesn't exist in
+// its pod. When the value is that host default, fall back to the pod-local dir;
+// an explicit override is preserved.
+func edgeStorageDir(configured string) string {
+	if configured == constants.DefaultHostCNIRegistryDir {
+		return constants.DefaultEdgeRegistryDir
+	}
+	return configured
 }
 
 // currentPodName returns the edge pod's name from the POD_NAME downward-API env

--- a/agent/internal/cmd/edge_test.go
+++ b/agent/internal/cmd/edge_test.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/bpalermo/aether/agent/constants"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestEdgeStorageDir guards the flag-clobber fix: the edge must fall back to the
+// pod-local registry dir when --mounted-registry-dir carries the root command's
+// node-hostPath default (which doesn't exist in the edge pod), while preserving
+// an explicit override.
+func TestEdgeStorageDir(t *testing.T) {
+	assert.Equal(t, constants.DefaultEdgeRegistryDir, edgeStorageDir(constants.DefaultHostCNIRegistryDir),
+		"the unusable node-hostPath default resolves to the pod-local dir")
+	assert.Equal(t, "/custom/dir", edgeStorageDir("/custom/dir"),
+		"an explicit override is preserved")
+}


### PR DESCRIPTION
**Regression caught by the 0.18.0 talos e2e.** The new edge pod crash-looped:
```
Error: failed to read directory: open /host/var/lib/aether/registry: no such file or directory
```
(No outage — the old `2/2` edge pods kept serving; I rolled back to 0.17.0 while fixing.)

## Root cause
#259 dropped the chart's explicit `--mounted-registry-dir=/var/lib/aether/registry`. But that flag is registered by **both** the root and edge commands on **one shared `cfg` field**, and the root's node-hostPath default (`/host/...`) wins the `init()` ordering — so the un-overridden edge inherited a path that doesn't exist in its pod. The explicit flag (the #242 workaround) was masking it; removing it re-exposed the clobber.

The rest of #259 was fine — the crash log confirms `proxy-id` = POD_NAME ✓, `edgeHTTPPort: 80` ✓, SPIRE identity ✓. Only the storage dir broke.

## Fix (code, not chart)
`runEdge` resolves `--mounted-registry-dir` to the pod-local `DefaultEdgeRegistryDir` (`/var/lib/aether/registry`) when it carries the host default, preserving an explicit override. Extracted as `edgeStorageDir()` with a unit test (`TestEdgeStorageDir`) so it can't regress.

Code-only (no chart change → no version bump). Build green; `cmd_test` passes.

## After merge
Redeploy the fixed chart to talos and complete the edge e2e (path routing + TLS on the trimmed-flag edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)