### PR TITLE
fix(capture): on-demand catch-all + default mesh-DNS/capture on

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -269,14 +269,21 @@ func runAgent(ctx context.Context) (retErr error) {
 	snapshotCache.SetCaptureEnabled(cfg.TransparentCapture)
 	if cfg.MeshDNS {
 		// In-process DNS resolver (Istio-style): a host-local miekg/dns server that
-		// answers <svc>.<meshDomain> and forwards the rest to kube-dns. The per-pod
-		// Envoy DNS listeners udp_proxy/tcp_proxy to it via the mesh_dns cluster
-		// (HOST_IP:resolverPort) — Envoy does the netns binding (NET_ADMIN), the
-		// resolver runs on the host (no setns, no privilege increase).
+		// answers <svc>.<meshDomain> and forwards the rest to kube-dns. The CNI DNATs
+		// each pod's :53 straight to it at HOST_IP:resolverPort (no Envoy DNS layer,
+		// no setns, no privilege increase).
 		hostIP := os.Getenv("HOST_IP")
 		resolverPort := uint32(commonconstants.ProxyDNSResolverPort)
 		dnsServer := meshdns.NewServer(cfg.MeshDomain, fmt.Sprintf("%s:%d", hostIP, resolverPort), l)
-		dnsServer.SetUpstreams(cfg.MeshDNSUpstream)
+		// Default the forward upstream to the agent's own resolv.conf (kube-dns, via
+		// ClusterFirstWithHostNet) when --mesh-dns-upstream is unset, so mesh DNS is
+		// safe to enable by default without per-cluster configuration.
+		upstreams := cfg.MeshDNSUpstream
+		if len(upstreams) == 0 {
+			upstreams = meshdns.NameserversFromResolvConf("/etc/resolv.conf")
+			l.Info("mesh-DNS upstream defaulted from /etc/resolv.conf", "upstreams", upstreams)
+		}
+		dnsServer.SetUpstreams(upstreams)
 		if err = m.Add(dnsServer); err != nil {
 			return fmt.Errorf("failed to add mesh-DNS resolver: %w", err)
 		}

--- a/agent/internal/meshdns/BUILD.bazel
+++ b/agent/internal/meshdns/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "meshdns",
     srcs = [
         "metrics.go",
+        "resolvconf.go",
         "server.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/meshdns",
@@ -19,7 +20,13 @@ go_library(
 
 go_test(
     name = "meshdns_test",
-    srcs = ["server_test.go"],
+    srcs = [
+        "resolvconf_test.go",
+        "server_test.go",
+    ],
     embed = [":meshdns"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/agent/internal/meshdns/resolvconf.go
+++ b/agent/internal/meshdns/resolvconf.go
@@ -1,0 +1,33 @@
+package meshdns
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+// NameserversFromResolvConf reads the nameserver entries from path (e.g.
+// /etc/resolv.conf). The node agent runs ClusterFirstWithHostNet, so its own
+// resolv.conf points at the cluster kube-dns — the correct default upstream for the
+// mesh resolver to forward non-mesh queries to when --mesh-dns-upstream is unset.
+// Returns nil on any read error (the caller logs and proceeds with no upstream).
+func NameserversFromResolvConf(path string) []string {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = f.Close() }()
+
+	var ns []string
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if fields := strings.Fields(line); len(fields) >= 2 && fields[0] == "nameserver" {
+			ns = append(ns, fields[1])
+		}
+	}
+	return ns
+}

--- a/agent/internal/meshdns/resolvconf_test.go
+++ b/agent/internal/meshdns/resolvconf_test.go
@@ -1,0 +1,19 @@
+package meshdns
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNameserversFromResolvConf(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "resolv.conf")
+	require.NoError(t, os.WriteFile(p, []byte(
+		"# comment\nsearch aether-test.svc.cluster.local svc.cluster.local\nnameserver 10.96.0.10\nnameserver 10.96.0.11\noptions ndots:2\n"), 0o644))
+	assert.Equal(t, []string{"10.96.0.10", "10.96.0.11"}, NameserversFromResolvConf(p))
+	assert.Nil(t, NameserversFromResolvConf(filepath.Join(dir, "missing")))
+}

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -93,10 +93,10 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 		}
 		// Transparent capture (proposal 018, Phase 3a): the cap_http table the per-pod
 		// capture listeners reference over RDS. Always emitted when capture is on (it
-		// carries a 404 default) so the listeners' RDS resolves even with no in-scope
-		// cluster.local authorities yet.
+		// carries the on-demand catch-all) so the listeners' RDS resolves even with no
+		// in-scope authorities yet, and cold/off-node services recover via ODCDS.
 		if c.captureEnabled {
-			routes = append(routes, proxy.BuildCaptureRouteConfiguration(c.captureVhosts()))
+			routes = append(routes, proxy.BuildCaptureRouteConfiguration(c.captureVhosts(), c.meshDomain))
 		}
 		if len(routes) > 0 {
 			resources[resourcev3.RouteType] = routes

--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -114,26 +114,16 @@ func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitSt
 
 // BuildCaptureRouteConfiguration builds the transparent-capture route table: the
 // given cluster.local authority -> service-cluster virtual hosts (built by the agent
-// from the generated mesh Services), plus a default 404 for unknown authorities.
-func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
+// from the generated mesh Services, scoped to the node dependency set), plus the
+// same on-demand catch-all the outbound listener uses. A captured request for a mesh
+// authority (<svc>.<meshDomain>) with no scoped vhost — a cold or off-node service —
+// then resolves via ODCDS (proposal 004 cold path) instead of a dead 404; anything
+// outside the mesh domain still 404s. This makes capture symmetric with outbound:
+// without it, a service whose pods all leave this node drops from the dependency set
+// and its scoped vhost vanishes, leaving it stuck 404 until something re-reconciles.
+func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost, meshDomain string) *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name:         CaptureHTTPRouteName,
-		VirtualHosts: append(vhosts, captureNotFoundVirtualHost()),
-	}
-}
-
-// captureNotFoundVirtualHost 404s any captured authority with no generated Service.
-func captureNotFoundVirtualHost() *routev3.VirtualHost {
-	return &routev3.VirtualHost{
-		Name:    "capture_not_found",
-		Domains: []string{"*"},
-		Routes: []*routev3.Route{
-			{
-				Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
-				Action: &routev3.Route_DirectResponse{
-					DirectResponse: &routev3.DirectResponseAction{Status: 404},
-				},
-			},
-		},
+		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain)),
 	}
 }

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -47,15 +47,27 @@ func TestBuildCaptureRouteConfiguration(t *testing.T) {
 		ServiceClusterName("svc-1", "aether.internal"),
 		[]string{"svc-1.aether-test.svc.cluster.local", "svc-1.aether-test.svc.cluster.local:18081"},
 	)
-	rc := BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vh})
+	rc := BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vh}, "aether.internal")
 	assert.Equal(t, CaptureHTTPRouteName, rc.GetName())
-	require.Len(t, rc.GetVirtualHosts(), 2, "the service vhost + the 404 default")
+	require.Len(t, rc.GetVirtualHosts(), 2, "the service vhost + the on-demand catch-all")
 
 	got := rc.GetVirtualHosts()[0]
 	assert.Contains(t, got.GetDomains(), "svc-1.aether-test.svc.cluster.local:18081")
 	assert.Equal(t, "svc-1.aether.internal", got.GetRoutes()[0].GetRoute().GetCluster())
 
-	def := rc.GetVirtualHosts()[1]
-	assert.Equal(t, []string{"*"}, def.GetDomains())
-	assert.Equal(t, uint32(404), def.GetRoutes()[0].GetDirectResponse().GetStatus())
+	// The catch-all recovers cold/off-node mesh services via ODCDS (ClusterHeader
+	// on :authority) and 404s only non-mesh authorities — symmetric with outbound.
+	catchAll := rc.GetVirtualHosts()[1]
+	assert.Equal(t, []string{"*"}, catchAll.GetDomains())
+	var hasOnDemand, has404 bool
+	for _, r := range catchAll.GetRoutes() {
+		if r.GetRoute().GetClusterHeader() == ":authority" {
+			hasOnDemand = true
+		}
+		if r.GetDirectResponse().GetStatus() == 404 {
+			has404 = true
+		}
+	}
+	assert.True(t, hasOnDemand, "catch-all routes mesh authorities to ODCDS via :authority")
+	assert.True(t, has404, "catch-all 404s non-mesh authorities")
 }

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.31.0-{GIT_COMMIT}"
+version: "0.32.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -103,14 +103,15 @@ agent:
   # Transparent capture (proposal 018, Phase 3a): per-pod capture listeners + the
   # cap_http route table built from the generated mesh Services. Pairs with
   # registrar.generateMeshServices (the VIPs) and the CNI dst-18081 redirect.
-  # Default off — adds the services-read RBAC only when enabled.
-  transparentCapture: false
-  # Mesh DNS (proposal 018, mesh-global FQDN): per-pod dns_filter answering
-  # <svc>.<meshDomain> from the generated mesh Services' ClusterIPs (namespace-free,
-  # globally routable), forwarding the rest to meshDnsUpstream. Pairs with the CNI
-  # :53 redirect. Default off. meshDnsUpstream is the cluster kube-dns (env-specific,
-  # e.g. the kube-dns Service ClusterIP); required when meshDns is on.
-  meshDns: false
+  # Default ON (validated hitless under churn); adds the services-read RBAC.
+  transparentCapture: true
+  # Mesh DNS (proposal 018, mesh-global FQDN): the node agent runs an in-process
+  # resolver answering <svc>.<meshDomain> from the generated mesh Services' ClusterIPs
+  # (namespace-free, globally routable) and forwarding the rest to meshDnsUpstream;
+  # the CNI DNATs each pod's :53 straight to it. Default ON. meshDnsUpstream defaults
+  # to the agent's own resolv.conf (kube-dns via ClusterFirstWithHostNet) when empty,
+  # so no per-cluster config is needed; set it only to override.
+  meshDns: true
   meshDnsUpstream: []
   # Image as repository + digest (digest-pinned for immutability). Mirror to a
   # private registry by overriding `repository` alone; the digest is preserved.
@@ -270,9 +271,9 @@ registrar:
   registryBackend: kubernetes
   # Transparent-capture VIPs (proposal 018, Phase 3a): the leader registrar projects
   # the mesh catalog into selectorless k8s Services on the mesh port (ClusterIP +
-  # cluster.local name + annotation; no EndpointSlices). Default off; adds Service
-  # CRUD RBAC only when enabled.
-  generateMeshServices: false
+  # cluster.local name + annotation; no EndpointSlices). Default ON — the VIPs +
+  # mesh-DNS records that capture and meshDns depend on; adds Service CRUD RBAC.
+  generateMeshServices: true
   # Region owning this registrar's etcd partition (etcd backend; proposal 006).
   # Keys are origin-first /aether/v1/regions/<region>/clusters/<clusterName>/…;
   # shared by every registrar on the same regional etcd.
@@ -301,8 +302,8 @@ controller:
   # ndots (= the mesh-domain label count) into managed pods so a mesh FQDN
   # (<svc>.<meshDomain>) resolves absolute-first, before the cluster.local search
   # list — without it, musl/Alpine clients fail to resolve mesh names. Scoped to
-  # aether.io/managed pods, failurePolicy=Ignore. Default off; pair with mesh DNS.
-  injectPodNdots: false
+  # aether.io/managed pods, failurePolicy=Ignore. Default ON; pairs with mesh DNS.
+  injectPodNdots: true
   webhook:
     # Webhook serving cert source — DECOUPLED from mesh SPIRE (spire.enabled).
     #   false (default): a Helm self-signed cert (genSignedCert, caBundle baked


### PR DESCRIPTION
The 6h soak surfaced a **stuck-404**: a service whose pods all leave a node drops from that node's dependency set, its scoped `cap_http` vhost vanishes, and the capture route table 404'd it with no recovery — while the **outbound** listener recovers the same case via its on-demand catch-all (ODCDS). Capture was asymmetric.

## What
- **capture fix**: `BuildCaptureRouteConfiguration` now appends the **same `buildOnDemandCatchAllVirtualHost`** the outbound listener uses (was `captureNotFoundVirtualHost`, a dead 404). A captured request for a cold/off-node mesh authority resolves via **ODCDS** instead of stuck-404; non-mesh authorities still 404.
- **mesh-DNS upstream auto-default**: falls back to the agent's own `/etc/resolv.conf` (kube-dns via ClusterFirstWithHostNet) when `--mesh-dns-upstream` is unset — no per-cluster config to enable.
- **defaults flipped ON** (validated hitless over the 6h churn soak): `registrar.generateMeshServices`, `agent.transparentCapture`, `agent.meshDns`, `controller.injectPodNdots`. `gamma` stays off. `0.31.0 → 0.32.0`.

## Validate on talos
Roll a service so its pods leave the client's node → `<svc>.aether.internal` recovers (no stuck 404); defaults give the full mesh-DNS+capture path working.