### PR TITLE
chore(proxy,cni): move capture/DNS ports off Istio's range (18001/18053)

### DIFF
--- a/cni/config/config.go
+++ b/cni/config/config.go
@@ -63,7 +63,7 @@ type AetherConf struct {
 
 	// TransparentCaptureEnabled installs, inside each pod's netns, an nft REDIRECT
 	// of outbound TCP to a mesh ClusterIP:18081 -> the pod's local capture listener
-	// :15001 (proposal 018, Phase 3a). Off by default; pairs with the agent's
+	// :18001 (proposal 018, Phase 3a). Off by default; pairs with the agent's
 	// --transparent-capture and the registrar's --generate-mesh-services. The
 	// loopback exclusion keeps the explicit 127.0.0.1:18081 fast-lane working.
 	TransparentCaptureEnabled bool `json:"transparent_capture_enabled"`

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -15,7 +15,7 @@ import (
 // would silently break the explicit fast-lane or fail to capture.
 func TestCaptureRedirectExprs(t *testing.T) {
 	mesh := uint16(commonconstants.ProxyOutboundPort) // 18081
-	cap := uint16(commonconstants.ProxyCapturePort)   // 15001
+	cap := uint16(commonconstants.ProxyCapturePort)   // 18001
 	exprs := captureRedirectExprs(mesh, cap)
 	require.Len(t, exprs, 9)
 
@@ -37,8 +37,8 @@ func TestCaptureRedirectExprs(t *testing.T) {
 	assert.Equal(t, expr.CmpOpEq, exprs[6].(*expr.Cmp).Op)
 	assert.Equal(t, []byte{0x46, 0xA1}, exprs[6].(*expr.Cmp).Data) // 18081
 
-	// redirect to 15001
+	// redirect to 18001
 	require.IsType(t, &expr.Immediate{}, exprs[7])
-	assert.Equal(t, []byte{0x3A, 0x99}, exprs[7].(*expr.Immediate).Data) // 15001
+	assert.Equal(t, []byte{0x46, 0x51}, exprs[7].(*expr.Immediate).Data) // 18001
 	assert.IsType(t, &expr.Redir{}, exprs[8])
 }

--- a/common/constants/proxy.go
+++ b/common/constants/proxy.go
@@ -9,12 +9,15 @@ const (
 	// inside the pod netns (proposal 018, Phase 3a). The CNI redirects outbound
 	// TCP to a mesh ClusterIP:ProxyOutboundPort here; the listener recovers the
 	// original ClusterIP and routes by cluster.local authority. Default off.
-	ProxyCapturePort = 15001
+	// In aether's 18xxx range (with ProxyOutboundPort) to avoid colliding with
+	// Istio's 15001 outbound-capture port if both meshes share a node.
+	ProxyCapturePort = 18001
 	// ProxyDNSCapturePort is the UDP port the per-pod mesh-DNS listener binds inside
 	// the pod netns (proposal 018, mesh-global FQDN). The CNI redirects the pod's
 	// outbound DNS (:53) here; Envoy's dns_filter answers <svc>.<meshDomain> with
 	// the sentinel VIP and forwards everything else to the upstream resolver.
-	ProxyDNSCapturePort = 15053
+	// In aether's 18xxx range to avoid colliding with Istio's 15053 DNS port.
+	ProxyDNSCapturePort = 18053
 	// ProxyReadinessPath is the path matched by the non-pass-through
 	// health_check filter on every outbound listener. A 200 proves the listener
 	// is active on worker threads in that netns; a 503 means the answering


### PR DESCRIPTION
The transparent-capture (`15001`) and mesh-DNS (`15053`) listener ports I introduced this session collided **exactly** with Istio's outbound-capture (`15001`) and DNS (`15053`) ports — a node running both meshes would clash on the per-pod redirects.

Move them into aether's own **`18xxx`** range (alongside `ProxyOutboundPort 18081`):
- `ProxyCapturePort` `15001 → 18001`
- `ProxyDNSCapturePort` `15053 → 18053`

Both are constants, so the proxy listeners and the CNI redirect targets move together. Internal pod-netns ports (no external contract); the next capture deploy picks them up.

> Note: the pre-existing inbound port `15008` also overlaps Istio's HBONE port, but it's load-bearing across the whole mesh (EDS endpoints dial `pod_ip:15008`) — changing it is a separate breaking migration, out of scope here.