### PR TITLE
feat(agent): Cilium-style startup taint to gate pods on CNI readiness

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//agent/internal/cni/server",
         "//agent/internal/edge",
         "//agent/internal/edge/secret",
+        "//agent/internal/node",
         "//agent/internal/proxy/hotrestart",
         "//agent/internal/spire",
         "//agent/internal/xds/ack",

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -71,6 +71,10 @@ type AgentConfig struct {
 	// CNIServerConfig holds CNI server configuration
 	CNIServerConfig *cniServer.CNIServerConfig
 
+	// RemoveStartupTaint removes the aether.io/agent-not-ready node taint once the
+	// CNI server is serving (node proxy only). Default true.
+	RemoveStartupTaint bool
+
 	// EdgeHTTPPort is the port the edge proxy's public-facing HTTP listener
 	// binds (edge subcommand only).
 	EdgeHTTPPort uint32
@@ -106,5 +110,6 @@ func NewAgentConfig() *AgentConfig {
 		SpireEnabled:            true,
 		SpireAdminSocketPath:    constants.DefaultSpireAdminSocketPath,
 		SpireWorkloadSocketPath: constants.DefaultSpireWorkloadSocketPath,
+		RemoveStartupTaint:      true,
 	}
 }

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/constants"
 	cniServer "github.com/bpalermo/aether/agent/internal/cni/server"
+	"github.com/bpalermo/aether/agent/internal/node"
 	"github.com/bpalermo/aether/agent/internal/spire"
 	"github.com/bpalermo/aether/agent/internal/xds/ack"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
@@ -105,6 +106,10 @@ func init() {
 	// SPIRE admin socket (node proxy only — delegated identity for many local
 	// workloads; the edge presents a single identity served by SPIRE directly).
 	rootCmd.Flags().StringVar(&cfg.SpireAdminSocketPath, "spire-admin-socket", constants.DefaultSpireAdminSocketPath, "Path to SPIRE agent admin socket for X.509 certificate delegation")
+
+	// Cold-start gate (node proxy only): remove the aether.io/agent-not-ready
+	// startup taint from this node once the CNI server is serving.
+	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
 }
 
 // registerSharedFlags registers the flags common to the node agent (root) and
@@ -283,6 +288,21 @@ func runAgent(ctx context.Context) (retErr error) {
 
 	if err = setupCNIServer(m, localStorage, reg, snapshotCache, ackTracker, spireBridge, identityTrustDomain); err != nil {
 		return err
+	}
+
+	// Remove the aether startup taint from this node once the CNI server is
+	// serving, so workload pods (which don't tolerate it) can schedule here. The
+	// operator registers the taint via the kubelet; this closes the cold-start
+	// window where a pod's CNI ADD would arrive before the agent is ready.
+	if cfg.RemoveStartupTaint {
+		if err = m.Add(&node.TaintRemover{
+			Client:     m.GetClient(),
+			NodeName:   cfg.NodeName,
+			SocketPath: cfg.CNIServerConfig.SocketPath,
+			Log:        l,
+		}); err != nil {
+			return fmt.Errorf("failed to add startup-taint remover: %w", err)
+		}
 	}
 
 	// Rebuild the cluster/endpoint/route snapshot when the registry reports

--- a/agent/internal/node/BUILD.bazel
+++ b/agent/internal/node/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "node",
+    srcs = ["taint.go"],
+    importpath = "github.com/bpalermo/aether/agent/internal/node",
+    visibility = ["//agent:__subpackages__"],
+    deps = [
+        "//common/constants",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
+)
+
+go_test(
+    name = "node_test",
+    srcs = ["taint_test.go"],
+    embed = [":node"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@io_k8s_api//core/v1:core",
+    ],
+)

--- a/agent/internal/node/taint.go
+++ b/agent/internal/node/taint.go
@@ -1,0 +1,112 @@
+// Package node provides node-level operations for the agent — notably removing
+// the aether startup taint once the agent's CNI is serving, so workload pods can
+// schedule onto the node (the Cilium-style cold-start gate; see issue #261).
+package node
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	commonconstants "github.com/bpalermo/aether/common/constants"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	socketPollInterval = 200 * time.Millisecond
+	patchRetries       = 5
+	patchRetryDelay    = time.Second
+)
+
+// removeTaint removes every taint with the given key from the node's spec,
+// returning whether any were removed. Pure (no API calls), unit-testable.
+func removeTaint(node *corev1.Node, key string) (changed bool) {
+	kept := node.Spec.Taints[:0]
+	for _, t := range node.Spec.Taints {
+		if t.Key == key {
+			changed = true
+			continue
+		}
+		kept = append(kept, t)
+	}
+	node.Spec.Taints = kept
+	return changed
+}
+
+// TaintRemover is a manager Runnable that removes the aether startup taint
+// (constants.TaintAgentNotReady) from this agent's OWN node once the CNI server
+// is serving — signalled by its Unix socket existing, which means a pod's CNI
+// ADD can now be handled. Workload pods don't tolerate the taint, so they wait
+// until this runs. Best-effort: it never fails agent startup.
+type TaintRemover struct {
+	Client     client.Client
+	NodeName   string
+	SocketPath string
+	Log        *slog.Logger
+}
+
+// NeedLeaderElection runs on every agent (the taint is per-node), not just the
+// leader.
+func (r *TaintRemover) NeedLeaderElection() bool { return false }
+
+// Start waits for the CNI server to be serving, then removes the startup taint.
+func (r *TaintRemover) Start(ctx context.Context) error {
+	if err := r.waitForCNIReady(ctx); err != nil {
+		r.Log.WarnContext(ctx, "CNI server not ready; skipping startup-taint removal", "error", err)
+		return nil // best-effort; never block/fail the manager
+	}
+	if err := r.removeFromNode(ctx); err != nil {
+		r.Log.ErrorContext(ctx, "failed to remove startup taint (best-effort)", "node", r.NodeName, "error", err)
+	}
+	return nil
+}
+
+// waitForCNIReady blocks until the CNI server's Unix socket exists (it's serving)
+// or the context is cancelled.
+func (r *TaintRemover) waitForCNIReady(ctx context.Context) error {
+	ticker := time.NewTicker(socketPollInterval)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Stat(r.SocketPath); err == nil {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// removeFromNode patches this agent's node to drop the startup taint, retrying a
+// few times on conflict/transient errors. A no-op if the taint is already absent.
+func (r *TaintRemover) removeFromNode(ctx context.Context) error {
+	var lastErr error
+	for i := 0; i < patchRetries; i++ {
+		node := &corev1.Node{}
+		if err := r.Client.Get(ctx, types.NamespacedName{Name: r.NodeName}, node); err != nil {
+			lastErr = err
+		} else {
+			base := node.DeepCopy()
+			if !removeTaint(node, commonconstants.TaintAgentNotReady) {
+				r.Log.DebugContext(ctx, "startup taint already absent", "node", r.NodeName)
+				return nil
+			}
+			if err := r.Client.Patch(ctx, node, client.MergeFrom(base)); err != nil {
+				lastErr = err
+			} else {
+				r.Log.InfoContext(ctx, "removed startup taint", "node", r.NodeName, "taint", commonconstants.TaintAgentNotReady)
+				return nil
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(patchRetryDelay):
+		}
+	}
+	return lastErr
+}

--- a/agent/internal/node/taint_test.go
+++ b/agent/internal/node/taint_test.go
@@ -1,0 +1,38 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestRemoveTaint(t *testing.T) {
+	const key = "aether.io/agent-not-ready"
+
+	t.Run("present -> removed, changed=true", func(t *testing.T) {
+		node := &corev1.Node{}
+		node.Spec.Taints = []corev1.Taint{
+			{Key: "other", Value: "x", Effect: corev1.TaintEffectNoSchedule},
+			{Key: key, Value: "true", Effect: corev1.TaintEffectNoSchedule},
+		}
+		assert.True(t, removeTaint(node, key))
+		// the aether taint is gone, the unrelated one is preserved
+		assert.Len(t, node.Spec.Taints, 1)
+		assert.Equal(t, "other", node.Spec.Taints[0].Key)
+	})
+
+	t.Run("absent -> changed=false, untouched", func(t *testing.T) {
+		node := &corev1.Node{}
+		node.Spec.Taints = []corev1.Taint{{Key: "other", Effect: corev1.TaintEffectNoSchedule}}
+		assert.False(t, removeTaint(node, key))
+		assert.Len(t, node.Spec.Taints, 1)
+		assert.Equal(t, "other", node.Spec.Taints[0].Key)
+	})
+
+	t.Run("no taints -> changed=false", func(t *testing.T) {
+		node := &corev1.Node{}
+		assert.False(t, removeTaint(node, key))
+		assert.Empty(t, node.Spec.Taints)
+	})
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.18.0-{GIT_COMMIT}"
+version: "0.19.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -22,6 +22,14 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ include "aether.agent.serviceAccountName" . }}
       priorityClassName: system-node-critical
+      tolerations:
+        # Tolerate the aether startup taint so the agent — which REMOVES it once
+        # its CNI is serving — runs on a not-yet-ready node. Workload pods do NOT
+        # tolerate it, so they wait until the agent untaints the node (#261). The
+        # operator registers the taint via the kubelet (--register-with-taints).
+        - key: aether.io/agent-not-ready
+          operator: Exists
+          effect: NoSchedule
       initContainers:
         - name: cni-install
           image: {{ include "aether.image" .Values.cniInstall.image | quote }}

--- a/charts/aether/templates/agent-proxy-daemonset.yaml
+++ b/charts/aether/templates/agent-proxy-daemonset.yaml
@@ -36,6 +36,13 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ include "aether.proxy.serviceAccountName" . }}
       priorityClassName: system-node-critical
+      tolerations:
+        # The proxy runs on every node and must tolerate the aether startup taint
+        # (the agent removes it once CNI is serving). Workload pods do NOT — they
+        # wait for a ready node (#261).
+        - key: aether.io/agent-not-ready
+          operator: Exists
+          effect: NoSchedule
       # The deleted (old) pod must keep its Envoy alive as the successor's
       # hot-restart parent until the successor's protocol terminates it — the
       # successor's timers start only after its xDS-gated init, which pod churn

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -10,7 +10,8 @@ rules:
     verbs: ["list", "get", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["list", "get", "watch"]
+    # patch: remove the aether.io/agent-not-ready startup taint once CNI is serving.
+    verbs: ["list", "get", "watch", "patch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/aether/templates/controller-deployment.yaml
+++ b/charts/aether/templates/controller-deployment.yaml
@@ -17,6 +17,16 @@ spec:
         {{- include "aether.controller.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "aether.controller.serviceAccountName" . }}
+      # Tolerate the aether startup taint. The controller MUST tolerate it or a
+      # fresh cluster deadlocks: it projects the MeshConfig ConfigMap the agent
+      # mounts and blocks on at startup, and the agent only removes the taint once
+      # its CNI is serving — so a non-tolerating controller could never schedule
+      # to break that cycle. It is also an aether-system pod, which the CNI plugin
+      # skips, so it has no node-readiness dependency anyway (#261).
+      tolerations:
+        - key: aether.io/agent-not-ready
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: controller
           image: {{ include "aether.image" .Values.controller.image | quote }}

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -25,6 +25,14 @@ spec:
         {{- include "aether.edge.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "aether.edge.serviceAccountName" . }}
+      # Tolerate the aether startup taint: the edge is an aether-system ingress
+      # gateway, not a mesh workload — it dials pods directly and never uses the
+      # node proxy. The CNI plugin skips aether-system pods, so it has no
+      # node-readiness dependency and must not wait for the agent (#261).
+      tolerations:
+        - key: aether.io/agent-not-ready
+          operator: Exists
+          effect: NoSchedule
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/charts/aether/templates/registrar-deployment.yaml
+++ b/charts/aether/templates/registrar-deployment.yaml
@@ -16,6 +16,14 @@ spec:
         {{- include "aether.registrar.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "aether.registrar.serviceAccountName" . }}
+      # Tolerate the aether startup taint: the registrar is an aether-system
+      # control-plane pod, not a mesh workload. The CNI plugin skips aether-system
+      # pods (they never touch the agent), so it has no node-readiness dependency
+      # and must not wait for the agent to untaint a node (#261).
+      tolerations:
+        - key: aether.io/agent-not-ready
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: registrar
           image: {{ include "aether.image" .Values.registrar.image | quote }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -7,6 +7,15 @@
 # proxy data plane is the only thing whose observability can be retuned at runtime
 # (via the MeshConfig CR); everything else is deterministic deploy-time config.
 # See docs/proposals/015_mesh-config.md.
+#
+# Startup taint (cold-start CNI gate, issue #261): this chart ships the
+# aether.io/agent-not-ready toleration (agent + proxy DaemonSets only), the
+# nodes/patch RBAC, and the agent-side taint removal (it drops the taint once its
+# CNI socket is serving). You MUST register nodes WITH the taint yourself so
+# workload pods wait for a ready agent — the chart cannot taint nodes. Examples:
+#   kubelet:  --register-with-taints=aether.io/agent-not-ready=true:NoSchedule
+#   Talos:    machine.kubelet.extraArgs."register-with-taints" (machineconfig)
+# The agent's --remove-startup-taint flag (default true) governs the removal.
 
 # Override the chart name / fully-qualified resource name.
 nameOverride: ""

--- a/common/constants/labels.go
+++ b/common/constants/labels.go
@@ -6,4 +6,10 @@ const (
 	// LabelAetherManaged is the Kubernetes label used to opt pods into the Aether
 	// service mesh. The value must be "true" for the pod to be managed.
 	LabelAetherManaged = aetherLabelPrefix + "/managed"
+
+	// TaintAgentNotReady is the startup taint that keeps workload pods off a node
+	// until the aether agent's CNI is serving. The operator registers nodes with
+	// it (kubelet --register-with-taints); the agent tolerates it and removes it
+	// once its CNI socket is up, so a pod's CNI ADD can be handled (issue #261).
+	TaintAgentNotReady = aetherLabelPrefix + "/agent-not-ready"
 )


### PR DESCRIPTION
## Summary

The aether CNI plugin **fails-closed**: until the node agent's gRPC CNI server is serving, a pod's CNI ADD errors and the kubelet retries. On a cold node — or an agent roll onto a fresh node — that leaves pods churning in `ContainerCreating`. This adds a **Cilium-style startup taint** (`aether.io/agent-not-ready`) so workload pods don't get scheduled onto a node until aether's CNI is actually functional.

This is the **cold-start prevention layer** of #261. The data-plane guaranteed-delete reorder (#262) and the storage↔pods reconcile (#264) are separate, already-merged changes.

## What's here

- **`common/constants`** — `TaintAgentNotReady = aether.io/agent-not-ready`.
- **`agent/internal/node`** — `TaintRemover`, a manager `Runnable` that removes the taint from the agent's **own** node (`cfg.NodeName`) once the CNI server is serving (signalled by its Unix socket existing). Best-effort with retry; **never fails agent startup**. The filtering logic is a pure, unit-tested `removeTaint(node, key) (changed bool)`. Gated by `--remove-startup-taint` (default `true`).
- **chart**:
  - Tolerate the taint on **every aether component** — the agent + proxy DaemonSets **and** the controller, registrar, and edge Deployments. Only actual mesh-managed user workloads do **not** tolerate it (see below).
  - Agent `ClusterRole`: add `nodes` `patch` (it already had get/list/watch) so it can remove the taint.
  - `values.yaml`: document that the **operator** must register nodes with the taint (`kubelet --register-with-taints=aether.io/agent-not-ready=true:NoSchedule`; Talos `machine.nodeTaints` / kubelet extraArgs). The chart ships removal + tolerations + RBAC; it cannot taint nodes itself.
  - Chart bumped `0.18.0` → `0.19.0`.

## Toleration decision

The taint gates **mesh-managed user workloads**, which aether's own control plane is not — so **every aether component tolerates it**; only real workloads wait for a node to become ready.

The control-plane Deployments (controller/registrar/edge) tolerate for two reasons:

1. **They don't depend on the agent.** They run in `aether-system`, and the CNI plugin **skips ignored namespaces before ever calling the agent** (`cni/internal/plugin/plugin.go`: *"skipping CNI add for system pod"*). They never touch the aether CNI, so they have no node-readiness dependency. The edge is an ingress gateway that dials pods directly and never uses the node proxy.
2. **The controller MUST tolerate, or a fresh cluster deadlocks.** It projects the `<release>-mesh-config` ConfigMap that the agent **mounts and blocks on at startup** (non-optional volume — *"stays in ContainerCreating until it exists"*), and the agent only removes the taint once its CNI is serving. So if the controller waited for a ready node, it could never schedule to create that ConfigMap → the agent stays blocked → the taint is never removed → nothing bootstraps.

On a fresh cluster: nodes register tainted → agent + proxy + control plane all tolerate and schedule → controller creates the MeshConfig ConfigMap → agent unblocks, serves CNI, and removes the taint → user workloads schedule.

## Validation

- `bazel build //agent/... //common/constants/...` green; `//agent/internal/node:node_test` and `//agent/internal/cmd:cmd_test` pass.
- `helm template` renders: agent RBAC `nodes` verbs include `patch`; **all five** aether components (agent, proxy, controller, registrar, edge) carry the toleration; controller RBAC unchanged (stays read-only).
- talos e2e pending (needs a node registered with the taint to exercise the cold-start → untaint flow).

Refs #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)