### PR TITLE
feat(edge): run the edge in its own aether-ingress namespace

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.20.0-{GIT_COMMIT}"
+version: "0.21.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/_helpers.tpl
+++ b/charts/aether/templates/_helpers.tpl
@@ -120,6 +120,11 @@ app.kubernetes.io/version: {{ . | quote }}
 {{- define "aether.edge.fullname" -}}
 {{- printf "%s-edge" (include "aether.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+{{- /* The edge is an ingress gateway, not a mesh workload — it runs in its own
+       namespace (aether-ingress by default), isolated from the control plane. */ -}}
+{{- define "aether.edge.namespace" -}}
+{{- default "aether-ingress" .Values.edge.namespace -}}
+{{- end -}}
 {{- define "aether.edge.serviceAccountName" -}}{{ include "aether.edge.fullname" . }}{{- end -}}
 {{- define "aether.edge.configMapName" -}}
 {{- printf "%s-config" (include "aether.edge.fullname" .) | trunc 63 | trimSuffix "-" -}}

--- a/charts/aether/templates/edge-clusterspiffeid.yaml
+++ b/charts/aether/templates/edge-clusterspiffeid.yaml
@@ -19,5 +19,5 @@ spec:
       {{- include "aether.edge.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ include "aether.namespace" . }}
+      kubernetes.io/metadata.name: {{ include "aether.edge.namespace" . }}
 {{- end }}

--- a/charts/aether/templates/edge-configmap.yaml
+++ b/charts/aether/templates/edge-configmap.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "aether.edge.configMapName" . }}
-  namespace: {{ include "aether.namespace" . }}
+  namespace: {{ include "aether.edge.namespace" . }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
 data:

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "aether.edge.fullname" . }}
-  namespace: {{ include "aether.namespace" . }}
+  namespace: {{ include "aether.edge.namespace" . }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
 spec:
@@ -54,6 +54,10 @@ spec:
             - "edge"
             - "--debug={{ .Values.debug }}"
             - "--cluster-name={{ .Values.clusterName }}"
+            # The registrar stays in the release namespace; the edge reaches it
+            # cross-namespace (the binary default assumes aether-system, so pass the
+            # release-namespace-correct address explicitly).
+            - "--registrar-address={{ include "aether.registrar.fullname" . }}.{{ include "aether.namespace" . }}.svc:{{ .Values.registrar.service.port }}"
             # proxy-id / node-name derive from POD_NAME (downward API, below); the
             # registry dir, ports, mesh domain, route namespace and SPIRE socket all
             # use the binary defaults — passed below only when overridden.

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -23,17 +23,18 @@ spec:
     metadata:
       labels:
         {{- include "aether.edge.labels" . | nindent 8 }}
-        # The edge is an ingress gateway, not a mesh workload: no per-pod proxy,
-        # never CNI-intercepted. It runs in aether-system (which the CNI plugin
-        # already skips), but mark it explicitly unmanaged so the exclusion never
-        # depends on the ignored-namespace list.
+        # The edge is an ingress gateway, not a mesh workload: no per-pod proxy.
+        # It runs in its own (non-aether-system) namespace, so the CNI plugin no
+        # longer skips it by namespace — this label is what keeps the agent's
+        # isIgnorablePod ignoring it. Namespace-agnostic, deliberately.
         aether.io/managed: "false"
     spec:
       serviceAccountName: {{ include "aether.edge.serviceAccountName" . }}
-      # Tolerate the aether startup taint: the edge is an aether-system ingress
-      # gateway, not a mesh workload — it dials pods directly and never uses the
-      # node proxy. The CNI plugin skips aether-system pods, so it has no
-      # node-readiness dependency and must not wait for the agent (#261).
+      # Tolerate the aether startup taint: the edge is an ingress gateway, not a
+      # mesh workload — it dials pods directly and never uses the node proxy, so it
+      # must not wait for a node's agent to become ready. (Its own CNI ADD goes
+      # through the agent, which ignores it via managed=false; fails-closed +
+      # retries, no deadlock.) See #261.
       tolerations:
         - key: aether.io/agent-not-ready
           operator: Exists

--- a/charts/aether/templates/edge-meshconfig.yaml
+++ b/charts/aether/templates/edge-meshconfig.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.edge.enabled .Values.meshConfig.createDefault }}
+{{- /*
+  The edge's own namespace-scoped MeshConfig. An empty spec inherits the
+  control-plane (release namespace) MeshConfig field-by-field via the controller's
+  fallback, so the edge's projected ConfigMap mirrors the mesh by default. Seeded
+  ONCE (lookup) + resource-policy: keep, like the control-plane CR — operators edit
+  it via kubectl to give the edge its own observability policy. See
+  docs/proposals/015_mesh-config.md.
+*/ -}}
+{{- $existing := lookup "config.aether.io/v1" "MeshConfig" (include "aether.edge.namespace" .) "default" -}}
+{{- if not $existing }}
+apiVersion: config.aether.io/v1
+kind: MeshConfig
+metadata:
+  name: default
+  namespace: {{ include "aether.edge.namespace" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec: {}
+{{- end }}
+{{- end }}

--- a/charts/aether/templates/edge-namespace.yaml
+++ b/charts/aether/templates/edge-namespace.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.edge.enabled .Values.edge.namespaceCreate }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "aether.edge.namespace" . }}
+  labels:
+    # The edge is an unprivileged ingress gateway (runs non-root, drops ALL caps,
+    # adds only NET_BIND_SERVICE) — baseline PSA, unlike the privileged
+    # control-plane namespace the agent/CNI require.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/warn: baseline
+    {{- include "aether.edge.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/aether/templates/edge-rbac.yaml
+++ b/charts/aether/templates/edge-rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.edge.enabled }}
-{{- $routeNamespace := default (include "aether.namespace" .) .Values.edge.routeNamespace }}
+{{- $routeNamespace := default (include "aether.edge.namespace" .) .Values.edge.routeNamespace }}
 # Namespaced: the edge only reads VirtualHosts (and their status) in the namespace
 # it watches. No cluster-wide access — exposure is delegable per namespace.
 apiVersion: rbac.authorization.k8s.io/v1
@@ -38,5 +38,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "aether.edge.serviceAccountName" . }}
-    namespace: {{ include "aether.namespace" . }}
+    namespace: {{ include "aether.edge.namespace" . }}
 {{- end }}

--- a/charts/aether/templates/edge-service.yaml
+++ b/charts/aether/templates/edge-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "aether.edge.fullname" . }}
-  namespace: {{ include "aether.namespace" . }}
+  namespace: {{ include "aether.edge.namespace" . }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
   {{- with .Values.edge.service.annotations }}

--- a/charts/aether/templates/edge-serviceaccount.yaml
+++ b/charts/aether/templates/edge-serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "aether.edge.serviceAccountName" . }}
-  namespace: {{ include "aether.namespace" . }}
+  namespace: {{ include "aether.edge.namespace" . }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
 {{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -172,6 +172,11 @@ proxy:
 # from SPIRE over the workload socket (no agent SPIRE bridge). Disabled by default.
 edge:
   enabled: false
+  # The edge is an ingress gateway, not a mesh workload, so it runs in its own
+  # namespace, isolated from the control plane. namespaceCreate lets the chart
+  # create it (with baseline PSA); set false if you manage the namespace yourself.
+  namespace: aether-ingress
+  namespaceCreate: true
   # Gateway replicas behind the Service; rolled with the standard RollingUpdate
   # + readiness gate (no hot-restart supervisor — nothing node-local to preserve).
   replicaCount: 2


### PR DESCRIPTION
**PR 2 of 2** for moving the edge out of the control-plane namespace. Depends on **#267** (namespaced MeshConfig).

The edge is an ingress gateway, not a mesh workload, so it gets its own namespace (`aether-ingress`), isolated from the control plane. #266's `aether.io/managed: "false"` label was the prerequisite — outside `aether-system` the CNI plugin no longer skips it by namespace, but the agent's `isIgnorablePod` still ignores it by **label**.

## What
- New `aether.edge.namespace` helper (default `aether-ingress`, via `edge.namespace`). The edge Deployment / Service / ServiceAccount / ConfigMap / Role+RoleBinding / ClusterSPIFFEID-selector all render into it.
- `edge-namespace.yaml` creates `aether-ingress` with **baseline PSA** (the edge is unprivileged — non-root, drops ALL caps, adds only `NET_BIND_SERVICE` — unlike the privileged control-plane namespace the agent/CNI need). Gated on `edge.enabled` + `edge.namespaceCreate`.
- `edge-meshconfig.yaml` seeds a namespaced `default` MeshConfig in `aether-ingress` with **`spec: {}`** — it inherits the control-plane MeshConfig field-by-field via #267's fallback, so the edge's projected ConfigMap mirrors the mesh by default; operators edit it for edge-specific observability.
- **SPIRE**: the ClusterSPIFFEID `namespaceSelector` targets `aether-ingress`; the `PodMeta.Namespace` template makes the SVID `spiffe://<td>/ns/aether-ingress/sa/aether-edge`.
- Pass `--registrar-address` explicitly (release-namespace-correct) — the edge now reaches the registrar cross-namespace and the binary default assumes `aether-system`.

Edge stays **opt-in** (`edge.enabled` default `false`).

## Verified
`helm template --set edge.enabled=true`: all edge resources render into `aether-ingress`; both MeshConfigs render (control-plane + edge `spec: {}`); `aether-ingress` namespace with baseline PSA; SPIRE selector = `aether-ingress`; registrar address = `<registrar>.<release-ns>.svc:443`; edge selector unchanged (upgrade-safe); `helm lint` clean. Chart `0.20.0 → 0.21.0`.

e2e on talos to follow once #267 + this land (includes the #267 CRD migration).