### PR TITLE
feat: GAMMA east-west L7 routing (proposal 018, Phase 2)

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//agent/internal/edge",
         "//agent/internal/edge/gatewayapi",
         "//agent/internal/edge/secret",
+        "//agent/internal/gamma",
         "//agent/internal/node",
         "//agent/internal/proxy/hotrestart",
         "//agent/internal/spire",

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -86,6 +86,11 @@ type AgentConfig struct {
 	// GatewayAPI makes the edge consume Gateway API (Gateway + HTTPRoute) instead
 	// of the VirtualHost CRD (proposal 018, Phase 1). Edge subcommand only.
 	GatewayAPI bool
+
+	// Gamma enables GAMMA east-west L7 routing on the node proxy: the agent watches
+	// HTTPRoutes parented to a Service and enriches the outbound routes (proposal
+	// 018, Phase 2). Default off — a no-op until enabled.
+	Gamma bool
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves when
 	// GatewayAPI is set.
 	GatewayClassName string

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/constants"
 	cniServer "github.com/bpalermo/aether/agent/internal/cni/server"
+	"github.com/bpalermo/aether/agent/internal/gamma"
 	"github.com/bpalermo/aether/agent/internal/node"
 	"github.com/bpalermo/aether/agent/internal/spire"
 	"github.com/bpalermo/aether/agent/internal/xds/ack"
@@ -52,6 +53,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
@@ -110,6 +112,7 @@ func init() {
 	// Cold-start gate (node proxy only): remove the aether.io/agent-not-ready
 	// startup taint from this node once the CNI server is serving.
 	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
+	rootCmd.Flags().BoolVar(&cfg.Gamma, "gamma", false, "Enable GAMMA east-west L7 routing: watch HTTPRoutes parented to a Service and enrich the node proxy's outbound routes (proposal 018, Phase 2)")
 }
 
 // registerSharedFlags registers the flags common to the node agent (root) and
@@ -311,6 +314,24 @@ func runAgent(ctx context.Context) (retErr error) {
 	refresher := xdsServer.NewRegistryRefresher(cfg.ClusterName, cfg.NodeName, snapshotCache, reg, l)
 	if err = m.Add(refresher); err != nil {
 		return fmt.Errorf("failed to add registry refresher: %w", err)
+	}
+
+	// GAMMA east-west L7 routing (proposal 018, Phase 2): watch HTTPRoutes parented
+	// to a Service and enrich the outbound routes. Default off — registers nothing
+	// (and adds no gateway-api watch) unless --gamma is set.
+	if cfg.Gamma {
+		if err = gatewayv1.Install(m.GetScheme()); err != nil {
+			return fmt.Errorf("register gateway.networking.k8s.io scheme: %w", err)
+		}
+		gammaReconciler := &gamma.Reconciler{
+			Client:     m.GetClient(),
+			Sink:       snapshotCache,
+			MeshDomain: cfg.MeshDomain,
+			Log:        l,
+		}
+		if err = gammaReconciler.SetupWithManager(m); err != nil {
+			return fmt.Errorf("failed to set up GAMMA reconciler: %w", err)
+		}
 	}
 
 	l.DebugContext(ctx, "waiting for local storage to be ready")

--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gamma",
+    srcs = ["reconciler.go"],
+    importpath = "github.com/bpalermo/aether/agent/internal/gamma",
+    visibility = ["//agent:__subpackages__"],
+    deps = [
+        "//agent/internal/xds/proxy",
+        "//common/log",
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile",
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@org_golang_google_protobuf//types/known/durationpb",
+    ],
+)
+
+go_test(
+    name = "gamma_test",
+    srcs = ["reconciler_test.go"],
+    embed = [":gamma"],
+    deps = [
+        "//agent/internal/xds/proxy",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+    ],
+)

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -1,0 +1,132 @@
+// Package gamma contains the node agent's GAMMA controller: it watches Gateway API
+// HTTPRoutes attached to a Service (parentRef kind=Service) and projects their L7
+// rules into the node proxy's outbound routing (proposal 018, Phase 2 — east-west).
+// Routing and mTLS are unchanged; HTTPRoute adds canary/header/timeout vocabulary
+// to the outbound path the proxy already serves.
+package gamma
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	commonlog "github.com/bpalermo/aether/common/log"
+	"google.golang.org/protobuf/types/known/durationpb"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// RouteSink receives the projected per-service GAMMA rules (the snapshot cache).
+type RouteSink interface {
+	SetServiceRoutes(routes map[string][]proxy.GammaRoute)
+}
+
+// Reconciler watches HTTPRoutes (parentRef=Service) cluster-wide and projects, on
+// any change, the complete service→rules map into the cache. Level-based: each
+// reconcile re-lists, so adds/updates/deletes converge without delta tracking.
+//
+// Phase 2 treats every Service-parented HTTPRoute as a producer route (applies to
+// all clients of that service); per-namespace consumer overrides are a follow-up.
+type Reconciler struct {
+	client.Client
+
+	// Sink receives the projected per-service rules (the snapshot cache).
+	Sink RouteSink
+	// MeshDomain resolves a backend Service to its data-plane cluster name.
+	MeshDomain string
+	Log        *slog.Logger
+}
+
+// SetupWithManager registers the reconciler to watch HTTPRoutes.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.Log = commonlog.Named(r.Log, "gamma")
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&gatewayv1.HTTPRoute{}).
+		Named("gamma").
+		Complete(r)
+}
+
+// Reconcile re-lists every HTTPRoute, keeps those attached to a Service, and
+// replaces the cache's per-service rule set.
+func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	list := &gatewayv1.HTTPRouteList{}
+	if err := r.List(ctx, list); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	routes := map[string][]proxy.GammaRoute{}
+	for i := range list.Items {
+		hr := &list.Items[i]
+		for _, svc := range serviceParents(hr) {
+			for _, rule := range hr.Spec.Rules {
+				routes[svc] = append(routes[svc], r.buildGammaRoute(rule))
+			}
+		}
+	}
+
+	r.Sink.SetServiceRoutes(routes)
+	r.Log.DebugContext(ctx, "projected gamma service routes", "httpRoutes", len(list.Items), "services", len(routes))
+	return reconcile.Result{}, nil
+}
+
+// serviceParents returns the names of the Services this HTTPRoute is attached to
+// (parentRef kind=Service, core group).
+func serviceParents(hr *gatewayv1.HTTPRoute) []string {
+	var svcs []string
+	for _, p := range hr.Spec.ParentRefs {
+		if p.Group != nil && string(*p.Group) != "" {
+			continue
+		}
+		if p.Kind == nil || string(*p.Kind) != "Service" {
+			continue
+		}
+		svcs = append(svcs, string(p.Name))
+	}
+	return svcs
+}
+
+func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule) proxy.GammaRoute {
+	gr := proxy.GammaRoute{}
+	if rule.Timeouts != nil && rule.Timeouts.Request != nil {
+		// HTTPRoute timeouts are GEP-2257 duration strings (a subset of Go's).
+		if d, err := time.ParseDuration(string(*rule.Timeouts.Request)); err == nil && d > 0 {
+			gr.Timeout = durationpb.New(d)
+		}
+	}
+	for _, b := range rule.BackendRefs {
+		if b.Group != nil && string(*b.Group) != "" {
+			continue
+		}
+		if b.Kind != nil && string(*b.Kind) != "Service" {
+			continue
+		}
+		name := string(b.Name)
+		weight := uint32(1)
+		if b.Weight != nil {
+			weight = uint32(*b.Weight)
+		}
+		gr.Backends = append(gr.Backends, proxy.GammaBackend{
+			Service: name,
+			Cluster: proxy.ServiceClusterName(name, r.MeshDomain),
+			Weight:  weight,
+		})
+	}
+	for _, m := range rule.Matches {
+		gm := proxy.GammaMatch{}
+		if m.Path != nil && m.Path.Value != nil {
+			if m.Path.Type != nil && *m.Path.Type == gatewayv1.PathMatchExact {
+				gm.Exact = *m.Path.Value
+			} else {
+				gm.Prefix = *m.Path.Value
+			}
+		}
+		for _, h := range m.Headers {
+			gm.Headers = append(gm.Headers, proxy.GammaHeaderMatch{Name: string(h.Name), Value: h.Value})
+		}
+		gr.Matches = append(gr.Matches, gm)
+	}
+	return gr
+}

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -1,0 +1,53 @@
+package gamma
+
+import (
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func TestServiceParents(t *testing.T) {
+	hr := &gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
+		ParentRefs: []gatewayv1.ParentReference{
+			{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-1"},
+			{Kind: ptr(gatewayv1.Kind("Gateway")), Name: "edge"}, // ignored
+			{Name: "no-kind"}, // no kind → ignored
+		},
+	}}}
+	assert.Equal(t, []string{"svc-1"}, serviceParents(hr))
+}
+
+// TestBuildGammaRoute: matches → GammaMatch, weighted backendRefs → GammaBackend
+// with resolved cluster names + bare service, request timeout parsed.
+func TestBuildGammaRoute(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	rule := gatewayv1.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{{
+			Path:    &gatewayv1.HTTPPathMatch{Type: ptr(gatewayv1.PathMatchExact), Value: ptr("/admin")},
+			Headers: []gatewayv1.HTTPHeaderMatch{{Name: "x-env", Value: "beta"}},
+		}},
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1-v1", Port: ptr(gatewayv1.PortNumber(8080))}, Weight: ptr(int32(90))}},
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1-v2"}, Weight: ptr(int32(10))}},
+		},
+		Timeouts: &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))},
+	}
+	gr := r.buildGammaRoute(rule)
+
+	require.Len(t, gr.Matches, 1)
+	assert.Equal(t, "/admin", gr.Matches[0].Exact)
+	require.Len(t, gr.Matches[0].Headers, 1)
+	assert.Equal(t, proxy.GammaHeaderMatch{Name: "x-env", Value: "beta"}, gr.Matches[0].Headers[0])
+
+	require.Len(t, gr.Backends, 2)
+	assert.Equal(t, proxy.GammaBackend{Service: "svc-1-v1", Cluster: proxy.ServiceClusterName("svc-1-v1", "mesh"), Weight: 90}, gr.Backends[0])
+	assert.Equal(t, uint32(10), gr.Backends[1].Weight)
+
+	require.NotNil(t, gr.Timeout)
+	assert.Equal(t, int64(5), gr.Timeout.GetSeconds())
+}

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "cluster.go",
         "dependencies.go",
         "edge.go",
+        "gamma.go",
         "listener.go",
         "metrics.go",
         "secret.go",

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/common/constants"
 
 	commonlog "github.com/bpalermo/aether/common/log"
@@ -133,6 +134,12 @@ type SnapshotCache struct {
 	// carries exactly the exposed services; updated by SetStaticDependencies
 	// when the exposed set changes (e.g. an EdgeRoute add/remove).
 	staticDeps map[string]struct{}
+	// serviceRoutes holds the GAMMA east-west L7 rules (HTTPRoute parentRef=Service,
+	// proposal 018 Phase 2), keyed by the parent service. Empty unless --gamma is
+	// enabled. A depended-on service's rule backends are unioned into the
+	// dependency set so their EDS clusters generate; the per-service outbound vhost
+	// is enriched with the rules. Guarded by depMu (dependency state).
+	serviceRoutes map[string][]proxy.GammaRoute
 	// observedTTL overrides defaultObservedTTL when > 0 (test hook).
 	observedTTL time.Duration
 	// depChanged receives a (coalesced) signal when the dependency set
@@ -233,6 +240,7 @@ func NewSnapshotCache(nodeName string, log *slog.Logger) *SnapshotCache {
 		podDeps:        make(map[string]podDependencies),
 		observedDeps:   make(map[string]time.Time),
 		staticDeps:     make(map[string]struct{}),
+		serviceRoutes:  make(map[string][]proxy.GammaRoute),
 		depChanged:     make(chan struct{}, 1),
 		version:        atomic.NewUint64(0),
 	}

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -179,6 +179,9 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 	}
 
 	deps := c.DependencySet()
+	// GAMMA L7 rules per service (empty unless --gamma), snapshotted once before
+	// the cluster lock so the per-service outbound vhost can be enriched.
+	gammaRoutes := c.serviceRoutesSnapshot()
 	localRegion, localZone := c.nodeLocality()
 
 	// RPC-fill (cold path): a dependency missing from the watch-fed listing —
@@ -314,7 +317,7 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 			cluster:        proxy.NewServiceCluster(fqdn, serviceName, serviceName, sortedKeys, c.perDownstreamConnectionPool()),
 			loadAssignment: defaultCla,
 			endpoints:      defaultEpMap,
-			vhost:          proxy.BuildOutboundClusterVirtualHost(fqdn, []string{fqdn, fmt.Sprintf("%s:%d", fqdn, defaultPort)}),
+			vhost:          proxy.BuildOutboundServiceVirtualHost(fqdn, []string{fqdn, fmt.Sprintf("%s:%d", fqdn, defaultPort)}, gammaRoutes[serviceName]),
 			sanNamespaces:  sanNamespaces,
 			service:        serviceName,
 			sni:            strconv.Itoa(int(defaultPort)),

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -153,6 +153,17 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 			set[svc] = struct{}{}
 		}
 	}
+	// GAMMA (proposal 018 Phase 2): a depended-on service's L7 rule backends must
+	// also be resolvable, so union them in (their EDS clusters then generate).
+	if len(c.serviceRoutes) > 0 {
+		base := make([]string, 0, len(set))
+		for svc := range set {
+			base = append(base, svc)
+		}
+		for _, svc := range base {
+			c.routeBackendsLocked(svc, set)
+		}
+	}
 	return set
 }
 

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -1,0 +1,94 @@
+package cache
+
+import (
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+)
+
+// SetServiceRoutes replaces the GAMMA east-west L7 rules (HTTPRoute parentRef=
+// Service, proposal 018 Phase 2). A depended-on service's rule backends enter the
+// dependency set (so their EDS clusters generate) and its outbound vhost is
+// enriched. Signals a scoped-snapshot rebuild on change.
+func (c *SnapshotCache) SetServiceRoutes(routes map[string][]proxy.GammaRoute) {
+	c.depMu.Lock()
+	changed := !equalServiceRoutes(c.serviceRoutes, routes)
+	c.serviceRoutes = routes
+	c.depMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// serviceRoutesSnapshot returns a shallow copy of the GAMMA rules for use during a
+// snapshot rebuild (read once, outside the cluster lock).
+func (c *SnapshotCache) serviceRoutesSnapshot() map[string][]proxy.GammaRoute {
+	c.depMu.RLock()
+	defer c.depMu.RUnlock()
+	out := make(map[string][]proxy.GammaRoute, len(c.serviceRoutes))
+	for k, v := range c.serviceRoutes {
+		out[k] = v
+	}
+	return out
+}
+
+// routeBackendsLocked appends the bare backend services of a service's GAMMA rules
+// to set. Caller holds depMu (it reads c.serviceRoutes).
+func (c *SnapshotCache) routeBackendsLocked(service string, set map[string]struct{}) {
+	for _, r := range c.serviceRoutes[service] {
+		for _, b := range r.Backends {
+			if b.Service != "" {
+				set[b.Service] = struct{}{}
+			}
+		}
+	}
+}
+
+func equalServiceRoutes(a, b map[string][]proxy.GammaRoute) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for svc, ra := range a {
+		rb, ok := b[svc]
+		if !ok || len(ra) != len(rb) {
+			return false
+		}
+		for i := range ra {
+			if !equalGammaRoute(ra[i], rb[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func equalGammaRoute(a, b proxy.GammaRoute) bool {
+	if len(a.Matches) != len(b.Matches) || len(a.Backends) != len(b.Backends) {
+		return false
+	}
+	if timeoutNanos(a) != timeoutNanos(b) {
+		return false
+	}
+	for i := range a.Matches {
+		ma, mb := a.Matches[i], b.Matches[i]
+		if ma.Prefix != mb.Prefix || ma.Exact != mb.Exact || len(ma.Headers) != len(mb.Headers) {
+			return false
+		}
+		for j := range ma.Headers {
+			if ma.Headers[j] != mb.Headers[j] {
+				return false
+			}
+		}
+	}
+	for i := range a.Backends {
+		if a.Backends[i] != b.Backends[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func timeoutNanos(r proxy.GammaRoute) int64 {
+	if r.Timeout == nil {
+		return 0
+	}
+	return r.Timeout.AsDuration().Nanoseconds()
+}

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
         "egress_test.go",
         "endpoint_test.go",
         "filterchain_test.go",
+        "gammaroute_test.go",
         "healthgateway_test.go",
         "httpfilter_test.go",
         "ingress_test.go",

--- a/agent/internal/xds/proxy/gammaroute_test.go
+++ b/agent/internal/xds/proxy/gammaroute_test.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"testing"
+
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildOutboundServiceVirtualHost_NoRules: with no GAMMA rules it is the plain
+// passthrough vhost (one route to the service cluster).
+func TestBuildOutboundServiceVirtualHost_NoRules(t *testing.T) {
+	vh := BuildOutboundServiceVirtualHost("svc-1.mesh", []string{"svc-1.mesh"}, nil)
+	require.Len(t, vh.Routes, 1)
+	assert.Equal(t, "svc-1.mesh", vh.Routes[0].GetRoute().GetCluster())
+}
+
+// TestBuildOutboundServiceVirtualHost_Rules: matches → routes, weighted backends →
+// WeightedClusters, plus the additive trailing default to the service cluster.
+func TestBuildOutboundServiceVirtualHost_Rules(t *testing.T) {
+	rules := []GammaRoute{
+		{
+			Matches:  []GammaMatch{{Exact: "/admin", Headers: []GammaHeaderMatch{{Name: "x-env", Value: "beta"}}}},
+			Backends: []GammaBackend{{Cluster: "svc-admin.mesh", Weight: 1}},
+		},
+		{
+			Backends: []GammaBackend{{Cluster: "svc-1-v1.mesh", Weight: 90}, {Cluster: "svc-1-v2.mesh", Weight: 10}},
+		},
+	}
+	vh := BuildOutboundServiceVirtualHost("svc-1.mesh", []string{"svc-1.mesh"}, rules)
+
+	// rule0 (1 match) + rule1 (default "/" match) + trailing catch-all = 3 routes.
+	require.Len(t, vh.Routes, 3)
+
+	// rule0: exact path + header match → single backend.
+	r0 := vh.Routes[0]
+	assert.Equal(t, "/admin", r0.GetMatch().GetPath())
+	require.Len(t, r0.GetMatch().GetHeaders(), 1)
+	assert.Equal(t, "x-env", r0.GetMatch().GetHeaders()[0].GetName())
+	assert.Equal(t, "svc-admin.mesh", r0.GetRoute().GetCluster())
+
+	// rule1: no match → default "/", weighted split.
+	r1 := vh.Routes[1]
+	assert.Equal(t, "/", r1.GetMatch().GetPrefix())
+	wc := r1.GetRoute().GetWeightedClusters().GetClusters()
+	require.Len(t, wc, 2)
+	assert.Equal(t, uint32(90), wc[0].GetWeight().GetValue())
+	assert.Equal(t, "svc-1-v2.mesh", wc[1].GetName())
+
+	// trailing additive default → the service's own cluster.
+	assert.Equal(t, "svc-1.mesh", vh.Routes[2].GetRoute().GetCluster())
+	assert.Equal(t, "/", vh.Routes[2].GetMatch().GetPrefix())
+
+	_ = routev3.RouteMatch{} // keep import
+}

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -161,3 +161,109 @@ func BuildOutboundClusterVirtualHost(clusterName string, domains []string) *rout
 		},
 	}
 }
+
+// GAMMA east-west L7 routing (proposal 018, Phase 2). A GammaRoute is one resolved
+// HTTPRoute rule: ordered matches forwarding to one or more weighted backend
+// clusters, with an optional timeout. Backends are already resolved to data-plane
+// cluster names (<backend>.<meshDomain>) by the reconciler.
+type GammaRoute struct {
+	Matches  []GammaMatch
+	Backends []GammaBackend
+	Timeout  *durationpb.Duration
+}
+
+// GammaMatch is one HTTPRoute match: a path (prefix OR exact; empty = prefix "/")
+// and zero or more exact header matches (ANDed).
+type GammaMatch struct {
+	Prefix  string
+	Exact   string
+	Headers []GammaHeaderMatch
+}
+
+// GammaHeaderMatch is an exact request-header match.
+type GammaHeaderMatch struct {
+	Name  string
+	Value string
+}
+
+// GammaBackend is one weighted backend cluster of a route.
+type GammaBackend struct {
+	Cluster string
+	Weight  uint32
+}
+
+// BuildOutboundServiceVirtualHost builds a service's outbound virtual host enriched
+// with GAMMA rules: each rule's matches become Envoy routes to its weighted backend
+// cluster(s), with the outbound retry policy and an optional timeout. A trailing
+// catch-all routes anything the rules don't match to the service's own cluster
+// (name), so producer rules are additive. With no rules it is the passthrough vhost.
+func BuildOutboundServiceVirtualHost(name string, domains []string, rules []GammaRoute) *routev3.VirtualHost {
+	if len(rules) == 0 {
+		return BuildOutboundClusterVirtualHost(name, domains)
+	}
+	var routes []*routev3.Route
+	for _, rule := range rules {
+		action := gammaRouteAction(name, rule)
+		matches := rule.Matches
+		if len(matches) == 0 {
+			matches = []GammaMatch{{Prefix: "/"}}
+		}
+		for _, m := range matches {
+			routes = append(routes, &routev3.Route{Match: gammaRouteMatch(m), Action: action})
+		}
+	}
+	routes = append(routes, &routev3.Route{
+		Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
+		Action: &routev3.Route_Route{Route: &routev3.RouteAction{
+			ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: name},
+			RetryPolicy:      outboundRetryPolicy(),
+		}},
+	})
+	return &routev3.VirtualHost{Name: name, Domains: domains, Routes: routes}
+}
+
+func gammaRouteMatch(m GammaMatch) *routev3.RouteMatch {
+	rm := &routev3.RouteMatch{}
+	switch {
+	case m.Exact != "":
+		rm.PathSpecifier = &routev3.RouteMatch_Path{Path: m.Exact}
+	case m.Prefix != "":
+		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: m.Prefix}
+	default:
+		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: "/"}
+	}
+	for _, h := range m.Headers {
+		rm.Headers = append(rm.Headers, &routev3.HeaderMatcher{
+			Name: h.Name,
+			HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+				StringMatch: &matcherv3.StringMatcher{
+					MatchPattern: &matcherv3.StringMatcher_Exact{Exact: h.Value},
+				},
+			},
+		})
+	}
+	return rm
+}
+
+func gammaRouteAction(serviceCluster string, rule GammaRoute) *routev3.Route_Route {
+	ra := &routev3.RouteAction{RetryPolicy: outboundRetryPolicy()}
+	if rule.Timeout != nil {
+		ra.Timeout = rule.Timeout
+	}
+	switch len(rule.Backends) {
+	case 0:
+		ra.ClusterSpecifier = &routev3.RouteAction_Cluster{Cluster: serviceCluster}
+	case 1:
+		ra.ClusterSpecifier = &routev3.RouteAction_Cluster{Cluster: rule.Backends[0].Cluster}
+	default:
+		weighted := &routev3.WeightedCluster{}
+		for _, b := range rule.Backends {
+			weighted.Clusters = append(weighted.Clusters, &routev3.WeightedCluster_ClusterWeight{
+				Name:   b.Cluster,
+				Weight: wrapperspb.UInt32(b.Weight),
+			})
+		}
+		ra.ClusterSpecifier = &routev3.RouteAction_WeightedClusters{WeightedClusters: weighted}
+	}
+	return &routev3.Route_Route{Route: ra}
+}

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -186,8 +186,10 @@ type GammaHeaderMatch struct {
 	Value string
 }
 
-// GammaBackend is one weighted backend cluster of a route.
+// GammaBackend is one weighted backend of a route: the resolved data-plane Cluster
+// the route forwards to, plus the bare Service name (for the dependency set).
 type GammaBackend struct {
+	Service string
 	Cluster string
 	Weight  uint32
 }

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.22.0-{GIT_COMMIT}"
+version: "0.23.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -63,6 +63,9 @@ spec:
             - "--proxy-id=$(NODE_NAME)"
             - "--cluster-name={{ .Values.clusterName }}"
             - "--node-name=$(NODE_NAME)"
+            {{- if .Values.agent.gamma }}
+            - "--gamma"
+            {{- end }}
             # Aether system config, inherited from the umbrella global block.
             - "--mesh-domain={{ .Values.meshDomain }}"
             {{- if .Values.otel.enabled }}

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -12,6 +12,12 @@ rules:
     resources: ["nodes"]
     # patch: remove the aether.io/agent-not-ready startup taint once CNI is serving.
     verbs: ["list", "get", "watch", "patch"]
+  {{- if .Values.agent.gamma }}
+  # GAMMA east-west (proposal 018): watch HTTPRoutes parented to Services cluster-wide.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["list", "get", "watch"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -95,6 +95,11 @@ meshConfig:
 
 # --------------------------------------------------------------------- agent
 agent:
+  # GAMMA east-west L7 routing (proposal 018, Phase 2): the node agent watches
+  # HTTPRoutes parented to a Service and enriches the outbound routes (canary /
+  # header / timeout). Requires the Gateway API CRDs. Default off — a no-op, and
+  # adds the cluster-wide httproutes RBAC only when enabled.
+  gamma: false
   # Image as repository + digest (digest-pinned for immutability). Mirror to a
   # private registry by overriding `repository` alone; the digest is preserved.
   image:


### PR DESCRIPTION
**Phase 2** of proposal 018 (#269) — east-west. The node agent consumes Gateway API **HTTPRoutes parented to a Service** (GAMMA) and enriches the node proxy's **outbound** routes — canary/weighted splits, header/path matching, per-route timeout — over the existing direct-to-pod SPIRE mTLS path. **Default off** (`--gamma`): a no-op until enabled, so it lands as a zero-behavior-change, opt-in feature.

## What
- `agent/internal/gamma`: a reconciler watching `HTTPRoute(parentRef=Service)` cluster-wide → a `service → []proxy.GammaRoute` map (matches, weighted backends resolved to `<backend>.<meshDomain>` clusters + bare service for deps, request timeout). Producer routes (all clients of the service); per-namespace consumer overrides are a follow-up.
- **cache**: `serviceRoutes` (depMu-guarded) + `SetServiceRoutes` (signals a scoped rebuild on change). `cluster.go`'s per-service outbound vhost uses `BuildOutboundServiceVirtualHost(...gammaRoutes[svc])`; `dependencySetLocked` unions a depended-on service's rule backends so their EDS clusters generate (the demand-scoped integration).
- **proxy**: `BuildOutboundServiceVirtualHost` + `GammaRoute/Match/Backend` — matches → routes, weighted backends → `WeightedClusters` + timeout + retry, **additive** trailing default to the service's own cluster (unmatched paths still reach the service).
- Wired into `agent` (`--gamma`); registers `gateway.networking.k8s.io` + watches HTTPRoutes **only when enabled**.
- Chart: `agent.gamma`; passes `--gamma`; agent ClusterRole reads `httproutes` cluster-wide when on. `0.22.0 → 0.23.0`.

## Safety
Default-off and the route primitive degenerates to the existing passthrough vhost when a service has no rules, so the core snapshot/dependency path is byte-identical until `--gamma` is set. Full agent test suite green (cache/snapshot tests unchanged).

## Tests
GammaRoute primitive (matches/weights/additive-default), reconciler mapping (`serviceParents`, `buildGammaRoute` incl. timeout parse), cache snapshot path.

## Deferred (follow-ups)
Consumer per-namespace overrides, per-port backends, request mirroring, `GRPCRoute`, full status conditions.

e2e on talos to follow (a producer canary split + header route over existing services).