### PR TITLE
feat(agent): per-pod mesh-DNS listener + DnsTable wiring (proposal 018, mesh-global FQDN — PR 2)

### DIFF
--- a/agent/internal/capture/reconciler.go
+++ b/agent/internal/capture/reconciler.go
@@ -20,9 +20,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// AuthoritySink receives the projected mesh service -> cluster.local FQDN map.
+// AuthoritySink receives the projections from the generated mesh Services:
+//   - SetCaptureAuthorities: service -> cluster.local FQDN (cap_http, transparent capture).
+//   - SetMeshDNSRecords:     service -> mesh-Service ClusterIP (the per-pod dns_filter's
+//     A record for <svc>.<meshDomain>, the mesh-global FQDN).
+//
+// Both are emitted every reconcile; the cache uses whichever feature is enabled.
 type AuthoritySink interface {
 	SetCaptureAuthorities(authorities map[string]string)
+	SetMeshDNSRecords(records map[string]string)
 }
 
 // Reconciler watches the generated mesh Services (labeled aether.io/mesh-service) and
@@ -55,6 +61,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 
 	authorities := make(map[string]string, len(list.Items))
+	records := make(map[string]string, len(list.Items))
 	for i := range list.Items {
 		s := &list.Items[i]
 		svc := s.Annotations[constants.AnnotationMeshService]
@@ -62,9 +69,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			svc = s.Name
 		}
 		authorities[svc] = fmt.Sprintf("%s.%s.svc.cluster.local", s.Name, s.Namespace)
+		// The mesh-Service ClusterIP is the A record for <svc>.<meshDomain>. Skip
+		// headless/unallocated Services (no routable VIP to answer with).
+		if ip := s.Spec.ClusterIP; ip != "" && ip != corev1.ClusterIPNone {
+			records[svc] = ip
+		}
 	}
 
 	r.Sink.SetCaptureAuthorities(authorities)
-	r.Log.DebugContext(ctx, "projected capture authorities", "meshServices", len(list.Items))
+	r.Sink.SetMeshDNSRecords(records)
+	r.Log.DebugContext(ctx, "projected mesh-Service authorities + DNS records", "meshServices", len(list.Items), "dnsRecords", len(records))
 	return reconcile.Result{}, nil
 }

--- a/agent/internal/capture/reconciler_test.go
+++ b/agent/internal/capture/reconciler_test.go
@@ -14,16 +14,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type fakeSink struct{ got map[string]string }
+type fakeSink struct {
+	got     map[string]string
+	records map[string]string
+}
 
 func (f *fakeSink) SetCaptureAuthorities(a map[string]string) { f.got = a }
+func (f *fakeSink) SetMeshDNSRecords(r map[string]string)     { f.records = r }
 
-func TestReconcile_ProjectsClusterLocalAuthorities(t *testing.T) {
-	mesh := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-		Name: "svc-1", Namespace: "aether-test",
-		Labels:      map[string]string{constants.LabelMeshService: "true"},
-		Annotations: map[string]string{constants.AnnotationMeshService: "svc-1", constants.AnnotationMeshPort: "8080"},
-	}}
+func TestReconcile_ProjectsAuthoritiesAndDNSRecords(t *testing.T) {
+	mesh := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-1", Namespace: "aether-test",
+			Labels:      map[string]string{constants.LabelMeshService: "true"},
+			Annotations: map[string]string{constants.AnnotationMeshService: "svc-1", constants.AnnotationMeshPort: "8080"},
+		},
+		Spec: corev1.ServiceSpec{ClusterIP: "10.96.0.42"},
+	}
 	// A non-mesh Service of the same shape must be ignored (label-scoped List).
 	user := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "other", Namespace: "default"}}
 
@@ -34,4 +41,5 @@ func TestReconcile_ProjectsClusterLocalAuthorities(t *testing.T) {
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"svc-1": "svc-1.aether-test.svc.cluster.local"}, sink.got)
+	assert.Equal(t, map[string]string{"svc-1": "10.96.0.42"}, sink.records, "ClusterIP -> the <svc>.<meshDomain> A record")
 }

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -98,6 +98,15 @@ type AgentConfig struct {
 	// with the registrar's --generate-mesh-services and the CNI dst-18081 redirect.
 	// Default off.
 	TransparentCapture bool
+
+	// MeshDNS enables the per-pod mesh-DNS listener (proposal 018, mesh-global FQDN):
+	// the agent answers <svc>.<meshDomain> from the generated mesh Services' ClusterIPs
+	// and forwards the rest to MeshDNSUpstream. Pairs with the CNI :53 redirect.
+	// Default off.
+	MeshDNS bool
+	// MeshDNSUpstream is the upstream resolver(s) (host[:port]) the mesh-DNS filter
+	// forwards non-mesh queries to — the cluster kube-dns.
+	MeshDNSUpstream []string
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves when
 	// GatewayAPI is set.
 	GatewayClassName string

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -115,6 +115,8 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
 	rootCmd.Flags().BoolVar(&cfg.Gamma, "gamma", false, "Enable GAMMA east-west L7 routing: watch HTTPRoutes parented to a Service and enrich the node proxy's outbound routes (proposal 018, Phase 2)")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCapture, "transparent-capture", false, "Enable transparent capture: per-pod capture listeners + cap_http route table from the generated mesh Services (proposal 018, Phase 3a)")
+	rootCmd.Flags().BoolVar(&cfg.MeshDNS, "mesh-dns", false, "Enable per-pod mesh DNS: answer <svc>.<mesh-domain> from the generated mesh Services and forward the rest to --mesh-dns-upstream (proposal 018, mesh-global FQDN)")
+	rootCmd.Flags().StringSliceVar(&cfg.MeshDNSUpstream, "mesh-dns-upstream", cfg.MeshDNSUpstream, "Upstream resolver(s) (host[:port]) the mesh-DNS filter forwards non-mesh queries to (the cluster kube-dns)")
 }
 
 // registerSharedFlags registers the flags common to the node agent (root) and
@@ -262,6 +264,8 @@ func runAgent(ctx context.Context) (retErr error) {
 	snapshotCache.SetMeshDomain(cfg.MeshDomain)
 	snapshotCache.SetEmitStatsPod(cfg.EmitStatsPod)
 	snapshotCache.SetCaptureEnabled(cfg.TransparentCapture)
+	snapshotCache.SetMeshDNSEnabled(cfg.MeshDNS)
+	snapshotCache.SetMeshDNSUpstream(cfg.MeshDNSUpstream)
 	// Global access-log config, set once before the cache builds any listener.
 	proxy.SetAccessLogConfig(proxy.AccessLogConfig{
 		Enabled:           cfg.AccessLogsEnabled,
@@ -337,10 +341,11 @@ func runAgent(ctx context.Context) (retErr error) {
 		}
 	}
 
-	// Transparent capture (proposal 018, Phase 3a): watch the generated mesh
-	// Services and project their cluster.local authorities so the cache can build
-	// the cap_http route table. Default off — registers no Service watch unless set.
-	if cfg.TransparentCapture {
+	// Transparent capture (Phase 3a) and/or mesh DNS (mesh-global FQDN) both read the
+	// generated mesh Services: capture wants their cluster.local authorities (cap_http),
+	// mesh DNS wants their ClusterIPs (the DnsTable). One reconciler feeds both; run it
+	// if either feature is on. Default off — no Service watch otherwise.
+	if cfg.TransparentCapture || cfg.MeshDNS {
 		captureReconciler := &capture.Reconciler{
 			Client: m.GetClient(),
 			Sink:   snapshotCache,

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -165,12 +165,22 @@ type SnapshotCache struct {
 	// capture listeners + the cap_http route table. Set once before the manager
 	// starts (SetCaptureEnabled); read without locking. Default off.
 	captureEnabled bool
-	// captureMu guards captureAuthorities: a mesh service -> its cluster.local FQDN
-	// (<svc>.<ns>.svc.cluster.local), fed by the agent's capture reconciler from the
-	// generated mesh Services. The cap_http route table maps each in-scope service's
-	// authority to its <svc>.<meshDomain> cluster.
+	// captureMu guards captureAuthorities + meshDNSRecords (both fed by the agent's
+	// mesh-Service reconciler).
+	//   captureAuthorities: mesh service -> its cluster.local FQDN, for cap_http.
+	//   meshDNSRecords:      mesh service -> its mesh-Service ClusterIP, the A-record
+	//     the per-pod dns_filter answers for <svc>.<meshDomain> (the namespace-free,
+	//     globally routable name; the ClusterIP then hits the :18081 capture and is
+	//     routed by Host). Proposal 018 mesh-global FQDN.
 	captureMu          sync.RWMutex
 	captureAuthorities map[string]string
+	meshDNSRecords     map[string]string
+
+	// meshDNSEnabled turns on the per-pod mesh-DNS listener (set once,
+	// SetMeshDNSEnabled). meshDNSUpstream is the upstream resolver(s) the dns_filter
+	// forwards non-mesh queries to (the cluster kube-dns; set once).
+	meshDNSEnabled  bool
+	meshDNSUpstream []string
 
 	version *atomic.Uint64
 }
@@ -189,6 +199,10 @@ type listenerEntry struct {
 	// pod netns; routes CNI-redirected ClusterIP:18081 traffic by cluster.local
 	// authority over the cap_http route table.
 	capture types.Resource
+	// dnsListener is the per-pod mesh-DNS listener (proposal 018, mesh-global FQDN):
+	// nil unless mesh DNS is enabled. Bound to the DNS capture port in the pod netns;
+	// answers <svc>.<meshDomain> and forwards the rest to the upstream resolver.
+	dnsListener types.Resource
 	// appClusters holds one per-port application cluster (multi-port pods); the
 	// SNI-selected inbound filter chains forward decrypted traffic to these.
 	appClusters []types.Resource
@@ -258,6 +272,7 @@ func NewSnapshotCache(nodeName string, log *slog.Logger) *SnapshotCache {
 		staticDeps:         make(map[string]struct{}),
 		serviceRoutes:      make(map[string][]proxy.GammaRoute),
 		captureAuthorities: make(map[string]string),
+		meshDNSRecords:     make(map[string]string),
 		depChanged:         make(chan struct{}, 1),
 		version:            atomic.NewUint64(0),
 	}

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -28,6 +28,58 @@ func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Res
 // cap_http route table.
 func (c *SnapshotCache) SetCaptureEnabled(v bool) { c.captureEnabled = v }
 
+// SetMeshDNSEnabled turns the per-pod mesh-DNS listener on (proposal 018, mesh-global
+// FQDN). SetMeshDNSUpstream sets the resolver(s) the dns_filter forwards non-mesh
+// queries to (the cluster kube-dns). Both set once before the manager starts.
+func (c *SnapshotCache) SetMeshDNSEnabled(v bool)       { c.meshDNSEnabled = v }
+func (c *SnapshotCache) SetMeshDNSUpstream(rs []string) { c.meshDNSUpstream = rs }
+
+// SetMeshDNSRecords replaces the mesh service -> ClusterIP map (fed by the mesh-Service
+// reconciler) and signals a rebuild on change so the per-pod DnsTable re-derives.
+func (c *SnapshotCache) SetMeshDNSRecords(records map[string]string) {
+	c.captureMu.Lock()
+	changed := !equalStringMaps(c.meshDNSRecords, records)
+	c.meshDNSRecords = records
+	c.captureMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// generateDNSListener builds a pod's mesh-DNS listener, or nil when mesh DNS is off.
+// The DnsTable answers each in-scope service's <svc>.<meshDomain> with its mesh-Service
+// ClusterIP (dep-scoped: a pod resolves only the mesh names it depends on).
+func (c *SnapshotCache) generateDNSListener(cniPod *cniv1.CNIPod) (types.Resource, error) {
+	if !c.meshDNSEnabled {
+		return nil, nil
+	}
+	l, err := proxy.GenerateDNSListener(cniPod, constants.ProxyDNSCapturePort, c.meshDNSVirtualDomains(), c.meshDNSUpstream)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+// meshDNSVirtualDomains builds the dep-scoped DnsTable entries: <svc>.<meshDomain> ->
+// the service's mesh-Service ClusterIP.
+func (c *SnapshotCache) meshDNSVirtualDomains() []proxy.DNSVirtualDomain {
+	deps := c.DependencySet()
+
+	c.captureMu.RLock()
+	defer c.captureMu.RUnlock()
+	vds := make([]proxy.DNSVirtualDomain, 0, len(c.meshDNSRecords))
+	for svc, clusterIP := range c.meshDNSRecords {
+		if _, ok := deps[svc]; !ok {
+			continue
+		}
+		vds = append(vds, proxy.DNSVirtualDomain{
+			Domain:    proxy.ServiceClusterName(svc, c.meshDomain),
+			Addresses: []string{clusterIP},
+		})
+	}
+	return vds
+}
+
 // SetCaptureAuthorities replaces the mesh service -> cluster.local FQDN map (fed by
 // the agent's capture reconciler from the generated mesh Services) and signals a
 // snapshot rebuild on change so cap_http re-derives.
@@ -55,10 +107,14 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		if _, ok := deps[svc]; !ok {
 			continue
 		}
-		vhosts = append(vhosts, proxy.BuildOutboundClusterVirtualHost(
-			proxy.ServiceClusterName(svc, c.meshDomain),
-			[]string{fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort)},
-		))
+		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
+		// Route both the cluster.local authority and the mesh-global <svc>.<meshDomain>
+		// authority (portless + :meshPort) to the service cluster, so a captured
+		// request reaches it under either name (the mesh-DNS path uses the latter).
+		vhosts = append(vhosts, proxy.BuildOutboundClusterVirtualHost(mesh, []string{
+			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
+			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
+		}))
 	}
 	return vhosts
 }

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -38,6 +38,10 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	if err != nil {
 		return err
 	}
+	dnsListener, err := c.generateDNSListener(cniPod)
+	if err != nil {
+		return err
+	}
 
 	c.listenerMu.Lock()
 	if c.listeners == nil {
@@ -47,6 +51,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 		inbound:       inbound,
 		outbound:      outbound,
 		capture:       capture,
+		dnsListener:   dnsListener,
 		appClusters:   clustersToResources(appClusters),
 		healthCluster: healthCluster,
 	}
@@ -117,6 +122,9 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 		resources = append(resources, entry.inbound, entry.outbound)
 		if entry.capture != nil {
 			resources = append(resources, entry.capture)
+		}
+		if entry.dnsListener != nil {
+			resources = append(resources, entry.dnsListener)
 		}
 		if hc, ok := entry.healthCluster.(*clusterv3.Cluster); ok && hc != nil {
 			probeClusters = append(probeClusters, hc.GetName())
@@ -204,11 +212,18 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 			errs = append(errs, captureErr)
 			continue
 		}
+		dnsListener, dnsErr := c.generateDNSListener(pod)
+		if dnsErr != nil {
+			c.log.ErrorContext(ctx, "failed to generate mesh-DNS listener for pod", "error", dnsErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())
+			errs = append(errs, dnsErr)
+			continue
+		}
 
 		c.listeners[netns] = listenerEntry{
 			inbound:       inbound,
 			outbound:      outbound,
 			capture:       capture,
+			dnsListener:   dnsListener,
 			appClusters:   clustersToResources(appClusters),
 			healthCluster: healthCluster,
 		}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.26.0-{GIT_COMMIT}"
+version: "0.27.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -72,6 +72,12 @@ spec:
             {{- if .Values.agent.transparentCapture }}
             - "--transparent-capture"
             {{- end }}
+            {{- if .Values.agent.meshDns }}
+            - "--mesh-dns"
+            {{- range .Values.agent.meshDnsUpstream }}
+            - "--mesh-dns-upstream={{ . }}"
+            {{- end }}
+            {{- end }}
             # Aether system config, inherited from the umbrella global block.
             - "--mesh-domain={{ .Values.meshDomain }}"
             {{- if .Values.otel.enabled }}

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -18,9 +18,9 @@ rules:
     resources: ["httproutes"]
     verbs: ["list", "get", "watch"]
   {{- end }}
-  {{- if .Values.agent.transparentCapture }}
-  # Transparent capture (proposal 018, Phase 3a): watch the generated mesh Services
-  # for their cluster.local authorities.
+  {{- if or .Values.agent.transparentCapture .Values.agent.meshDns }}
+  # Transparent capture (Phase 3a) / mesh DNS (mesh-global FQDN): watch the generated
+  # mesh Services for their cluster.local authorities + ClusterIPs.
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["list", "get", "watch"]

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -105,6 +105,13 @@ agent:
   # registrar.generateMeshServices (the VIPs) and the CNI dst-18081 redirect.
   # Default off — adds the services-read RBAC only when enabled.
   transparentCapture: false
+  # Mesh DNS (proposal 018, mesh-global FQDN): per-pod dns_filter answering
+  # <svc>.<meshDomain> from the generated mesh Services' ClusterIPs (namespace-free,
+  # globally routable), forwarding the rest to meshDnsUpstream. Pairs with the CNI
+  # :53 redirect. Default off. meshDnsUpstream is the cluster kube-dns (env-specific,
+  # e.g. the kube-dns Service ClusterIP); required when meshDns is on.
+  meshDns: false
+  meshDnsUpstream: []
   # Image as repository + digest (digest-pinned for immutability). Mirror to a
   # private registry by overriding `repository` alone; the digest is preserved.
   image:


### PR DESCRIPTION
**PR 2** of the mesh-global-FQDN series. Makes PR 1's `dns_filter` primitive live: the agent answers `<svc>.<meshDomain>` at the node proxy from the generated mesh Services' ClusterIPs — so clients use a **namespace-free, globally routable** name instead of the namespace-leaking `cluster.local` FQDN. **Default off** (`--mesh-dns` / `agent.meshDns`).

## What
- **cache**: `meshDNSEnabled` + `meshDNSUpstream` + `meshDNSRecords` (service → ClusterIP). Per-pod DNS listener generated alongside inbound/outbound/capture; `meshDNSVirtualDomains` builds the **dep-scoped** DnsTable (`<svc>.<meshDomain>` → the service's ClusterIP) — a pod resolves only the mesh names it depends on. `cap_http` now also routes the `<svc>.<meshDomain>` authority (the captured mesh-DNS path).
- **reconciler**: now emits **both** cluster.local authorities (`cap_http`) **and** `service→ClusterIP` DNS records from the same mesh-Service watch; runs if capture **or** mesh-DNS is on.
- **Reuses the per-service mesh Services as the DNS answers** (no separate sentinel) — the ClusterIP is just a capturable IP, and the `:18001` capture routes by the mesh Host.
- Chart: `agent.meshDns` + `agent.meshDnsUpstream` (the cluster kube-dns, env-specific); services-read RBAC now covers mesh-DNS. `0.26.0 → 0.27.0`.

## Tests
reconciler emits authorities + ClusterIP DNS records (label-scoped); cache snapshot path unchanged.

## Roadmap
PR 3: CNI `:53` redirect → `:18053` with **loop-prevention** (the proxy's forward to kube-dns must be excluded). Then the e2e: dial `svc-1.<meshDomain>` from a pod, no cluster.local. All default-off.