### PR TITLE
feat(agent): wire transparent-capture listeners + cap_http (proposal 018, Phase 3a — PR 3)

### DIFF
--- a/agent/internal/capture/BUILD.bazel
+++ b/agent/internal/capture/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "capture",
+    srcs = ["reconciler.go"],
+    importpath = "github.com/bpalermo/aether/agent/internal/capture",
+    visibility = ["//agent:__subpackages__"],
+    deps = [
+        "//common/constants",
+        "//common/log",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/builder",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/predicate",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile",
+    ],
+)
+
+go_test(
+    name = "capture_test",
+    srcs = ["reconciler_test.go"],
+    embed = [":capture"],
+    deps = [
+        "//common/constants",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile",
+    ],
+)

--- a/agent/internal/capture/reconciler.go
+++ b/agent/internal/capture/reconciler.go
@@ -1,0 +1,70 @@
+// Package capture contains the node agent's transparent-capture controller: it
+// watches the generated selectorless mesh Services (proposal 018, Phase 3a) and
+// projects their cluster.local authorities into the snapshot cache, which builds the
+// cap_http route table the per-pod capture listeners serve. Endpoints stay in the
+// registry; this only maps a captured authority to its existing service cluster.
+package capture
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/bpalermo/aether/common/constants"
+	commonlog "github.com/bpalermo/aether/common/log"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// AuthoritySink receives the projected mesh service -> cluster.local FQDN map.
+type AuthoritySink interface {
+	SetCaptureAuthorities(authorities map[string]string)
+}
+
+// Reconciler watches the generated mesh Services (labeled aether.io/mesh-service) and
+// replaces, on any change, the cache's service -> cluster.local authority map.
+// Level-based: each reconcile re-lists, so adds/updates/deletes converge.
+type Reconciler struct {
+	client.Client
+
+	Sink AuthoritySink
+	Log  *slog.Logger
+}
+
+// SetupWithManager registers the reconciler to watch mesh Services only.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	r.Log = commonlog.Named(r.Log, "capture")
+	meshService := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		return o.GetLabels()[constants.LabelMeshService] == "true"
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}, builder.WithPredicates(meshService)).
+		Named("capture").
+		Complete(r)
+}
+
+// Reconcile re-lists the mesh Services and projects their cluster.local authorities.
+func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	list := &corev1.ServiceList{}
+	if err := r.List(ctx, list, client.MatchingLabels{constants.LabelMeshService: "true"}); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	authorities := make(map[string]string, len(list.Items))
+	for i := range list.Items {
+		s := &list.Items[i]
+		svc := s.Annotations[constants.AnnotationMeshService]
+		if svc == "" {
+			svc = s.Name
+		}
+		authorities[svc] = fmt.Sprintf("%s.%s.svc.cluster.local", s.Name, s.Namespace)
+	}
+
+	r.Sink.SetCaptureAuthorities(authorities)
+	r.Log.DebugContext(ctx, "projected capture authorities", "meshServices", len(list.Items))
+	return reconcile.Result{}, nil
+}

--- a/agent/internal/capture/reconciler_test.go
+++ b/agent/internal/capture/reconciler_test.go
@@ -1,0 +1,37 @@
+package capture
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/bpalermo/aether/common/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type fakeSink struct{ got map[string]string }
+
+func (f *fakeSink) SetCaptureAuthorities(a map[string]string) { f.got = a }
+
+func TestReconcile_ProjectsClusterLocalAuthorities(t *testing.T) {
+	mesh := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
+		Name: "svc-1", Namespace: "aether-test",
+		Labels:      map[string]string{constants.LabelMeshService: "true"},
+		Annotations: map[string]string{constants.AnnotationMeshService: "svc-1", constants.AnnotationMeshPort: "8080"},
+	}}
+	// A non-mesh Service of the same shape must be ignored (label-scoped List).
+	user := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"}}
+
+	c := fake.NewClientBuilder().WithObjects(mesh, user).Build()
+	sink := &fakeSink{}
+	r := &Reconciler{Client: c, Sink: sink, Log: slog.New(slog.DiscardHandler)}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"svc-1": "svc-1.aether-test.svc.cluster.local"}, sink.got)
+}

--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//agent/constants",
+        "//agent/internal/capture",
         "//agent/internal/cni/server",
         "//agent/internal/edge",
         "//agent/internal/edge/gatewayapi",

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -91,6 +91,13 @@ type AgentConfig struct {
 	// HTTPRoutes parented to a Service and enriches the outbound routes (proposal
 	// 018, Phase 2). Default off — a no-op until enabled.
 	Gamma bool
+
+	// TransparentCapture enables transparent capture (proposal 018, Phase 3a): the
+	// agent generates per-pod capture listeners + the cap_http route table and
+	// watches the generated mesh Services for their cluster.local authorities. Pairs
+	// with the registrar's --generate-mesh-services and the CNI dst-18081 redirect.
+	// Default off.
+	TransparentCapture bool
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves when
 	// GatewayAPI is set.
 	GatewayClassName string

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"log/slog"
 
 	"github.com/bpalermo/aether/agent/constants"
+	"github.com/bpalermo/aether/agent/internal/capture"
 	cniServer "github.com/bpalermo/aether/agent/internal/cni/server"
 	"github.com/bpalermo/aether/agent/internal/gamma"
 	"github.com/bpalermo/aether/agent/internal/node"
@@ -113,6 +114,7 @@ func init() {
 	// startup taint from this node once the CNI server is serving.
 	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
 	rootCmd.Flags().BoolVar(&cfg.Gamma, "gamma", false, "Enable GAMMA east-west L7 routing: watch HTTPRoutes parented to a Service and enrich the node proxy's outbound routes (proposal 018, Phase 2)")
+	rootCmd.Flags().BoolVar(&cfg.TransparentCapture, "transparent-capture", false, "Enable transparent capture: per-pod capture listeners + cap_http route table from the generated mesh Services (proposal 018, Phase 3a)")
 }
 
 // registerSharedFlags registers the flags common to the node agent (root) and
@@ -259,6 +261,7 @@ func runAgent(ctx context.Context) (retErr error) {
 	snapshotCache := cache.NewSnapshotCache(cfg.NodeName, l)
 	snapshotCache.SetMeshDomain(cfg.MeshDomain)
 	snapshotCache.SetEmitStatsPod(cfg.EmitStatsPod)
+	snapshotCache.SetCaptureEnabled(cfg.TransparentCapture)
 	// Global access-log config, set once before the cache builds any listener.
 	proxy.SetAccessLogConfig(proxy.AccessLogConfig{
 		Enabled:           cfg.AccessLogsEnabled,
@@ -331,6 +334,20 @@ func runAgent(ctx context.Context) (retErr error) {
 		}
 		if err = gammaReconciler.SetupWithManager(m); err != nil {
 			return fmt.Errorf("failed to set up GAMMA reconciler: %w", err)
+		}
+	}
+
+	// Transparent capture (proposal 018, Phase 3a): watch the generated mesh
+	// Services and project their cluster.local authorities so the cache can build
+	// the cap_http route table. Default off — registers no Service watch unless set.
+	if cfg.TransparentCapture {
+		captureReconciler := &capture.Reconciler{
+			Client: m.GetClient(),
+			Sink:   snapshotCache,
+			Log:    l,
+		}
+		if err = captureReconciler.SetupWithManager(m); err != nil {
+			return fmt.Errorf("failed to set up transparent-capture reconciler: %w", err)
 		}
 	}
 

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "cache",
     srcs = [
         "cache.go",
+        "capture.go",
         "cluster.go",
         "dependencies.go",
         "edge.go",

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -161,6 +161,17 @@ type SnapshotCache struct {
 	// injection is skipped.
 	nodeSpiffeID string
 
+	// captureEnabled turns on transparent capture (proposal 018, Phase 3a): per-pod
+	// capture listeners + the cap_http route table. Set once before the manager
+	// starts (SetCaptureEnabled); read without locking. Default off.
+	captureEnabled bool
+	// captureMu guards captureAuthorities: a mesh service -> its cluster.local FQDN
+	// (<svc>.<ns>.svc.cluster.local), fed by the agent's capture reconciler from the
+	// generated mesh Services. The cap_http route table maps each in-scope service's
+	// authority to its <svc>.<meshDomain> cluster.
+	captureMu          sync.RWMutex
+	captureAuthorities map[string]string
+
 	version *atomic.Uint64
 }
 
@@ -173,6 +184,11 @@ type SnapshotCache struct {
 type listenerEntry struct {
 	inbound  types.Resource
 	outbound types.Resource
+	// capture is the per-pod transparent-capture listener (proposal 018, Phase 3a):
+	// nil unless transparent capture is enabled. Bound to the capture port in the
+	// pod netns; routes CNI-redirected ClusterIP:18081 traffic by cluster.local
+	// authority over the cap_http route table.
+	capture types.Resource
 	// appClusters holds one per-port application cluster (multi-port pods); the
 	// SNI-selected inbound filter chains forward decrypted traffic to these.
 	appClusters []types.Resource
@@ -233,16 +249,17 @@ func NewSnapshotCache(nodeName string, log *slog.Logger) *SnapshotCache {
 		// Initialize the resource maps up front so callers never assign to a nil
 		// map. LoadListenersFromStorage assigns directly (no lazy init), which
 		// panics on agent restart when pods already exist in local storage.
-		listeners:      make(map[string]listenerEntry),
-		clusters:       make(map[string]clusterEntry),
-		secrets:        make(map[string]*tlsv3.Secret),
-		localWorkloads: make(map[string]string),
-		podDeps:        make(map[string]podDependencies),
-		observedDeps:   make(map[string]time.Time),
-		staticDeps:     make(map[string]struct{}),
-		serviceRoutes:  make(map[string][]proxy.GammaRoute),
-		depChanged:     make(chan struct{}, 1),
-		version:        atomic.NewUint64(0),
+		listeners:          make(map[string]listenerEntry),
+		clusters:           make(map[string]clusterEntry),
+		secrets:            make(map[string]*tlsv3.Secret),
+		localWorkloads:     make(map[string]string),
+		podDeps:            make(map[string]podDependencies),
+		observedDeps:       make(map[string]time.Time),
+		staticDeps:         make(map[string]struct{}),
+		serviceRoutes:      make(map[string][]proxy.GammaRoute),
+		captureAuthorities: make(map[string]string),
+		depChanged:         make(chan struct{}, 1),
+		version:            atomic.NewUint64(0),
 	}
 }
 

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -1,0 +1,76 @@
+package cache
+
+import (
+	"fmt"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	"github.com/bpalermo/aether/common/constants"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+)
+
+// generateCaptureListener builds a pod's transparent-capture listener, or returns
+// nil when capture is disabled (so the listenerEntry carries no capture resource).
+func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Resource, error) {
+	if !c.captureEnabled {
+		return nil, nil
+	}
+	l, err := proxy.GenerateCaptureListener(cniPod, constants.ProxyCapturePort, c.meshDomain, c.emitStatsPod)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// SetCaptureEnabled turns transparent capture (proposal 018, Phase 3a) on. Call once
+// before the manager starts: it gates per-pod capture listener generation and the
+// cap_http route table.
+func (c *SnapshotCache) SetCaptureEnabled(v bool) { c.captureEnabled = v }
+
+// SetCaptureAuthorities replaces the mesh service -> cluster.local FQDN map (fed by
+// the agent's capture reconciler from the generated mesh Services) and signals a
+// snapshot rebuild on change so cap_http re-derives.
+func (c *SnapshotCache) SetCaptureAuthorities(authorities map[string]string) {
+	c.captureMu.Lock()
+	changed := !equalStringMaps(c.captureAuthorities, authorities)
+	c.captureAuthorities = authorities
+	c.captureMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// captureVhosts builds the cap_http virtual hosts: each in-scope service that has a
+// cluster.local authority routes (both the portless and :meshPort spellings) to its
+// <svc>.<meshDomain> cluster. Scoped to the dependency set so cap_http only references
+// clusters the scoped snapshot carries; unknown authorities hit the 404 default.
+func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
+	deps := c.DependencySet()
+
+	c.captureMu.RLock()
+	defer c.captureMu.RUnlock()
+	vhosts := make([]*routev3.VirtualHost, 0, len(c.captureAuthorities))
+	for svc, fqdn := range c.captureAuthorities {
+		if _, ok := deps[svc]; !ok {
+			continue
+		}
+		vhosts = append(vhosts, proxy.BuildOutboundClusterVirtualHost(
+			proxy.ServiceClusterName(svc, c.meshDomain),
+			[]string{fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort)},
+		))
+	}
+	return vhosts
+}
+
+func equalStringMaps(a, b map[string]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		if b[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -34,6 +34,10 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	if err != nil {
 		return err
 	}
+	capture, err := c.generateCaptureListener(cniPod)
+	if err != nil {
+		return err
+	}
 
 	c.listenerMu.Lock()
 	if c.listeners == nil {
@@ -42,6 +46,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	c.listeners[netns] = listenerEntry{
 		inbound:       inbound,
 		outbound:      outbound,
+		capture:       capture,
 		appClusters:   clustersToResources(appClusters),
 		healthCluster: healthCluster,
 	}
@@ -110,6 +115,9 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 	probeClusters := make([]string, 0, len(c.listeners))
 	for _, entry := range c.listeners {
 		resources = append(resources, entry.inbound, entry.outbound)
+		if entry.capture != nil {
+			resources = append(resources, entry.capture)
+		}
 		if hc, ok := entry.healthCluster.(*clusterv3.Cluster); ok && hc != nil {
 			probeClusters = append(probeClusters, hc.GetName())
 		}
@@ -190,10 +198,17 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 			errs = append(errs, listenerErr)
 			continue
 		}
+		capture, captureErr := c.generateCaptureListener(pod)
+		if captureErr != nil {
+			c.log.ErrorContext(ctx, "failed to generate capture listener for pod", "error", captureErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())
+			errs = append(errs, captureErr)
+			continue
+		}
 
 		c.listeners[netns] = listenerEntry{
 			inbound:       inbound,
 			outbound:      outbound,
+			capture:       capture,
 			appClusters:   clustersToResources(appClusters),
 			healthCluster: healthCluster,
 		}

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -86,8 +86,21 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 		// reference resolves; the catch-all 404 vhost handles unmatched
 		// authorities. No ODCDS.
 		resources[resourcev3.RouteType] = []types.Resource{proxy.BuildEdgeRouteConfiguration(c.virtualHostVhosts())}
-	} else if len(vhosts) > 0 {
-		resources[resourcev3.RouteType] = []types.Resource{proxy.BuildOutboundRouteConfiguration(vhosts, c.meshDomain)}
+	} else {
+		var routes []types.Resource
+		if len(vhosts) > 0 {
+			routes = append(routes, proxy.BuildOutboundRouteConfiguration(vhosts, c.meshDomain))
+		}
+		// Transparent capture (proposal 018, Phase 3a): the cap_http table the per-pod
+		// capture listeners reference over RDS. Always emitted when capture is on (it
+		// carries a 404 default) so the listeners' RDS resolves even with no in-scope
+		// cluster.local authorities yet.
+		if c.captureEnabled {
+			routes = append(routes, proxy.BuildCaptureRouteConfiguration(c.captureVhosts()))
+		}
+		if len(routes) > 0 {
+			resources[resourcev3.RouteType] = routes
+		}
 	}
 
 	c.log.DebugContext(ctx, "setting snapshot", "version", v,

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.24.0-{GIT_COMMIT}"
+version: "0.25.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -66,6 +66,9 @@ spec:
             {{- if .Values.agent.gamma }}
             - "--gamma"
             {{- end }}
+            {{- if .Values.agent.transparentCapture }}
+            - "--transparent-capture"
+            {{- end }}
             # Aether system config, inherited from the umbrella global block.
             - "--mesh-domain={{ .Values.meshDomain }}"
             {{- if .Values.otel.enabled }}

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -18,6 +18,13 @@ rules:
     resources: ["httproutes"]
     verbs: ["list", "get", "watch"]
   {{- end }}
+  {{- if .Values.agent.transparentCapture }}
+  # Transparent capture (proposal 018, Phase 3a): watch the generated mesh Services
+  # for their cluster.local authorities.
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "get", "watch"]
+  {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -100,6 +100,11 @@ agent:
   # header / timeout). Requires the Gateway API CRDs. Default off — a no-op, and
   # adds the cluster-wide httproutes RBAC only when enabled.
   gamma: false
+  # Transparent capture (proposal 018, Phase 3a): per-pod capture listeners + the
+  # cap_http route table built from the generated mesh Services. Pairs with
+  # registrar.generateMeshServices (the VIPs) and the CNI dst-18081 redirect.
+  # Default off — adds the services-read RBAC only when enabled.
+  transparentCapture: false
   # Image as repository + digest (digest-pinned for immutability). Mirror to a
   # private registry by overriding `repository` alone; the digest is preserved.
   image:


### PR DESCRIPTION
**PR 3 of 4** for Phase 3a. Makes PR 1's mesh-Service VIPs (#273) and PR 2's capture primitives (#274) **live on the node proxy**. **Default off** (`--transparent-capture` / `agent.transparentCapture`): the cache generates nothing extra and the agent watches no Services until enabled.

## What
- **cache**: `captureEnabled` (`SetCaptureEnabled`) + `captureAuthorities` (service → cluster.local FQDN, `SetCaptureAuthorities`). Per-pod capture listeners generated alongside inbound/outbound in `AddPod`/`LoadListenersFromStorage` and emitted from `Listeners()`; `generateSnapshot` emits the `cap_http` `RouteConfiguration` whenever capture is on. `captureVhosts` maps each in-scope service's cluster.local authority (portless + `:18081`) → its `<svc>.<meshDomain>` cluster, **scoped to the dependency set** (unknown → 404 default).
- **agent/internal/capture.Reconciler**: watches the generated mesh Services (label-scoped) → projects their cluster.local authorities into the cache. **Endpoints stay in the registry** — this only maps an authority to its existing EDS cluster.
- Wired into the agent; ClusterRole gains `services` read only when on. `0.24.0 → 0.25.0`.

## Tests
reconciler projects cluster.local authorities (label-scoped, ignores non-mesh Services); existing cache snapshot tests unchanged (default-off).

## Roadmap
PR 4 CNI dst-18081 → `:15001` REDIRECT (networking-critical, before `KUBE-SERVICES`), then the talos e2e: dial `<svc>.<ns>.svc.cluster.local:18081` transparently.