### PR TITLE
docs(018): proposal as-built + Gateway API conformance features

### DIFF
--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -1,0 +1,52 @@
+# Gateway API — supported features (aether)
+
+Aether implements Gateway API natively on its own SPIRE-mTLS + registry-EDS data plane
+(proposal 018), both north-south (edge `Gateway`/`HTTPRoute`) and east-west (GAMMA,
+`HTTPRoute`/`GRPCRoute` with `parentRef: Service`). This is the honest
+supported-features list — "ship support first, report it honestly, chase the badge
+later". `Supported` = implemented and e2e-validated on talos; `Partial` = implemented
+with the noted limitation; `Planned` = on the 018 roadmap, not yet shipped.
+
+## Route types
+
+| Feature | Status | Notes |
+|---|---|---|
+| `HTTPRoute` (edge, parentRef=Gateway) | Supported | path + host matches, wildcard TLS; `backendRef` requires `port` (use the service default) |
+| `HTTPRoute` (GAMMA, parentRef=Service) | Supported | path/header matches, weighted backendRefs, per-rule request timeout; producer routes |
+| `GRPCRoute` (GAMMA) | Supported | method match → `/<service>/<method>`; service-only → prefix; header matches; weighted backends |
+| `TCPRoute` / `TLSRoute` / `UDPRoute` | Planned | Phase 3b; layers on the TCP-over-mTLS floor |
+
+## Routing vocabulary (HTTP/gRPC)
+
+| Feature | Status | Notes |
+|---|---|---|
+| Path match (Exact, PathPrefix) | Supported | |
+| Header match (Exact) | Supported | |
+| Method match (gRPC) | Supported | |
+| Weighted backends (canary/split) | Supported | `WeightedClusters` |
+| Request timeout | Supported | HTTPRoute `timeouts.request` |
+| Request mirroring | Planned | |
+| Request/response header & redirect filters | Planned | |
+| RegularExpression matches | Partial | gRPC method RegularExpression type is not translated (Exact only) |
+
+## Mesh & multi-cluster
+
+| Feature | Status | Notes |
+|---|---|---|
+| GAMMA Mesh profile (parentRef=Service) | Supported | producer routes; consumer (per-namespace) overrides Planned |
+| GAMMA rules on the transparent-capture path | Supported | applies to clients dialing `<svc>.<meshDomain>` (the default path) |
+| `ReferenceGrant` (cross-namespace backendRefs) | N/A → Planned | aether's data-plane cluster name is namespace-free (`<svc>.<meshDomain>`), so cross-namespace backend references are not part of the routing model today; grant enforcement is a conformance-only follow-up |
+| MCS `ServiceExport`/`ServiceImport`, `clusterset.local` | Planned | registry-backed (proposal 006), DNS strictly local |
+
+## Transport / security
+
+| Feature | Status | Notes |
+|---|---|---|
+| Listener TLS termination (edge) | Supported | SDS; wildcard certs |
+| Upstream mTLS (SPIRE) on every hop | Supported | per-endpoint SPIFFE SAN from registry EDS |
+| TCP-over-mTLS passthrough (non-HTTP) | Planned | Phase 3a floor |
+
+## Status reporting
+
+GatewayClass/Gateway/Route status-condition reporting (Accepted/Programmed/ResolvedRefs)
+and a machine-readable supported-features report are a Planned conformance follow-up.

--- a/docs/proposals/018_gateway-api-gamma.md
+++ b/docs/proposals/018_gateway-api-gamma.md
@@ -279,3 +279,54 @@ data-plane detail below the API).
   namespace overrides only that client; a `/admin` match routes elsewhere; a
   per-route timeout takes effect — all over the existing SPIRE mTLS, with the
   routes pushed only to proxies whose dependency set includes the service.
+
+## As-built status (2026-06-24)
+
+Tracking what has actually shipped vs the design above. Validated end-to-end on the
+talos-main cluster unless noted.
+
+**Shipped + e2e-green:**
+- **Gateway API dependency** upgraded to `sigs.k8s.io/gateway-api` v1.5.1 (#272).
+- **Phase 1 — edge HTTPRoute** (#270): `edge.gatewayApi.enabled`; Gateway+HTTPRoute
+  (parentRef=Gateway) → the edge data plane; GatewayClass `gateway.aether.io/edge`;
+  listener TLS via SDS. HTTPRoute `backendRef` requires a `port` (use the service
+  default, 8080).
+- **Phase 2 — GAMMA east-west** (#271): `agent.gamma`; HTTPRoute (parentRef=Service)
+  → per-service outbound vhost enrichment (matches→routes, weighted backendRefs,
+  timeout, additive default). Producer routes; the dependency set unions a route's
+  backends.
+- **GRPCRoute** (#289): the GAMMA reconciler also watches GRPCRoutes; a gRPC method
+  match (`/<service>/<method>`) maps into the same route vocabulary; weighted
+  backends + header matches identical to HTTPRoute.
+- **GAMMA on the capture path** (#290): GAMMA was outbound-only; once transparent
+  capture + mesh-DNS became the default client path, captured requests bypassed the
+  rules. `captureVhosts` now builds the gamma-enriched vhost, so HTTP/gRPC route
+  rules apply on the captured path too.
+- **Mesh-global FQDN** (proposal-018 sub-thread, #277→#288): clients dial the
+  namespace-free `<svc>.<meshDomain>`. Final design is an **in-agent miekg/dns
+  resolver** (not the Envoy `dns_filter`, which broke c-ares) reached by a CNI
+  **DNAT** of each pod's `:53` straight to `HOST_IP:18054` (no Envoy DNS layer); a
+  pod-ndots mutating webhook injects `ndots` so musl/Alpine clients resolve the mesh
+  FQDN absolute-first; the resolver answers mesh names authoritatively for all types
+  (A→record, else NODATA) and forwards the rest to kube-dns (auto-discovered from the
+  agent's resolv.conf).
+- **Phase 3a — HTTP transparent capture** (#273→#276): selectorless mesh-Service VIPs
+  on :18081, the `cap_http` route table, and the CNI dst-18081 REDIRECT. Hardened
+  with an **on-demand catch-all** (#288) so a cold/off-node service recovers via
+  ODCDS instead of a stuck 404.
+- **Defaults flipped ON** (#288): `generateMeshServices`, `transparentCapture`,
+  `meshDns`, `injectPodNdots` (gamma stays opt-in). Validated hitless over a 6h churn
+  soak (7 agent/proxy rolls + 29 service rolls, prober 100%, mesh 5xx 0).
+
+**In progress / not yet shipped:**
+- **Phase 3a TCP-over-mTLS floor**: protocol-detect (`tls_inspector`+`http_inspector`)
+  → HCM for HTTP/gRPC, `tcp_proxy`-over-mTLS for everything else, on both the capture
+  path and inbound `:15008`. Needs `appProtocol` metadata + capture broader than the
+  :18081 mesh port to be exercised.
+- **Phase 3b**: `TCPRoute`/`TLSRoute`/`UDPRoute` L4 routing (layers on the floor).
+- **VirtualHost CRD retirement**: edge migrates fully to HTTPRoute; the dup-FQDN
+  webhook generalizes to a Gateway/HTTPRoute hostname-conflict check.
+- **Multi-cluster MCS**: `ServiceExport`/`ServiceImport` + `clusterset.local`
+  materialized from the registry; cross-cluster data path is a later phase.
+- **Conformance**: `ReferenceGrant` and supported-features/Mesh-profile reporting
+  (see `docs/conformance/gateway-api-features.md`).


### PR DESCRIPTION
Brings the proposal 018 doc onto main with an **as-built status** section (what shipped this session vs what remains) and adds **docs/conformance/gateway-api-features.md** — an honest Supported/Partial/Planned feature list. Docs-only.