### PR TITLE
feat(cni): reconcile local storage against the node's actual pods (#261)

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -10,10 +10,12 @@ import (
 	"github.com/bpalermo/aether/agent/types"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/common/telemetry"
 	"github.com/bpalermo/aether/registry"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Registry reconciliation (e2e findings, 2026-06-10).
@@ -102,14 +104,16 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	// pipeline, so each iteration is traced with the corrections it made.
 	ctx, span := otel.Tracer(tracerName).Start(ctx, "agent.ghost_sweep")
 	var retErr error
-	ghostsRemoved, missingRegistered, stalePruned, storedPods := 0, 0, 0, 0
+	ghostsRemoved, missingRegistered, stalePruned, orphansPruned, missingStorage, storedPods := 0, 0, 0, 0, 0, 0
 	defer func() {
 		span.SetAttributes(
 			attribute.Int("aether.sweep.ghosts_removed", ghostsRemoved),
 			attribute.Int("aether.sweep.missing_registered", missingRegistered),
 			attribute.Int("aether.sweep.stale_pruned", stalePruned),
+			attribute.Int("aether.sweep.orphans_pruned", orphansPruned),
+			attribute.Int("aether.sweep.missing_storage", missingStorage),
 		)
-		s.metrics.sweepCompleted(ctx, ghostsRemoved, missingRegistered, stalePruned, storedPods, retErr)
+		s.metrics.sweepCompleted(ctx, ghostsRemoved, missingRegistered, stalePruned, orphansPruned, missingStorage, storedPods, retErr)
 		telemetry.EndSpan(span, retErr)
 	}()
 
@@ -146,39 +150,86 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		return
 	}
 	storedPods = len(pods)
-	// Prune storage entries whose network namespace no longer exists: a missed
-	// CNI DEL left the file behind. Keeping it both re-registers a dead endpoint
-	// (the missing-direction loop would treat it as a live local pod) and makes
-	// Envoy fault creating a connection in the gone netns when the per-pod app
-	// cluster is programmed (talos worker-01, 2026-06-19). RemovePod drops the
-	// whole listenerEntry — inbound/outbound listeners AND the per-pod app/health
+
+	// Ground-truth reconcile: the manager cache is scoped to spec.nodeName=<this
+	// node>, so this lists exactly this node's pods, cheaply. Used to prune
+	// storage entries whose pod K8s no longer has, and to surface live pods
+	// storage is missing. If the list fails we must NOT prune by pod-absence (an
+	// empty list would nuke every entry), so that half is skipped this cycle.
+	nodePods, nodePodsOK := s.listNodePods(ctx)
+
+	// Prune storage entries that no longer correspond to a live pod: a missed CNI
+	// DEL left the file behind. Keeping it both re-registers a dead endpoint (the
+	// missing-direction loop would treat it as a live local pod) and makes Envoy
+	// fault creating a connection in the gone netns when the per-pod app cluster
+	// is programmed (talos worker-01, 2026-06-19). Two independent signals catch
+	// it: the netns path is gone, OR the Kubernetes pod is gone. The latter is
+	// essential because a missed DEL can leave the netns bind-mount pin behind, so
+	// netnsExists reports present and the netns check alone never prunes it
+	// (talos worker-01, 2026-06-22: prober-vhbp8 ghost). RemovePod drops the whole
+	// listenerEntry — inbound/outbound listeners AND the per-pod app/health
 	// clusters (which carry the netns) — so the dead-netns cluster leaves the
 	// snapshot. The pruned pod's registry endpoints then fall through to ghost
 	// deregistration below.
 	fresh := pods[:0]
 	for _, p := range pods {
 		netns := p.GetNetworkNamespace()
-		if netns == "" {
-			fresh = append(fresh, p)
-			continue
-		}
-		if netnsExists(netns) {
+		netnsGone := netns != "" && !netnsExists(netns)
+		orphaned := nodePodsOK && !podInNode(nodePods, p)
+		if !netnsGone && !orphaned {
 			fresh = append(fresh, p)
 			continue
 		}
 		if err := s.storage.RemoveResource(ctx, types.ContainerID(p.GetContainerId())); err != nil {
-			s.log.ErrorContext(ctx, "ghost sweep: failed to prune stale pod storage", "pod", p.GetName(), "netns", netns, "error", err)
+			s.log.ErrorContext(ctx, "ghost sweep: failed to prune pod storage", "pod", p.GetName(), "netns", netns, "error", err)
 			fresh = append(fresh, p) // keep it; retry next sweep
 			continue
 		}
-		if err := s.snapshotCache.RemovePod(ctx, netns); err != nil {
-			s.log.ErrorContext(ctx, "ghost sweep: failed to drop listener for pruned pod", "pod", p.GetName(), "netns", netns, "error", err)
+		if netns != "" {
+			if err := s.snapshotCache.RemovePod(ctx, netns); err != nil {
+				s.log.ErrorContext(ctx, "ghost sweep: failed to drop listener for pruned pod", "pod", p.GetName(), "netns", netns, "error", err)
+			}
 		}
-		stalePruned++
-		s.log.InfoContext(ctx, "ghost sweep: pruned stale pod (network namespace gone; CNI DEL missed)",
-			"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+		if orphaned {
+			orphansPruned++
+			s.log.InfoContext(ctx, "ghost sweep: pruned orphaned pod (Kubernetes pod gone; CNI DEL missed, netns pin lingered)",
+				"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+		} else {
+			stalePruned++
+			s.log.InfoContext(ctx, "ghost sweep: pruned stale pod (network namespace gone; CNI DEL missed)",
+				"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+		}
 	}
 	pods = fresh
+
+	// Surface live mesh-managed pods on this node that local storage has no entry
+	// for: a lost CNI ADD (talos worker-01, 2026-06-22: prober-k7vsm running with
+	// no listener). The agent has no CNI data (netns, IPs) to synthesize a
+	// listener, so it cannot self-heal — emit a metric + warning so the gap is
+	// visible (the pod must be rolled) instead of silently serving no listener.
+	if nodePodsOK {
+		stored := make(map[string]struct{}, len(pods))
+		for _, p := range pods {
+			stored[podKey(p.GetNamespace(), p.GetName())] = struct{}{}
+		}
+		for key, kp := range nodePods {
+			if _, ok := stored[key]; ok {
+				continue
+			}
+			// Only a Running, non-terminating, mesh-managed pod is a genuine lost
+			// ADD; a Pending pod is mid-CNI-ADD and a terminating one is mid-removal
+			// — both have a legitimately transient storage gap.
+			if kp.Status.Phase != corev1.PodRunning || kp.DeletionTimestamp != nil {
+				continue
+			}
+			if !isMeshManagedK8sPod(kp) {
+				continue
+			}
+			missingStorage++
+			s.log.WarnContext(ctx, "ghost sweep: live mesh pod missing from local storage (CNI ADD lost; pod has no listener and must be rolled)",
+				"pod", kp.GetName(), "namespace", kp.GetNamespace(), "podIP", kp.Status.PodIP)
+		}
+	}
 
 	// Live local pods by IP. Terminating pods are tracked separately: their
 	// endpoints are deliberately still registered (marked DRAINING by the
@@ -255,4 +306,48 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		s.log.InfoContext(ctx, "ghost sweep: registered missing endpoint",
 			"service", serviceName, "ip", ip, "pod", pod.GetName())
 	}
+}
+
+// listNodePods returns this node's pods keyed by namespace/name. The agent's
+// manager cache is scoped to spec.nodeName=<this node>, so the List is local and
+// cheap. The bool is false (and the map nil) if the list failed — callers must
+// then skip any prune-by-absence, since an empty list would prune every entry.
+func (s *CNIServer) listNodePods(ctx context.Context) (map[string]*corev1.Pod, bool) {
+	if s.k8sClient == nil {
+		return nil, false
+	}
+	var list corev1.PodList
+	if err := s.k8sClient.List(ctx, &list); err != nil {
+		s.log.WarnContext(ctx, "ghost sweep: failed to list node pods; skipping pod-existence reconcile", "error", err)
+		return nil, false
+	}
+	pods := make(map[string]*corev1.Pod, len(list.Items))
+	for i := range list.Items {
+		p := &list.Items[i]
+		pods[podKey(p.Namespace, p.Name)] = p
+	}
+	return pods, true
+}
+
+// podKey is the namespace/name identity shared by CNIPod storage entries and
+// Kubernetes pods (pod names are unique within a namespace at any instant).
+func podKey(namespace, name string) string { return namespace + "/" + name }
+
+// podInNode reports whether a stored pod still has a live Kubernetes pod on this node.
+func podInNode(nodePods map[string]*corev1.Pod, p *cniv1.CNIPod) bool {
+	_, ok := nodePods[podKey(p.GetNamespace(), p.GetName())]
+	return ok
+}
+
+// isMeshManagedK8sPod mirrors isIgnorablePod for a Kubernetes pod: a pod aether
+// should manage is in a non-ignored namespace, carries aether.io/managed=true,
+// and has been assigned an IP (so its CNI ADD should have stored it).
+func isMeshManagedK8sPod(p *corev1.Pod) bool {
+	if constants.IsIgnoredNamespace(p.Namespace) {
+		return false
+	}
+	if p.Labels[constants.LabelAetherManaged] != "true" {
+		return false
+	}
+	return p.Status.PodIP != ""
 }

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -12,6 +12,8 @@ import (
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // Sweep tests use synthetic netns paths that don't exist on disk; treat them as
@@ -169,6 +171,67 @@ func TestSweepRegistersMissingEndpoint(t *testing.T) {
 	s.drainLivenessForget(state)
 	assert.NotContains(t, state.last, "container-missing")
 	assert.NotContains(t, state.sawHealthy, "container-missing", "forget must clear warm-up memory too")
+}
+
+// TestSweepPrunesOrphanedPods: a stored pod whose Kubernetes pod no longer
+// exists is pruned from storage and its registry endpoint deregistered — even
+// though its netns pin lingers (netnsExists reports present), the case the netns
+// check alone cannot catch (talos worker-01, 2026-06-22: prober-vhbp8). A pod
+// that still exists in Kubernetes is kept.
+func TestSweepPrunesOrphanedPods(t *testing.T) {
+	ctx := context.Background()
+	// netnsExists stays true (package init): the orphan's pin lingers, so only the
+	// pod-existence check can prune it.
+
+	orphan := validCNIPod("pod-orphan", "default", "container-orphan")
+	orphan.Ips = []string{"10.0.0.9"}
+	live := validCNIPod("pod-live", "default", "container-live") // 10.0.0.1
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-orphan"), orphan))
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-live"), live))
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{
+		"default": {
+			sweepEndpoint("10.0.0.9", "test-node", "pod-orphan"), // orphan -> pruned -> ghost-deregistered
+			sweepEndpoint("10.0.0.1", "test-node", "pod-live"),   // live -> kept
+		},
+	}}
+	// Kubernetes has only the live pod; the orphan's pod is gone (missed CNI DEL).
+	k8s := fake.NewClientBuilder().WithObjects(validK8sPod("pod-live", "default")).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	s.sweepGhostEndpoints(ctx)
+
+	_, err := store.GetResource(ctx, types.ContainerID("container-orphan"))
+	require.Error(t, err, "orphaned pod pruned from storage despite a lingering netns pin")
+	_, err = store.GetResource(ctx, types.ContainerID("container-live"))
+	require.NoError(t, err, "live pod kept")
+	assert.Equal(t, map[string][]string{"default": {"10.0.0.9"}}, reg.unregistered)
+}
+
+// TestIsMeshManagedK8sPod mirrors the CNIPod ignorable rules for the
+// missing-storage surfacing: only a managed pod in a non-ignored namespace with
+// an assigned IP qualifies.
+func TestIsMeshManagedK8sPod(t *testing.T) {
+	managed := func() *corev1.Pod {
+		p := validK8sPod("p", "default")
+		p.Status.PodIP = "10.0.0.1"
+		return p
+	}
+	assert.True(t, isMeshManagedK8sPod(managed()))
+
+	ignoredNS := managed()
+	ignoredNS.Namespace = "kube-system"
+	assert.False(t, isMeshManagedK8sPod(ignoredNS), "ignored namespace")
+
+	unmanaged := managed()
+	unmanaged.Labels = map[string]string{}
+	assert.False(t, isMeshManagedK8sPod(unmanaged), "missing managed label")
+
+	noIP := managed()
+	noIP.Status.PodIP = ""
+	assert.False(t, isMeshManagedK8sPod(noIP), "no pod IP (not yet networked)")
 }
 
 // authoritativeSweepRegistry simulates the post-backend-switch trap: the

--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -27,6 +27,8 @@ type cniMetrics struct {
 	ghostsRemoved     metric.Int64Counter
 	missingRegistered metric.Int64Counter
 	stalePruned       metric.Int64Counter
+	orphansPruned     metric.Int64Counter
+	missingStorage    metric.Int64Counter
 	sweepErrors       metric.Int64Counter
 	storagePods       metric.Int64Gauge
 	healthTransitions metric.Int64Counter
@@ -50,6 +52,14 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 		metric.WithDescription("Local storage pod entries pruned because their network namespace no longer exists (missed CNI DEL); keeping them faults Envoy on the dead netns")); err != nil {
 		return nil, fmt.Errorf("stale pruned: %w", err)
 	}
+	if m.orphansPruned, err = meter.Int64Counter("aether.agent.ghost_sweep.orphans_pruned",
+		metric.WithDescription("Local storage pod entries pruned because the Kubernetes pod no longer exists (missed CNI DEL whose netns pin lingered, so the netns check could not catch it)")); err != nil {
+		return nil, fmt.Errorf("orphans pruned: %w", err)
+	}
+	if m.missingStorage, err = meter.Int64Counter("aether.agent.ghost_sweep.missing_storage",
+		metric.WithDescription("Live mesh-managed pods on this node with no local storage entry (lost CNI ADD); the agent cannot self-heal these — the pod must be rolled")); err != nil {
+		return nil, fmt.Errorf("missing storage: %w", err)
+	}
 	if m.sweepErrors, err = meter.Int64Counter("aether.agent.ghost_sweep.errors",
 		metric.WithDescription("Ghost sweep cycles that failed before reconciling")); err != nil {
 		return nil, fmt.Errorf("sweep errors: %w", err)
@@ -71,7 +81,7 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 	return m, nil
 }
 
-func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingRegistered, stalePruned, storedPods int, err error) {
+func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingRegistered, stalePruned, orphansPruned, missingStorage, storedPods int, err error) {
 	if m == nil {
 		return
 	}
@@ -87,6 +97,12 @@ func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingR
 	}
 	if stalePruned > 0 {
 		m.stalePruned.Add(ctx, int64(stalePruned))
+	}
+	if orphansPruned > 0 {
+		m.orphansPruned.Add(ctx, int64(orphansPruned))
+	}
+	if missingStorage > 0 {
+		m.missingStorage.Add(ctx, int64(missingStorage))
 	}
 	m.storagePods.Record(ctx, int64(storedPods))
 }

--- a/agent/internal/cni/server/metrics_test.go
+++ b/agent/internal/cni/server/metrics_test.go
@@ -54,8 +54,8 @@ func metricSum(t *testing.T, reader *sdkmetric.ManualReader, name string) (int64
 func TestCNIMetrics_NilReceiverSafe(t *testing.T) {
 	var m *cniMetrics
 	ctx := context.Background()
-	m.sweepCompleted(ctx, 1, 1, 1, 1, nil)
-	m.sweepCompleted(ctx, 0, 0, 0, 0, errors.New("boom"))
+	m.sweepCompleted(ctx, 1, 1, 1, 0, 0, 1, nil)
+	m.sweepCompleted(ctx, 0, 0, 0, 0, 0, 0, errors.New("boom"))
 	m.healthTransition(ctx, "HEALTH_UNHEALTHY", "HEALTH_HEALTHY")
 }
 
@@ -63,13 +63,19 @@ func TestCNIMetrics_SweepCompleted(t *testing.T) {
 	m, reader := newTestCNIMetrics(t)
 	ctx := context.Background()
 
-	m.sweepCompleted(ctx, 2, 1, 3, 7, nil)
+	m.sweepCompleted(ctx, 2, 1, 3, 4, 5, 7, nil)
 
 	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.ghosts_removed"); got != 2 {
 		t.Errorf("ghosts_removed = %d, want 2", got)
 	}
 	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.missing_registered"); got != 1 {
 		t.Errorf("missing_registered = %d, want 1", got)
+	}
+	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.orphans_pruned"); got != 4 {
+		t.Errorf("orphans_pruned = %d, want 4", got)
+	}
+	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.missing_storage"); got != 5 {
+		t.Errorf("missing_storage = %d, want 5", got)
 	}
 	if got, _ := metricSum(t, reader, "aether.agent.storage.pods"); got != 7 {
 		t.Errorf("storage.pods = %d, want 7", got)
@@ -79,7 +85,7 @@ func TestCNIMetrics_SweepCompleted(t *testing.T) {
 func TestCNIMetrics_SweepFailed(t *testing.T) {
 	m, reader := newTestCNIMetrics(t)
 
-	m.sweepCompleted(context.Background(), 0, 0, 0, 0, errors.New("registry down"))
+	m.sweepCompleted(context.Background(), 0, 0, 0, 0, 0, 0, errors.New("registry down"))
 
 	if got, _ := metricSum(t, reader, "aether.agent.ghost_sweep.errors"); got != 1 {
 		t.Errorf("sweep errors = %d, want 1", got)


### PR DESCRIPTION
The **cure** layer for #261 — the storage↔pods reconcile that fixes the two desync classes the existing sweep couldn't.

## Problem
The ghost sweep reconciled *registry ↔ local storage* but never *local storage ↔ the node's real pods*, so two classes went uncured (talos worker-01, 2026-06-22):
- **Orphan ghost** (`prober-vhbp8`): a missed CNI DEL left the netns bind-mount pin behind. `netnsExists()` stats the lingering pin and reports **present**, so the existing stale-prune never caught it — the agent kept emitting a listener bound to a **dead netns** (a connection sink + latent #245 segfault).
- **Missing pod** (`prober-k7vsm`): a live, mesh-managed pod with **no storage entry** (lost CNI ADD) → no listener → 100% `connection_error`, never self-healing.

## Fix
The manager cache is already scoped to `spec.nodeName=<this node>`, so listing the node's pods is local + cheap — **no new RBAC** (agent already has `pods get/list/watch`). The sweep now:
- **Prunes by pod-existence**: a stored pod is pruned when its netns is gone (existing) **OR** its Kubernetes pod no longer exists — by pod identity, regardless of a lingering pin. The pruned pod's registry endpoint then ghost-deregisters as before. If the pod list **fails**, prune-by-absence is skipped (an empty list would nuke every entry); the netns prune still runs.
- **Surfaces missing ADDs**: a live, `Running`, mesh-managed pod with no storage entry gets a **metric + warning** (the agent can't synthesize the CNI data to self-heal — the pod must be rolled) instead of silently serving no listener.

## Metrics
`aether.agent.ghost_sweep.orphans_pruned`, `aether.agent.ghost_sweep.missing_storage` — both desyncs are now visible.

## Tests
- `TestSweepPrunesOrphanedPods`: a lingering-pin orphan (netns present, K8s pod gone) is pruned + ghost-deregistered; the live pod is kept.
- `TestIsMeshManagedK8sPod`: the managed-pod predicate (namespace / label / IP).
- Existing sweep tests keep a nil `k8sClient` and skip the pod reconcile via a defensive guard.

Build green (`bazel build //...`, agent suite passes). The **prevention** is #262 (guaranteed delete) and the **cold-start** layer is #263 (startup taint) — the three layers of #261.