### PR TITLE
feat(cni): per-pod transparent-capture redirect (proposal 018, Phase 3a — PR 4)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -90,6 +90,7 @@ use_repo(
     "com_github_fsnotify_fsnotify",
     "com_github_go_jose_go_jose_v4",
     "com_github_go_logr_logr",
+    "com_github_google_nftables",
     "com_github_google_renameio_v2",
     "com_github_grpc_ecosystem_go_grpc_middleware_v2",
     "com_github_klauspost_compress",

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.25.0-{GIT_COMMIT}"
+version: "0.26.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -43,6 +43,9 @@ spec:
             # from the agent's runtime OTLP in the MeshConfig CR.
             - "--otlp-endpoint={{ . }}"
             {{- end }}
+            {{- if .Values.agent.transparentCapture }}
+            - "--transparent-capture"
+            {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/cni/config/config.go
+++ b/cni/config/config.go
@@ -61,6 +61,13 @@ type AetherConf struct {
 	// Best-effort: a probe timeout is logged, never fails the CNI operation.
 	ReadinessProbeDisabled bool `json:"readiness_probe_disabled"`
 
+	// TransparentCaptureEnabled installs, inside each pod's netns, an nft REDIRECT
+	// of outbound TCP to a mesh ClusterIP:18081 -> the pod's local capture listener
+	// :15001 (proposal 018, Phase 3a). Off by default; pairs with the agent's
+	// --transparent-capture and the registrar's --generate-mesh-services. The
+	// loopback exclusion keeps the explicit 127.0.0.1:18081 fast-lane working.
+	TransparentCaptureEnabled bool `json:"transparent_capture_enabled"`
+
 	// OTLPEndpoint enables OTel telemetry (traces + metrics) pushed to the
 	// given OTLP gRPC collector (host:port, insecure). The plugin binary is
 	// exec'd by the container runtime, so its environment is the runtime's,

--- a/cni/internal/cmd/root.go
+++ b/cni/internal/cmd/root.go
@@ -37,6 +37,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.CNIBinTargetDir, "cni-bin-target-dir", constants.DefaultHostCNIBinDir, "Directory into which to copy the CNI binaries")
 	rootCmd.Flags().StringVar(&cfg.MountedCNINetDir, "mounted-cni-net-dir", constants.DefaultHostCNINetDir, "Directory where CNI network configuration files are located")
 	rootCmd.Flags().StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP gRPC collector endpoint written into the netconf so the CNI plugin pushes traces and metrics (e.g. collector:4317); empty disables plugin telemetry")
+	rootCmd.Flags().BoolVar(&cfg.TransparentCaptureEnabled, "transparent-capture", false, "Write transparent_capture_enabled into the netconf so the CNI plugin installs the per-pod capture redirect (proposal 018, Phase 3a)")
 }
 
 // GetCommand returns the main cobra.Command object for this application

--- a/cni/internal/install/cniconfig.go
+++ b/cni/internal/install/cniconfig.go
@@ -45,6 +45,7 @@ func createCNIConfigFile(ctx context.Context, cfg *InstallerConfig) (string, err
 	pluginConfig.CNIVersion = "0.0.1"
 	pluginConfig.AgentCNIPath = constants.DefaultCNISocketPath
 	pluginConfig.OTLPEndpoint = cfg.OTLPEndpoint
+	pluginConfig.TransparentCaptureEnabled = cfg.TransparentCaptureEnabled
 
 	marshalledJSON, err := json.MarshalIndent(pluginConfig, "", "  ")
 	if err != nil {

--- a/cni/internal/install/config.go
+++ b/cni/internal/install/config.go
@@ -26,6 +26,10 @@ type InstallerConfig struct {
 	// plugin binary pushes traces and metrics to this OTLP gRPC collector.
 	// Empty leaves plugin telemetry disabled.
 	OTLPEndpoint string
+	// TransparentCaptureEnabled writes transparent_capture_enabled into the netconf
+	// so the CNI plugin installs the per-pod capture redirect (proposal 018, Phase
+	// 3a). Off by default.
+	TransparentCaptureEnabled bool
 }
 
 // NewInstallerConfig creates a new InstallerConfig with default values.

--- a/cni/internal/plugin/BUILD.bazel
+++ b/cni/internal/plugin/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "plugin",
     srcs = [
+        "capture.go",
         "client.go",
         "netnspin.go",
         "plugin.go",
@@ -22,6 +23,8 @@ go_library(
         "@com_github_containernetworking_cni//pkg/skel",
         "@com_github_containernetworking_cni//pkg/types",
         "@com_github_containernetworking_cni//pkg/types/100",
+        "@com_github_google_nftables//:nftables",
+        "@com_github_google_nftables//expr",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_grpc//:grpc",
@@ -36,6 +39,7 @@ go_library(
 go_test(
     name = "plugin_test",
     srcs = [
+        "capture_test.go",
         "client_test.go",
         "netnspin_test.go",
         "plugin_test.go",
@@ -45,8 +49,10 @@ go_test(
     deps = [
         "//api/aether/cni/v1:cni",
         "//cni/config",
+        "//common/constants",
         "@com_github_containernetworking_cni//pkg/skel",
         "@com_github_containernetworking_cni//pkg/types",
+        "@com_github_google_nftables//expr",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
@@ -55,6 +61,7 @@ go_test(
         "@org_golang_google_grpc//status",
         "@org_golang_google_grpc//test/bufconn",
         "@org_golang_google_protobuf//types/known/wrapperspb",
+        "@org_golang_x_sys//unix",
         "@org_uber_go_zap//:zap",
     ],
 )

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -1,0 +1,123 @@
+package plugin
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"runtime"
+
+	commonconstants "github.com/bpalermo/aether/common/constants"
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// captureTableName is the nft table the redirect rule lives in, inside the pod netns.
+const captureTableName = "aether_capture"
+
+// installCaptureRedirect programs, inside the pod's network namespace, an nftables
+// REDIRECT of outbound TCP destined for a mesh ClusterIP:<meshPort> to the pod-local
+// transparent-capture listener on <capturePort> (proposal 018, Phase 3a).
+//
+// The rule lives in the POD netns nat/output chain, so it fires before the packet
+// egresses to the host (independent of host kube-proxy/flannel). The loopback
+// exclusion (ip daddr != 127.0.0.0/8) leaves the explicit 127.0.0.1:<meshPort>
+// fast-lane untouched — only ClusterIP traffic is captured. nftables is programmed
+// over netlink (no iptables binary), so it works in the minimal CNI exec environment.
+// The rule dies with the netns on pod teardown; no DEL cleanup is needed.
+//
+// It enters the netns by setns on a locked OS thread (matching netnsDialContext): the
+// netlink socket nftables opens then lives in the pod netns. A failed restore leaves
+// the thread locked so the Go runtime destroys it rather than reusing a poisoned one.
+func installCaptureRedirect(netnsPath string, logger *zap.Logger) error {
+	target, err := os.Open(netnsPath)
+	if err != nil {
+		return fmt.Errorf("opening netns %s: %w", netnsPath, err)
+	}
+	defer func() { _ = target.Close() }()
+
+	runtime.LockOSThread()
+	origin, err := os.Open(fmt.Sprintf("/proc/self/task/%d/ns/net", unix.Gettid()))
+	if err != nil {
+		runtime.UnlockOSThread()
+		return fmt.Errorf("opening current netns: %w", err)
+	}
+	defer func() { _ = origin.Close() }()
+
+	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
+		runtime.UnlockOSThread()
+		return fmt.Errorf("entering netns %s: %w", netnsPath, err)
+	}
+
+	progErr := programCaptureRedirect(logger)
+
+	if err := unix.Setns(int(origin.Fd()), unix.CLONE_NEWNET); err != nil {
+		// Thread poisoned (stuck in the pod netns): keep it locked and let the
+		// goroutine's thread be destroyed rather than reused.
+		return fmt.Errorf("restoring host netns: %w", err)
+	}
+	runtime.UnlockOSThread()
+	return progErr
+}
+
+// programCaptureRedirect adds the nat/output REDIRECT rule in the CURRENT netns.
+func programCaptureRedirect(logger *zap.Logger) error {
+	meshPort := uint16(commonconstants.ProxyOutboundPort)
+	capturePort := uint16(commonconstants.ProxyCapturePort)
+
+	c, err := nftables.New()
+	if err != nil {
+		return fmt.Errorf("open nftables netlink: %w", err)
+	}
+
+	table := c.AddTable(&nftables.Table{Family: nftables.TableFamilyIPv4, Name: captureTableName})
+	chain := c.AddChain(&nftables.Chain{
+		Name:     "output",
+		Table:    table,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookOutput,
+		Priority: nftables.ChainPriorityNATDest,
+	})
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: captureRedirectExprs(meshPort, capturePort),
+	})
+
+	if err := c.Flush(); err != nil {
+		return fmt.Errorf("apply capture redirect (nft flush): %w", err)
+	}
+	logger.Info("installed transparent-capture redirect",
+		zap.Uint16("mesh_port", meshPort), zap.Uint16("capture_port", capturePort))
+	return nil
+}
+
+// captureRedirectExprs builds the rule:
+//
+//	meta l4proto tcp
+//	ip daddr & 255.0.0.0 != 127.0.0.0      (skip the loopback fast-lane)
+//	tcp dport <meshPort>
+//	redirect to :<capturePort>
+func captureRedirectExprs(meshPort, capturePort uint16) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
+		// ip daddr (IPv4 dest = offset 16, len 4), masked to /8, != 127.0.0.0
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 16, Len: 4},
+		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: []byte{0xff, 0x00, 0x00, 0x00}, Xor: []byte{0x00, 0x00, 0x00, 0x00}},
+		&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{127, 0, 0, 0}},
+		// tcp dport == meshPort (transport dest = offset 2, len 2, big-endian)
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(meshPort)},
+		// redirect to capturePort
+		&expr.Immediate{Register: 1, Data: beUint16(capturePort)},
+		&expr.Redir{RegisterProtoMin: 1},
+	}
+}
+
+func beUint16(v uint16) []byte {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, v)
+	return b
+}

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"testing"
+
+	commonconstants "github.com/bpalermo/aether/common/constants"
+	"github.com/google/nftables/expr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestCaptureRedirectExprs verifies the nft rule: tcp + non-loopback daddr +
+// dport meshPort -> redirect to capturePort. A wrong loopback exclusion or port
+// would silently break the explicit fast-lane or fail to capture.
+func TestCaptureRedirectExprs(t *testing.T) {
+	mesh := uint16(commonconstants.ProxyOutboundPort) // 18081
+	cap := uint16(commonconstants.ProxyCapturePort)   // 15001
+	exprs := captureRedirectExprs(mesh, cap)
+	require.Len(t, exprs, 9)
+
+	// l4proto == tcp
+	require.IsType(t, &expr.Meta{}, exprs[0])
+	assert.Equal(t, expr.MetaKeyL4PROTO, exprs[0].(*expr.Meta).Key)
+	require.IsType(t, &expr.Cmp{}, exprs[1])
+	assert.Equal(t, []byte{unix.IPPROTO_TCP}, exprs[1].(*expr.Cmp).Data)
+
+	// loopback exclusion: mask /8 then NEQ 127.0.0.0
+	require.IsType(t, &expr.Bitwise{}, exprs[3])
+	assert.Equal(t, []byte{0xff, 0x00, 0x00, 0x00}, exprs[3].(*expr.Bitwise).Mask)
+	require.IsType(t, &expr.Cmp{}, exprs[4])
+	assert.Equal(t, expr.CmpOpNeq, exprs[4].(*expr.Cmp).Op)
+	assert.Equal(t, []byte{127, 0, 0, 0}, exprs[4].(*expr.Cmp).Data)
+
+	// tcp dport == 18081 (big-endian)
+	require.IsType(t, &expr.Cmp{}, exprs[6])
+	assert.Equal(t, expr.CmpOpEq, exprs[6].(*expr.Cmp).Op)
+	assert.Equal(t, []byte{0x46, 0xA1}, exprs[6].(*expr.Cmp).Data) // 18081
+
+	// redirect to 15001
+	require.IsType(t, &expr.Immediate{}, exprs[7])
+	assert.Equal(t, []byte{0x3A, 0x99}, exprs[7].(*expr.Immediate).Data) // 15001
+	assert.IsType(t, &expr.Redir{}, exprs[8])
+}

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -100,6 +100,17 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	// Transparent capture (proposal 018, Phase 3a): redirect outbound ClusterIP:18081
+	// to the pod-local capture listener. Best-effort — a failure leaves the explicit
+	// fast-lane working, so it must not fail the pod's networking. Uses the runtime
+	// netns path (the rule lives in the kernel netns, not the bind-mount pin).
+	if netConf.TransparentCaptureEnabled {
+		if err := installCaptureRedirect(args.Netns, p.logger); err != nil {
+			p.logger.Warn("failed to install transparent-capture redirect; continuing without capture",
+				zap.String("netns", args.Netns), zap.Error(err))
+		}
+	}
+
 	return p.sendAddPod(context.Background(), netConf, cniPod, prevResult)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -209,6 +209,12 @@ require (
 )
 
 require (
+	github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 // indirect
+	github.com/mdlayher/socket v0.5.0 // indirect
+)
+
+require (
+	github.com/google/nftables v0.3.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/log v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/nftables v0.3.0 h1:bkyZ0cbpVeMHXOrtlFc8ISmfVqq5gPJukoYieyVmITg=
+github.com/google/nftables v0.3.0/go.mod h1:BCp9FsrbF1Fn/Yu6CLUc9GGZFw/+hsxfluNXXmxBfRM=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/renameio/v2 v2.0.1 h1:HyOM6qd9gF9sf15AvhbptGHUnaLTpEI9akAFFU3VyW0=
@@ -363,6 +365,10 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.9.1 h1:LbtsOm5WAswyWbvTEOqhypdPeZzHavpZx96/n553mR8=
 github.com/mailru/easyjson v0.9.1/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42 h1:A1Cq6Ysb0GM0tpKMbdCXCIfBclan4oHk1Jb+Hrejirg=
+github.com/mdlayher/netlink v1.7.3-0.20250113171957-fbb4dce95f42/go.mod h1:BB4YCPDOzfy7FniQ/lxuYQ3dgmM2cZumHbK8RpTjN2o=
+github.com/mdlayher/socket v0.5.0 h1:ilICZmJcQz70vrWVes1MFera4jGiWNocSkykwwoy3XI=
+github.com/mdlayher/socket v0.5.0/go.mod h1:WkcBFfvyG8QENs5+hfQPl1X6Jpd2yeLIYgrGFmJiJxI=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=


### PR DESCRIPTION
**PR 4 of 4** — the networking piece that makes transparent capture live. The CNI plugin installs, inside each pod's netns, an **nftables REDIRECT** of outbound TCP to a mesh `ClusterIP:18081` → the pod-local capture listener `:15001`. **Default off** (`transparent_capture_enabled` in the netconf; `--transparent-capture` on cni-install, set by `agent.transparentCapture`).

## What
- `installCaptureRedirect`: enters the pod netns via `setns` on a locked OS thread (matching `netnsDialContext`) and programs, **over netlink (pure-Go nftables — no iptables binary**, so it works in the minimal/immutable Talos CNI exec env), a `nat/output` rule:
  `l4proto tcp · ip daddr & /8 != 127.0.0.0 · tcp dport 18081 → redirect :15001`.
  - **Loopback exclusion** keeps the explicit `127.0.0.1:18081` fast-lane working — only ClusterIP traffic is captured.
  - Rule lives in the **pod netns** (independent of host kube-proxy/flannel), **dies with the netns** (no DEL cleanup).
  - **Best-effort**: a failure logs and continues (fast-lane still works) — never fails pod networking.
- Wired into `CmdAdd` (after pinning) behind `netConf.TransparentCaptureEnabled`; `cni-install --transparent-capture` writes it. `0.25.0 → 0.26.0`.

## Tests
the rule exprs (tcp / loopback-exclusion mask+cmp / dport 18081 / redirect 15001).

## Completes Phase 3a (PRs 1–4)
Registrar VIPs (#273) + capture listener (#274) + agent cap_http wiring (#275) + this. Next: enable on talos (`registrar.generateMeshServices` + `agent.transparentCapture`) and the e2e — dial `<svc>.<ns>.svc.cluster.local:18081` transparently. All default-off until then.