### PR TITLE
feat(controller): pod-ndots mutating webhook for musl mesh-FQDN resolution

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.28.0-{GIT_COMMIT}"
+version: "0.29.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-deployment.yaml
+++ b/charts/aether/templates/controller-deployment.yaml
@@ -48,10 +48,18 @@ spec:
             {{- if .Values.otel.traceExport }}
             - "--trace-export=true"
             {{- end }}
+            {{- if .Values.controller.injectPodNdots }}
+            # ndots = the mesh-domain label count, so <svc>.<meshDomain> resolves
+            # absolute-first (musl mesh-FQDN fix).
+            - "--pod-ndots={{ len (splitList "." .Values.meshDomain) }}"
+            {{- end }}
             {{- if .Values.controller.webhook.spire }}
             - "--spire-enabled=true"
             - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
             - "--webhook-config-name={{ include "aether.controller.clusterScopedName" . }}"
+            {{- if .Values.controller.injectPodNdots }}
+            - "--mutating-webhook-config-name={{ include "aether.controller.clusterScopedName" . }}-pod-ndots"
+            {{- end }}
             {{- end }}
           ports:
             - name: webhook

--- a/charts/aether/templates/controller-rbac.yaml
+++ b/charts/aether/templates/controller-rbac.yaml
@@ -21,6 +21,11 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["get", "list", "watch", "update", "patch"]
+  {{- if .Values.controller.injectPodNdots }}
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  {{- end }}
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/aether/templates/controller-webhook.yaml
+++ b/charts/aether/templates/controller-webhook.yaml
@@ -85,3 +85,43 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["virtualhosts"]
         scope: "Namespaced"
+{{- if .Values.controller.injectPodNdots }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "aether.controller.clusterScopedName" . }}-pod-ndots
+  labels:
+    {{- include "aether.controller.labels" . | nindent 4 }}
+webhooks:
+  # Inject dnsConfig ndots into MANAGED pods so a mesh FQDN (<svc>.<meshDomain>) is
+  # resolved absolute-first, before the cluster.local search list — musl clients
+  # otherwise fail to resolve mesh names (proposal 018, mesh-global FQDN).
+  - name: ndots.pods.aether.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    # Ignore: a down webhook must never block pod scheduling (a fail-closed pod
+    # webhook is a cluster-wide outage). Missing ndots only degrades musl mesh-DNS.
+    failurePolicy: Ignore
+    timeoutSeconds: 5
+    reinvocationPolicy: Never
+    # Only pods that opted into the mesh; never control-plane / system pods.
+    objectSelector:
+      matchLabels:
+        aether.io/managed: "true"
+    clientConfig:
+      service:
+        name: {{ $svc }}
+        namespace: {{ $ns }}
+        path: /mutate
+        port: 443
+      {{- if not .Values.controller.webhook.spire }}
+      caBundle: {{ $caBundle }}
+      {{- end }}
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+        scope: "Namespaced"
+{{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -297,6 +297,12 @@ controller:
     pullPolicy: Always
   # Leader election is on; extra replicas are warm standbys.
   replicaCount: 1
+  # Pod-ndots mutating webhook (proposal 018, mesh-global FQDN): inject dnsConfig
+  # ndots (= the mesh-domain label count) into managed pods so a mesh FQDN
+  # (<svc>.<meshDomain>) resolves absolute-first, before the cluster.local search
+  # list — without it, musl/Alpine clients fail to resolve mesh names. Scoped to
+  # aether.io/managed pods, failurePolicy=Ignore. Default off; pair with mesh DNS.
+  injectPodNdots: false
   webhook:
     # Webhook serving cert source — DECOUPLED from mesh SPIRE (spire.enabled).
     #   false (default): a Helm self-signed cert (genSignedCert, caBundle baked

--- a/controller/internal/cmd/BUILD.bazel
+++ b/controller/internal/cmd/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//common/manager",
         "//common/spire",
         "//controller/internal/meshconfig",
+        "//controller/internal/podmutate",
         "//controller/internal/virtualhost",
         "//controller/internal/webhook",
         "@com_github_spf13_cobra//:cobra",

--- a/controller/internal/cmd/config.go
+++ b/controller/internal/cmd/config.go
@@ -31,6 +31,16 @@ type ControllerConfig struct {
 	// WebhookConfigName is the ValidatingWebhookConfiguration whose caBundle the
 	// controller patches with the SPIRE trust bundle (SPIRE mode only).
 	WebhookConfigName string
+	// MutatingWebhookConfigName is the MutatingWebhookConfiguration (pod ndots
+	// injection) whose caBundle the controller patches with the SPIRE trust bundle
+	// (SPIRE mode only). Empty disables that patch.
+	MutatingWebhookConfigName string
+
+	// PodNDots is the dnsConfig ndots value the pod-mutating webhook injects into
+	// managed pods (= the label count of the mesh domain; 2 for aether.internal), so
+	// mesh FQDNs resolve absolute-first and musl clients stop tripping on the
+	// cluster.local search list.
+	PodNDots string
 }
 
 // DefaultSpireWorkloadSocketPath is the default SPIRE CSI-mounted socket path.
@@ -48,5 +58,6 @@ func NewControllerConfig() *ControllerConfig {
 		},
 		MeshConfigMapName:       meshconfig.DefaultMeshConfigMapName,
 		SpireWorkloadSocketPath: DefaultSpireWorkloadSocketPath,
+		PodNDots:                "2",
 	}
 }

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bpalermo/aether/common/manager"
 	"github.com/bpalermo/aether/common/spire"
 	"github.com/bpalermo/aether/controller/internal/meshconfig"
+	"github.com/bpalermo/aether/controller/internal/podmutate"
 	"github.com/bpalermo/aether/controller/internal/virtualhost"
 	cwebhook "github.com/bpalermo/aether/controller/internal/webhook"
 	"github.com/spf13/cobra"
@@ -72,6 +73,8 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", cfg.SpireEnabled, "Serve the validating webhook with a SPIRE X.509 SVID and inject the SPIRE trust bundle into the webhook caBundle (instead of a static cert)")
 	rootCmd.Flags().StringVar(&cfg.SpireWorkloadSocketPath, "spire-workload-socket", cfg.SpireWorkloadSocketPath, "Path to the SPIRE Workload API UDS socket")
 	rootCmd.Flags().StringVar(&cfg.WebhookConfigName, "webhook-config-name", cfg.WebhookConfigName, "ValidatingWebhookConfiguration to patch with the SPIRE caBundle (SPIRE mode)")
+	rootCmd.Flags().StringVar(&cfg.MutatingWebhookConfigName, "mutating-webhook-config-name", cfg.MutatingWebhookConfigName, "MutatingWebhookConfiguration (pod ndots) to patch with the SPIRE caBundle (SPIRE mode); empty disables")
+	rootCmd.Flags().StringVar(&cfg.PodNDots, "pod-ndots", cfg.PodNDots, "dnsConfig ndots the pod-mutating webhook injects into managed pods (the mesh-domain label count; 2 for aether.internal)")
 }
 
 func runController(ctx context.Context) (retErr error) {
@@ -158,15 +161,22 @@ func runController(ctx context.Context) (retErr error) {
 		crdv1.VirtualHostKind: &virtualhost.Validator{Reader: m.GetAPIReader(), Log: l},
 	}).SetupWithManager(m)
 
+	// Pod-ndots mutating webhook (musl mesh-FQDN resolution; opt-in via the chart's
+	// MutatingWebhookConfiguration, scoped to managed pods, failurePolicy=Ignore).
+	// Served on /mutate (mirrors the shared /validate endpoint); inert unless the
+	// apiserver routes pods here.
+	m.GetWebhookServer().Register("/mutate", &admission.Webhook{Handler: podmutate.NewMutator(cfg.PodNDots, l)})
+
 	// In SPIRE mode the webhook presents an SVID, so the apiserver must trust the
 	// SPIRE CA: keep the ValidatingWebhookConfiguration caBundle in sync with the
 	// rotating trust bundle.
 	if cfg.SpireEnabled {
 		injector := &meshconfig.CABundleInjector{
-			Client:            m.GetClient(),
-			Source:            spireSource,
-			WebhookConfigName: cfg.WebhookConfigName,
-			Log:               l,
+			Client:                    m.GetClient(),
+			Source:                    spireSource,
+			WebhookConfigName:         cfg.WebhookConfigName,
+			MutatingWebhookConfigName: cfg.MutatingWebhookConfigName,
+			Log:                       l,
 		}
 		if err = m.Add(injector); err != nil {
 			return fmt.Errorf("failed to add caBundle injector: %w", err)

--- a/controller/internal/meshconfig/cabundle.go
+++ b/controller/internal/meshconfig/cabundle.go
@@ -21,7 +21,10 @@ type CABundleInjector struct {
 	Client            client.Client
 	Source            *spire.Source
 	WebhookConfigName string
-	Log               *slog.Logger
+	// MutatingWebhookConfigName is the pod-ndots MutatingWebhookConfiguration to
+	// keep in sync too; empty skips it.
+	MutatingWebhookConfigName string
+	Log                       *slog.Logger
 }
 
 // NeedLeaderElection keeps caBundle writes to a single replica.
@@ -63,7 +66,6 @@ func (i *CABundleInjector) inject(ctx context.Context) error {
 	if err := i.Client.Get(ctx, types.NamespacedName{Name: i.WebhookConfigName}, &vwc); err != nil {
 		return fmt.Errorf("get ValidatingWebhookConfiguration %q: %w", i.WebhookConfigName, err)
 	}
-
 	changed := false
 	for idx := range vwc.Webhooks {
 		if !bytes.Equal(vwc.Webhooks[idx].ClientConfig.CABundle, bundle) {
@@ -71,12 +73,34 @@ func (i *CABundleInjector) inject(ctx context.Context) error {
 			changed = true
 		}
 	}
-	if !changed {
+	if changed {
+		if err := i.Client.Update(ctx, &vwc); err != nil {
+			return fmt.Errorf("update validating webhook caBundle: %w", err)
+		}
+		i.Log.InfoContext(ctx, "injected SPIRE trust bundle into webhook caBundle", "webhookConfig", i.WebhookConfigName)
+	}
+
+	// The pod-ndots MutatingWebhookConfiguration shares the same SVID, so keep its
+	// caBundle in sync too.
+	if i.MutatingWebhookConfigName == "" {
 		return nil
 	}
-	if err := i.Client.Update(ctx, &vwc); err != nil {
-		return fmt.Errorf("update webhook caBundle: %w", err)
+	var mwc admissionregistrationv1.MutatingWebhookConfiguration
+	if err := i.Client.Get(ctx, types.NamespacedName{Name: i.MutatingWebhookConfigName}, &mwc); err != nil {
+		return fmt.Errorf("get MutatingWebhookConfiguration %q: %w", i.MutatingWebhookConfigName, err)
 	}
-	i.Log.InfoContext(ctx, "injected SPIRE trust bundle into webhook caBundle", "webhookConfig", i.WebhookConfigName)
+	mChanged := false
+	for idx := range mwc.Webhooks {
+		if !bytes.Equal(mwc.Webhooks[idx].ClientConfig.CABundle, bundle) {
+			mwc.Webhooks[idx].ClientConfig.CABundle = bundle
+			mChanged = true
+		}
+	}
+	if mChanged {
+		if err := i.Client.Update(ctx, &mwc); err != nil {
+			return fmt.Errorf("update mutating webhook caBundle: %w", err)
+		}
+		i.Log.InfoContext(ctx, "injected SPIRE trust bundle into mutating webhook caBundle", "webhookConfig", i.MutatingWebhookConfigName)
+	}
 	return nil
 }

--- a/controller/internal/podmutate/BUILD.bazel
+++ b/controller/internal/podmutate/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "podmutate",
+    srcs = ["mutator.go"],
+    importpath = "github.com/bpalermo/aether/controller/internal/podmutate",
+    visibility = ["//controller:__subpackages__"],
+    deps = [
+        "//common/log",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)
+
+go_test(
+    name = "podmutate_test",
+    srcs = ["mutator_test.go"],
+    embed = [":podmutate"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//admission/v1:admission",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)

--- a/controller/internal/podmutate/mutator.go
+++ b/controller/internal/podmutate/mutator.go
@@ -1,0 +1,73 @@
+// Package podmutate contains the controller's pod-mutating admission webhook: it
+// injects a low dnsConfig `ndots` into managed pods so a mesh FQDN
+// (<svc>.<meshDomain>, e.g. 2 dots) is tried as an absolute name BEFORE the
+// cluster.local search list. Without it, the k8s default ndots:5 makes the resolver
+// apply the search domains first; glibc tolerates the fall-through to the bare name,
+// but musl (Alpine) trips on the churn and fails to resolve mesh names. Mirrors how
+// Istio's sidecar injector sets dnsConfig. Default off; opt-in alongside mesh DNS.
+package podmutate
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	commonlog "github.com/bpalermo/aether/common/log"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const ndotsOption = "ndots"
+
+// Mutator injects dnsConfig ndots=NDots into a pod on CREATE. NDots is the dot count
+// of <svc>.<meshDomain> (= the label count of meshDomain; 2 for aether.internal), so
+// mesh FQDNs are resolved absolute-first while shorter k8s names keep their search
+// behavior.
+type Mutator struct {
+	NDots string
+	Log   *slog.Logger
+}
+
+// NewMutator builds the pod-ndots mutator.
+func NewMutator(ndots string, log *slog.Logger) *Mutator {
+	return &Mutator{NDots: ndots, Log: commonlog.Named(log, "pod-ndots")}
+}
+
+// Handle injects the ndots option unless the pod already sets one. The webhook's
+// objectSelector scopes it to managed pods; this stays a no-op otherwise.
+func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	pod := &corev1.Pod{}
+	if err := json.Unmarshal(req.Object.Raw, pod); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if hasNdots(pod) {
+		return admission.Allowed("pod already sets dnsConfig ndots")
+	}
+
+	if pod.Spec.DNSConfig == nil {
+		pod.Spec.DNSConfig = &corev1.PodDNSConfig{}
+	}
+	v := m.NDots
+	pod.Spec.DNSConfig.Options = append(pod.Spec.DNSConfig.Options, corev1.PodDNSConfigOption{Name: ndotsOption, Value: &v})
+
+	marshaled, err := json.Marshal(pod)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+	m.Log.DebugContext(ctx, "injected dnsConfig ndots into managed pod", "namespace", req.Namespace, "ndots", v)
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
+}
+
+func hasNdots(pod *corev1.Pod) bool {
+	if pod.Spec.DNSConfig == nil {
+		return false
+	}
+	for _, o := range pod.Spec.DNSConfig.Options {
+		if o.Name == ndotsOption {
+			return true
+		}
+	}
+	return false
+}

--- a/controller/internal/podmutate/mutator_test.go
+++ b/controller/internal/podmutate/mutator_test.go
@@ -1,0 +1,39 @@
+package podmutate
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func request(pod *corev1.Pod) admission.Request {
+	raw, _ := json.Marshal(pod)
+	return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}}}
+}
+
+func TestMutator_InjectsNdotsWhenAbsent(t *testing.T) {
+	m := NewMutator("2", slog.New(slog.DiscardHandler))
+	resp := m.Handle(context.Background(), request(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches, "a dnsConfig patch is produced")
+}
+
+func TestMutator_RespectsExistingNdots(t *testing.T) {
+	m := NewMutator("2", slog.New(slog.DiscardHandler))
+	v := "1"
+	pod := &corev1.Pod{Spec: corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{
+		Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &v}},
+	}}}
+	resp := m.Handle(context.Background(), request(pod))
+	require.True(t, resp.Allowed)
+	assert.Empty(t, resp.Patches, "no patch when the pod already sets ndots")
+}


### PR DESCRIPTION
musl (Alpine) clients can't resolve `<svc>.<meshDomain>`: the k8s default `ndots:5` makes the resolver apply the `cluster.local` search list **before** the bare name; glibc tolerates the fall-through, musl doesn't (it gave HTTP `000` while the aether data path was proven fine — forced ClusterIP/pod-IP/explicit all **200**). Fix (Istio-injector style): a mutating webhook injects `dnsConfig` `ndots` into managed pods so a mesh FQDN is tried **absolute-first**. **Default off** (`controller.injectPodNdots`).

## What
- `controller/internal/podmutate.Mutator` — on pod `CREATE`, injects `dnsConfig.options ndots=<N>` (unless already set). `N` = the mesh-domain **label count** (2 for `aether.internal`), so `<svc>.<meshDomain>` (2 dots) resolves absolute-first while 1-dot k8s shorthand keeps search behavior — **no regression**. Served on **`/mutate`** (mirrors `/validate`).
- `CABundleInjector` also syncs the `MutatingWebhookConfiguration`'s caBundle in SPIRE mode.
- Chart: `controller.injectPodNdots` renders a `MutatingWebhookConfiguration` scoped to `aether.io/managed=true` pods, **`failurePolicy=Ignore`** (a fail-closed pod webhook is a cluster-wide outage; missing ndots only degrades musl mesh-DNS). Passes `--pod-ndots={{ len (splitList "." meshDomain) }}` + `--mutating-webhook-config-name`; RBAC gains `mutatingwebhookconfigurations` patch. `0.28.0 → 0.29.0`.

## Tests
injects when absent; respects an existing ndots.

## Validate on talos
enable `injectPodNdots`, roll a musl/alpine pod, confirm it resolves + dials `<svc>.<meshDomain>`.