### PR TITLE
feat(gamma): GRPCRoute support (proposal 018, Phase 2)

### DIFF
--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//common/log",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/handler",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@org_golang_google_protobuf//types/known/durationpb",

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -7,6 +7,7 @@ package gamma
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -40,43 +42,62 @@ type Reconciler struct {
 	Log        *slog.Logger
 }
 
-// SetupWithManager registers the reconciler to watch HTTPRoutes.
+// SetupWithManager registers the reconciler to watch HTTPRoutes and GRPCRoutes. Both
+// feed the same per-service rule map; any change re-lists both (level-based), so a
+// single fixed request enqueued for either type is enough.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Log = commonlog.Named(r.Log, "gamma")
+	enqueueAll := handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
+		return []reconcile.Request{{}}
+	})
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.HTTPRoute{}).
+		Watches(&gatewayv1.GRPCRoute{}, enqueueAll).
 		Named("gamma").
 		Complete(r)
 }
 
-// Reconcile re-lists every HTTPRoute, keeps those attached to a Service, and
-// replaces the cache's per-service rule set.
+// Reconcile re-lists every HTTPRoute and GRPCRoute, keeps those attached to a Service,
+// and replaces the cache's per-service rule set.
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
-	list := &gatewayv1.HTTPRouteList{}
-	if err := r.List(ctx, list); err != nil {
+	httpList := &gatewayv1.HTTPRouteList{}
+	if err := r.List(ctx, httpList); err != nil {
+		return reconcile.Result{}, err
+	}
+	grpcList := &gatewayv1.GRPCRouteList{}
+	if err := r.List(ctx, grpcList); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	routes := map[string][]proxy.GammaRoute{}
-	for i := range list.Items {
-		hr := &list.Items[i]
-		for _, svc := range serviceParents(hr) {
+	for i := range httpList.Items {
+		hr := &httpList.Items[i]
+		for _, svc := range serviceParents(hr.Spec.ParentRefs) {
 			for _, rule := range hr.Spec.Rules {
 				routes[svc] = append(routes[svc], r.buildGammaRoute(rule))
 			}
 		}
 	}
+	for i := range grpcList.Items {
+		gr := &grpcList.Items[i]
+		for _, svc := range serviceParents(gr.Spec.ParentRefs) {
+			for _, rule := range gr.Spec.Rules {
+				routes[svc] = append(routes[svc], r.buildGammaRouteFromGRPC(rule))
+			}
+		}
+	}
 
 	r.Sink.SetServiceRoutes(routes)
-	r.Log.DebugContext(ctx, "projected gamma service routes", "httpRoutes", len(list.Items), "services", len(routes))
+	r.Log.DebugContext(ctx, "projected gamma service routes",
+		"httpRoutes", len(httpList.Items), "grpcRoutes", len(grpcList.Items), "services", len(routes))
 	return reconcile.Result{}, nil
 }
 
-// serviceParents returns the names of the Services this HTTPRoute is attached to
-// (parentRef kind=Service, core group).
-func serviceParents(hr *gatewayv1.HTTPRoute) []string {
+// serviceParents returns the names of the Services these parentRefs attach to
+// (kind=Service, core group). Shared by HTTPRoute and GRPCRoute.
+func serviceParents(refs []gatewayv1.ParentReference) []string {
 	var svcs []string
-	for _, p := range hr.Spec.ParentRefs {
+	for _, p := range refs {
 		if p.Group != nil && string(*p.Group) != "" {
 			continue
 		}
@@ -121,6 +142,58 @@ func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule) proxy.GammaRo
 				gm.Exact = *m.Path.Value
 			} else {
 				gm.Prefix = *m.Path.Value
+			}
+		}
+		for _, h := range m.Headers {
+			gm.Headers = append(gm.Headers, proxy.GammaHeaderMatch{Name: string(h.Name), Value: h.Value})
+		}
+		gr.Matches = append(gr.Matches, gm)
+	}
+	return gr
+}
+
+// buildGammaRouteFromGRPC translates a GRPCRouteRule into the same GammaRoute
+// vocabulary the HTTP path uses: gRPC rides HTTP/2 as POST /<service>/<method>, so a
+// method match becomes a path match (service+method = exact /svc/method; service-only
+// = prefix /svc/), and gRPC header matches map to request-header matches. GRPCRoute
+// has no per-rule timeout. The backends are identical (weighted Service refs).
+func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule) proxy.GammaRoute {
+	gr := proxy.GammaRoute{}
+	for _, b := range rule.BackendRefs {
+		if b.Group != nil && string(*b.Group) != "" {
+			continue
+		}
+		if b.Kind != nil && string(*b.Kind) != "Service" {
+			continue
+		}
+		name := string(b.Name)
+		weight := uint32(1)
+		if b.Weight != nil {
+			weight = uint32(*b.Weight)
+		}
+		gr.Backends = append(gr.Backends, proxy.GammaBackend{
+			Service: name,
+			Cluster: proxy.ServiceClusterName(name, r.MeshDomain),
+			Weight:  weight,
+		})
+	}
+	for _, m := range rule.Matches {
+		gm := proxy.GammaMatch{}
+		if m.Method != nil {
+			svc, method := "", ""
+			if m.Method.Service != nil {
+				svc = *m.Method.Service
+			}
+			if m.Method.Method != nil {
+				method = *m.Method.Method
+			}
+			// Only the Exact method-match type maps to a literal path (the
+			// GammaMatch vocabulary has no regex). svc+method = exact, svc = prefix.
+			exactType := m.Method.Type == nil || *m.Method.Type == gatewayv1.GRPCMethodMatchExact
+			if exactType && svc != "" && method != "" {
+				gm.Exact = fmt.Sprintf("/%s/%s", svc, method)
+			} else if exactType && svc != "" {
+				gm.Prefix = fmt.Sprintf("/%s/", svc)
 			}
 		}
 		for _, h := range m.Headers {

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -19,7 +19,7 @@ func TestServiceParents(t *testing.T) {
 			{Name: "no-kind"}, // no kind → ignored
 		},
 	}}}
-	assert.Equal(t, []string{"svc-1"}, serviceParents(hr))
+	assert.Equal(t, []string{"svc-1"}, serviceParents(hr.Spec.ParentRefs))
 }
 
 // TestBuildGammaRoute: matches → GammaMatch, weighted backendRefs → GammaBackend
@@ -50,4 +50,27 @@ func TestBuildGammaRoute(t *testing.T) {
 
 	require.NotNil(t, gr.Timeout)
 	assert.Equal(t, int64(5), gr.Timeout.GetSeconds())
+}
+
+// TestBuildGammaRouteFromGRPC: gRPC method match -> path, weighted backendRefs.
+func TestBuildGammaRouteFromGRPC(t *testing.T) {
+	r := &Reconciler{MeshDomain: "aether.internal"}
+	w := ptr(int32(7))
+	rule := gatewayv1.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{
+			{Method: &gatewayv1.GRPCMethodMatch{Service: ptr("foo.Bar"), Method: ptr("Baz")}},
+			{Method: &gatewayv1.GRPCMethodMatch{Service: ptr("foo.Bar")}},
+		},
+		BackendRefs: []gatewayv1.GRPCBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-2"}, Weight: w}},
+		},
+	}
+	gr := r.buildGammaRouteFromGRPC(rule)
+	require.Len(t, gr.Matches, 2)
+	assert.Equal(t, "/foo.Bar/Baz", gr.Matches[0].Exact, "service+method -> exact path")
+	assert.Equal(t, "/foo.Bar/", gr.Matches[1].Prefix, "service-only -> prefix path")
+	require.Len(t, gr.Backends, 1)
+	assert.Equal(t, "svc-2", gr.Backends[0].Service)
+	assert.Equal(t, "svc-2.aether.internal", gr.Backends[0].Cluster)
+	assert.Equal(t, uint32(7), gr.Backends[0].Weight)
 }

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.32.0-{GIT_COMMIT}"
+version: "0.33.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -13,9 +13,9 @@ rules:
     # patch: remove the aether.io/agent-not-ready startup taint once CNI is serving.
     verbs: ["list", "get", "watch", "patch"]
   {{- if .Values.agent.gamma }}
-  # GAMMA east-west (proposal 018): watch HTTPRoutes parented to Services cluster-wide.
+  # GAMMA east-west (proposal 018): watch HTTP/GRPCRoutes parented to Services cluster-wide.
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["httproutes"]
+    resources: ["httproutes", "grpcroutes"]
     verbs: ["list", "get", "watch"]
   {{- end }}
   {{- if or .Values.agent.transparentCapture .Values.agent.meshDns }}


### PR DESCRIPTION
Extends the GAMMA reconciler to watch **GRPCRoutes** alongside HTTPRoutes (same Service-parent semantics). gRPC rides HTTP/2 as `POST /<service>/<method>`, so a method match maps to the existing GammaRoute path vocab: service+method → exact `/svc/method`, service-only → prefix `/svc/`; gRPC header matches → request-header matches; weighted backendRefs identical. Both kinds feed the same per-service rule map.

- gamma reconciler: `For(HTTPRoute).Watches(GRPCRoute)`, lists both, `buildGammaRouteFromGRPC`.
- agent RBAC: add `grpcroutes` to the gamma watch. `0.32.0 → 0.33.0`.