### PR TITLE
feat(cni): per-pod mesh-DNS :53 redirect (proposal 018, mesh-global FQDN — PR 3)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.27.0-{GIT_COMMIT}"
+version: "0.28.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -46,6 +46,9 @@ spec:
             {{- if .Values.agent.transparentCapture }}
             - "--transparent-capture"
             {{- end }}
+            {{- if .Values.agent.meshDns }}
+            - "--mesh-dns"
+            {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/cni/config/config.go
+++ b/cni/config/config.go
@@ -68,6 +68,11 @@ type AetherConf struct {
 	// loopback exclusion keeps the explicit 127.0.0.1:18081 fast-lane working.
 	TransparentCaptureEnabled bool `json:"transparent_capture_enabled"`
 
+	// MeshDNSEnabled installs, inside each pod's netns, an nft REDIRECT of outbound
+	// DNS (UDP+TCP :53, non-loopback) -> the pod-local mesh-DNS listener (proposal
+	// 018, mesh-global FQDN). Off by default; pairs with the agent's --mesh-dns.
+	MeshDNSEnabled bool `json:"mesh_dns_enabled"`
+
 	// OTLPEndpoint enables OTel telemetry (traces + metrics) pushed to the
 	// given OTLP gRPC collector (host:port, insecure). The plugin binary is
 	// exec'd by the container runtime, so its environment is the runtime's,

--- a/cni/internal/cmd/root.go
+++ b/cni/internal/cmd/root.go
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.MountedCNINetDir, "mounted-cni-net-dir", constants.DefaultHostCNINetDir, "Directory where CNI network configuration files are located")
 	rootCmd.Flags().StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP gRPC collector endpoint written into the netconf so the CNI plugin pushes traces and metrics (e.g. collector:4317); empty disables plugin telemetry")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCaptureEnabled, "transparent-capture", false, "Write transparent_capture_enabled into the netconf so the CNI plugin installs the per-pod capture redirect (proposal 018, Phase 3a)")
+	rootCmd.Flags().BoolVar(&cfg.MeshDNSEnabled, "mesh-dns", false, "Write mesh_dns_enabled into the netconf so the CNI plugin installs the per-pod :53 redirect (proposal 018, mesh-global FQDN)")
 }
 
 // GetCommand returns the main cobra.Command object for this application

--- a/cni/internal/install/cniconfig.go
+++ b/cni/internal/install/cniconfig.go
@@ -46,6 +46,7 @@ func createCNIConfigFile(ctx context.Context, cfg *InstallerConfig) (string, err
 	pluginConfig.AgentCNIPath = constants.DefaultCNISocketPath
 	pluginConfig.OTLPEndpoint = cfg.OTLPEndpoint
 	pluginConfig.TransparentCaptureEnabled = cfg.TransparentCaptureEnabled
+	pluginConfig.MeshDNSEnabled = cfg.MeshDNSEnabled
 
 	marshalledJSON, err := json.MarshalIndent(pluginConfig, "", "  ")
 	if err != nil {

--- a/cni/internal/install/config.go
+++ b/cni/internal/install/config.go
@@ -30,6 +30,9 @@ type InstallerConfig struct {
 	// so the CNI plugin installs the per-pod capture redirect (proposal 018, Phase
 	// 3a). Off by default.
 	TransparentCaptureEnabled bool
+	// MeshDNSEnabled writes mesh_dns_enabled into the netconf so the CNI plugin
+	// installs the per-pod :53 redirect (proposal 018, mesh-global FQDN). Off by default.
+	MeshDNSEnabled bool
 }
 
 // NewInstallerConfig creates a new InstallerConfig with default values.

--- a/cni/internal/plugin/BUILD.bazel
+++ b/cni/internal/plugin/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "capture.go",
         "client.go",
+        "dns.go",
+        "netns.go",
         "netnspin.go",
         "plugin.go",
         "readyprobe.go",
@@ -41,6 +43,7 @@ go_test(
     srcs = [
         "capture_test.go",
         "client_test.go",
+        "dns_test.go",
         "netnspin_test.go",
         "plugin_test.go",
         "readyprobe_test.go",

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -3,8 +3,6 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
-	"os"
-	"runtime"
 
 	commonconstants "github.com/bpalermo/aether/common/constants"
 	"github.com/google/nftables"
@@ -31,34 +29,7 @@ const captureTableName = "aether_capture"
 // netlink socket nftables opens then lives in the pod netns. A failed restore leaves
 // the thread locked so the Go runtime destroys it rather than reusing a poisoned one.
 func installCaptureRedirect(netnsPath string, logger *zap.Logger) error {
-	target, err := os.Open(netnsPath)
-	if err != nil {
-		return fmt.Errorf("opening netns %s: %w", netnsPath, err)
-	}
-	defer func() { _ = target.Close() }()
-
-	runtime.LockOSThread()
-	origin, err := os.Open(fmt.Sprintf("/proc/self/task/%d/ns/net", unix.Gettid()))
-	if err != nil {
-		runtime.UnlockOSThread()
-		return fmt.Errorf("opening current netns: %w", err)
-	}
-	defer func() { _ = origin.Close() }()
-
-	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
-		runtime.UnlockOSThread()
-		return fmt.Errorf("entering netns %s: %w", netnsPath, err)
-	}
-
-	progErr := programCaptureRedirect(logger)
-
-	if err := unix.Setns(int(origin.Fd()), unix.CLONE_NEWNET); err != nil {
-		// Thread poisoned (stuck in the pod netns): keep it locked and let the
-		// goroutine's thread be destroyed rather than reused.
-		return fmt.Errorf("restoring host netns: %w", err)
-	}
-	runtime.UnlockOSThread()
-	return progErr
+	return withPodNetns(netnsPath, func() error { return programCaptureRedirect(logger) })
 }
 
 // programCaptureRedirect adds the nat/output REDIRECT rule in the CURRENT netns.

--- a/cni/internal/plugin/dns.go
+++ b/cni/internal/plugin/dns.go
@@ -1,0 +1,72 @@
+package plugin
+
+import (
+	"fmt"
+
+	commonconstants "github.com/bpalermo/aether/common/constants"
+	"github.com/google/nftables"
+	"github.com/google/nftables/expr"
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
+
+// dnsRedirectTableName is the nft table the DNS redirect rules live in (pod netns).
+const dnsRedirectTableName = "aether_dns_capture"
+
+// installDNSRedirect programs, inside the pod's network namespace, an nftables REDIRECT
+// of the pod's outbound DNS (UDP+TCP dst-port 53, non-loopback) to the pod-local
+// mesh-DNS listener on ProxyDNSCapturePort (proposal 018, mesh-global FQDN). Envoy's
+// dns_filter answers <svc>.<meshDomain> and forwards the rest to the upstream resolver.
+//
+// No loop-prevention is needed: the node agent (and the Envoy it supervises) is
+// host-network, so the dns_filter's forward to kube-dns originates in the HOST netns
+// and never traverses this pod-netns redirect. The loopback exclusion leaves any
+// pod-local resolver (127.x) alone. The rule dies with the netns; best-effort.
+func installDNSRedirect(netnsPath string, logger *zap.Logger) error {
+	return withPodNetns(netnsPath, func() error { return programDNSRedirect(logger) })
+}
+
+func programDNSRedirect(logger *zap.Logger) error {
+	dnsPort := uint16(commonconstants.ProxyDNSCapturePort)
+
+	c, err := nftables.New()
+	if err != nil {
+		return fmt.Errorf("open nftables netlink: %w", err)
+	}
+
+	table := c.AddTable(&nftables.Table{Family: nftables.TableFamilyIPv4, Name: dnsRedirectTableName})
+	chain := c.AddChain(&nftables.Chain{
+		Name:     "output",
+		Table:    table,
+		Type:     nftables.ChainTypeNAT,
+		Hooknum:  nftables.ChainHookOutput,
+		Priority: nftables.ChainPriorityNATDest,
+	})
+	// DNS is UDP-primary with a TCP fallback (large answers / zone transfers), so
+	// redirect both.
+	c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: dnsRedirectExprs(unix.IPPROTO_UDP, dnsPort)})
+	c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: dnsRedirectExprs(unix.IPPROTO_TCP, dnsPort)})
+
+	if err := c.Flush(); err != nil {
+		return fmt.Errorf("apply mesh-DNS redirect (nft flush): %w", err)
+	}
+	logger.Info("installed mesh-DNS redirect", zap.Uint16("dns_port", dnsPort))
+	return nil
+}
+
+// dnsRedirectExprs builds: meta l4proto <proto> · ip daddr & /8 != 127.0.0.0 ·
+// <proto> dport 53 · redirect to redirectPort. The transport dest port is at offset 2
+// for both UDP and TCP.
+func dnsRedirectExprs(proto byte, redirectPort uint16) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{proto}},
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 16, Len: 4},
+		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: []byte{0xff, 0x00, 0x00, 0x00}, Xor: []byte{0x00, 0x00, 0x00, 0x00}},
+		&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{127, 0, 0, 0}},
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(53)},
+		&expr.Immediate{Register: 1, Data: beUint16(redirectPort)},
+		&expr.Redir{RegisterProtoMin: 1},
+	}
+}

--- a/cni/internal/plugin/dns_test.go
+++ b/cni/internal/plugin/dns_test.go
@@ -1,0 +1,31 @@
+package plugin
+
+import (
+	"testing"
+
+	commonconstants "github.com/bpalermo/aether/common/constants"
+	"github.com/google/nftables/expr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestDNSRedirectExprs verifies the rule: <proto> + non-loopback daddr + dport 53 ->
+// redirect to the mesh-DNS port, for both UDP and TCP.
+func TestDNSRedirectExprs(t *testing.T) {
+	dnsPort := uint16(commonconstants.ProxyDNSCapturePort) // 18053
+	for _, proto := range []byte{unix.IPPROTO_UDP, unix.IPPROTO_TCP} {
+		exprs := dnsRedirectExprs(proto, dnsPort)
+		require.Len(t, exprs, 9)
+
+		assert.Equal(t, []byte{proto}, exprs[1].(*expr.Cmp).Data, "l4proto match")
+		// loopback exclusion
+		assert.Equal(t, []byte{0xff, 0x00, 0x00, 0x00}, exprs[3].(*expr.Bitwise).Mask)
+		assert.Equal(t, expr.CmpOpNeq, exprs[4].(*expr.Cmp).Op)
+		assert.Equal(t, []byte{127, 0, 0, 0}, exprs[4].(*expr.Cmp).Data)
+		// dport 53 (big-endian) -> redirect 18053
+		assert.Equal(t, []byte{0x00, 0x35}, exprs[6].(*expr.Cmp).Data, "dport 53")
+		assert.Equal(t, []byte{0x46, 0x85}, exprs[7].(*expr.Immediate).Data, "redirect to 18053")
+		assert.IsType(t, &expr.Redir{}, exprs[8])
+	}
+}

--- a/cni/internal/plugin/netns.go
+++ b/cni/internal/plugin/netns.go
@@ -1,0 +1,44 @@
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// withPodNetns runs fn with the calling goroutine setns'd into the network namespace
+// at netnsPath, on a locked OS thread (so a netlink/nftables socket fn opens lands in
+// that netns), then restores the original netns. A failed restore leaves the thread
+// locked so the Go runtime destroys it rather than reusing a thread stuck in the pod
+// netns. Used by the transparent-capture and mesh-DNS redirect installers.
+func withPodNetns(netnsPath string, fn func() error) error {
+	target, err := os.Open(netnsPath)
+	if err != nil {
+		return fmt.Errorf("opening netns %s: %w", netnsPath, err)
+	}
+	defer func() { _ = target.Close() }()
+
+	runtime.LockOSThread()
+	origin, err := os.Open(fmt.Sprintf("/proc/self/task/%d/ns/net", unix.Gettid()))
+	if err != nil {
+		runtime.UnlockOSThread()
+		return fmt.Errorf("opening current netns: %w", err)
+	}
+	defer func() { _ = origin.Close() }()
+
+	if err := unix.Setns(int(target.Fd()), unix.CLONE_NEWNET); err != nil {
+		runtime.UnlockOSThread()
+		return fmt.Errorf("entering netns %s: %w", netnsPath, err)
+	}
+
+	fnErr := fn()
+
+	if err := unix.Setns(int(origin.Fd()), unix.CLONE_NEWNET); err != nil {
+		// Thread poisoned (stuck in the pod netns): keep it locked.
+		return fmt.Errorf("restoring host netns: %w", err)
+	}
+	runtime.UnlockOSThread()
+	return fnErr
+}

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -111,6 +111,16 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	// Mesh DNS (proposal 018, mesh-global FQDN): redirect the pod's :53 to the
+	// pod-local mesh-DNS listener. Best-effort — a failure leaves the pod's DNS on
+	// the original resolver (mesh names just won't resolve), never breaks networking.
+	if netConf.MeshDNSEnabled {
+		if err := installDNSRedirect(args.Netns, p.logger); err != nil {
+			p.logger.Warn("failed to install mesh-DNS redirect; continuing without mesh DNS",
+				zap.String("netns", args.Netns), zap.Error(err))
+		}
+	}
+
 	return p.sendAddPod(context.Background(), netConf, cniPod, prevResult)
 }
 


### PR DESCRIPTION
**PR 3 of 3** — completes mesh DNS. The CNI plugin installs, inside each pod's netns, an **nftables REDIRECT** of outbound DNS (UDP+TCP `:53`, non-loopback) → the pod-local mesh-DNS listener (`:18053`). **Default off** (`mesh_dns_enabled` in the netconf; `cni-install --mesh-dns`, set by `agent.meshDns`).

## What
- `installDNSRedirect`: `nat/output` rule — `l4proto udp|tcp · ip daddr & /8 != 127.0.0.0 · dport 53 → redirect :18053`, for both UDP and TCP.
- **No loop-prevention needed**: the node agent (and its Envoy) is **host-network**, so the `dns_filter`'s forward to kube-dns originates in the **host netns** and never traverses this pod-netns redirect — cleaner than Istio's in-pod UID exclusion. The loopback exclusion leaves a pod-local resolver (`127.x`) alone. Best-effort: a failure leaves the pod on its original resolver, never breaks networking.
- Extracted `withPodNetns` (setns on a locked thread) shared by the capture + DNS redirect installers; refactored `installCaptureRedirect` onto it.
- `0.27.0 → 0.28.0`.

## Tests
the DNS rule exprs (udp/tcp / loopback-exclusion / dport 53 / redirect 18053).

## Completes the mesh-DNS stack (PRs 1–3)
dns_filter primitive (#277) + agent DnsTable wiring (#279) + this. Next: enable on talos (`agent.meshDns` + `agent.meshDnsUpstream`=kube-dns) and the e2e — dial `svc-1.<meshDomain>` from a pod, no cluster.local, no namespace.