### PR TITLE
chore(edge): mark edge pods explicitly unmanaged (aether.io/managed=false)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.19.0-{GIT_COMMIT}"
+version: "0.19.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -23,6 +23,11 @@ spec:
     metadata:
       labels:
         {{- include "aether.edge.labels" . | nindent 8 }}
+        # The edge is an ingress gateway, not a mesh workload: no per-pod proxy,
+        # never CNI-intercepted. It runs in aether-system (which the CNI plugin
+        # already skips), but mark it explicitly unmanaged so the exclusion never
+        # depends on the ignored-namespace list.
+        aether.io/managed: "false"
     spec:
       serviceAccountName: {{ include "aether.edge.serviceAccountName" . }}
       # Tolerate the aether startup taint: the edge is an aether-system ingress


### PR DESCRIPTION
The edge is an ingress gateway, not a mesh workload — no per-pod proxy, never CNI-intercepted. Today it's excluded from the mesh only **implicitly**, by living in `aether-system` (which the CNI plugin skips).

This adds `aether.io/managed: "false"` to the edge pod template so the exclusion is **explicit** and no longer depends on the ignored-namespace list — or on the edge always running in `aether-system`.

- Label is on the **pod template only**, not the Deployment selector (which uses the minimal `selectorLabels`), so it's upgrade-safe (`helm template` confirms: 1 occurrence, on the pod template, not the selector).
- Chart `0.19.0` → `0.19.1`.