### PR TITLE
feat(registrar): generate selectorless mesh-service VIPs (proposal 018, Phase 3a — PR 1)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.23.0-{GIT_COMMIT}"
+version: "0.24.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/registrar-deployment.yaml
+++ b/charts/aether/templates/registrar-deployment.yaml
@@ -51,6 +51,9 @@ spec:
             - "--region={{ .Values.registrar.region }}"
             {{- end }}
             - "--grpc-address=:{{ .Values.registrar.service.targetPort }}"
+            {{- if .Values.registrar.generateMeshServices }}
+            - "--generate-mesh-services"
+            {{- end }}
             - "--spire-enabled={{ .Values.spire.enabled }}"
             {{- if .Values.spire.enabled }}
             {{- with .Values.spire.trustDomain }}

--- a/charts/aether/templates/registrar-rbac.yaml
+++ b/charts/aether/templates/registrar-rbac.yaml
@@ -11,6 +11,13 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list", "get", "watch"]
+  {{- if .Values.registrar.generateMeshServices }}
+  # Transparent-capture VIPs (proposal 018, Phase 3a): the leader registrar
+  # creates/prunes selectorless mesh Services across namespaces.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "get", "watch", "create", "update", "patch", "delete"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -256,6 +256,11 @@ registrar:
     targetPort: 8443
   # Registry backend (`--registry-backend`): kubernetes, dynamodb, etcd.
   registryBackend: kubernetes
+  # Transparent-capture VIPs (proposal 018, Phase 3a): the leader registrar projects
+  # the mesh catalog into selectorless k8s Services on the mesh port (ClusterIP +
+  # cluster.local name + annotation; no EndpointSlices). Default off; adds Service
+  # CRUD RBAC only when enabled.
+  generateMeshServices: false
   # Region owning this registrar's etcd partition (etcd backend; proposal 006).
   # Keys are origin-first /aether/v1/regions/<region>/clusters/<clusterName>/…;
   # shared by every registrar on the same regional etcd.

--- a/common/constants/labels.go
+++ b/common/constants/labels.go
@@ -12,4 +12,16 @@ const (
 	// it (kubelet --register-with-taints); the agent tolerates it and removes it
 	// once its CNI socket is up, so a pod's CNI ADD can be handled (issue #261).
 	TaintAgentNotReady = aetherLabelPrefix + "/agent-not-ready"
+
+	// LabelMeshService marks a generated, selectorless k8s Service that fronts a
+	// mesh service as a transparent-capture VIP/name handle (proposal 018, Phase
+	// 3a). The registrar owns these — it lists/prunes by this label.
+	LabelMeshService = aetherLabelPrefix + "/mesh-service"
+
+	// AnnotationMeshService / AnnotationMeshPort link a generated Service to the
+	// mesh service + app port it fronts. The agent reads them to map a captured
+	// ClusterIP (original-dst) back to the registry-backed EDS cluster — endpoints
+	// stay in the registry, the Service is a pure name/VIP/identity handle.
+	AnnotationMeshService = aetherLabelPrefix + "/service"
+	AnnotationMeshPort    = aetherLabelPrefix + "/port"
 )

--- a/registrar/internal/cmd/BUILD.bazel
+++ b/registrar/internal/cmd/BUILD.bazel
@@ -9,10 +9,12 @@ go_library(
     importpath = "github.com/bpalermo/aether/registrar/internal/cmd",
     visibility = ["//registrar:__subpackages__"],
     deps = [
+        "//common/constants",
         "//common/manager",
         "//common/must",
         "//common/spire",
         "//registrar/internal/server",
+        "//registrar/internal/services",
         "//registry",
         "@com_github_aws_aws_sdk_go_v2_config//:config",
         "@com_github_spf13_cobra//:cobra",

--- a/registrar/internal/cmd/config.go
+++ b/registrar/internal/cmd/config.go
@@ -40,6 +40,11 @@ type RegistrarConfig struct {
 	// SyncInterval is how often the registrar polls the external registry
 	SyncInterval time.Duration
 
+	// GenerateMeshServices makes the leader registrar project the mesh catalog into
+	// selectorless k8s Services on the mesh port (transparent-capture VIP/name
+	// handles, proposal 018 Phase 3a). Default off.
+	GenerateMeshServices bool
+
 	// GRPCAddress is the address for the registrar gRPC server
 	GRPCAddress string
 

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -7,10 +7,12 @@ import (
 	"log/slog"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/common/manager"
 	"github.com/bpalermo/aether/common/must"
 	"github.com/bpalermo/aether/common/spire"
 	"github.com/bpalermo/aether/registrar/internal/server"
+	"github.com/bpalermo/aether/registrar/internal/services"
 	"github.com/bpalermo/aether/registry"
 	"github.com/spf13/cobra"
 	"go.opentelemetry.io/otel"
@@ -61,6 +63,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", cfg.RegistryBackend, "Registry backend (kubernetes, dynamodb, or etcd)")
 	rootCmd.Flags().StringSliceVar(&cfg.EtcdEndpoints, "etcd-endpoints", cfg.EtcdEndpoints, "Comma-separated etcd endpoints")
 	rootCmd.Flags().DurationVar(&cfg.SyncInterval, "sync-interval", cfg.SyncInterval, "How often to sync from the registry")
+	rootCmd.Flags().BoolVar(&cfg.GenerateMeshServices, "generate-mesh-services", false, "Project the mesh catalog into selectorless k8s Services on the mesh port (transparent-capture VIPs, proposal 018 Phase 3a)")
 	rootCmd.Flags().StringVar(&cfg.GRPCAddress, "grpc-address", cfg.GRPCAddress, "gRPC listen address")
 
 	// SPIRE on/off is aether system config (inherited from the umbrella globals);
@@ -132,6 +135,22 @@ func runRegistrar(ctx context.Context) (retErr error) {
 	syncer := server.NewSyncer(reg, snapshot, broadcaster, cfg.SyncInterval, l, serverMetrics)
 	if err = m.Add(syncer); err != nil {
 		return fmt.Errorf("failed to add syncer: %w", err)
+	}
+
+	// Transparent-capture VIPs (proposal 018, Phase 3a): the leader registrar
+	// projects the mesh catalog into selectorless k8s Services on the mesh port.
+	// Default off — adds nothing (and no Service-write RBAC) unless enabled.
+	if cfg.GenerateMeshServices {
+		gen := &services.Generator{
+			Client:   m.GetClient(),
+			Snapshot: snapshot,
+			MeshPort: int32(constants.ProxyOutboundPort),
+			Interval: cfg.SyncInterval,
+			Log:      l,
+		}
+		if err = m.Add(gen); err != nil {
+			return fmt.Errorf("failed to add mesh-Service generator: %w", err)
+		}
 	}
 
 	var grpcOpts []grpc.ServerOption

--- a/registrar/internal/services/BUILD.bazel
+++ b/registrar/internal/services/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "services",
+    srcs = ["generator.go"],
+    importpath = "github.com/bpalermo/aether/registrar/internal/services",
+    visibility = ["//registrar:__subpackages__"],
+    deps = [
+        "//api/aether/registry/v1:registry",
+        "//common/constants",
+        "//common/log",
+        "//registrar/internal/server",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/util/intstr",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
+)
+
+go_test(
+    name = "services_test",
+    srcs = ["generator_test.go"],
+    embed = [":services"],
+    deps = [
+        "//api/aether/registry/v1:registry",
+        "//common/constants",
+        "//registrar/internal/server",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
+    ],
+)

--- a/registrar/internal/services/generator.go
+++ b/registrar/internal/services/generator.go
@@ -1,0 +1,160 @@
+// Package services contains the registrar's mesh-Service generator: it projects the
+// mesh service catalog into selectorless k8s Services on the mesh port — transparent-
+// capture VIP/name handles (proposal 018, Phase 3a). Endpoints stay in the registry
+// (the Services carry no selector, so no EndpointSlices); each Service is annotated
+// with the mesh service + app port so the agent can map a captured ClusterIP
+// (original-dst) back to the registry-backed EDS cluster.
+package services
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"time"
+
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
+	commonlog "github.com/bpalermo/aether/common/log"
+	"github.com/bpalermo/aether/registrar/internal/server"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Generator reconciles the registrar snapshot's mesh services into selectorless
+// k8s Services (one per service, in the service's namespace, on MeshPort). It is a
+// leader-elected manager Runnable: only the leader writes Services.
+type Generator struct {
+	client.Client
+	Snapshot *server.Snapshot
+	MeshPort int32
+	Interval time.Duration
+	Log      *slog.Logger
+}
+
+// NeedLeaderElection makes the generator run only on the elected leader (single writer).
+func (g *Generator) NeedLeaderElection() bool { return true }
+
+// Start runs the reconcile loop until the context is cancelled.
+func (g *Generator) Start(ctx context.Context) error {
+	g.Log = commonlog.Named(g.Log, "service-generator")
+	ticker := time.NewTicker(g.Interval)
+	defer ticker.Stop()
+	g.reconcile(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			g.reconcile(ctx)
+		}
+	}
+}
+
+type desiredService struct {
+	service   string
+	namespace string
+	port      uint32
+}
+
+// reconcile makes the managed Services equal the snapshot catalog: create missing,
+// update drifted, prune stale (only Services this generator owns, by label).
+func (g *Generator) reconcile(ctx context.Context) {
+	desired := map[client.ObjectKey]desiredService{}
+	for svc, eps := range g.Snapshot.GetAll(registryv1.Service_PROTOCOL_HTTP) {
+		ep := firstNamespaced(eps)
+		if ep == nil {
+			continue
+		}
+		ns := ep.GetKubernetesMetadata().GetNamespace()
+		desired[client.ObjectKey{Namespace: ns, Name: svc}] = desiredService{service: svc, namespace: ns, port: ep.GetPort()}
+	}
+
+	var managed corev1.ServiceList
+	if err := g.List(ctx, &managed, client.MatchingLabels{constants.LabelMeshService: "true"}); err != nil {
+		g.Log.ErrorContext(ctx, "list managed mesh Services failed", "error", err)
+		return
+	}
+	for i := range managed.Items {
+		s := &managed.Items[i]
+		key := client.ObjectKeyFromObject(s)
+		if _, ok := desired[key]; ok {
+			continue // converged below
+		}
+		if err := g.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
+			g.Log.ErrorContext(ctx, "prune mesh Service failed", "service", key.String(), "error", err)
+		} else {
+			g.Log.InfoContext(ctx, "pruned mesh Service (service gone from registry)", "service", key.String())
+		}
+	}
+	for _, d := range desired {
+		g.apply(ctx, d)
+	}
+}
+
+// apply creates or updates the VIP Service for one mesh service. It NEVER touches a
+// Service it doesn't own — a name collision with a user's Service is logged, not
+// clobbered.
+func (g *Generator) apply(ctx context.Context, d desiredService) {
+	key := client.ObjectKey{Namespace: d.namespace, Name: d.service}
+	port := strconv.Itoa(int(d.port))
+
+	existing := &corev1.Service{}
+	if err := g.Get(ctx, key, existing); err == nil {
+		if existing.Labels[constants.LabelMeshService] != "true" {
+			g.Log.WarnContext(ctx, "a non-aether Service owns this name; skipping mesh VIP", "service", key.String())
+			return
+		}
+		if existing.Annotations[constants.AnnotationMeshPort] == port {
+			return // converged
+		}
+		existing.Annotations[constants.AnnotationMeshService] = d.service
+		existing.Annotations[constants.AnnotationMeshPort] = port
+		if err := g.Update(ctx, existing); err != nil {
+			g.Log.ErrorContext(ctx, "update mesh Service failed", "service", key.String(), "error", err)
+		}
+		return
+	} else if !apierrors.IsNotFound(err) {
+		g.Log.ErrorContext(ctx, "get mesh Service failed", "service", key.String(), "error", err)
+		return
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      d.service,
+			Namespace: d.namespace,
+			Labels:    map[string]string{constants.LabelMeshService: "true"},
+			Annotations: map[string]string{
+				constants.AnnotationMeshService: d.service,
+				constants.AnnotationMeshPort:    port,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			// Selectorless: a pure VIP + cluster.local name handle. Endpoints stay in
+			// the aether registry; the agent maps this ClusterIP -> the EDS cluster.
+			Ports: []corev1.ServicePort{{
+				Name:       "mesh",
+				Port:       g.MeshPort,
+				Protocol:   corev1.ProtocolTCP,
+				TargetPort: intstr.FromInt32(g.MeshPort),
+			}},
+		},
+	}
+	if err := g.Create(ctx, svc); err != nil && !apierrors.IsAlreadyExists(err) {
+		g.Log.ErrorContext(ctx, "create mesh Service failed", "service", key.String(), "error", err)
+	} else if err == nil {
+		g.Log.InfoContext(ctx, "created mesh Service (transparent-capture VIP)", "service", key.String(), "port", port)
+	}
+}
+
+func firstNamespaced(eps []*registryv1.ServiceEndpoint) *registryv1.ServiceEndpoint {
+	for _, ep := range eps {
+		if ep.GetKubernetesMetadata().GetNamespace() != "" {
+			return ep
+		}
+	}
+	return nil
+}

--- a/registrar/internal/services/generator_test.go
+++ b/registrar/internal/services/generator_test.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
+	"github.com/bpalermo/aether/registrar/internal/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func seed(svc, ns string, port uint32) *server.Snapshot {
+	s := server.NewSnapshot()
+	s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
+		svc: {registryv1.Service_PROTOCOL_HTTP: {{
+			Ip:                 "10.0.0.1",
+			Port:               port,
+			KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{Namespace: ns},
+		}}},
+	})
+	return s
+}
+
+func newGen(snap *server.Snapshot, objs ...client.Object) (*Generator, client.Client) {
+	c := fake.NewClientBuilder().WithObjects(objs...).Build()
+	return &Generator{Client: c, Snapshot: snap, MeshPort: 18081, Log: slog.New(slog.DiscardHandler)}, c
+}
+
+func get(t *testing.T, c client.Client, ns, name string) (*corev1.Service, error) {
+	t.Helper()
+	s := &corev1.Service{}
+	return s, c.Get(context.Background(), types.NamespacedName{Namespace: ns, Name: name}, s)
+}
+
+func TestGenerator_CreatesSelectorlessMeshService(t *testing.T) {
+	g, c := newGen(seed("svc-1", "aether-test", 8080))
+	g.reconcile(context.Background())
+
+	svc, err := get(t, c, "aether-test", "svc-1")
+	require.NoError(t, err)
+	assert.Equal(t, "true", svc.Labels[constants.LabelMeshService])
+	assert.Equal(t, "svc-1", svc.Annotations[constants.AnnotationMeshService])
+	assert.Equal(t, "8080", svc.Annotations[constants.AnnotationMeshPort])
+	assert.Empty(t, svc.Spec.Selector, "selectorless: no EndpointSlices, endpoints stay in the registry")
+	require.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, int32(18081), svc.Spec.Ports[0].Port)
+}
+
+func TestGenerator_PrunesStale(t *testing.T) {
+	stale := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "old", Namespace: "aether-test",
+		Labels: map[string]string{constants.LabelMeshService: "true"},
+	}}
+	g, c := newGen(seed("svc-1", "aether-test", 8080), stale)
+	g.reconcile(context.Background())
+
+	_, err := get(t, c, "aether-test", "old")
+	assert.True(t, apierrors.IsNotFound(err), "managed Service for a vanished mesh service is pruned")
+	_, err = get(t, c, "aether-test", "svc-1")
+	require.NoError(t, err, "current mesh service still has its VIP")
+}
+
+func TestGenerator_DoesNotClobberUserService(t *testing.T) {
+	user := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "aether-test"},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "svc-1"}},
+	}
+	g, c := newGen(seed("svc-1", "aether-test", 8080), user)
+	g.reconcile(context.Background())
+
+	got, err := get(t, c, "aether-test", "svc-1")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"app": "svc-1"}, got.Spec.Selector, "a user's Service of the same name is left untouched")
+	assert.NotEqual(t, "true", got.Labels[constants.LabelMeshService])
+}


### PR DESCRIPTION
**PR 1 of 4** for Phase 3a transparent capture. The leader registrar projects the mesh catalog into **selectorless k8s Services** (ClusterIP + `cluster.local` name) on the mesh port `:18081` — the VIP/name handles capture needs. **Default off** (`--generate-mesh-services`).

## What
- `registrar/internal/services.Generator` — a leader-elected Runnable reconciling `Snapshot.GetAll` → one Service per mesh service, in the service's namespace, on `:18081`, labeled `aether.io/mesh-service` and annotated `aether.io/service` + `aether.io/port`.
- **Selectorless** (no Pod selector → **no EndpointSlices**): endpoints stay in the aether registry; the Service is a pure VIP/name/identity handle. The agent (PR 3) maps the ClusterIP (`original_dst`) + annotation → the registry-backed EDS cluster.
- Prunes managed Services for vanished services; **never clobbers** a user's Service of the same name (ownership guard by label).
- Chart: `registrar.generateMeshServices`; ClusterRole gains `services` CRUD only when on. `0.23.0 → 0.24.0`.

## Tests
create (selectorless + labels/annotations/port), prune-stale, don't-clobber-user-Service.

## Roadmap
PR 2 proxy capture listener (`original_dst` + protocol-detect), PR 3 agent ClusterIP→service map, PR 4 CNI dst-18081 redirect (the networking-critical piece, gates the e2e). Multi-port (per-port Services) deferred. All default-off.