### PR TITLE
fix(proxy): TCP floor OnNoMatch must reference the bare node SPIFFE ID

### DIFF
--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -299,7 +299,7 @@ func InjectUpstreamTCPMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[strin
 		cluster.TransportSocket = UpstreamTCPTransportSocket(nodeSpiffeID, validationContextName, sanURIs, sni)
 		return
 	}
-	matcher.OnNoMatch = transportSocketNameOnMatch(nodeSpiffeID + ":tcp")
+	matcher.OnNoMatch = transportSocketNameOnMatch(nodeSpiffeID)
 
 	cluster.TransportSocketMatcher = matcher
 	cluster.TransportSocketMatches = UpstreamTCPTransportSocketMatches(append(spiffeIDs, nodeSpiffeID), validationContextName, sanURIs, sni)


### PR DESCRIPTION
Follow-up to #298. `InjectUpstreamTCPMTLS` still set `OnNoMatch` to `<nodeSpiffeID>:tcp` — dangling now that the TCP matches are bare-named. The tcp_proxy fallback then selected no transport socket → upstream mTLS never formed (`upstream_cx_total=0`) → reset. Fix: OnNoMatch → bare node SPIFFE ID.