### PR TITLE
feat(mesh): support non-HTTP (TCP) services end-to-end

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -38,6 +38,14 @@ import (
 
 const ghostSweepInterval = 60 * time.Second
 
+// sweptProtocols are the registry protocols the ghost sweep reconciles. Both
+// HTTP and TCP services are owned per node, so a missed deregistration of either
+// must be caught.
+var sweptProtocols = []registryv1.Service_Protocol{
+	registryv1.Service_PROTOCOL_HTTP,
+	registryv1.Service_PROTOCOL_TCP,
+}
+
 // netnsExists reports whether a pod's network-namespace path is still present.
 // Overridable in tests (which use synthetic netns paths). A stored pod whose
 // netns is gone is a stale entry from a missed CNI DEL — see sweepGhostEndpoints.
@@ -125,17 +133,28 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	// implements (observed 2026-06-11: a registry-backend switch left the
 	// registry empty while every agent no-op'd; only an agent restart healed
 	// it).
-	var all map[string][]*registryv1.ServiceEndpoint
-	var err error
-	if al, ok := s.registry.(registry.AuthoritativeLister); ok {
-		all, err = al.ListAllEndpointsAuthoritative(ctx, registryv1.Service_PROTOCOL_HTTP)
-	} else {
-		all, err = s.registry.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
-	}
-	if err != nil {
-		s.log.DebugContext(ctx, "ghost sweep: failed to list registry endpoints", "error", err)
-		retErr = err
-		return
+	// Sweep every protocol so TCP (non-HTTP) endpoints are reconciled too — a
+	// stale TCP ghost is as dangerous as an HTTP one (a HEALTHY ghost in EDS mode
+	// keeps receiving traffic). A service is registered under exactly one
+	// protocol, so merging the per-protocol listings never collides on a name.
+	al, authoritative := s.registry.(registry.AuthoritativeLister)
+	all := make(map[string][]*registryv1.ServiceEndpoint)
+	for _, protocol := range sweptProtocols {
+		var listed map[string][]*registryv1.ServiceEndpoint
+		var err error
+		if authoritative {
+			listed, err = al.ListAllEndpointsAuthoritative(ctx, protocol)
+		} else {
+			listed, err = s.registry.ListAllEndpoints(ctx, protocol)
+		}
+		if err != nil {
+			s.log.DebugContext(ctx, "ghost sweep: failed to list registry endpoints", "protocol", protocol.String(), "error", err)
+			retErr = err
+			return
+		}
+		for svc, eps := range listed {
+			all[svc] = append(all[svc], eps...)
+		}
 	}
 
 	// Serialize against pod lifecycle so an in-flight AddPod (stored after the

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -29,7 +29,13 @@ type sweepRegistry struct {
 	registered   map[string]*registryv1.ServiceEndpoint // service/ip -> endpoint
 }
 
-func (r *sweepRegistry) ListAllEndpoints(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+func (r *sweepRegistry) ListAllEndpoints(_ context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	// These tests register HTTP services; the sweep now lists every protocol.
+	// Return the listing only for HTTP so the TCP pass contributes nothing (an
+	// HTTP service must not be double-counted as a TCP one).
+	if protocol != registryv1.Service_PROTOCOL_HTTP {
+		return nil, nil
+	}
 	return r.listing, nil
 }
 
@@ -242,7 +248,11 @@ type authoritativeSweepRegistry struct {
 	authoritative map[string][]*registryv1.ServiceEndpoint
 }
 
-func (r *authoritativeSweepRegistry) ListAllEndpointsAuthoritative(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+func (r *authoritativeSweepRegistry) ListAllEndpointsAuthoritative(_ context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	// HTTP-only fixtures; the sweep lists every protocol (see sweepRegistry).
+	if protocol != registryv1.Service_PROTOCOL_HTTP {
+		return nil, nil
+	}
 	return r.authoritative, nil
 }
 

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -59,10 +59,12 @@ go_test(
         "outbound_mtls_test.go",
         "races_test.go",
         "snapshot_test.go",
+        "tcp_service_test.go",
         "version_test.go",
     ],
     embed = [":cache"],
     deps = [
+        "//agent/internal/capture",
         "//agent/internal/xds/proxy",
         "//agent/storage",
         "//api/aether/cni/v1:cni",

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -255,6 +255,11 @@ type clusterEntry struct {
 	// mTLS transport socket so the destination inbound demuxes to the right
 	// loopback port (multi-port routing, proposal 005). Empty = default chain.
 	sni string
+	// tcp marks a PROTOCOL_TCP service entry. Such entries hold only the
+	// bare-name EDS load assignment (+ sanNamespaces/sni) for the transparent-
+	// capture TCP floor's "tcp:<svc>" cluster to reference; no HTTP (h2) cluster
+	// or outbound vhost is emitted for them (clustersEndpointsAndVhosts skips it).
+	tcp bool
 	// absentSince is non-zero while the service is missing from the registry
 	// listing. Such entries are retained (with empty endpoints) for
 	// serviceRetentionGrace before being pruned: during pod churn a service

--- a/agent/internal/xds/cache/cache_test.go
+++ b/agent/internal/xds/cache/cache_test.go
@@ -14,6 +14,11 @@ import (
 // mockRegistry implements registry.Registry for testing purposes.
 type mockRegistry struct {
 	listAllEndpointsFunc func(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error)
+	// tcpAware lets a test's listAllEndpointsFunc handle PROTOCOL_TCP itself
+	// (returning per-protocol data). When false (default), the wrapper scopes a
+	// protocol-agnostic callback to HTTP so an HTTP service isn't double-counted
+	// as a TCP service.
+	tcpAware bool
 }
 
 var _ registry.Registry = (*mockRegistry)(nil)
@@ -39,7 +44,19 @@ func (m *mockRegistry) ListEndpoints(_ context.Context, _ string, _ registryv1.S
 
 func (m *mockRegistry) ListAllEndpoints(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 	if m.listAllEndpointsFunc != nil {
-		return m.listAllEndpointsFunc(ctx, protocol)
+		eps, err := m.listAllEndpointsFunc(ctx, protocol)
+		if err != nil {
+			return nil, err
+		}
+		// Most tests register HTTP services and their callbacks ignore the
+		// protocol; LoadClustersFromRegistry now also lists PROTOCOL_TCP. Scope
+		// the default (protocol-agnostic) callbacks to HTTP so an HTTP service
+		// isn't also returned as a (TCP-floor) service. A protocol-aware test
+		// returns its own per-protocol data and is not filtered here.
+		if protocol != registryv1.Service_PROTOCOL_HTTP && !m.tcpAware {
+			return map[string][]*registryv1.ServiceEndpoint{}, nil
+		}
+		return eps, nil
 	}
 	return map[string][]*registryv1.ServiceEndpoint{}, nil
 }

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -101,6 +101,16 @@ func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.
 	clas := make([]types.Resource, 0, len(c.clusters))
 	vhosts := make([]*routev3.VirtualHost, 0, len(c.clusters))
 	for _, entry := range c.clusters {
+		// TCP services carry no HTTP (h2) cluster or outbound vhost: their data
+		// path is the transparent-capture TCP floor's "tcp:<svc>" cluster (built
+		// in captureTCPClusters), which shares this entry's bare-name EDS load
+		// assignment. Emit only the load assignment so that EDS resolves.
+		if entry.tcp {
+			if entry.loadAssignment != nil {
+				clas = append(clas, entry.loadAssignment)
+			}
+			continue
+		}
 		cluster := entry.cluster
 		if nodeSpiffeID != "" {
 			// Expected server identities for this service: one SPIFFE ID per
@@ -210,8 +220,40 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 		}
 	}
 
+	// TCP (non-HTTP) services: their endpoints are the SAME pods reached over a
+	// raw mTLS passthrough through the transparent-capture TCP floor. The floor's
+	// "tcp:<svc>" cluster (built in captureTCPClusters) references the bare-name
+	// EDS this method publishes, so a TCP service needs a cluster entry here too
+	// — holding only the load assignment (no HTTP h2 cluster/vhost). A service is
+	// HTTP or TCP, never both, so the two sets never share a name.
+	tcpServiceEndpoints, err := reg.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_TCP)
+	if err != nil {
+		return fmt.Errorf("failed to list TCP endpoints from registry: %w", err)
+	}
+	if cat, ok := reg.(registry.ServiceCatalog); ok {
+		for svc := range deps {
+			if _, have := tcpServiceEndpoints[svc]; have {
+				continue
+			}
+			if _, have := serviceEndpoints[svc]; have {
+				continue // already an HTTP dependency
+			}
+			if !cat.HasService(svc) {
+				continue
+			}
+			eps, err := reg.ListEndpoints(ctx, svc, registryv1.Service_PROTOCOL_TCP)
+			if err != nil {
+				c.log.InfoContext(ctx, "cold-path TCP endpoint fetch failed; watch catch-up will fill in", "service", svc, "error", err.Error())
+				continue
+			}
+			if len(eps) > 0 {
+				tcpServiceEndpoints[svc] = eps
+			}
+		}
+	}
+
 	c.log.DebugContext(ctx, "found service endpoints in registry",
-		"count", len(serviceEndpoints), "dependencySet", len(deps))
+		"count", len(serviceEndpoints), "tcpCount", len(tcpServiceEndpoints), "dependencySet", len(deps))
 
 	c.clusterMu.Lock()
 	// Rebuild the cluster set so this method is idempotent and safe to call
@@ -338,6 +380,48 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 				service:        serviceName,
 				sni:            strconv.Itoa(int(port)),
 			}
+		}
+	}
+
+	// TCP service entries: bare-name EDS load assignment + SAN/sni only. The
+	// capture TCP floor's "tcp:<svc>" cluster (captureTCPClusters) references
+	// this EDS resource (by bare name) and pins peer identity from sanNamespaces.
+	for serviceName, endpoints := range tcpServiceEndpoints {
+		if _, inScope := deps[serviceName]; !inScope {
+			continue
+		}
+		if len(endpoints) == 0 {
+			continue
+		}
+		nsSet := make(map[string]struct{})
+		for _, endpoint := range endpoints {
+			if ns := endpoint.GetKubernetesMetadata().GetNamespace(); ns != "" {
+				nsSet[ns] = struct{}{}
+			}
+		}
+		sanNamespaces := make([]string, 0, len(nsSet))
+		for ns := range nsSet {
+			sanNamespaces = append(sanNamespaces, ns)
+		}
+		sort.Strings(sanNamespaces)
+
+		defaultPort := endpoints[0].GetPort()
+		cla := proxy.NewClusterLoadAssignment(serviceName)
+		epMap := make(map[string]*endpointv3.LocalityLbEndpoints, len(endpoints))
+		for _, endpoint := range endpoints {
+			lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, localRegion, localZone)
+			cla.Endpoints = append(cla.Endpoints, lbEp)
+			epMap[endpoint.GetIp()] = lbEp
+		}
+		proxy.SortLocalityLbEndpoints(cla.Endpoints)
+
+		c.clusters[serviceName] = clusterEntry{
+			loadAssignment: cla,
+			endpoints:      epMap,
+			sanNamespaces:  sanNamespaces,
+			service:        serviceName,
+			sni:            strconv.Itoa(int(defaultPort)),
+			tcp:            true,
 		}
 	}
 

--- a/agent/internal/xds/cache/tcp_service_test.go
+++ b/agent/internal/xds/cache/tcp_service_test.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/capture"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadClustersFromRegistry_TCPCluster verifies that a PROTOCOL_TCP service
+// produces a "tcp:<svc>.<domain>" floor cluster whose EDS resolves to the
+// service's registry endpoints — the data path the transparent-capture TCP floor
+// routes a raw mTLS passthrough onto. The HTTP "<svc>.<domain>" cluster is NOT
+// emitted for a TCP service (its data path is the floor cluster).
+func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetCaptureEnabled(true)
+	ctx := context.Background()
+
+	// A local pod establishes the netns -> SPIFFE ID mapping; SetNodeIdentity
+	// gates the upstream mTLS injection captureTCPClusters depends on.
+	pod := &cniv1.CNIPod{
+		Name:             "echo-tcp-0",
+		Namespace:        "aether-test",
+		ServiceAccount:   "echo-tcp",
+		NetworkNamespace: "/var/run/netns/cni-tcp",
+	}
+	require.NoError(t, c.AddPod(ctx, pod, "aether.internal"))
+	require.NoError(t, c.SetNodeIdentity(ctx, nodeIdentity))
+	declareDeps(c, "echo-tcp")
+
+	reg := &mockRegistry{
+		tcpAware: true,
+		listAllEndpointsFunc: func(_ context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			if protocol == registryv1.Service_PROTOCOL_TCP {
+				return map[string][]*registryv1.ServiceEndpoint{
+					"echo-tcp": {makeEndpoint("10.0.0.9", "cluster-1", "node-2", 9000)},
+				}, nil
+			}
+			return map[string][]*registryv1.ServiceEndpoint{}, nil
+		},
+	}
+
+	// The capture reconciler classified echo-tcp as a TCP service (annotation
+	// "tcp" on its mesh Service) and projected its ClusterIP.
+	c.SetCaptureTCPServices([]capture.CaptureTCPService{{ServiceName: "echo-tcp", ClusterIP: "10.96.0.50"}})
+
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+
+	snap, err := c.GetSnapshot("node-1")
+	require.NoError(t, err)
+
+	clusters := snap.GetResources(resourcev3.ClusterType)
+	// The TCP floor cluster is present, named tcp:<svc>.<domain>.
+	tcpCluster, ok := clusters["tcp:echo-tcp.aether.internal"].(*clusterv3.Cluster)
+	require.True(t, ok, "tcp floor cluster must be present")
+	assert.Equal(t, "echo-tcp", tcpCluster.GetEdsClusterConfig().GetServiceName(),
+		"tcp cluster EDS resource is the bare service name")
+	// With a local pod present, the per-source mTLS transport socket is injected
+	// via the matcher (not a single TransportSocket).
+	require.NotNil(t, tcpCluster.GetTransportSocketMatcher(), "tcp floor cluster must carry the per-source mTLS matcher")
+
+	// No HTTP cluster/vhost for a TCP-only service.
+	_, hasHTTP := clusters["echo-tcp.aether.internal"]
+	assert.False(t, hasHTTP, "a TCP service must not also emit an HTTP cluster")
+
+	// EDS for the bare service name carries the endpoint (the tcp: cluster
+	// references it by ServiceName).
+	endpoints := snap.GetResources(resourcev3.EndpointType)
+	cla, ok := endpoints["echo-tcp"].(*endpointv3.ClusterLoadAssignment)
+	require.True(t, ok, "bare-name EDS load assignment must be present for the tcp cluster")
+	require.NotEmpty(t, cla.GetEndpoints(), "tcp cluster EDS must carry the registry endpoint")
+	require.NotEmpty(t, cla.GetEndpoints()[0].GetLbEndpoints())
+	addr := cla.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "10.0.0.9", addr.GetAddress())
+}

--- a/api/aether/registry/v1/service.proto
+++ b/api/aether/registry/v1/service.proto
@@ -19,6 +19,10 @@ message Service {
   enum Protocol {
     PROTOCOL_UNSPECIFIED = 0;
     PROTOCOL_HTTP = 1;
+    // PROTOCOL_TCP marks a non-HTTP (raw TCP-over-mTLS) mesh service. Its
+    // endpoints are reached through the transparent-capture TCP floor as a raw
+    // mTLS passthrough (proposal 018, Phase 3a), not the HTTP HCM path.
+    PROTOCOL_TCP = 2;
   }
 
   Protocol protocol = 2 [(buf.validate.field).enum.defined_only = true];

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.37.0-{GIT_COMMIT}"
+version: "0.38.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -50,6 +50,20 @@ const (
 	HealthCheckModeActive = "active"
 	HealthCheckModeEDS    = "eds"
 
+	// AnnotationEndpointProtocol is the pod annotation selecting the mesh
+	// service's wire protocol (a registration fact: what the pod serves). Unset
+	// or "http" (default) registers the workload as a PROTOCOL_HTTP service
+	// reached via the HCM path; "tcp" registers it as a PROTOCOL_TCP service
+	// reached as a raw mTLS passthrough through the transparent-capture TCP
+	// floor (proposal 018, Phase 3a). Distinct from aether.io/app-protocol
+	// (AnnotationMeshAppProtocol), which the registrar STAMPS on the generated
+	// mesh Service for the agent's capture reconciler to read.
+	AnnotationEndpointProtocol = annotationAetherEndpointPrefix + "protocol"
+	// ProtocolHTTP / ProtocolTCP are the accepted AnnotationEndpointProtocol
+	// values.
+	ProtocolHTTP = "http"
+	ProtocolTCP  = "tcp"
+
 	// AnnotationAetherEndpointMetadataPrefix is the prefix for endpoint metadata annotations
 	AnnotationAetherEndpointMetadataPrefix = "metadata." + annotationAetherEndpointPrefix
 

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -141,10 +141,14 @@ func (s *RegistrarServer) UnregisterEndpoint(ctx context.Context, req *registrar
 	ips := req.GetIps()
 	if s.writeBehind != nil {
 		for _, ip := range ips {
-			// UnregisterEndpointRequest carries no protocol; the registrar is
-			// HTTP-only end-to-end today (the sync loop lists PROTOCOL_HTTP),
-			// and the key must match the register side's for supersede.
-			s.writeBehind.EnqueueUnregister(req.GetServiceName(), registryv1.Service_PROTOCOL_HTTP, ip)
+			// UnregisterEndpointRequest carries no protocol, but a service is
+			// registered under exactly one (HTTP or TCP). Supersede the pending
+			// register on every synced protocol so a TCP endpoint's removal isn't
+			// defeated by a still-pending TCP register keyed under a protocol the
+			// HTTP-only key would miss. The external delete is protocol-agnostic.
+			for _, protocol := range syncedProtocols {
+				s.writeBehind.EnqueueUnregister(req.GetServiceName(), protocol, ip)
+			}
 		}
 	} else if len(ips) == 1 {
 		if err := s.registry.UnregisterEndpoint(ctx, req.GetServiceName(), ips[0]); err != nil {

--- a/registrar/internal/server/sync.go
+++ b/registrar/internal/server/sync.go
@@ -18,6 +18,15 @@ import (
 // tracerName identifies this instrumentation scope in trace backends.
 const tracerName = "aether/registrar"
 
+// syncedProtocols are the registry protocols the syncer reflects into the
+// snapshot each cycle. HTTP services ride the HCM path; TCP services ride the
+// transparent-capture TCP floor. Each cycle lists every protocol so both flow
+// through the snapshot, the agent watch stream, and name resolution.
+var syncedProtocols = []registryv1.Service_Protocol{
+	registryv1.Service_PROTOCOL_HTTP,
+	registryv1.Service_PROTOCOL_TCP,
+}
+
 // Syncer periodically polls an external registry, computes a diff against the
 // local snapshot, and broadcasts changes to all watching agents. It implements
 // the controller-runtime Runnable interface.
@@ -128,21 +137,24 @@ func (s *Syncer) sync(ctx context.Context) {
 	defer func() { telemetry.EndSpan(span, retErr) }()
 	start := time.Now()
 
-	endpoints, err := s.registry.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
-	if err != nil {
-		s.log.ErrorContext(ctx, "failed to list endpoints from registry", "error", err)
-		s.metrics.syncFailed(ctx, time.Since(start).Seconds())
-		retErr = err
-		return
-	}
-
-	// Build the new state in the format the snapshot expects.
+	// Build the new state in the format the snapshot expects, listing every
+	// protocol so non-HTTP (TCP) services flow through the snapshot, watch
+	// stream, and name resolution alongside HTTP.
 	newState := make(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint)
-	for svcName, eps := range endpoints {
-		if newState[svcName] == nil {
-			newState[svcName] = make(map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint)
+	for _, protocol := range syncedProtocols {
+		endpoints, err := s.registry.ListAllEndpoints(ctx, protocol)
+		if err != nil {
+			s.log.ErrorContext(ctx, "failed to list endpoints from registry", "protocol", protocol.String(), "error", err)
+			s.metrics.syncFailed(ctx, time.Since(start).Seconds())
+			retErr = err
+			return
 		}
-		newState[svcName][registryv1.Service_PROTOCOL_HTTP] = eps
+		for svcName, eps := range endpoints {
+			if newState[svcName] == nil {
+				newState[svcName] = make(map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint)
+			}
+			newState[svcName][protocol] = eps
+		}
 	}
 
 	// Reconcile pending write-behind intents: release the observed ones,

--- a/registrar/internal/server/sync_test.go
+++ b/registrar/internal/server/sync_test.go
@@ -228,12 +228,21 @@ func TestSyncer_Start_RegistryErrorDoesNotCrash(t *testing.T) {
 // registry error on a periodic (non-initial) sync is handled gracefully, with
 // the snapshot retaining its last known good state.
 func TestSyncer_Start_RegistryErrorOnSubsequentSyncDoesNotCrash(t *testing.T) {
-	callCount := 0
+	// Each sync cycle now lists every protocol (HTTP then TCP). Count cycles by
+	// the HTTP call so the first cycle succeeds (HTTP data + empty TCP) and every
+	// subsequent cycle fails transiently.
+	httpCalls := 0
 
 	reg := &mockRegistry{
-		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
-			callCount++
-			if callCount == 1 {
+		listAllEndpointsFunc: func(_ context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			if protocol == registryv1.Service_PROTOCOL_TCP {
+				if httpCalls <= 1 {
+					return map[string][]*registryv1.ServiceEndpoint{}, nil
+				}
+				return nil, errors.New("transient registry error")
+			}
+			httpCalls++
+			if httpCalls == 1 {
 				return map[string][]*registryv1.ServiceEndpoint{
 					"svc": {{Ip: "10.0.2.1", Port: 8080, Weight: 100}},
 				}, nil

--- a/registrar/internal/services/generator.go
+++ b/registrar/internal/services/generator.go
@@ -57,24 +57,44 @@ type desiredService struct {
 	service     string
 	namespace   string
 	port        uint32
-	appProtocol string // "http" for all current registry services (PROTOCOL_HTTP)
+	appProtocol string // "http" (PROTOCOL_HTTP) or "tcp" (PROTOCOL_TCP)
+}
+
+// protocolAppProtocol maps a registry service protocol to the AnnotationMeshAppProtocol
+// value the generator stamps on the mesh Service (the agent's capture reconciler reads
+// it to decide HCM vs. TCP-floor chain emission).
+var protocolAppProtocol = map[registryv1.Service_Protocol]string{
+	registryv1.Service_PROTOCOL_HTTP: AppProtocolHTTP,
+	registryv1.Service_PROTOCOL_TCP:  AppProtocolTCP,
 }
 
 // reconcile makes the managed Services equal the snapshot catalog: create missing,
 // update drifted, prune stale (only Services this generator owns, by label).
 func (g *Generator) reconcile(ctx context.Context) {
 	desired := map[client.ObjectKey]desiredService{}
-	for svc, eps := range g.Snapshot.GetAll(registryv1.Service_PROTOCOL_HTTP) {
-		ep := firstNamespaced(eps)
-		if ep == nil {
-			continue
-		}
-		ns := ep.GetKubernetesMetadata().GetNamespace()
-		desired[client.ObjectKey{Namespace: ns, Name: svc}] = desiredService{
-			service:     svc,
-			namespace:   ns,
-			port:        ep.GetPort(),
-			appProtocol: AppProtocolHTTP,
+	// A service is registered under exactly one protocol (the registry key is
+	// name+protocol; the pod annotation picks it). Iterate every protocol so an
+	// HTTP service gets an "http" mesh Service and a TCP service a "tcp" one.
+	// Iteration is ordered (HTTP before TCP) so the no-clobber convergence is
+	// deterministic if a name ever appeared under both.
+	for _, protocol := range []registryv1.Service_Protocol{registryv1.Service_PROTOCOL_HTTP, registryv1.Service_PROTOCOL_TCP} {
+		appProto := protocolAppProtocol[protocol]
+		for svc, eps := range g.Snapshot.GetAll(protocol) {
+			ep := firstNamespaced(eps)
+			if ep == nil {
+				continue
+			}
+			ns := ep.GetKubernetesMetadata().GetNamespace()
+			key := client.ObjectKey{Namespace: ns, Name: svc}
+			if _, exists := desired[key]; exists {
+				continue // already claimed by an earlier protocol; one Service per name
+			}
+			desired[key] = desiredService{
+				service:     svc,
+				namespace:   ns,
+				port:        ep.GetPort(),
+				appProtocol: appProto,
+			}
 		}
 	}
 

--- a/registrar/internal/services/generator_test.go
+++ b/registrar/internal/services/generator_test.go
@@ -109,6 +109,36 @@ func TestGenerator_UpdatesStaleAppProtocol(t *testing.T) {
 		"stale app-protocol annotation must be corrected on reconcile")
 }
 
+// seedProtocol seeds a snapshot with a single service under the given protocol.
+func seedProtocol(svc, ns string, port uint32, protocol registryv1.Service_Protocol) *server.Snapshot {
+	s := server.NewSnapshot()
+	s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
+		svc: {protocol: {{
+			Ip:                 "10.0.0.1",
+			Port:               port,
+			KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{Namespace: ns},
+		}}},
+	})
+	return s
+}
+
+// TestGenerator_EmitsTCPMeshService verifies a PROTOCOL_TCP service is projected
+// into a selectorless mesh Service annotated as "tcp" — the signal the agent's
+// capture reconciler reads to emit the per-ClusterIP TCP-proxy floor chain.
+func TestGenerator_EmitsTCPMeshService(t *testing.T) {
+	g, c := newGen(seedProtocol("tcp-svc", "aether-test", 9000, registryv1.Service_PROTOCOL_TCP))
+	g.reconcile(context.Background())
+
+	svc, err := get(t, c, "aether-test", "tcp-svc")
+	require.NoError(t, err)
+	assert.Equal(t, "true", svc.Labels[constants.LabelMeshService])
+	assert.Equal(t, "tcp-svc", svc.Annotations[constants.AnnotationMeshService])
+	assert.Equal(t, "9000", svc.Annotations[constants.AnnotationMeshPort])
+	assert.Equal(t, AppProtocolTCP, svc.Annotations[constants.AnnotationMeshAppProtocol],
+		"PROTOCOL_TCP services must be annotated as tcp")
+	assert.Empty(t, svc.Spec.Selector, "selectorless: endpoints stay in the registry")
+}
+
 func TestGenerator_DoesNotClobberUserService(t *testing.T) {
 	user := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "aether-test"},

--- a/registry/BUILD.bazel
+++ b/registry/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "registry",
@@ -23,5 +23,18 @@ go_library(
         "//registry/internal/registrar",
         "@com_github_aws_aws_sdk_go_v2//aws",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+    ],
+)
+
+go_test(
+    name = "registry_test",
+    srcs = ["cni_test.go"],
+    embed = [":registry"],
+    deps = [
+        "//api/aether/cni/v1:cni",
+        "//api/aether/registry/v1:registry",
+        "//common/constants",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -13,10 +13,14 @@ import (
 
 // NewServiceEndpointFromCNIPod creates a ServiceEndpoint from a CNIPod.
 // It extracts the service name from the pod's labels and the port and weight from annotations.
-// The service protocol is always HTTP. Container and Kubernetes metadata are included
-// along with node locality information.
+// The service protocol comes from the endpoint.aether.io/protocol annotation
+// (default HTTP; "tcp" registers a non-HTTP TCP-over-mTLS service). Container
+// and Kubernetes metadata are included along with node locality information.
 func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
-	protocol := registryv1.Service_PROTOCOL_HTTP
+	protocol, err := getProtocolFromAnnotations(cniPod.GetAnnotations())
+	if err != nil {
+		return "", registryv1.Service_PROTOCOL_UNSPECIFIED, nil, err
+	}
 
 	serviceName, err := getServiceName(cniPod)
 	if err != nil {
@@ -81,6 +85,23 @@ func getServiceName(cniPod *cniv1.CNIPod) (string, error) {
 		return "", fmt.Errorf("missing service account")
 	}
 	return sa, nil
+}
+
+// getProtocolFromAnnotations maps the endpoint.aether.io/protocol annotation to
+// the service protocol. Unset or "http" yields PROTOCOL_HTTP (default); "tcp"
+// yields PROTOCOL_TCP (a non-HTTP TCP-over-mTLS service, reached through the
+// transparent-capture TCP floor). Any other value is rejected so a typo never
+// silently registers a service under the wrong (or unspecified) protocol.
+func getProtocolFromAnnotations(annotations map[string]string) (registryv1.Service_Protocol, error) {
+	switch annotations[constants.AnnotationEndpointProtocol] {
+	case "", constants.ProtocolHTTP:
+		return registryv1.Service_PROTOCOL_HTTP, nil
+	case constants.ProtocolTCP:
+		return registryv1.Service_PROTOCOL_TCP, nil
+	default:
+		return registryv1.Service_PROTOCOL_UNSPECIFIED, fmt.Errorf("invalid protocol annotation %q (want %q or %q)",
+			annotations[constants.AnnotationEndpointProtocol], constants.ProtocolHTTP, constants.ProtocolTCP)
+	}
 }
 
 // getPortFromAnnotations extracts the endpoint port from pod annotations.

--- a/registry/cni_test.go
+++ b/registry/cni_test.go
@@ -1,0 +1,73 @@
+package registry
+
+import (
+	"testing"
+
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCNIPod(annotations map[string]string) *cniv1.CNIPod {
+	return &cniv1.CNIPod{
+		Name:             "echo-0",
+		Namespace:        "default",
+		NetworkNamespace: "/var/run/netns/echo-0",
+		ContainerId:      "container-0",
+		Ips:              []string{"10.0.0.1"},
+		ServiceAccount:   "echo",
+		Annotations:      annotations,
+	}
+}
+
+// TestNewServiceEndpointFromCNIPod_Protocol verifies the service protocol is
+// chosen from the endpoint.aether.io/protocol annotation: default HTTP, explicit
+// "http", explicit "tcp", and a rejected unknown value.
+func TestNewServiceEndpointFromCNIPod_Protocol(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation map[string]string
+		want       registryv1.Service_Protocol
+		wantErr    bool
+	}{
+		{
+			name:       "unset defaults to HTTP",
+			annotation: nil,
+			want:       registryv1.Service_PROTOCOL_HTTP,
+		},
+		{
+			name:       "explicit http",
+			annotation: map[string]string{constants.AnnotationEndpointProtocol: "http"},
+			want:       registryv1.Service_PROTOCOL_HTTP,
+		},
+		{
+			name:       "tcp annotation selects PROTOCOL_TCP",
+			annotation: map[string]string{constants.AnnotationEndpointProtocol: "tcp"},
+			want:       registryv1.Service_PROTOCOL_TCP,
+		},
+		{
+			name:       "unknown value is rejected",
+			annotation: map[string]string{constants.AnnotationEndpointProtocol: "udp"},
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service, protocol, ep, err := NewServiceEndpointFromCNIPod(
+				"cluster-a", "node-1", "region-1", "zone-a", testCNIPod(tt.annotation))
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, registryv1.Service_PROTOCOL_UNSPECIFIED, protocol)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, "echo", service)
+			assert.Equal(t, tt.want, protocol)
+			require.NotNil(t, ep)
+			assert.Equal(t, "10.0.0.1", ep.GetIp())
+		})
+	}
+}

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -59,8 +59,14 @@ type RegistrarRegistry struct {
 	conn   *grpc.ClientConn
 	client registrarv1.RegistrarServiceClient
 
-	mu    sync.RWMutex
-	cache map[string][]*registryv1.ServiceEndpoint // keyed by serviceName
+	mu sync.RWMutex
+	// cache is the watch-fed endpoint store, partitioned by protocol so a
+	// ListAllEndpoints(protocol) returns only that protocol's services (HTTP
+	// services ride the HCM path, TCP services the transparent-capture floor).
+	// A service is registered under exactly one protocol, so the two partitions
+	// never hold the same service name. The watch stream carries the protocol on
+	// every endpoint event.
+	cache map[registryv1.Service_Protocol]map[string][]*registryv1.ServiceEndpoint
 	// services is the full mesh service-name catalog (every watcher receives
 	// catalog events regardless of filter): the ODCDS cold path answers
 	// existence locally instead of stalling on nonexistent services. Replayed
@@ -116,7 +122,7 @@ func NewRegistrarRegistry(log *slog.Logger, cfg Config) *RegistrarRegistry {
 		log:         commonlog.Named(log, "registrar-registry"),
 		config:      cfg,
 		metrics:     metrics,
-		cache:       make(map[string][]*registryv1.ServiceEndpoint),
+		cache:       make(map[registryv1.Service_Protocol]map[string][]*registryv1.ServiceEndpoint),
 		services:    make(map[string]struct{}),
 		notify:      make(chan struct{}, 1),
 		ready:       make(chan struct{}),
@@ -202,7 +208,9 @@ func (r *RegistrarRegistry) SetServiceFilter(services []string) {
 		r.mu.Lock()
 		for _, svc := range previous {
 			if _, ok := keep[svc]; !ok {
-				delete(r.cache, svc)
+				for _, byName := range r.cache {
+					delete(byName, svc)
+				}
 			}
 		}
 		r.mu.Unlock()
@@ -319,7 +327,7 @@ func (r *RegistrarRegistry) UnregisterEndpoints(ctx context.Context, serviceName
 // Falls back to the Registrar RPC if the cache is empty.
 func (r *RegistrarRegistry) ListEndpoints(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
 	r.mu.RLock()
-	eps, ok := r.cache[service]
+	eps, ok := r.cache[protocol][service]
 	r.mu.RUnlock()
 
 	if ok {
@@ -333,21 +341,24 @@ func (r *RegistrarRegistry) ListEndpoints(ctx context.Context, service string, p
 // ListAllEndpoints returns all endpoints from the local cache.
 // Falls back to the Registrar RPC if the cache is empty.
 func (r *RegistrarRegistry) ListAllEndpoints(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
-	r.mu.RLock()
-	cacheLen := len(r.cache)
-	r.mu.RUnlock()
-
-	if cacheLen > 0 {
+	// Serve from the watch-fed cache once it holds a complete world view (first
+	// SNAPSHOT_COMPLETE). Gating on readiness — not on a non-empty partition —
+	// lets a protocol with no services (e.g. TCP when only HTTP exists) return
+	// the truthful empty set instead of falling back to an RPC.
+	select {
+	case <-r.ready:
 		r.mu.RLock()
-		result := make(map[string][]*registryv1.ServiceEndpoint, len(r.cache))
-		for k, v := range r.cache {
+		byName := r.cache[protocol]
+		result := make(map[string][]*registryv1.ServiceEndpoint, len(byName))
+		for k, v := range byName {
 			result[k] = v
 		}
 		r.mu.RUnlock()
 		return result, nil
+	default:
 	}
 
-	// Fallback to RPC.
+	// Cache not yet ready: fall back to RPC.
 	return r.listAllEndpointsFromServer(ctx, protocol)
 }
 
@@ -494,7 +505,7 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 		// Clear cache before the first FULL_SNAPSHOT event to replace stale data.
 		if event.GetType() == registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT && !snapshotCleared {
 			r.mu.Lock()
-			r.cache = make(map[string][]*registryv1.ServiceEndpoint)
+			r.cache = make(map[registryv1.Service_Protocol]map[string][]*registryv1.ServiceEndpoint)
 			r.mu.Unlock()
 			snapshotCleared = true
 		}
@@ -543,18 +554,19 @@ func (r *RegistrarRegistry) applyEvent(event *registrarv1.WatchEndpointsResponse
 	defer r.mu.Unlock()
 
 	svcName := event.GetServiceName()
+	protocol := event.GetProtocol()
 	ep := event.GetEndpoint()
 
 	switch event.GetType() {
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT:
 		// Upsert for full snapshot events.
-		r.upsertLocked(svcName, ep)
+		r.upsertLocked(protocol, svcName, ep)
 
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED:
-		r.upsertLocked(svcName, ep)
+		r.upsertLocked(protocol, svcName, ep)
 
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED:
-		r.removeLocked(svcName, ep.GetIp())
+		r.removeLocked(protocol, svcName, ep.GetIp())
 
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE:
 		// Marker only; no cache mutation. The change signal below still fires
@@ -566,26 +578,34 @@ func (r *RegistrarRegistry) applyEvent(event *registrarv1.WatchEndpointsResponse
 	r.signalChange()
 }
 
-// upsertLocked adds or updates an endpoint in the cache. Caller must hold mu.
-func (r *RegistrarRegistry) upsertLocked(svcName string, ep *registryv1.ServiceEndpoint) {
-	eps := r.cache[svcName]
+// upsertLocked adds or updates an endpoint in the protocol's partition of the
+// cache. Caller must hold mu.
+func (r *RegistrarRegistry) upsertLocked(protocol registryv1.Service_Protocol, svcName string, ep *registryv1.ServiceEndpoint) {
+	byName := r.cache[protocol]
+	if byName == nil {
+		byName = make(map[string][]*registryv1.ServiceEndpoint)
+		r.cache[protocol] = byName
+	}
+	eps := byName[svcName]
 	for i, existing := range eps {
 		if existing.GetIp() == ep.GetIp() {
 			eps[i] = ep
 			return
 		}
 	}
-	r.cache[svcName] = append(eps, ep)
+	byName[svcName] = append(eps, ep)
 }
 
-// removeLocked removes an endpoint from the cache by IP. Caller must hold mu.
-func (r *RegistrarRegistry) removeLocked(svcName string, ip string) {
-	eps := r.cache[svcName]
+// removeLocked removes an endpoint by IP from the protocol's partition of the
+// cache. Caller must hold mu.
+func (r *RegistrarRegistry) removeLocked(protocol registryv1.Service_Protocol, svcName string, ip string) {
+	byName := r.cache[protocol]
+	eps := byName[svcName]
 	for i, existing := range eps {
 		if existing.GetIp() == ip {
-			r.cache[svcName] = append(eps[:i], eps[i+1:]...)
-			if len(r.cache[svcName]) == 0 {
-				delete(r.cache, svcName)
+			byName[svcName] = append(eps[:i], eps[i+1:]...)
+			if len(byName[svcName]) == 0 {
+				delete(byName, svcName)
 			}
 			return
 		}

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -58,7 +58,7 @@ func TestApplyEvent_FullSnapshot_AddsToCache(t *testing.T) {
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
 			})
-			assert.Equal(t, tt.expected, r.cache)
+			assert.Equal(t, tt.expected, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 		})
 	}
 }
@@ -109,13 +109,13 @@ func TestApplyEvent_EndpointAdded(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
-			r.cache = tt.initialCache
+			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
 			r.applyEvent(&registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
 			})
-			assert.Equal(t, tt.expected, r.cache)
+			assert.Equal(t, tt.expected, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 		})
 	}
 }
@@ -173,13 +173,13 @@ func TestApplyEvent_EndpointUpdated(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
-			r.cache = tt.initialCache
+			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
 			r.applyEvent(&registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
 			})
-			assert.Equal(t, tt.expected, r.cache)
+			assert.Equal(t, tt.expected, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 		})
 	}
 }
@@ -238,13 +238,13 @@ func TestApplyEvent_EndpointRemoved(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
-			r.cache = tt.initialCache
+			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
 			r.applyEvent(&registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
 			})
-			assert.Equal(t, tt.expected, r.cache)
+			assert.Equal(t, tt.expected, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 		})
 	}
 }
@@ -252,17 +252,17 @@ func TestApplyEvent_EndpointRemoved(t *testing.T) {
 func TestRemoveLocked_CleansUpEmptyServiceKey(t *testing.T) {
 	ep := makeEndpoint("10.0.0.1", 8080)
 	r := newTestRegistry()
-	r.cache = map[string][]*registryv1.ServiceEndpoint{
+	r.cache[registryv1.Service_PROTOCOL_HTTP] = map[string][]*registryv1.ServiceEndpoint{
 		"svc-a": {ep},
 	}
 
 	r.mu.Lock()
-	r.removeLocked("svc-a", "10.0.0.1")
+	r.removeLocked(registryv1.Service_PROTOCOL_HTTP, "svc-a", "10.0.0.1")
 	r.mu.Unlock()
 
-	_, exists := r.cache["svc-a"]
+	_, exists := r.cache[registryv1.Service_PROTOCOL_HTTP]["svc-a"]
 	assert.False(t, exists, "service key should be removed from cache when no endpoints remain")
-	assert.Empty(t, r.cache)
+	assert.Empty(t, r.cache[registryv1.Service_PROTOCOL_HTTP])
 }
 
 func TestListAllEndpoints_ReadsFromCache(t *testing.T) {
@@ -299,7 +299,8 @@ func TestListAllEndpoints_ReadsFromCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
-			r.cache = tt.initialCache
+			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
+			close(r.ready) // cache is populated; serve from it (not RPC)
 			got, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_UNSPECIFIED)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
@@ -339,7 +340,7 @@ func TestListEndpoints_ReadsFromCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
-			r.cache = tt.initialCache
+			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
 			got, err := r.ListEndpoints(context.Background(), tt.service, registryv1.Service_PROTOCOL_UNSPECIFIED)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
@@ -374,7 +375,7 @@ func TestCache_MultipleServices(t *testing.T) {
 	assert.Equal(t, map[string][]*registryv1.ServiceEndpoint{
 		"svc-a": {ep1, ep3},
 		"svc-b": {ep2},
-	}, r.cache)
+	}, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 
 	// Remove svc-a entirely.
 	r.applyEvent(&registrarv1.WatchEndpointsResponse{
@@ -390,9 +391,9 @@ func TestCache_MultipleServices(t *testing.T) {
 
 	assert.Equal(t, map[string][]*registryv1.ServiceEndpoint{
 		"svc-b": {ep2},
-	}, r.cache)
+	}, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 
-	_, exists := r.cache["svc-a"]
+	_, exists := r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED]["svc-a"]
 	assert.False(t, exists, "svc-a key should be absent after all endpoints removed")
 }
 
@@ -520,6 +521,7 @@ func TestSnapshotCompleteClosesReady(t *testing.T) {
 			{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT,
 				ServiceName: "svc-a",
+				Protocol:    registryv1.Service_PROTOCOL_HTTP,
 				Endpoint:    makeEndpoint("10.0.0.1", 8080),
 				Version:     "7",
 			},
@@ -651,8 +653,12 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 func TestSetServiceFilter_PurgesOutOfScopeCache(t *testing.T) {
 	r := NewRegistrarRegistry(slog.New(slog.DiscardHandler), Config{Address: "test"})
 	r.mu.Lock()
-	r.cache["svc-a"] = []*registryv1.ServiceEndpoint{{Ip: "10.0.0.1"}}
-	r.cache["svc-b"] = []*registryv1.ServiceEndpoint{{Ip: "10.0.0.2"}}
+	r.cache[registryv1.Service_PROTOCOL_HTTP] = map[string][]*registryv1.ServiceEndpoint{
+		"svc-a": {{Ip: "10.0.0.1"}},
+	}
+	r.cache[registryv1.Service_PROTOCOL_TCP] = map[string][]*registryv1.ServiceEndpoint{
+		"svc-b": {{Ip: "10.0.0.2"}}, // a TCP service must purge with the filter too
+	}
 	r.mu.Unlock()
 
 	r.SetServiceFilter([]string{"svc-a", "svc-b"})
@@ -660,6 +666,6 @@ func TestSetServiceFilter_PurgesOutOfScopeCache(t *testing.T) {
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	assert.Contains(t, r.cache, "svc-a")
-	assert.NotContains(t, r.cache, "svc-b", "out-of-scope entries must purge with the filter")
+	assert.Contains(t, r.cache[registryv1.Service_PROTOCOL_HTTP], "svc-a")
+	assert.NotContains(t, r.cache[registryv1.Service_PROTOCOL_TCP], "svc-b", "out-of-scope entries must purge with the filter, across protocols")
 }


### PR DESCRIPTION
## Why

PR #294 shipped a transparent-capture **TCP-over-mTLS floor** and #296 shipped **TCPRoute/TLSRoute/UDPRoute** L4 routing, but both were **unreachable**: the service model was HTTP-only, so a workload could never be classified as TCP. This makes a workload registerable/generatable as a **PROTOCOL_TCP** service so the floor + L4 routes become reachable and e2e-testable.

Goal e2e (parent runs it): an HTTP echo workload annotated `tcp` is reached via the capture TCP floor as a raw mTLS **passthrough** (the HTTP request rides the passthrough connection) → HTTP 200.

## How an operator marks a workload TCP

Add a pod annotation (a registration fact — what the pod serves):

```yaml
metadata:
  annotations:
    endpoint.aether.io/protocol: tcp   # default "http"; "tcp" => PROTOCOL_TCP
```

Unset or `http` registers a normal HTTP service (unchanged). `tcp` registers the workload under `PROTOCOL_TCP`; the registrar then projects a selectorless mesh Service annotated `aether.io/app-protocol=tcp`, which the agent's capture reconciler reads to emit the per-ClusterIP TCP-proxy floor chain. An unknown value is rejected (no silent mis-registration).

## What changed

- **proto** (`api/aether/registry/v1/service.proto`): `Service.Protocol PROTOCOL_TCP = 2`.
- **registration** (`registry/cni.go`): protocol chosen from `endpoint.aether.io/protocol` (new constant `AnnotationEndpointProtocol` + `ProtocolHTTP`/`ProtocolTCP` in `common/constants/annotations.go`).
- **generator** (`registrar/internal/services/generator.go`): iterates every protocol and emits TCP services with `appProtocol=tcp`; one mesh Service per name (HTTP claimed first), no-clobber convergence preserved.
- **registrar snapshot/sync/server**: the sync loop lists+syncs every protocol (new `syncedProtocols`); write-behind unregister supersedes across protocols (the request carries no protocol; a service is registered under exactly one, and the external delete is protocol-agnostic).
- **agent watch cache** (`registry/internal/registrar/registrar.go`): the watch-fed cache is **partitioned by protocol** so `ListAllEndpoints(protocol)` returns only that protocol's services. `ListAllEndpoints` now gates on watch **readiness** (first `SNAPSHOT_COMPLETE`) instead of a non-empty partition, so a protocol with no services returns the truthful empty set instead of falling back to an RPC.
- **agent EDS** (`agent/internal/xds/cache/cluster.go` + `cache.go`): TCP services get a cluster entry holding only the **bare-name EDS load assignment** (+ `sanNamespaces`/`sni`); the floor's `tcp:<svc>.<domain>` cluster (built in `captureTCPClusters`) references that EDS by `ServiceName`. No HTTP h2 cluster/vhost is emitted for a TCP service (new `clusterEntry.tcp` flag).
- **ghost sweep** (`agent/internal/cni/server/ghostsweep.go`): reconciles both protocols (new `sweptProtocols`) so TCP endpoints aren't ghost-pruned.
- **chart**: `charts/aether/Chart.yaml` bumped to `0.38.0`.

## Tests

- `registry/cni_test.go`: registration picks TCP from the annotation (and rejects unknown).
- `registrar/internal/services/generator_test.go`: generator emits a `tcp`-annotated mesh Service.
- `agent/internal/xds/cache/tcp_service_test.go`: agent builds a `tcp:<svc>.<domain>` cluster (EDS service = bare name, per-source mTLS matcher) with the registry endpoint in EDS, and emits **no** HTTP cluster for it.
- Existing registrar/sweep/cache test mocks updated to be protocol-aware (HTTP-only fixtures no longer double-count as TCP).

`bazel build //...`, `bazel test //...` (59 pass), `bazel run //:format`, `--config=lint` all clean.

## Design note (called out per task)

The agent's watch-fed `RegistrarRegistry` cache was keyed by service name only and `ListAllEndpoints` ignored its `protocol` argument. The clean generalization is to **partition the cache by protocol** (the watch stream already carries `Protocol` per event). HTTP services land in the HTTP partition exactly as before, so HTTP behavior is identical; TCP services get their own partition. This is the one place the protocol partitioning was deeper than a pure additive change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S