### PR TITLE
fix(proxy): TCP floor transport_socket_match name must be the bare SPIFFE ID

### DIFF
--- a/agent/internal/xds/proxy/transportsocketmatch.go
+++ b/agent/internal/xds/proxy/transportsocketmatch.go
@@ -105,8 +105,13 @@ func UpstreamTransportSocketMatcher(netnsToSpiffeID map[string]string) *matcherv
 
 // UpstreamTCPTransportSocketMatches is UpstreamTransportSocketMatches for TCP floor
 // clusters: each match uses UpstreamTCPTransportSocket (ALPN "aether-tcp") instead
-// of UpstreamTransportSocket ("h2"). Match names are suffixed with ":tcp" to keep
-// them distinct from the HTTP matches when both cluster types coexist in the snapshot.
+// of UpstreamTransportSocket ("h2"). Match names are the bare SPIFFE ID — identical
+// to the HTTP matches — because the shared UpstreamTransportSocketMatcher selects by
+// the source pod's SPIFFE ID, and transport_socket_matches are scoped per cluster
+// (the HTTP <svc> and TCP tcp:<svc> clusters are distinct, so the names never
+// collide). A ":tcp" suffix would never be selected (the matcher emits the bare ID),
+// leaving the floor connection on the default socket with no "aether-tcp" ALPN, so
+// the inbound floor chain wouldn't match and the mTLS connection would reset.
 func UpstreamTCPTransportSocketMatches(spiffeIDs []string, validationContextName string, sanURIs []string, sni string) []*clusterv3.Cluster_TransportSocketMatch {
 	unique := make([]string, 0, len(spiffeIDs))
 	seen := make(map[string]struct{}, len(spiffeIDs))
@@ -125,7 +130,7 @@ func UpstreamTCPTransportSocketMatches(spiffeIDs []string, validationContextName
 	matches := make([]*clusterv3.Cluster_TransportSocketMatch, 0, len(unique))
 	for _, id := range unique {
 		matches = append(matches, &clusterv3.Cluster_TransportSocketMatch{
-			Name:            id + ":tcp",
+			Name:            id,
 			Match:           &structpb.Struct{},
 			TransportSocket: UpstreamTCPTransportSocket(id, validationContextName, sanURIs, sni),
 		})


### PR DESCRIPTION
First real TCP-floor e2e (HTTP echo registered `appProtocol=tcp`, raw mTLS passthrough) reset on the upstream. Root cause: `tcp:<svc>` named its `transport_socket_matches` `<spiffe-id>:tcp`, but the shared `UpstreamTransportSocketMatcher` selects by the **bare** SPIFFE ID → no match → default socket → no `aether-tcp` ALPN → inbound floor chain (ALPN match) doesn't match → reset. The `:tcp` suffix was unnecessary (matches are per-cluster; `<svc>` vs `tcp:<svc>` don't collide). Drop it. Validated: `echo-tcp.aether.internal:18081` → 200 (was reset).