### PR TITLE
fix(cni): guarantee the local storage delete on CNI DEL (#261)

### DIFF
--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -28,6 +28,12 @@ import (
 // data-plane proof that the listener serves is the CNI plugin's in-netns probe.
 const envoyAckTimeout = 2 * time.Second
 
+// unregisterTimeout bounds the best-effort registry deregistration on CNI DEL.
+// The local storage removal is already durable by then and the ghost sweep
+// reconciles any endpoint left behind, so this only caps how long the DEL waits
+// on the registrar (which may be rolling) before falling through to the sweep.
+const unregisterTimeout = 5 * time.Second
+
 // tracerName identifies this instrumentation scope in trace backends. The RPC
 // span itself comes from the otelgrpc stats handler; spans started here break
 // the pod lifecycle down into its API-server / registry / xDS / Envoy steps.
@@ -171,47 +177,67 @@ func (s *CNIServer) RemovePod(ctx context.Context, req *cniv1.RemovePodRequest) 
 		return &cniv1.RemovePodResponse{Result: cniv1.RemovePodResponse_RESULT_SUCCESS}, nil
 	}
 
-	// Hold lifecycleMu from unregistration through storage removal so the
-	// liveness loop cannot interleave a health re-registration of a pod whose
-	// endpoint was just unregistered (which would resurrect it in the registry
-	// permanently).
+	// Detach from the request context so neither the durable local removal nor the
+	// best-effort registry/listener cleanup is skipped when the request ctx is
+	// canceled — the plugin's del timeout, a kubelet cancel, or agent SIGTERM (the
+	// xDS server force-stops in-flight RPCs after ShutdownTimeout). RemoveResource
+	// ignores ctx, but a canceled handler that returns early before reaching it is
+	// exactly what left ghost storage entries with lingering netns pins.
+	bgCtx := context.WithoutCancel(ctx)
+
+	// Serialize against the liveness loop and ghost sweep across the removal.
 	s.lifecycleMu.Lock()
 
-	serviceName, ips, err := registry.ExtractCNIPodInformation(storedPod)
-	unregCtx, unregSpan := startStepSpan(ctx, "cni_server.unregister_endpoints", storedPod)
-	err = s.registry.UnregisterEndpoints(unregCtx, serviceName, ips)
-	telemetry.EndSpan(unregSpan, err)
-	if err != nil {
+	// Remove from local storage FIRST. Local storage is the authoritative source
+	// of truth: the listener snapshot is rebuilt from it, the liveness loop reads
+	// it, and the ghost sweep reconciles the registry against it. Removing it first
+	// makes the delete durable even if the steps below fail, stops the liveness
+	// loop resurrecting the endpoint, and lets the sweep deregister whatever is
+	// left in the registry. This mirrors AddPod, which stores first and treats
+	// registration as best-effort. The ONLY fatal error here (kubelet retries the
+	// DEL) is the storage removal itself.
+	if err := s.storage.RemoveResource(bgCtx, containerID); err != nil {
 		s.lifecycleMu.Unlock()
-		return nil, status.Errorf(codes.Internal, "failed to unregister endpoints from service: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to remove pod from storage: %v", err)
 	}
 
-	// Unsubscribe from SVID for this pod (keyed by its network namespace).
-	if s.spireBridge != nil {
-		if unsubErr := s.spireBridge.UnsubscribePod(ctx, storedPod.GetNetworkNamespace()); unsubErr != nil {
-			log.ErrorContext(ctx, "failed to unsubscribe from SVID", "error", unsubErr, "netns", storedPod.GetNetworkNamespace())
+	// Remove the per-pod listeners (best-effort): on failure the next snapshot
+	// rebuild — or an agent restart's load from the now-empty storage — drops them.
+	xdsCtx, xdsSpan := startStepSpan(bgCtx, "cni_server.xds_remove_pod", storedPod)
+	xdsErr := s.snapshotCache.RemovePod(xdsCtx, storedPod.GetNetworkNamespace())
+	telemetry.EndSpan(xdsSpan, xdsErr)
+	if xdsErr != nil {
+		log.ErrorContext(ctx, "failed to remove listener; snapshot rebuild will reconcile", "error", xdsErr, "netns", storedPod.GetNetworkNamespace())
+	}
+
+	// Deregister the endpoint (best-effort): the ghost sweep deregisters any
+	// endpoint with no live local pod, so a failure here (registrar rolling,
+	// shutdown) self-heals on the next sweep. Bounded so it can't hang the DEL.
+	if serviceName, ips, extractErr := registry.ExtractCNIPodInformation(storedPod); extractErr != nil {
+		log.ErrorContext(ctx, "failed to extract endpoint info; ghost sweep will reconcile", "error", extractErr)
+	} else {
+		unregCtx, unregCancel := context.WithTimeout(bgCtx, unregisterTimeout)
+		unregSpanCtx, unregSpan := startStepSpan(unregCtx, "cni_server.unregister_endpoints", storedPod)
+		unregErr := s.registry.UnregisterEndpoints(unregSpanCtx, serviceName, ips)
+		telemetry.EndSpan(unregSpan, unregErr)
+		unregCancel()
+		if unregErr != nil {
+			log.ErrorContext(ctx, "failed to unregister endpoints; ghost sweep will retry", "error", unregErr, "service", serviceName)
 		}
 	}
 
-	// Remove listener from xDS first
-	xdsCtx, xdsSpan := startStepSpan(ctx, "cni_server.xds_remove_pod", storedPod)
-	err = s.snapshotCache.RemovePod(xdsCtx, storedPod.GetNetworkNamespace())
-	telemetry.EndSpan(xdsSpan, err)
-	if err != nil {
-		s.lifecycleMu.Unlock()
-		return nil, status.Errorf(codes.Internal, "failed to remove listener: %v", err)
-	}
-
-	// Remove from the local storage
-	if err = s.storage.RemoveResource(ctx, containerID); err != nil {
-		s.lifecycleMu.Unlock()
-		return nil, status.Errorf(codes.Internal, "failed to remove pod from storage: %v", err)
+	// Unsubscribe from SVID for this pod (best-effort; keyed by its netns).
+	if s.spireBridge != nil {
+		if unsubErr := s.spireBridge.UnsubscribePod(bgCtx, storedPod.GetNetworkNamespace()); unsubErr != nil {
+			log.ErrorContext(ctx, "failed to unsubscribe from SVID", "error", unsubErr, "netns", storedPod.GetNetworkNamespace())
+		}
 	}
 	s.lifecycleMu.Unlock()
 
 	// Best-effort: wait for Envoy to ACK removal of both per-pod listeners —
 	// the inbound listener also binds (and dials) inside the pod netns, so
-	// netns teardown must not race either of them.
+	// netns teardown must not race either of them. Uses the request ctx so it
+	// short-circuits on shutdown (the durable work above is already done).
 	ackCtx, ackCancel := context.WithTimeout(ctx, envoyAckTimeout)
 	defer ackCancel()
 	waitCtx, waitSpan := startStepSpan(ackCtx, "cni_server.envoy_ack_wait", storedPod)

--- a/agent/internal/cni/server/pod_test.go
+++ b/agent/internal/cni/server/pod_test.go
@@ -485,7 +485,10 @@ func TestRemovePod(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "registry unregister failure returns error",
+			// The DEL removes local storage first (durable), then deregisters
+			// best-effort: a registrar failure must NOT fail the DEL — it would
+			// leave a ghost — the ghost sweep reconciles the registry instead.
+			name: "registry unregister failure is tolerated",
 			setupStorage: func() *storage.MockStorage[*cniv1.CNIPod] {
 				s := storage.NewMockStorage[*cniv1.CNIPod]()
 				s.GetResourceFunc = func(_ context.Context, _ types.ContainerID) (*cniv1.CNIPod, error) {
@@ -501,8 +504,8 @@ func TestRemovePod(t *testing.T) {
 				Namespace:   storedPod.GetNamespace(),
 				ContainerId: containerID,
 			},
-			want:    nil,
-			wantErr: true,
+			want:    &cniv1.RemovePodResponse{Result: cniv1.RemovePodResponse_RESULT_SUCCESS},
+			wantErr: false,
 		},
 		{
 			name: "storage remove failure returns error",
@@ -561,4 +564,40 @@ func TestRemovePod(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestRemovePodDurableDeleteOnCanceledCtx is the guarantee: a CNI DEL removes
+// local storage even when the request context is already canceled (a SIGTERM-
+// aborted RPC or a plugin del-timeout) AND the registrar is unavailable. The
+// durable local delete must not be skipped — otherwise a ghost storage entry
+// (with a lingering netns pin) is left behind (issue #261).
+func TestRemovePodDurableDeleteOnCanceledCtx(t *testing.T) {
+	const containerID = "abc123"
+	storedPod := validCNIPod("my-pod", "default", containerID)
+
+	removed := false
+	st := storage.NewMockStorage[*cniv1.CNIPod]()
+	st.GetResourceFunc = func(_ context.Context, _ types.ContainerID) (*cniv1.CNIPod, error) {
+		return storedPod, nil
+	}
+	st.RemoveResourceFunc = func(_ context.Context, _ types.ContainerID) error {
+		removed = true
+		return nil
+	}
+	reg := &testRegistry{unregisterEndpointsErr: errors.New("registrar unavailable")}
+
+	sc := cache.NewSnapshotCache("test-node", slog.New(slog.DiscardHandler))
+	srv := newTestCNIServer(fake.NewClientBuilder().Build(), st, reg, sc, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already canceled, like a SIGTERM-aborted DEL
+
+	resp, err := srv.RemovePod(ctx, &cniv1.RemovePodRequest{
+		Name:        storedPod.GetName(),
+		Namespace:   storedPod.GetNamespace(),
+		ContainerId: containerID,
+	})
+	require.NoError(t, err, "a canceled ctx + down registrar must not fail the DEL")
+	assert.Equal(t, cniv1.RemovePodResponse_RESULT_SUCCESS, resp.GetResult())
+	assert.True(t, removed, "local storage must be removed despite the canceled ctx and down registrar")
 }


### PR DESCRIPTION
The **prevention** layer for #261 (ghost storage entries → dead-netns listeners → `connection_error`).

## Root cause
`RemovePod` removed local storage **last**, gated behind a **fatal**, request-ctx-bound `UnregisterEndpoints` (and the listener removal). So when the request ctx is canceled — the plugin's del timeout, a kubelet cancel, or **agent SIGTERM** (the xDS server force-`Stop()`s in-flight RPCs after `ShutdownTimeout`) — **or** the registrar is briefly unavailable (we observed `UnregisterEndpoints` fail `context canceled` during a registrar roll), the handler returns **before `storage.RemoveResource`**. That leaves a ghost storage entry whose netns pin lingers (so the #245 stale-netns guard can't prune it) and whose listener is re-emitted against a dead netns on agent restart.

`AddPod` is already robust the right way: it **stores first** and treats `RegisterEndpoint` as best-effort. `RemovePod` was the asymmetric opposite.

## Fix
Make DEL mirror ADD:
- **Detached context** (`context.WithoutCancel`) so request-ctx cancellation can't skip the removal.
- **Remove local storage FIRST** — the authoritative local truth, and the **only** fatal error (kubelet retries the DEL). Once gone, the liveness loop can't resurrect the endpoint and the ghost sweep deregisters whatever's left in the registry.
- **Listener removal + endpoint deregistration are best-effort** (logged, not fatal); the snapshot rebuild/restart drops the listener and the ghost sweep reconciles the registry. The deregister is **bounded** (`unregisterTimeout`) so a rolling registrar can't hang the DEL.

## Why this is safe (the reconcile question)
The ghost sweep already deregisters any registry endpoint with **no live local pod** (every 60s + on registrar reconnect), with local storage as the source of truth. So removing storage-first + best-effort unregister self-heals: a failed unregister leaves an orphan that the next sweep (this agent, or its successor after SIGTERM) deregisters. No resurrection — the sweep only *re-registers* live local pods, and this one is gone.

## Tests
- The old `unregister failure returns error` case now asserts the DEL is **tolerated** (SUCCESS).
- New `TestRemovePodDurableDeleteOnCanceledCtx`: with an **already-canceled ctx AND a down registrar**, the DEL succeeds **and** local storage is still removed.

Code-only; `bazel build //...` green; cni-server tests pass. The **reconcile** (cure) and **startup taint** (cold-start) are separate PRs on #261.