### PR TITLE
feat(proxy): transparent-capture listener + route table (proposal 018, Phase 3a — PR 2)

### DIFF
--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "proxy",
     srcs = [
         "accesslog.go",
+        "capture.go",
         "cluster.go",
         "edge.go",
         "egress.go",
@@ -46,6 +47,8 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/on_demand/v3:on_demand",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/router/v3:router",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/listener/http_inspector/v3:http_inspector",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/listener/original_dst/v3:original_dst",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/listener/tls_inspector/v3:tls_inspector",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/set_filter_state/v3:set_filter_state",
@@ -67,6 +70,7 @@ go_test(
     name = "proxy_test",
     srcs = [
         "accesslog_test.go",
+        "capture_test.go",
         "edge_test.go",
         "egress_test.go",
         "endpoint_test.go",

--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -1,0 +1,139 @@
+package proxy
+
+import (
+	"fmt"
+
+	"github.com/bpalermo/aether/agent/internal/xds/config"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	http_inspectorv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/http_inspector/v3"
+	original_dstv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/original_dst/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// CaptureHTTPRouteName is the RDS route configuration the per-pod transparent-capture
+// listeners use (proposal 018, Phase 3a). It maps cluster.local authorities (the
+// generated mesh-Service names) to the registry-backed service clusters.
+const CaptureHTTPRouteName = "cap_http"
+
+const (
+	listenerFilterOriginalDstName   = "envoy.filters.listener.original_dst"
+	listenerFilterHTTPInspectorName = "envoy.filters.listener.http_inspector"
+)
+
+// CaptureListenerName returns the per-pod transparent-capture listener name.
+func CaptureListenerName(cniPod *cniv1.CNIPod) string {
+	return fmt.Sprintf("capture_%s", cniPod.GetName())
+}
+
+// GenerateCaptureListener builds the per-pod transparent-capture listener (proposal
+// 018, Phase 3a): bound to capturePort inside the pod netns, it accepts the outbound
+// traffic the CNI redirects from a mesh ClusterIP:meshPort, recovers the original
+// destination, and routes by cluster.local authority (the request Host) to the
+// service's registry-backed EDS cluster — the same SPIRE-mTLS egress path the
+// explicit :18081 listener serves. HTTP only for now; the TCP-over-mTLS floor is a
+// follow-up. Default off (no listener is generated unless transparent capture is on).
+func GenerateCaptureListener(cniPod *cniv1.CNIPod, capturePort uint32, meshDomain string, emitStatsPod bool) (*listenerv3.Listener, error) {
+	if cniPod == nil {
+		return nil, fmt.Errorf("pod is required")
+	}
+	if cniPod.GetNetworkNamespace() == "" {
+		return nil, fmt.Errorf("network namespace is required")
+	}
+
+	return &listenerv3.Listener{
+		Name: CaptureListenerName(cniPod),
+		Address: &corev3.Address{
+			Address: &corev3.Address_SocketAddress{
+				SocketAddress: &corev3.SocketAddress{
+					Protocol: corev3.SocketAddress_TCP,
+					// 0.0.0.0: the CNI REDIRECTs the original ClusterIP dst to this
+					// port on the pod's loopback/interface; the bind must catch it.
+					Address: defaultInboundAddress,
+					PortSpecifier: &corev3.SocketAddress_PortValue{
+						PortValue: capturePort,
+					},
+					NetworkNamespaceFilepath: cniPod.GetNetworkNamespace(),
+				},
+			},
+		},
+		// original_dst recovers the pre-REDIRECT ClusterIP:meshPort (SO_ORIGINAL_DST);
+		// http_inspector lets the AUTO codec detect HTTP/1 vs HTTP/2 on the captured
+		// stream. use_original_dst keeps the recovered destination on the connection.
+		ListenerFilters:               buildCaptureListenerFilters(),
+		UseOriginalDst:                wrapperspb.Bool(true),
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		StatPrefix:                    fmt.Sprintf("capture_%s", cniPod.GetName()),
+		TrafficDirection:              corev3.TrafficDirection_OUTBOUND,
+		FilterChains: []*listenerv3.FilterChain{
+			buildCaptureHTTPFilterChain(cniPod, meshDomain, emitStatsPod),
+		},
+	}, nil
+}
+
+// buildCaptureListenerFilters: recover the original destination, then sniff HTTP.
+func buildCaptureListenerFilters() []*listenerv3.ListenerFilter {
+	return []*listenerv3.ListenerFilter{
+		listenerFilter(listenerFilterOriginalDstName, &original_dstv3.OriginalDst{}),
+		listenerFilter(listenerFilterHTTPInspectorName, &http_inspectorv3.HttpInspector{}),
+	}
+}
+
+// buildCaptureHTTPFilterChain mirrors the outbound HTTP chain but serves the capture
+// route table (cluster.local authorities) over RDS. Same readiness/subset/on-demand/
+// stats filters and per-source mTLS egress path.
+func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool) *listenerv3.FilterChain {
+	hcm := buildHTTPConnectionManager("capture_http", ReporterSource, cniPod.GetName(), cniPod.GetNamespace(), nil)
+
+	prefix := []*http_connection_managerv3.HttpFilter{
+		readinessHttpFilter(),
+		subsetHeadersHttpFilter(),
+		onDemandHttpFilter(),
+		outboundStatsFilter(cniPod, meshDomain, emitStatsPod),
+	}
+	hcm.HttpFilters = append(prefix, hcm.HttpFilters...)
+
+	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
+		Rds: &http_connection_managerv3.Rds{
+			RouteConfigName: CaptureHTTPRouteName,
+			ConfigSource:    config.XDSConfigSourceADS(),
+		},
+	}
+
+	return &listenerv3.FilterChain{
+		Name: fmt.Sprintf("capture_%s", cniPod.GetName()),
+		Filters: []*listenerv3.Filter{
+			buildNetworkNamespaceFilterState(),
+			buildHTTPConnectionManagerFilter(hcm),
+		},
+	}
+}
+
+// BuildCaptureRouteConfiguration builds the transparent-capture route table: the
+// given cluster.local authority -> service-cluster virtual hosts (built by the agent
+// from the generated mesh Services), plus a default 404 for unknown authorities.
+func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
+	return &routev3.RouteConfiguration{
+		Name:         CaptureHTTPRouteName,
+		VirtualHosts: append(vhosts, captureNotFoundVirtualHost()),
+	}
+}
+
+// captureNotFoundVirtualHost 404s any captured authority with no generated Service.
+func captureNotFoundVirtualHost() *routev3.VirtualHost {
+	return &routev3.VirtualHost{
+		Name:    "capture_not_found",
+		Domains: []string{"*"},
+		Routes: []*routev3.Route{
+			{
+				Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
+				Action: &routev3.Route_DirectResponse{
+					DirectResponse: &routev3.DirectResponseAction{Status: 404},
+				},
+			},
+		},
+	}
+}

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -1,0 +1,61 @@
+package proxy
+
+import (
+	"testing"
+
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateCaptureListener(t *testing.T) {
+	pod := &cniv1.CNIPod{Name: "p1", NetworkNamespace: "/var/run/netns/p1"}
+	l, err := GenerateCaptureListener(pod, 15001, "aether.internal", false)
+	require.NoError(t, err)
+
+	assert.Equal(t, "capture_p1", l.GetName())
+	sa := l.GetAddress().GetSocketAddress()
+	assert.Equal(t, "0.0.0.0", sa.GetAddress())
+	assert.Equal(t, uint32(15001), sa.GetPortValue())
+	assert.Equal(t, "/var/run/netns/p1", sa.GetNetworkNamespaceFilepath())
+	assert.True(t, l.GetUseOriginalDst().GetValue(), "use_original_dst set")
+
+	// listener filters: original_dst then http_inspector.
+	require.Len(t, l.GetListenerFilters(), 2)
+	assert.Equal(t, listenerFilterOriginalDstName, l.GetListenerFilters()[0].GetName())
+	assert.Equal(t, listenerFilterHTTPInspectorName, l.GetListenerFilters()[1].GetName())
+
+	// the HCM serves the capture RDS route table.
+	require.Len(t, l.GetFilterChains(), 1)
+	filters := l.GetFilterChains()[0].GetFilters()
+	hcmFilter := filters[len(filters)-1]
+	var hcm http_connection_managerv3.HttpConnectionManager
+	require.NoError(t, hcmFilter.GetTypedConfig().UnmarshalTo(&hcm))
+	assert.Equal(t, CaptureHTTPRouteName, hcm.GetRds().GetRouteConfigName())
+}
+
+func TestGenerateCaptureListener_RequiresNetns(t *testing.T) {
+	_, err := GenerateCaptureListener(&cniv1.CNIPod{Name: "p1"}, 15001, "aether.internal", false)
+	assert.Error(t, err)
+}
+
+func TestBuildCaptureRouteConfiguration(t *testing.T) {
+	// cluster.local authority -> service cluster, reusing the outbound vhost builder.
+	vh := BuildOutboundClusterVirtualHost(
+		ServiceClusterName("svc-1", "aether.internal"),
+		[]string{"svc-1.aether-test.svc.cluster.local", "svc-1.aether-test.svc.cluster.local:18081"},
+	)
+	rc := BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vh})
+	assert.Equal(t, CaptureHTTPRouteName, rc.GetName())
+	require.Len(t, rc.GetVirtualHosts(), 2, "the service vhost + the 404 default")
+
+	got := rc.GetVirtualHosts()[0]
+	assert.Contains(t, got.GetDomains(), "svc-1.aether-test.svc.cluster.local:18081")
+	assert.Equal(t, "svc-1.aether.internal", got.GetRoutes()[0].GetRoute().GetCluster())
+
+	def := rc.GetVirtualHosts()[1]
+	assert.Equal(t, []string{"*"}, def.GetDomains())
+	assert.Equal(t, uint32(404), def.GetRoutes()[0].GetDirectResponse().GetStatus())
+}

--- a/common/constants/proxy.go
+++ b/common/constants/proxy.go
@@ -5,6 +5,11 @@ const (
 	// binds inside each pod's network namespace. The CNI plugin probes this
 	// address (from within the netns) to confirm the data plane is serving.
 	ProxyOutboundPort = 18081
+	// ProxyCapturePort is the port the per-pod transparent-capture listener binds
+	// inside the pod netns (proposal 018, Phase 3a). The CNI redirects outbound
+	// TCP to a mesh ClusterIP:ProxyOutboundPort here; the listener recovers the
+	// original ClusterIP and routes by cluster.local authority. Default off.
+	ProxyCapturePort = 15001
 	// ProxyReadinessPath is the path matched by the non-pass-through
 	// health_check filter on every outbound listener. A 200 proves the listener
 	// is active on worker threads in that netns; a 503 means the answering


### PR DESCRIPTION
**PR 2 of 4** for Phase 3a. The per-pod Envoy primitives for transparent capture. **Purely additive** — nothing generates a capture listener until PR 3 wires the cache, so this is a **no-op merge**.

## What
- `proxy.GenerateCaptureListener` — a per-pod listener bound to the capture port (`constants.ProxyCapturePort=15001`) inside the pod netns, with `original_dst` + `http_inspector` listener filters and `use_original_dst`. The CNI (PR 4) redirects outbound TCP to a mesh `ClusterIP:18081` here; the listener recovers the original dest and routes by **cluster.local authority (request Host)** over RDS `cap_http`. Same readiness/subset/on-demand/stats filters + per-source SPIRE-mTLS egress path as the explicit `:18081` listener. HTTP only; TCP-over-mTLS floor is a follow-up.
- `proxy.BuildCaptureRouteConfiguration` — the `cap_http` table: the agent's cluster.local authority → service-cluster vhosts (reusing `BuildOutboundClusterVirtualHost`) + a 404 default for unknown authorities.

## Tests
listener bind/netns/`use_original_dst`/filters/RDS name; route-config vhost mapping + 404 default.

## Roadmap
PR 3 agent `ClusterIP`/cluster.local → service map (builds `cap_http` + per-pod capture listeners), PR 4 CNI dst-18081 redirect (networking-critical, gates the e2e). All default-off.