### PR TITLE
fix(gamma): apply GAMMA rules on the capture path (HTTP + gRPC)

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -62,6 +62,10 @@ func (c *SnapshotCache) SetCaptureAuthorities(authorities map[string]string) {
 // clusters the scoped snapshot carries; unknown authorities hit the 404 default.
 func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 	deps := c.DependencySet()
+	// GAMMA (HTTPRoute/GRPCRoute) rules enrich the captured path too — capture is the
+	// default client path (mesh-DNS), so the same L7 vocabulary the outbound listener
+	// applies must apply here; no rules = passthrough to the service cluster.
+	gammaRoutes := c.serviceRoutesSnapshot()
 
 	c.captureMu.RLock()
 	defer c.captureMu.RUnlock()
@@ -74,10 +78,10 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		// Route both the cluster.local authority and the mesh-global <svc>.<meshDomain>
 		// authority (portless + :meshPort) to the service cluster, so a captured
 		// request reaches it under either name (the mesh-DNS path uses the latter).
-		vhosts = append(vhosts, proxy.BuildOutboundClusterVirtualHost(mesh, []string{
+		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, []string{
 			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
 			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
-		}))
+		}, gammaRoutes[svc]))
 	}
 	return vhosts
 }

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.33.0-{GIT_COMMIT}"
+version: "0.34.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether


### PR DESCRIPTION
GAMMA enriched only the **outbound** service vhost, but transparent capture — now the default client path via mesh-DNS — routed captured requests straight to the service cluster, **bypassing HTTPRoute/GRPCRoute rules**. A GRPCRoute/HTTPRoute rule projected fine but never took effect for a client dialing `<svc>.aether.internal` (e2e caught this).

Fix: `captureVhosts` builds the gamma-enriched vhost (`serviceRoutesSnapshot()[svc]`), identical to outbound — no rules = passthrough. The dependency set already unions GAMMA backends. `0.33.0 → 0.34.0`.