### PR TITLE
fix(xds): unlink a stale Unix socket before binding

### DIFF
--- a/common/xds/server.go
+++ b/common/xds/server.go
@@ -80,6 +80,19 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 	}
 
+	if s.cfg.Network == "unix" {
+		// net.Listen("unix", …) fails with EADDRINUSE if the socket file already
+		// exists. Go unlinks it on a graceful Close, but a non-graceful exit
+		// (SIGKILL, OOM, a segfault) leaves it behind — every subsequent restart
+		// would then crash-loop on bind until the file is cleared by hand. Remove a
+		// stale socket first so the agent restarts cleanly however its predecessor
+		// died. Safe in the node-singleton model: only one process binds this path,
+		// and the roll is delete-then-add, so no live listener is ever displaced.
+		if err := os.Remove(s.cfg.Address); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to remove stale socket %s: %w", s.cfg.Address, err)
+		}
+	}
+
 	listener, err := net.Listen(s.cfg.Network, s.cfg.Address)
 	if err != nil {
 		s.Log.ErrorContext(ctx, "failed to listen", "error", err, "network", s.cfg.Network, "address", s.cfg.Address)

--- a/common/xds/server_test.go
+++ b/common/xds/server_test.go
@@ -246,3 +246,34 @@ func TestServerLifecycle_LivenessAndReadiness(t *testing.T) {
 		})
 	}
 }
+
+// TestStart_RemovesStaleSocket: a leftover Unix socket file from a non-graceful
+// predecessor (SIGKILL/OOM/segfault) must not block startup — the server unlinks
+// it before binding, so it never crash-loops on EADDRINUSE.
+func TestStart_RemovesStaleSocket(t *testing.T) {
+	cfg := newUDSConfig(t)
+	require.Equal(t, "unix", cfg.Network)
+
+	// Simulate the leftover: occupy the bind path. Without unlink-before-bind,
+	// net.Listen("unix", …) would fail with EADDRINUSE.
+	require.NoError(t, os.WriteFile(cfg.Address, []byte{}, 0o600))
+
+	grpcSrv := grpc.NewServer()
+	srv := NewServer(cfg, slog.New(slog.DiscardHandler), WithGRPCServer(grpcSrv))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx) }()
+
+	assert.Eventually(t, func() bool {
+		return srv.liveness.Load() && srv.readiness.Load()
+	}, time.Second, 10*time.Millisecond, "server should bind despite a stale socket file")
+
+	cancel()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for server to shut down")
+	}
+}


### PR DESCRIPTION
## Problem
`net.Listen("unix", addr)` fails with **EADDRINUSE** if the socket file already exists. Go unlinks the socket on a *graceful* listener `Close()`, but a **non-graceful exit** (SIGKILL, OOM, the stale-netns **segfault**) leaves it behind — and then **every subsequent restart crash-loops on bind** until the file is cleared by hand. This is the "EADDRINUSE Phase 0" seen in e2e.

Both the agent **xDS server** and the **CNI gRPC server** embed this `Server` and serve **singleton sockets on a shared hostPath** (`/run/aether`), so a hard death of either wedged its own restart — turning a transient crash into a persistent crash-loop.

## Fix
Remove a stale socket before `net.Listen` for the `unix` network:
```go
if s.cfg.Network == "unix" {
    if err := os.Remove(s.cfg.Address); err != nil && !errors.Is(err, os.ErrNotExist) {
        return fmt.Errorf("failed to remove stale socket %s: %w", s.cfg.Address, err)
    }
}
```
Safe in the node-singleton model: only one process binds each path, and the DaemonSet roll is **delete-then-add**, so no live listener is ever displaced.

## Why this matters for the agent roll
Came out of the #261 discussion on making agent rolls gapless. `maxSurge` isn't viable (two agents would collide on the fixed singleton socket), and the gap itself is benign (the proxy keeps its listeners; CNI events are covered by #262/#264). The real reliability gap was **restart after a hard death** — this closes it: the agent now self-heals instead of needing manual `/run/aether/*.sock` cleanup.

## Tests
`TestStart_RemovesStaleSocket` pre-creates a leftover file at the bind path and asserts the server still comes up live + ready. `bazel build //...` green; `//common/xds:xds_test` passes.