### PR TITLE
fix(agent): echo EDNS0 in mesh-DNS inline answers (c-ares compatibility)

### DIFF
--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -89,6 +89,12 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 			m := new(dns.Msg)
 			m.SetReply(r)
 			m.Authoritative = true
+			// Echo the client's EDNS0 OPT (UDP size + DO). Strict resolvers (c-ares,
+			// which curl/Alpine use) send EDNS0 and reject an answer that omits the
+			// OPT — getaddrinfo/dig are lenient, c-ares is not.
+			if opt := r.IsEdns0(); opt != nil {
+				m.SetEdns0(opt.UDPSize(), opt.Do())
+			}
 			m.Answer = []dns.RR{&dns.A{
 				Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: answerTTL},
 				A:   net.ParseIP(ip).To4(),


### PR DESCRIPTION
c-ares (curl/Alpine) resolved `cluster.local` through the resolver's **forward** path but reported "Could not resolve host" for `<svc>.<meshDomain>` — the resolver's **inline** answer. The forward path preserves the client's EDNS0 OPT (kube-dns echoes it); the inline answer dropped it, and c-ares (strict) rejects a response missing the OPT it asked with. `getaddrinfo`/dig are lenient and accepted it, masking the bug. Fix: echo the client's EDNS0 (UDP size + DO) on inline mesh answers. Code-only. Validate: curl/c-ares dials `<svc>.<meshDomain>` → 200.