### PR TITLE
feat(controller): namespaced MeshConfig with aether-system fallback

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.19.1-{GIT_COMMIT}"
+version: "0.20.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-meshconfig.yaml
+++ b/charts/aether/templates/controller-meshconfig.yaml
@@ -7,12 +7,13 @@
   own the CR via kubectl, and new chart versions (with new config defaults) never
   clobber it. See docs/proposals/015_mesh-config.md.
 */ -}}
-{{- $existing := lookup "config.aether.io/v1" "MeshConfig" "" "default" -}}
+{{- $existing := lookup "config.aether.io/v1" "MeshConfig" (include "aether.namespace" .) "default" -}}
 {{- if not $existing }}
 apiVersion: config.aether.io/v1
 kind: MeshConfig
 metadata:
   name: default
+  namespace: {{ include "aether.namespace" . }}
   labels:
     {{- include "aether.controller.labels" . | nindent 4 }}
   annotations:

--- a/charts/aether/templates/controller-rbac.yaml
+++ b/charts/aether/templates/controller-rbac.yaml
@@ -46,10 +46,6 @@ metadata:
   labels:
     {{- include "aether.controller.labels" . | nindent 4 }}
 rules:
-  # Project the MeshConfig into the mounted ConfigMap.
-  - apiGroups: [""]
-    resources: ["configmaps"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
   # Leader election (controller-runtime Lease) + events.
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -69,6 +65,35 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "aether.controller.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aether.controller.serviceAccountName" . }}
+    namespace: {{ include "aether.namespace" . }}
+---
+# MeshConfig is namespaced and the reconciler co-locates its projected ConfigMap in
+# each MeshConfig's own namespace (any namespace), so ConfigMap write must be
+# cluster-wide.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "aether.controller.clusterScopedName" . }}-meshconfig
+  labels:
+    {{- include "aether.controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "aether.controller.clusterScopedName" . }}-meshconfig
+  labels:
+    {{- include "aether.controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "aether.controller.clusterScopedName" . }}-meshconfig
 subjects:
   - kind: ServiceAccount
     name: {{ include "aether.controller.serviceAccountName" . }}

--- a/charts/crds/Chart.yaml
+++ b/charts/crds/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   docs/proposals/017_virtual-host-l7-routing.md).
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.3.0-{GIT_COMMIT}"
+version: "0.4.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/crds/templates/meshconfig.yaml
+++ b/charts/crds/templates/meshconfig.yaml
@@ -8,7 +8,11 @@ metadata:
     helm.sh/resource-policy: keep
 spec:
   group: config.aether.io
-  scope: Cluster
+  # Namespaced: each namespace has a `default` MeshConfig. A namespace inherits the
+  # control-plane namespace's MeshConfig (field-by-field) unless it sets its own, so
+  # an isolated component (e.g. the edge in aether-ingress) gets a co-located,
+  # namespace-scoped projected ConfigMap. See docs/proposals/015_mesh-config.md.
+  scope: Namespaced
   names:
     kind: MeshConfig
     listKind: MeshConfigList

--- a/common/apis/config/v1/meshconfig_types.go
+++ b/common/apis/config/v1/meshconfig_types.go
@@ -33,8 +33,10 @@ func addKnownTypes(s *runtime.Scheme) error {
 	return nil
 }
 
-// MeshConfig is the cluster-scoped singleton custom resource carrying the proxy
-// data-plane observability override. Its `.spec` is the protobuf MeshConfigSpec.
+// MeshConfig is a namespaced custom resource carrying the proxy data-plane
+// observability override: one `default` per namespace, inheriting the control-plane
+// namespace's MeshConfig unless it sets its own. Its `.spec` is the protobuf
+// MeshConfigSpec.
 type MeshConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/controller/internal/cmd/config.go
+++ b/controller/internal/cmd/config.go
@@ -15,10 +15,10 @@ import (
 type ControllerConfig struct {
 	manager.Config
 
-	// MeshConfigMapName / MeshConfigMapNamespace identify the ConfigMap the
-	// reconciler projects into. Namespace empty = the controller's own namespace.
-	MeshConfigMapName      string
-	MeshConfigMapNamespace string
+	// MeshConfigMapName is the name of the ConfigMap the reconciler projects each
+	// namespace's MeshConfig into. The namespace is the MeshConfig CR's own namespace
+	// (co-located), so there is no namespace setting.
+	MeshConfigMapName string
 
 	// SpireEnabled serves the validating webhook with a SPIRE-issued X.509 SVID
 	// (via the Workload API) instead of the Helm self-signed cert, and injects the

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -68,8 +68,7 @@ func GetCommand() *cobra.Command {
 
 func init() {
 	manager.RegisterFlags(rootCmd, &cfg.Config)
-	rootCmd.Flags().StringVar(&cfg.MeshConfigMapName, "mesh-config-configmap", cfg.MeshConfigMapName, "Name of the ConfigMap the MeshConfig reconciler projects into")
-	rootCmd.Flags().StringVar(&cfg.MeshConfigMapNamespace, "mesh-config-namespace", cfg.MeshConfigMapNamespace, "Namespace for the projected ConfigMap (empty = the controller's own namespace)")
+	rootCmd.Flags().StringVar(&cfg.MeshConfigMapName, "mesh-config-configmap", cfg.MeshConfigMapName, "Name of the ConfigMap the MeshConfig reconciler projects into (in each MeshConfig's own namespace)")
 	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", cfg.SpireEnabled, "Serve the validating webhook with a SPIRE X.509 SVID and inject the SPIRE trust bundle into the webhook caBundle (instead of a static cert)")
 	rootCmd.Flags().StringVar(&cfg.SpireWorkloadSocketPath, "spire-workload-socket", cfg.SpireWorkloadSocketPath, "Path to the SPIRE Workload API UDS socket")
 	rootCmd.Flags().StringVar(&cfg.WebhookConfigName, "webhook-config-name", cfg.WebhookConfigName, "ValidatingWebhookConfiguration to patch with the SPIRE caBundle (SPIRE mode)")
@@ -137,16 +136,15 @@ func runController(ctx context.Context) (retErr error) {
 
 	m := result.Manager
 
-	cmNamespace := cfg.MeshConfigMapNamespace
-	if cmNamespace == "" {
-		cmNamespace = currentNamespace()
-	}
+	// The controller's own namespace holds the canonical (fallback) MeshConfig that
+	// other namespaces inherit from unless they set their own.
+	fallbackNamespace := currentNamespace()
 
 	reconciler := &meshconfig.Reconciler{
-		Client:             m.GetClient(),
-		ConfigMapName:      cfg.MeshConfigMapName,
-		ConfigMapNamespace: cmNamespace,
-		Log:                l,
+		Client:            m.GetClient(),
+		ConfigMapName:     cfg.MeshConfigMapName,
+		FallbackNamespace: fallbackNamespace,
+		Log:               l,
 	}
 	if err = reconciler.SetupWithManager(m); err != nil {
 		return fmt.Errorf("failed to set up MeshConfig reconciler: %w", err)
@@ -176,7 +174,8 @@ func runController(ctx context.Context) (retErr error) {
 	}
 
 	l.InfoContext(ctx, "MeshConfig controller configured",
-		"configMap", cmNamespace+"/"+cfg.MeshConfigMapName,
+		"configMapName", cfg.MeshConfigMapName,
+		"fallbackNamespace", fallbackNamespace,
 		"webhookPath", cwebhook.Path,
 	)
 	return m.Start(ctx)

--- a/controller/internal/meshconfig/BUILD.bazel
+++ b/controller/internal/meshconfig/BUILD.bazel
@@ -22,21 +22,32 @@ go_library(
         "@io_k8s_apimachinery//pkg/types",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/handler",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
         "@io_k8s_sigs_yaml//:yaml",
         "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 
 go_test(
     name = "meshconfig_test",
-    srcs = ["meshconfig_test.go"],
+    srcs = [
+        "meshconfig_test.go",
+        "reconciler_test.go",
+    ],
     embed = [":meshconfig"],
     deps = [
         "//api/aether/config/v1:config",
         "//common/apis/config/v1:config",
         "//common/config",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/controller/internal/meshconfig/reconciler.go
+++ b/controller/internal/meshconfig/reconciler.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"log/slog"
 
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"google.golang.org/protobuf/proto"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -18,31 +21,60 @@ import (
 // writes (the projected ConfigMap and the MeshConfig status).
 const fieldOwner = "aether-controller"
 
-// Reconciler projects the singleton MeshConfig CR into a ConfigMap that the agent
-// mounts and loads. It re-validates with protovalidate before writing, so an
-// invalid CR that slipped past the (best-effort) webhook never overwrites the
+// Reconciler projects each namespace's MeshConfig CR into a ConfigMap in that SAME
+// namespace (co-located), which the agent/edge in that namespace mount. MeshConfig
+// is namespaced: a namespace's `default` CR overrides the FallbackNamespace
+// (aether-system) MeshConfig field-by-field, so a namespace inherits the mesh-wide
+// config unless it sets its own. It re-validates with protovalidate before writing,
+// so an invalid CR that slipped past the (best-effort) webhook never overwrites the
 // last-good ConfigMap — the failure surfaces on the CR's status instead.
 type Reconciler struct {
 	client.Client
-	ConfigMapName      string
-	ConfigMapNamespace string
-	Log                *slog.Logger
+	ConfigMapName     string
+	FallbackNamespace string
+	Log               *slog.Logger
 }
 
-// SetupWithManager registers the reconciler to watch the MeshConfig CR.
+// SetupWithManager registers the reconciler. A change to a namespace's MeshConfig
+// re-projects that namespace (For); a change to the FallbackNamespace MeshConfig
+// re-projects every inheriting namespace (the fan-out map func).
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&crdv1.MeshConfig{}).
+		Watches(&crdv1.MeshConfig{}, handler.EnqueueRequestsFromMapFunc(r.enqueueInheritors)).
 		Named("meshconfig").
 		Complete(r)
 }
 
-// Reconcile validates the singleton MeshConfig and upserts the projected
-// ConfigMap. A validation failure is recorded on the CR status and does not
-// return an error (retrying wouldn't help an invalid spec).
+// enqueueInheritors fans a FallbackNamespace MeshConfig change out to every other
+// namespace's MeshConfig (which inherit from it). Changes outside the fallback
+// namespace enqueue nothing here — For() already re-projects them.
+func (r *Reconciler) enqueueInheritors(ctx context.Context, obj client.Object) []reconcile.Request {
+	if obj.GetNamespace() != r.FallbackNamespace {
+		return nil
+	}
+	var list crdv1.MeshConfigList
+	if err := r.List(ctx, &list); err != nil {
+		r.Log.WarnContext(ctx, "failed to list MeshConfigs for fallback fan-out", "error", err)
+		return nil
+	}
+	reqs := make([]reconcile.Request, 0, len(list.Items))
+	for i := range list.Items {
+		m := &list.Items[i]
+		if m.Namespace == r.FallbackNamespace || m.Name != SingletonName {
+			continue
+		}
+		reqs = append(reqs, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(m)})
+	}
+	return reqs
+}
+
+// Reconcile validates a namespace's effective MeshConfig and upserts the co-located
+// ConfigMap. A validation failure is recorded on the CR status and does not return
+// an error (retrying wouldn't help an invalid spec).
 func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	if req.Name != SingletonName {
-		// Only the singleton is authoritative; ignore any other names.
+		// Only the per-namespace singleton is authoritative; ignore any other names.
 		return reconcile.Result{}, nil
 	}
 
@@ -56,14 +88,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	if err := Validate(mc.Spec); err != nil {
+	spec, err := r.effectiveSpec(ctx, mc)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := Validate(spec); err != nil {
 		r.Log.ErrorContext(ctx, "MeshConfig is invalid; keeping last-good ConfigMap",
-			"name", req.Name, "error", err)
+			"namespace", req.Namespace, "error", err)
 		r.setProjected(ctx, mc, false, err.Error())
 		return reconcile.Result{}, nil
 	}
 
-	data, err := RenderConfigMapData(mc.Spec)
+	data, err := RenderConfigMapData(spec)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -73,7 +110,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 	// projection without a read-modify-write and without fighting other managers.
 	cm := &corev1.ConfigMap{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
-		ObjectMeta: metav1.ObjectMeta{Name: r.ConfigMapName, Namespace: r.ConfigMapNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: r.ConfigMapName, Namespace: req.Namespace},
 		Data:       data,
 	}
 	if err := r.serverApply(ctx, cm); err != nil {
@@ -81,10 +118,35 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, fmt.Errorf("apply MeshConfig ConfigMap: %w", err)
 	}
 
-	r.Log.InfoContext(ctx, "projected MeshConfig into ConfigMap",
-		"configMap", r.ConfigMapNamespace+"/"+r.ConfigMapName)
-	r.setProjected(ctx, mc, true, "projected to "+r.ConfigMapName)
+	target := req.Namespace + "/" + r.ConfigMapName
+	r.Log.InfoContext(ctx, "projected MeshConfig into ConfigMap", "configMap", target)
+	r.setProjected(ctx, mc, true, "projected to "+target)
 	return reconcile.Result{}, nil
+}
+
+// effectiveSpec returns the config to project for mc's namespace: the
+// FallbackNamespace MeshConfig as the base with mc's spec merged over it (mc's set
+// fields win, edition-2024 presence respected). The fallback namespace itself — or a
+// missing/empty fallback — projects mc's spec verbatim.
+func (r *Reconciler) effectiveSpec(ctx context.Context, mc *crdv1.MeshConfig) (*configv1.MeshConfigSpec, error) {
+	if mc.Namespace == r.FallbackNamespace {
+		return mc.Spec, nil
+	}
+	base := &crdv1.MeshConfig{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: r.FallbackNamespace, Name: SingletonName}, base); err != nil {
+		if apierrors.IsNotFound(err) {
+			return mc.Spec, nil // no fallback source; project this namespace's own spec
+		}
+		return nil, fmt.Errorf("get fallback MeshConfig: %w", err)
+	}
+	if base.Spec == nil {
+		return mc.Spec, nil
+	}
+	eff := proto.Clone(base.Spec).(*configv1.MeshConfigSpec)
+	if mc.Spec != nil {
+		proto.Merge(eff, mc.Spec)
+	}
+	return eff, nil
 }
 
 // serverApply server-side-applies an object owned by the controller's field
@@ -94,8 +156,8 @@ func (r *Reconciler) serverApply(ctx context.Context, obj client.Object) error {
 }
 
 // setProjected records the "Projected" status condition via Server-Side Apply on
-// the status subresource. The apply object carries only TypeMeta, the name and
-// status (no spec), so the controller's field manager owns just the status.
+// the status subresource. The apply object carries only TypeMeta, the name+namespace
+// and status (no spec), so the controller's field manager owns just the status.
 // Best-effort: a write failure is logged, not surfaced.
 func (r *Reconciler) setProjected(ctx context.Context, mc *crdv1.MeshConfig, ok bool, msg string) {
 	cond := metav1.Condition{
@@ -112,7 +174,7 @@ func (r *Reconciler) setProjected(ctx context.Context, mc *crdv1.MeshConfig, ok 
 	}
 	apply := &crdv1.MeshConfig{
 		TypeMeta:   metav1.TypeMeta{APIVersion: crdv1.GroupVersion.String(), Kind: crdv1.MeshConfigKind},
-		ObjectMeta: metav1.ObjectMeta{Name: mc.GetName()},
+		ObjectMeta: metav1.ObjectMeta{Name: mc.GetName(), Namespace: mc.GetNamespace()},
 		Status:     crdv1.MeshConfigStatus{Conditions: []metav1.Condition{cond}},
 	}
 	if err := r.Status().Patch(ctx, apply, client.Apply, client.FieldOwner(fieldOwner), client.ForceOwnership); err != nil {

--- a/controller/internal/meshconfig/reconciler_test.go
+++ b/controller/internal/meshconfig/reconciler_test.go
@@ -1,0 +1,102 @@
+package meshconfig
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const fallbackNS = "aether-system"
+
+func meshCfg(ns string, spec *configv1.MeshConfigSpec) *crdv1.MeshConfig {
+	return &crdv1.MeshConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: SingletonName, Namespace: ns},
+		Spec:       spec,
+	}
+}
+
+func newReconciler(t *testing.T, objs ...client.Object) *Reconciler {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, crdv1.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &Reconciler{
+		Client:            c,
+		ConfigMapName:     DefaultMeshConfigMapName,
+		FallbackNamespace: fallbackNS,
+		Log:               slog.New(slog.DiscardHandler),
+	}
+}
+
+// TestEffectiveSpec covers the namespaced fallback: a namespace inherits the
+// control-plane MeshConfig field-by-field unless it overrides.
+func TestEffectiveSpec(t *testing.T) {
+	ctx := context.Background()
+	fallback := configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{
+		AccessLogsEnabled: proto.Bool(true),
+		TraceSampleRate:   proto.Float64(0.5),
+	}.Build()}.Build()
+
+	t.Run("fallback namespace projects its own spec verbatim", func(t *testing.T) {
+		r := newReconciler(t, meshCfg(fallbackNS, fallback))
+		got, err := r.effectiveSpec(ctx, meshCfg(fallbackNS, fallback))
+		require.NoError(t, err)
+		assert.True(t, got.GetProxy().GetAccessLogsEnabled())
+		assert.InEpsilon(t, 0.5, got.GetProxy().GetTraceSampleRate(), 1e-9)
+	})
+
+	t.Run("override merges over the fallback (set fields win, unset inherit)", func(t *testing.T) {
+		override := configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{
+			TraceSampleRate: proto.Float64(0.1), // override only the sample rate
+		}.Build()}.Build()
+		r := newReconciler(t, meshCfg(fallbackNS, fallback), meshCfg("aether-ingress", override))
+		got, err := r.effectiveSpec(ctx, meshCfg("aether-ingress", override))
+		require.NoError(t, err)
+		assert.True(t, got.GetProxy().GetAccessLogsEnabled(), "inherited from the fallback")
+		assert.InEpsilon(t, 0.1, got.GetProxy().GetTraceSampleRate(), 1e-9, "override wins")
+	})
+
+	t.Run("no fallback present projects the namespace's own spec", func(t *testing.T) {
+		own := configv1.MeshConfigSpec_builder{Proxy: configv1.ProxyTelemetry_builder{
+			TracingEnabled: proto.Bool(true),
+		}.Build()}.Build()
+		r := newReconciler(t, meshCfg("aether-ingress", own))
+		got, err := r.effectiveSpec(ctx, meshCfg("aether-ingress", own))
+		require.NoError(t, err)
+		assert.True(t, got.GetProxy().GetTracingEnabled())
+	})
+}
+
+// TestEnqueueInheritors: a change to the fallback namespace's MeshConfig fans out to
+// every other namespace's MeshConfig; a change elsewhere enqueues nothing (For
+// handles it).
+func TestEnqueueInheritors(t *testing.T) {
+	ctx := context.Background()
+	r := newReconciler(t,
+		meshCfg(fallbackNS, nil),
+		meshCfg("aether-ingress", nil),
+		meshCfg("team-a", nil),
+	)
+
+	reqs := r.enqueueInheritors(ctx, meshCfg(fallbackNS, nil))
+	got := map[string]bool{}
+	for _, rq := range reqs {
+		got[rq.Namespace] = true
+	}
+	assert.True(t, got["aether-ingress"])
+	assert.True(t, got["team-a"])
+	assert.False(t, got[fallbackNS], "the fallback itself is handled by For()")
+
+	assert.Empty(t, r.enqueueInheritors(ctx, meshCfg("aether-ingress", nil)),
+		"a non-fallback change enqueues nothing here")
+}


### PR DESCRIPTION
**PR 1 of 2** for moving the edge into its own `aether-ingress` namespace. (PR 2 = the edge chart migration, depends on this.)

## Why
The edge will live in `aether-ingress` and mount a `<release>-mesh-config` ConfigMap — but mounts are namespace-local, and the controller projected the singleton MeshConfig only into the control-plane namespace. Rather than a configured target-namespace list (and two flags), make MeshConfig **namespaced** and have the controller **co-locate** the projected ConfigMap with the CR — so there's no namespace setting at all.

## What
- **CRD** `scope: Cluster → Namespaced` — one `default` MeshConfig per namespace.
- **Reconciler co-locates**: projects into `ConfigMap{Name, Namespace: req.Namespace}`. The `ConfigMapNamespace` field + `--mesh-config-namespace` flag are removed.
- **aether-system fallback**: a namespace's effective config = the control-plane (controller's own) namespace MeshConfig, with that namespace's CR **merged over it** (set fields win; edition-2024 field presence respected). A namespace inherits the mesh-wide config unless it overrides; the fallback namespace projects verbatim.
- **Fan-out**: a change to the fallback MeshConfig re-projects every inheriting namespace (`Watches` + a map func over `MeshConfigList`).
- **RBAC**: ConfigMap write is now cluster-wide (a MeshConfig can be in any namespace) — a `ClusterRole` + `ClusterRoleBinding`; leases/events stay a namespaced `Role`.
- **Seed CR** is namespaced (release ns); the `lookup` is namespace-scoped.

## Tests
`effectiveSpec` (verbatim in the fallback ns; merge-over-fallback for an override; own-spec when no fallback) and `enqueueInheritors` (fan-out only on a fallback-ns change). `bazel build //...` + `//controller/...` tests green.

## ⚠️ BREAKING — CRD scope migration
A CRD's scope can't change in place. **Upgrading requires** deleting the old cluster-scoped CRD first:
```
kubectl delete crd meshconfigs.config.aether.io   # removes the cluster-scoped 'default' CR
```
then applying the namespaced CRD; the chart re-seeds a namespaced `default` in the release namespace. Operators with hand-edited mesh config re-apply it after.