### PR TITLE
feat(edge): TCPRoute + TLSRoute → L4 Gateway listeners (proposal 018 Phase 3b)

### DIFF
--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 // edgeName is the controller/logging name for the edge proxy control plane.
@@ -117,6 +118,10 @@ func runEdge(ctx context.Context) (retErr error) {
 	}
 	if err := gatewayv1.Install(scheme); err != nil {
 		return fmt.Errorf("register gateway.networking.k8s.io scheme: %w", err)
+	}
+	// TCPRoute/TLSRoute live in v1alpha2 (not yet promoted to v1 in gateway-api v1.5.1).
+	if err := gatewayv1alpha2.Install(scheme); err != nil {
+		return fmt.Errorf("register gateway.networking.k8s.io/v1alpha2 scheme: %w", err)
 	}
 
 	result, err := manager.Bootstrap(ctx, cfg.Config, edgeName, Version, func(o *ctrl.Options) { o.Scheme = scheme })
@@ -221,6 +226,7 @@ func runEdge(ctx context.Context) (retErr error) {
 		Sink:             snapshotCache,
 		Namespace:        routeNamespace,
 		GatewayClassName: cfg.GatewayClassName,
+		MeshDomain:       cfg.MeshDomain,
 		Secrets:          secretRegistry,
 		Log:              l,
 	}

--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//agent/internal/edge/secret",
         "//agent/internal/xds/cache",
+        "//agent/internal/xds/proxy",
         "//api/aether/config/v1:config",
         "//common/log",
         "@io_k8s_api//core/v1:core",
@@ -17,6 +18,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/handler",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1alpha2",
     ],
 )
 
@@ -26,8 +28,11 @@ go_test(
     embed = [":gatewayapi"],
     deps = [
         "//agent/internal/xds/cache",
+        "//agent/internal/xds/proxy",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1alpha2",
     ],
 )

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -1,8 +1,8 @@
 // Package gatewayapi contains the edge proxy's Gateway API controller: it watches
-// Gateway API HTTPRoutes attached to a Gateway of the aether GatewayClass and
-// projects them into the edge data plane (proposal 018 — north-south). It is the
-// edge's only routing API (the VirtualHost CRD was retired); routing is
-// direct-to-pod mTLS.
+// Gateway API HTTPRoutes, TCPRoutes, and TLSRoutes attached to a Gateway of the
+// aether GatewayClass and projects them into the edge data plane (proposal 018 —
+// north-south). It is the edge's only routing API (the VirtualHost CRD was retired);
+// routing is direct-to-pod mTLS.
 package gatewayapi
 
 import (
@@ -13,6 +13,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/edge/secret"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	commonlog "github.com/bpalermo/aether/common/log"
 	corev1 "k8s.io/api/core/v1"
@@ -22,34 +23,42 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-// RouteSink receives the projected virtual hosts and TLS certs (the snapshot cache).
+// RouteSink receives the projected virtual hosts, TLS certs, and L4 routes
+// (the snapshot cache).
 type RouteSink interface {
 	SetVirtualHosts(vhosts []cache.VirtualHost)
 	SetEdgeTLSSecrets(ctx context.Context, certs map[string]cache.EdgeTLSCert) error
+	SetEdgeTCPRoutes(routes []proxy.EdgeL4TCPRoute)
+	SetEdgeTLSRoutes(routes []proxy.EdgeL4TLSRoute)
 }
 
-// Reconciler watches Gateway API HTTPRoutes (and the Gateways/Secrets they depend
-// on) in a namespace and projects, on any change, the complete virtual-host set
-// into the cache. Level-based: each reconcile re-lists, so adds/updates/deletes
-// converge without delta tracking — the same model as the VirtualHost reconciler.
+// Reconciler watches Gateway API HTTPRoutes, TCPRoutes, and TLSRoutes (and the
+// Gateways/Secrets they depend on) in a namespace and projects, on any change,
+// the complete virtual-host and L4 route sets into the cache. Level-based: each
+// reconcile re-lists, so adds/updates/deletes converge without delta tracking —
+// the same model as the VirtualHost reconciler.
 type Reconciler struct {
 	client.Client
 
-	// Sink receives the projected virtual hosts/certs (the snapshot cache).
+	// Sink receives the projected virtual hosts/certs and L4 routes (the snapshot cache).
 	Sink RouteSink
-	// Namespace is the namespace Gateways/HTTPRoutes (and their TLS Secrets) live in.
+	// Namespace is the namespace Gateways/HTTPRoutes/TCPRoutes/TLSRoutes live in.
 	Namespace string
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves.
 	GatewayClassName string
 	// Secrets resolves Gateway listener TLS cert material; nil disables TLS.
 	Secrets *secret.Registry
-	Log     *slog.Logger
+	// MeshDomain is the mesh DNS domain used to build TCP cluster names.
+	MeshDomain string
+	Log        *slog.Logger
 }
 
-// SetupWithManager registers the reconciler to watch HTTPRoutes, Gateways and (when
-// TLS is enabled) Secrets — any change re-projects the whole set.
+// SetupWithManager registers the reconciler to watch HTTPRoutes, TCPRoutes,
+// TLSRoutes, Gateways and (when TLS is enabled) Secrets — any change
+// re-projects the whole set.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Log = commonlog.Named(r.Log, "gatewayapi")
 	resync := handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
@@ -58,6 +67,8 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.HTTPRoute{}).
 		Watches(&gatewayv1.Gateway{}, resync).
+		Watches(&gatewayv1alpha2.TCPRoute{}, resync).
+		Watches(&gatewayv1alpha2.TLSRoute{}, resync).
 		Named("gatewayapi")
 	if r.Secrets != nil {
 		b = b.Watches(&corev1.Secret{}, resync)
@@ -65,29 +76,30 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return b.Complete(r)
 }
 
-// Reconcile re-lists our Gateways and the HTTPRoutes attached to them, resolves
-// each Gateway listener's TLS cert, and replaces the cache's virtual-host set.
+// Reconcile re-lists our Gateways and the HTTPRoutes, TCPRoutes, and TLSRoutes
+// attached to them, resolves each Gateway listener's TLS cert, and replaces the
+// cache's virtual-host and L4 route sets.
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	// Our Gateways (those of our GatewayClass) and, per listener hostname, the SDS
 	// cert name to present. listenerCerts also accumulates the cert bytes to push.
-	gateways, hostCerts, certs, err := r.resolveGateways(ctx)
+	gateways, gatewayListeners, hostCerts, certs, err := r.resolveGateways(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
-	routes := &gatewayv1.HTTPRouteList{}
-	if err := r.List(ctx, routes, client.InNamespace(r.Namespace)); err != nil {
+	// --- HTTPRoutes ---
+	httpRoutes := &gatewayv1.HTTPRouteList{}
+	if err := r.List(ctx, httpRoutes, client.InNamespace(r.Namespace)); err != nil {
 		return reconcile.Result{}, err
 	}
 	// Deterministic order so keep-first host-dedup in the cache is stable.
-	slices.SortFunc(routes.Items, func(a, b gatewayv1.HTTPRoute) int {
+	slices.SortFunc(httpRoutes.Items, func(a, b gatewayv1.HTTPRoute) int {
 		return strings.Compare(a.Name, b.Name)
 	})
-
-	vhosts := make([]cache.VirtualHost, 0, len(routes.Items))
-	for i := range routes.Items {
-		hr := &routes.Items[i]
-		if !attachedToOurGateway(hr, gateways) {
+	vhosts := make([]cache.VirtualHost, 0, len(httpRoutes.Items))
+	for i := range httpRoutes.Items {
+		hr := &httpRoutes.Items[i]
+		if !attachedToOurGateway(hr.Spec.ParentRefs, gateways) {
 			continue
 		}
 		vh := r.buildVirtualHost(hr, hostCerts)
@@ -97,25 +109,110 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		vhosts = append(vhosts, vh)
 	}
 
+	// --- TCPRoutes ---
+	tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
+	if err := r.List(ctx, tcpRouteList, client.InNamespace(r.Namespace)); err != nil {
+		return reconcile.Result{}, err
+	}
+	tcpByPort := make(map[uint32][]proxy.L4Backend)
+	for i := range tcpRouteList.Items {
+		tr := &tcpRouteList.Items[i]
+		ports := gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TCPProtocolType, gatewayListeners)
+		for _, port := range ports {
+			for _, rule := range tr.Spec.Rules {
+				tcpByPort[port] = append(tcpByPort[port], r.buildL4Backends(rule.BackendRefs)...)
+			}
+		}
+	}
+	tcpRoutes := make([]proxy.EdgeL4TCPRoute, 0, len(tcpByPort))
+	for port, backends := range tcpByPort {
+		tcpRoutes = append(tcpRoutes, proxy.EdgeL4TCPRoute{Port: port, Backends: backends})
+	}
+	slices.SortFunc(tcpRoutes, func(a, b proxy.EdgeL4TCPRoute) int {
+		if a.Port < b.Port {
+			return -1
+		}
+		if a.Port > b.Port {
+			return 1
+		}
+		return 0
+	})
+
+	// --- TLSRoutes ---
+	tlsRouteList := &gatewayv1alpha2.TLSRouteList{}
+	if err := r.List(ctx, tlsRouteList, client.InNamespace(r.Namespace)); err != nil {
+		return reconcile.Result{}, err
+	}
+	tlsByPort := make(map[uint32][]proxy.L4ServiceRoute)
+	for i := range tlsRouteList.Items {
+		tr := &tlsRouteList.Items[i]
+		ports := gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TLSProtocolType, gatewayListeners)
+		hostnames := make([]string, 0, len(tr.Spec.Hostnames))
+		for _, h := range tr.Spec.Hostnames {
+			hostnames = append(hostnames, string(h))
+		}
+		for _, port := range ports {
+			for _, rule := range tr.Spec.Rules {
+				tlsByPort[port] = append(tlsByPort[port], proxy.L4ServiceRoute{
+					SNIHostnames: hostnames,
+					Backends:     r.buildL4Backends(rule.BackendRefs),
+				})
+			}
+		}
+	}
+	tlsRoutes := make([]proxy.EdgeL4TLSRoute, 0, len(tlsByPort))
+	for port, rules := range tlsByPort {
+		tlsRoutes = append(tlsRoutes, proxy.EdgeL4TLSRoute{Port: port, Rules: rules})
+	}
+	slices.SortFunc(tlsRoutes, func(a, b proxy.EdgeL4TLSRoute) int {
+		if a.Port < b.Port {
+			return -1
+		}
+		if a.Port > b.Port {
+			return 1
+		}
+		return 0
+	})
+
 	if r.Secrets != nil {
 		if err := r.Sink.SetEdgeTLSSecrets(ctx, certs); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 	r.Sink.SetVirtualHosts(vhosts)
-	r.Log.DebugContext(ctx, "projected gateway-api routes", "httpRoutes", len(routes.Items), "virtualHosts", len(vhosts), "tlsCerts", len(certs))
+	r.Sink.SetEdgeTCPRoutes(tcpRoutes)
+	r.Sink.SetEdgeTLSRoutes(tlsRoutes)
+	r.Log.DebugContext(ctx, "projected gateway-api routes",
+		"httpRoutes", len(httpRoutes.Items),
+		"tcpRoutes", len(tcpRouteList.Items),
+		"tlsRoutes", len(tlsRouteList.Items),
+		"virtualHosts", len(vhosts),
+		"tcpListeners", len(tcpRoutes),
+		"tlsListeners", len(tlsRoutes),
+		"tlsCerts", len(certs),
+	)
 	return reconcile.Result{}, nil
 }
 
+// gatewayListenerKey identifies a listener within a gateway by name+protocol+port.
+// Used to scope TCPRoute/TLSRoute parentRef port matching.
+type gatewayListenerKey struct {
+	Gateway  string
+	Port     uint32
+	Protocol gatewayv1.ProtocolType
+}
+
 // resolveGateways lists the Gateways of our GatewayClass and resolves each TLS
-// listener's cert. It returns the set of our Gateway names, a hostname→SDS-name map
-// for cert selection, and the SDS-name→bytes map to push.
-func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, map[string]string, map[string]cache.EdgeTLSCert, error) {
+// listener's cert. It returns the set of our Gateway names, a set of listener
+// keys (for TCPRoute/TLSRoute port matching), a hostname→SDS-name map for HTTP
+// cert selection, and the SDS-name→bytes map to push.
+func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, map[gatewayListenerKey]struct{}, map[string]string, map[string]cache.EdgeTLSCert, error) {
 	list := &gatewayv1.GatewayList{}
 	if err := r.List(ctx, list, client.InNamespace(r.Namespace)); err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	gateways := map[string]struct{}{}
+	listenerKeys := map[gatewayListenerKey]struct{}{}
 	hostCerts := map[string]string{} // listener hostname ("" = catch-all) -> SDS name
 	certs := map[string]cache.EdgeTLSCert{}
 	for i := range list.Items {
@@ -124,6 +221,13 @@ func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, 
 			continue
 		}
 		gateways[gw.Name] = struct{}{}
+		for _, ln := range gw.Spec.Listeners {
+			listenerKeys[gatewayListenerKey{
+				Gateway:  gw.Name,
+				Port:     uint32(ln.Port),
+				Protocol: ln.Protocol,
+			}] = struct{}{}
+		}
 		if r.Secrets == nil {
 			continue
 		}
@@ -156,7 +260,7 @@ func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, 
 			}
 		}
 	}
-	return gateways, hostCerts, certs, nil
+	return gateways, listenerKeys, hostCerts, certs, nil
 }
 
 // buildVirtualHost maps one HTTPRoute to an edge VirtualHost: its hostnames become
@@ -202,10 +306,10 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 	return vh
 }
 
-// attachedToOurGateway reports whether the HTTPRoute has a parentRef to one of our
-// Gateways (same namespace; Gateway kind/group).
-func attachedToOurGateway(hr *gatewayv1.HTTPRoute, gateways map[string]struct{}) bool {
-	for _, p := range hr.Spec.ParentRefs {
+// attachedToOurGateway reports whether the given parentRefs include a reference
+// to one of our Gateways (same namespace; Gateway kind/group).
+func attachedToOurGateway(parentRefs []gatewayv1.ParentReference, gateways map[string]struct{}) bool {
+	for _, p := range parentRefs {
 		if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
 			continue
 		}
@@ -217,6 +321,82 @@ func attachedToOurGateway(hr *gatewayv1.HTTPRoute, gateways map[string]struct{})
 		}
 	}
 	return false
+}
+
+// gatewayParentPorts returns the distinct ports of our Gateway listeners that
+// match the given protocol and are referenced by the given parentRefs. Used to
+// scope TCPRoute/TLSRoute attachments to the exact Gateway listener ports.
+func gatewayParentPorts(
+	parentRefs []gatewayv1alpha2.ParentReference,
+	gateways map[string]struct{},
+	protocol gatewayv1.ProtocolType,
+	listenerKeys map[gatewayListenerKey]struct{},
+) []uint32 {
+	seen := map[uint32]struct{}{}
+	var ports []uint32
+	for _, p := range parentRefs {
+		if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
+			continue
+		}
+		if p.Kind != nil && string(*p.Kind) != "Gateway" {
+			continue
+		}
+		gwName := string(p.Name)
+		if _, ok := gateways[gwName]; !ok {
+			continue
+		}
+		// If a sectionName (listener name) is specified, match only that listener;
+		// otherwise match all listeners of the given protocol on this gateway.
+		if p.Port != nil {
+			port := uint32(*p.Port)
+			key := gatewayListenerKey{Gateway: gwName, Port: port, Protocol: protocol}
+			if _, ok := listenerKeys[key]; ok {
+				if _, dup := seen[port]; !dup {
+					seen[port] = struct{}{}
+					ports = append(ports, port)
+				}
+			}
+			continue
+		}
+		// No port specified: include all matching-protocol listeners on this gateway.
+		for k := range listenerKeys {
+			if k.Gateway == gwName && k.Protocol == protocol {
+				if _, dup := seen[k.Port]; !dup {
+					seen[k.Port] = struct{}{}
+					ports = append(ports, k.Port)
+				}
+			}
+		}
+	}
+	return ports
+}
+
+// buildL4Backends converts a BackendRef slice into L4Backends with resolved TCP
+// cluster names. Refs with a non-core group or non-Service kind are skipped.
+func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef) []proxy.L4Backend {
+	backends := make([]proxy.L4Backend, 0, len(refs))
+	for _, b := range refs {
+		if b.Group != nil && string(*b.Group) != "" {
+			continue
+		}
+		if b.Kind != nil && string(*b.Kind) != "Service" {
+			continue
+		}
+		name := string(b.Name)
+		if name == "" {
+			continue
+		}
+		weight := uint32(1)
+		if b.Weight != nil {
+			weight = uint32(*b.Weight)
+		}
+		backends = append(backends, proxy.L4Backend{
+			Service: name,
+			Cluster: proxy.TCPClusterName(name, r.MeshDomain),
+			Weight:  weight,
+		})
+	}
+	return backends
 }
 
 func firstBackendService(refs []gatewayv1.HTTPBackendRef) string {

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -72,12 +75,131 @@ func TestBuildVirtualHost_TLS(t *testing.T) {
 // project.
 func TestAttachedToOurGateway(t *testing.T) {
 	ours := map[string]struct{}{"edge-gw": {}}
-	assert.True(t, attachedToOurGateway(httpRoute(nil, nil, "edge-gw"), ours))
-	assert.False(t, attachedToOurGateway(httpRoute(nil, nil, "other-gw"), ours))
-	assert.False(t, attachedToOurGateway(httpRoute(nil, nil), ours), "no parentRef")
+	assert.True(t, attachedToOurGateway(httpRoute(nil, nil, "edge-gw").Spec.ParentRefs, ours))
+	assert.False(t, attachedToOurGateway(httpRoute(nil, nil, "other-gw").Spec.ParentRefs, ours))
+	assert.False(t, attachedToOurGateway(httpRoute(nil, nil).Spec.ParentRefs, ours), "no parentRef")
 }
 
 func TestFirstBackendService(t *testing.T) {
 	assert.Equal(t, "echo", firstBackendService(backend("echo", 0)))
 	assert.Empty(t, firstBackendService(nil))
+}
+
+// --- L4 edge helpers ---
+
+func gatewayParentRef(name string, port int32) gatewayv1alpha2.ParentReference {
+	p := gatewayv1alpha2.ParentReference{Name: gatewayv1alpha2.ObjectName(name)}
+	if port != 0 {
+		pp := gatewayv1alpha2.PortNumber(port)
+		p.Port = &pp
+	}
+	return p
+}
+
+func tcpBackendRef(svc string, weight int32) gatewayv1.BackendRef {
+	ref := gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(svc)}}
+	if weight > 0 {
+		w := weight
+		ref.Weight = &w
+	}
+	return ref
+}
+
+// TestBuildL4Backends verifies the edge reconciler's L4 backend builder resolves
+// cluster names using TCPClusterName (tcp:<svc>.<meshDomain>).
+func TestBuildL4Backends(t *testing.T) {
+	r := &Reconciler{MeshDomain: "aether.internal"}
+	refs := []gatewayv1.BackendRef{
+		tcpBackendRef("pg", 1),
+		tcpBackendRef("cache", 2),
+	}
+	backends := r.buildL4Backends(refs)
+	require.Len(t, backends, 2)
+	assert.Equal(t, "pg", backends[0].Service)
+	assert.Equal(t, proxy.TCPClusterName("pg", "aether.internal"), backends[0].Cluster)
+	assert.Equal(t, uint32(1), backends[0].Weight)
+	assert.Equal(t, "cache", backends[1].Service)
+	assert.Equal(t, uint32(2), backends[1].Weight)
+}
+
+// TestBuildL4Backends_ForeignGroupSkipped verifies non-core refs are skipped.
+func TestBuildL4Backends_ForeignGroupSkipped(t *testing.T) {
+	r := &Reconciler{MeshDomain: "aether.internal"}
+	refs := []gatewayv1.BackendRef{
+		{BackendObjectReference: gatewayv1.BackendObjectReference{
+			Group: ptr(gatewayv1.Group("apps")), Name: "skip",
+		}},
+		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "keep"}},
+	}
+	backends := r.buildL4Backends(refs)
+	require.Len(t, backends, 1)
+	assert.Equal(t, "keep", backends[0].Service)
+}
+
+// TestAttachedToOurGateway_L4 verifies the refactored attachedToOurGateway accepts
+// a []ParentReference slice directly (used by TCPRoute/TLSRoute path).
+func TestAttachedToOurGateway_L4(t *testing.T) {
+	ours := map[string]struct{}{"edge-gw": {}}
+	refs := []gatewayv1.ParentReference{
+		{Name: "edge-gw"},
+	}
+	assert.True(t, attachedToOurGateway(refs, ours))
+	assert.False(t, attachedToOurGateway([]gatewayv1.ParentReference{{Name: "other"}}, ours))
+}
+
+// TestGatewayParentPorts_WithPort verifies port-scoped parentRefs are matched
+// against the listener key set.
+func TestGatewayParentPorts_WithPort(t *testing.T) {
+	gateways := map[string]struct{}{"edge-gw": {}}
+	keys := map[gatewayListenerKey]struct{}{
+		{Gateway: "edge-gw", Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: "edge-gw", Port: 8443, Protocol: gatewayv1.TLSProtocolType}: {},
+	}
+
+	tcpRefs := []gatewayv1alpha2.ParentReference{gatewayParentRef("edge-gw", 5432)}
+	ports := gatewayParentPorts(tcpRefs, gateways, gatewayv1.TCPProtocolType, keys)
+	assert.Equal(t, []uint32{5432}, ports)
+
+	// Wrong protocol: TLS ref not matched as TCP.
+	wrongProto := []gatewayv1alpha2.ParentReference{gatewayParentRef("edge-gw", 8443)}
+	tcpPorts := gatewayParentPorts(wrongProto, gateways, gatewayv1.TCPProtocolType, keys)
+	assert.Empty(t, tcpPorts)
+}
+
+// TestGatewayParentPorts_NoPort verifies that a parentRef with no port matches
+// all listeners of the given protocol on the gateway.
+func TestGatewayParentPorts_NoPort(t *testing.T) {
+	gateways := map[string]struct{}{"edge-gw": {}}
+	keys := map[gatewayListenerKey]struct{}{
+		{Gateway: "edge-gw", Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: "edge-gw", Port: 5433, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: "edge-gw", Port: 8443, Protocol: gatewayv1.TLSProtocolType}: {},
+	}
+	// No port: should match all TCP listeners.
+	refs := []gatewayv1alpha2.ParentReference{gatewayParentRef("edge-gw", 0)}
+	ports := gatewayParentPorts(refs, gateways, gatewayv1.TCPProtocolType, keys)
+	assert.Len(t, ports, 2)
+	for _, p := range ports {
+		assert.True(t, p == 5432 || p == 5433)
+	}
+}
+
+// TestGatewayParentPorts_UnknownGateway verifies refs to unknown gateways are ignored.
+func TestGatewayParentPorts_UnknownGateway(t *testing.T) {
+	gateways := map[string]struct{}{"edge-gw": {}}
+	keys := map[gatewayListenerKey]struct{}{
+		{Gateway: "other-gw", Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
+	}
+	refs := []gatewayv1alpha2.ParentReference{gatewayParentRef("other-gw", 5432)}
+	ports := gatewayParentPorts(refs, gateways, gatewayv1.TCPProtocolType, keys)
+	assert.Empty(t, ports)
+}
+
+// TestBuildVirtualHost_ParentRefsRefactored verifies the refactored
+// attachedToOurGateway still works for HTTPRoutes.
+func TestBuildVirtualHost_ParentRefsRefactored(t *testing.T) {
+	ours := map[string]struct{}{"edge-gw": {}}
+	hr := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "r"}}
+	hr.Spec.ParentRefs = []gatewayv1.ParentReference{{Name: "edge-gw"}}
+	assert.True(t, attachedToOurGateway(hr.Spec.ParentRefs, ours))
 }

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -104,11 +104,17 @@ type SnapshotCache struct {
 	// edgeHTTPSPort is the port the edge TLS listener binds when edgeTLSEnabled.
 	edgeHTTPSPort uint32
 
-	// edgeMu guards virtualHosts: the external-host -> mesh-service routing the
-	// edge serves (derived from VirtualHost CRs). The edge route config is built
-	// from them, and their backend-service set scopes the dependency set.
+	// edgeMu guards virtualHosts, edgeTCPRoutes, and edgeTLSRoutes: the routing
+	// the edge serves. The HTTP route config and L4 listeners are built from them,
+	// and their backend-service set scopes the dependency set.
 	edgeMu       sync.RWMutex
 	virtualHosts []VirtualHost
+	// edgeTCPRoutes holds the edge's TCP listener routes (one per Gateway TCP
+	// listener port, derived from TCPRoutes parented to a Gateway of our class).
+	edgeTCPRoutes []proxy.EdgeL4TCPRoute
+	// edgeTLSRoutes holds the edge's TLS passthrough listener routes (one per
+	// Gateway TLS listener port, derived from TLSRoutes parented to a Gateway).
+	edgeTLSRoutes []proxy.EdgeL4TLSRoute
 
 	listenerMu sync.RWMutex
 	listeners  map[string]listenerEntry // keyed by container network namespace

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -25,8 +25,8 @@ func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Res
 	for i, e := range c.captureTCPServices {
 		tcpServices[i] = proxy.CaptureTCPService{
 			// TCP clusters are separate from HTTP clusters: they share the same EDS
-			// resource (same endpoint set) but use ALPN "aether-tcp" on the transport
-			// socket so the destination inbound demuxes to the TCP floor chain.
+			// resource (same endpoint set) but use no ALPN on the transport socket so
+			// the destination inbound demuxes to the TCP floor DEFAULT chain.
 			ClusterName: proxy.TCPClusterName(e.serviceName, c.meshDomain),
 			ClusterIP:   e.clusterIP,
 			// L4 route rules (Phase 3b): override the passthrough floor chain when
@@ -126,8 +126,8 @@ func (c *SnapshotCache) SetCaptureTCPServices(services []capture.CaptureTCPServi
 
 // captureTCPClusters returns the TCP floor clusters for non-HTTP services as a resource
 // slice. These are separate EDS clusters (prefixed "tcp:") that share the same endpoints
-// as the HTTP clusters but use ALPN "aether-tcp" on their transport socket so the
-// destination inbound routes to the TCP floor filter chain. Called from generateSnapshot.
+// as the HTTP clusters but use NO ALPN on their transport socket so the destination
+// inbound routes to the TCP floor DEFAULT chain. Called from generateSnapshot.
 func (c *SnapshotCache) captureTCPClusters() []types.Resource {
 	if !c.captureEnabled {
 		return nil
@@ -187,6 +187,79 @@ func (c *SnapshotCache) captureTCPClusters() []types.Resource {
 	}
 	c.clusterMu.RUnlock()
 
+	return resources
+}
+
+// edgeTCPClusters returns TCP floor clusters for services referenced by the edge's
+// L4 routes (TCPRoute/TLSRoute parented to a Gateway). Called from generateSnapshot
+// when in edge mode; parallel to captureTCPClusters but for the edge identity
+// (EdgeUpstreamTCPTransportSocket fetches SDS from spire_agent, not ADS).
+//
+// The edge has one identity so no per-source matcher is needed: the cluster gets
+// a single transport socket presenting the edge SVID with no ALPN and no SNI,
+// so the destination inbound demuxes to the TCP floor DEFAULT chain.
+func (c *SnapshotCache) edgeTCPClusters() []types.Resource {
+	c.edgeMu.RLock()
+	tcpRoutes := append([]proxy.EdgeL4TCPRoute(nil), c.edgeTCPRoutes...)
+	tlsRoutes := append([]proxy.EdgeL4TLSRoute(nil), c.edgeTLSRoutes...)
+	c.edgeMu.RUnlock()
+
+	// Collect the distinct service names referenced by edge L4 routes.
+	seen := make(map[string]struct{})
+	var services []string
+	for _, r := range tcpRoutes {
+		for _, b := range r.Backends {
+			if b.Service != "" && b.Cluster != "" {
+				if _, ok := seen[b.Service]; !ok {
+					seen[b.Service] = struct{}{}
+					services = append(services, b.Service)
+				}
+			}
+		}
+	}
+	for _, r := range tlsRoutes {
+		for _, rule := range r.Rules {
+			for _, b := range rule.Backends {
+				if b.Service != "" && b.Cluster != "" {
+					if _, ok := seen[b.Service]; !ok {
+						seen[b.Service] = struct{}{}
+						services = append(services, b.Service)
+					}
+				}
+			}
+		}
+	}
+	if len(services) == 0 {
+		return nil
+	}
+
+	c.localMu.RLock()
+	nodeSpiffeID := c.nodeSpiffeID
+	trustDomain := c.trustDomain
+	c.localMu.RUnlock()
+	if nodeSpiffeID == "" {
+		return nil
+	}
+	validationContextName := fmt.Sprintf("spiffe://%s", trustDomain)
+
+	c.clusterMu.RLock()
+	resources := make([]types.Resource, 0, len(services))
+	for _, svc := range services {
+		entry, ok := c.clusters[svc]
+		if !ok {
+			continue // not yet in scope; will appear when registry delivers endpoints
+		}
+		sanURIs := make([]string, 0, len(entry.sanNamespaces))
+		for _, ns := range entry.sanNamespaces {
+			sanURIs = append(sanURIs, fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ns, entry.service))
+		}
+		tcpName := proxy.TCPClusterName(svc, c.meshDomain)
+		cl := proxy.NewTCPServiceCluster(tcpName, svc, svc, false /* edge = single identity, no per-downstream pool */)
+		// Edge variant: fetch SVID/bundle from spire_agent (not ADS), no ALPN, no SNI (TCP floor).
+		cl.TransportSocket = proxy.EdgeUpstreamTCPTransportSocket(nodeSpiffeID, validationContextName, sanURIs)
+		resources = append(resources, cl)
+	}
+	c.clusterMu.RUnlock()
 	return resources
 }
 

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
 // VirtualHost is the cache's projection of a VirtualHost CR (without the
@@ -72,41 +73,21 @@ func (c *SnapshotCache) edgeTLSSecretNames() []string {
 }
 
 // SetVirtualHosts replaces the edge's exposed virtual hosts. It scopes the
-// dependency set to the union of every route's backend service (so the registrar
-// watch and clusters follow the exposed set) and rebuilds the snapshot's route
-// table — including when only the hostnames or matches changed (the service set,
-// and therefore the dependency set, didn't).
+// dependency set to the union of every route's backend service (plus L4 route
+// backends) and rebuilds the snapshot's route table — including when only the
+// hostnames or matches changed (the service set, and therefore the dependency set,
+// didn't).
 func (c *SnapshotCache) SetVirtualHosts(vhosts []VirtualHost) {
 	c.edgeMu.Lock()
 	changed := !equalVirtualHosts(c.virtualHosts, vhosts)
 	c.virtualHosts = vhosts
 	c.edgeMu.Unlock()
 
-	// Dependency set = the distinct backend services of every ROUTABLE virtual
-	// host (those with at least one external host). A vhost without hosts exposes
-	// nothing — it must not pull its services into scope. Signals a reload when
-	// the set changed.
-	seen := make(map[string]struct{})
-	services := make([]string, 0, len(vhosts))
-	for _, v := range vhosts {
-		if len(v.Hosts) == 0 {
-			continue
-		}
-		for _, r := range v.Routes {
-			if r.Service == "" {
-				continue
-			}
-			if _, ok := seen[r.Service]; ok {
-				continue
-			}
-			seen[r.Service] = struct{}{}
-			services = append(services, r.Service)
-		}
-	}
-	c.SetStaticDependencies(services)
+	// Rebuild the full static dependency set (HTTP vhosts + any L4 routes).
+	c.rebuildEdgeDependencies()
 
 	// A host/match-only change leaves the dependency set untouched, so signal a
-	// rebuild directly; the send is coalesced, so the SetStaticDependencies
+	// rebuild directly; the send is coalesced, so the rebuildEdgeDependencies
 	// signal (if any) is not duplicated.
 	if changed {
 		c.signalDependencyChange()
@@ -181,6 +162,120 @@ func (c *SnapshotCache) edgeClusterNameLocked(service string, port uint32) strin
 	return portName
 }
 
+// SetEdgeTCPRoutes replaces the edge's TCP listener routes (one per Gateway TCP
+// listener port). On change it updates the dependency set and signals a rebuild
+// so the new tcp_proxy listeners appear in the snapshot.
+func (c *SnapshotCache) SetEdgeTCPRoutes(routes []proxy.EdgeL4TCPRoute) {
+	c.edgeMu.Lock()
+	changed := !equalEdgeTCPRoutes(c.edgeTCPRoutes, routes)
+	c.edgeTCPRoutes = routes
+	c.edgeMu.Unlock()
+
+	if !changed {
+		return
+	}
+
+	// Extend the static dependency set with the backends' services so their EDS
+	// clusters generate. We re-derive the full set here (HTTP + L4) rather than
+	// patching to keep the logic idempotent.
+	c.rebuildEdgeDependencies()
+	c.signalDependencyChange()
+}
+
+// SetEdgeTLSRoutes replaces the edge's TLS passthrough listener routes (one per
+// Gateway TLS listener port). On change it updates the dependency set and signals
+// a rebuild.
+func (c *SnapshotCache) SetEdgeTLSRoutes(routes []proxy.EdgeL4TLSRoute) {
+	c.edgeMu.Lock()
+	changed := !equalEdgeTLSRoutes(c.edgeTLSRoutes, routes)
+	c.edgeTLSRoutes = routes
+	c.edgeMu.Unlock()
+
+	if !changed {
+		return
+	}
+
+	c.rebuildEdgeDependencies()
+	c.signalDependencyChange()
+}
+
+// rebuildEdgeDependencies recomputes the static dependency set from the union of
+// all edge route backends (HTTP virtual-hosts + TCP routes + TLS routes) and calls
+// SetStaticDependencies. Called whenever any edge route set changes.
+func (c *SnapshotCache) rebuildEdgeDependencies() {
+	c.edgeMu.RLock()
+	vhosts := slices.Clone(c.virtualHosts)
+	tcpRoutes := append([]proxy.EdgeL4TCPRoute(nil), c.edgeTCPRoutes...)
+	tlsRoutes := append([]proxy.EdgeL4TLSRoute(nil), c.edgeTLSRoutes...)
+	c.edgeMu.RUnlock()
+
+	seen := make(map[string]struct{})
+	var services []string
+
+	for _, v := range vhosts {
+		if len(v.Hosts) == 0 {
+			continue
+		}
+		for _, r := range v.Routes {
+			if r.Service == "" {
+				continue
+			}
+			if _, ok := seen[r.Service]; !ok {
+				seen[r.Service] = struct{}{}
+				services = append(services, r.Service)
+			}
+		}
+	}
+	for _, r := range tcpRoutes {
+		for _, b := range r.Backends {
+			if b.Service == "" {
+				continue
+			}
+			if _, ok := seen[b.Service]; !ok {
+				seen[b.Service] = struct{}{}
+				services = append(services, b.Service)
+			}
+		}
+	}
+	for _, r := range tlsRoutes {
+		for _, rule := range r.Rules {
+			for _, b := range rule.Backends {
+				if b.Service == "" {
+					continue
+				}
+				if _, ok := seen[b.Service]; !ok {
+					seen[b.Service] = struct{}{}
+					services = append(services, b.Service)
+				}
+			}
+		}
+	}
+	c.SetStaticDependencies(services)
+}
+
+// edgeTCPListeners returns the edge's L4 listeners (TCP + TLS passthrough) derived
+// from the current EdgeL4TCPRoute and EdgeL4TLSRoute sets. Called from Listeners()
+// in edge mode.
+func (c *SnapshotCache) edgeTCPListeners() []types.Resource {
+	c.edgeMu.RLock()
+	tcpRoutes := append([]proxy.EdgeL4TCPRoute(nil), c.edgeTCPRoutes...)
+	tlsRoutes := append([]proxy.EdgeL4TLSRoute(nil), c.edgeTLSRoutes...)
+	c.edgeMu.RUnlock()
+
+	var out []types.Resource
+	for _, r := range tcpRoutes {
+		if ln := proxy.BuildEdgeTCPListener(r.Port, r.Backends); ln != nil {
+			out = append(out, ln)
+		}
+	}
+	for _, r := range tlsRoutes {
+		if ln := proxy.BuildEdgeTLSPassthroughListener(r.Port, r.Rules); ln != nil {
+			out = append(out, ln)
+		}
+	}
+	return out
+}
+
 // equalVirtualHosts reports whether two virtual-host slices are identical (order
 // and contents), so a no-op SetVirtualHosts call skips a snapshot rebuild.
 func equalVirtualHosts(a, b []VirtualHost) bool {
@@ -192,6 +287,54 @@ func equalVirtualHosts(a, b []VirtualHost) bool {
 			!slices.Equal(a[i].Hosts, b[i].Hosts) ||
 			!slices.Equal(a[i].Routes, b[i].Routes) {
 			return false
+		}
+	}
+	return true
+}
+
+// equalEdgeTCPRoutes reports whether two EdgeL4TCPRoute slices are identical.
+func equalEdgeTCPRoutes(a, b []proxy.EdgeL4TCPRoute) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Port != b[i].Port || len(a[i].Backends) != len(b[i].Backends) {
+			return false
+		}
+		for j := range a[i].Backends {
+			if a[i].Backends[j] != b[i].Backends[j] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// equalEdgeTLSRoutes reports whether two EdgeL4TLSRoute slices are identical.
+func equalEdgeTLSRoutes(a, b []proxy.EdgeL4TLSRoute) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Port != b[i].Port {
+			return false
+		}
+		if len(a[i].Rules) != len(b[i].Rules) {
+			return false
+		}
+		for j := range a[i].Rules {
+			ra, rb := a[i].Rules[j], b[i].Rules[j]
+			if !slices.Equal(ra.SNIHostnames, rb.SNIHostnames) {
+				return false
+			}
+			if len(ra.Backends) != len(rb.Backends) {
+				return false
+			}
+			for k := range ra.Backends {
+				if ra.Backends[k] != rb.Backends[k] {
+					return false
+				}
+			}
 		}
 	}
 	return true

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -95,18 +95,23 @@ func (c *SnapshotCache) RemovePod(ctx context.Context, netns string) error {
 // Thread-safe.
 func (c *SnapshotCache) Listeners() []types.Resource {
 	// Edge mode: public-facing listener(s) (no per-pod inbound/outbound
-	// listeners, no health gateway — the edge runs no local workloads). With TLS
-	// enabled it serves a TLS-terminating listener on the https port (certs
-	// SNI-selected from SDS) plus an HTTP->HTTPS redirect on the plain port;
-	// otherwise a single plain-HTTP listener.
+	// listeners, no health gateway — the edge runs no local workloads). The edge
+	// serves:
+	//   - HTTP listener (plain or TLS-terminating) from HTTPRoutes
+	//   - TCP listener(s) for each Gateway TCP port from TCPRoutes
+	//   - TLS passthrough listener(s) for each Gateway TLS port from TLSRoutes
 	if c.edge {
+		var resources []types.Resource
 		if c.edgeTLSEnabled {
-			return []types.Resource{
+			resources = append(resources,
 				proxy.BuildEdgeListener(c.edgeHTTPSPort, c.edgeTLSSecretNames()),
 				proxy.BuildEdgeRedirectListener(c.edgeHTTPPort),
-			}
+			)
+		} else {
+			resources = append(resources, proxy.BuildEdgeListener(c.edgeHTTPPort, nil))
 		}
-		return []types.Resource{proxy.BuildEdgeListener(c.edgeHTTPPort, nil)}
+		resources = append(resources, c.edgeTCPListeners()...)
+		return resources
 	}
 
 	c.listenerMu.RLock()

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -64,6 +64,13 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 	// is enabled and there are non-HTTP services.
 	clusters = append(clusters, c.captureTCPClusters()...)
 
+	// Edge L4 TCP clusters (proposal 018, Phase 3b north-south): one per service
+	// referenced by an edge TCPRoute or TLSRoute. Like capture TCP clusters but use
+	// the edge SPIRE identity and fetch SDS from spire_agent directly.
+	if c.edge {
+		clusters = append(clusters, c.edgeTCPClusters()...)
+	}
+
 	c.secretMu.RLock()
 	secrets := make([]types.Resource, 0, len(c.secrets))
 	for _, s := range c.secrets {

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -1,6 +1,8 @@
 package proxy
 
 import (
+	"fmt"
+
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -42,6 +44,114 @@ const (
 	// external traffic, unlike the node proxy's loopback-only outbound listener).
 	defaultEdgeAddress = "0.0.0.0"
 )
+
+// EdgeTCPListenerName returns the name of an edge TCP listener for a given port.
+// TCPRoute listeners are named edge_tcp_<port> so each Gateway TCP listener
+// gets its own Envoy listener and stats prefix.
+func EdgeTCPListenerName(port uint32) string {
+	return fmt.Sprintf("edge_tcp_%d", port)
+}
+
+// EdgeTLSListenerName returns the name of an edge TLS passthrough listener for
+// a given port. TLSRoute (Passthrough) listeners are named edge_tls_<port>.
+func EdgeTLSListenerName(port uint32) string {
+	return fmt.Sprintf("edge_tls_%d", port)
+}
+
+// EdgeL4TCPRoute describes one edge TCP listener: a Gateway TCP listener on
+// port with all backends consolidated from the attached TCPRoute rules.
+type EdgeL4TCPRoute struct {
+	// Port is the Gateway listener port (TCP protocol) this route is bound to.
+	Port uint32
+	// Backends is the flat weighted backend list from all attached TCPRoute rules.
+	Backends []L4Backend
+}
+
+// EdgeL4TLSRoute describes one edge TLS passthrough listener: a Gateway TLS
+// listener (mode: Passthrough) on port with per-SNI route rules.
+type EdgeL4TLSRoute struct {
+	// Port is the Gateway listener port (TLS protocol, Passthrough mode).
+	Port uint32
+	// Rules are the ordered per-SNI rules from all attached TLSRoutes; each
+	// rule's SNIHostnames become a filter_chain_match.server_names set.
+	Rules []L4ServiceRoute
+}
+
+// BuildEdgeTCPListener builds a 0.0.0.0:<port> TCP listener for an edge TCPRoute.
+// It routes all inbound TCP to the named upstream cluster via tcp_proxy (no TLS
+// termination — the upstream hop to the mesh pod is SPIRE mTLS with no ALPN).
+// The cluster name is the "tcp:<svc>.<meshDomain>" cluster whose transport socket
+// is injected at snapshot time via InjectUpstreamTCPMTLS (same path as the east-west
+// TCP floor). When rules is empty or all backends are missing, the listener is
+// omitted (returns nil) — a Gateway TCP listener with no TCPRoute attached should
+// not produce an Envoy listener.
+func BuildEdgeTCPListener(port uint32, backends []L4Backend) *listenerv3.Listener {
+	clusters := l4BackendsToWeightedClusters(backends)
+	tcpProxy := buildWeightedTCPProxy(EdgeTCPListenerName(port), clusters)
+	if tcpProxy == nil {
+		return nil
+	}
+	fc := &listenerv3.FilterChain{
+		Name:    EdgeTCPListenerName(port),
+		Filters: []*listenerv3.Filter{tcpProxy},
+	}
+	return edgeListener(EdgeTCPListenerName(port), port, fc)
+}
+
+// BuildEdgeTLSPassthroughListener builds a 0.0.0.0:<port> TLS passthrough listener
+// for an edge TLSRoute. It installs a tls_inspector listener filter so Envoy reads
+// the client SNI; each rule's SNIHostnames become a filter_chain_match.server_names
+// set routing via tcp_proxy to the rule's backends. No TLS termination: the SNI is
+// read for routing only; the backend connection is SPIRE mTLS with no ALPN (TCP floor).
+// Returns nil if rules is empty or none has both SNI hostnames and backends.
+func BuildEdgeTLSPassthroughListener(port uint32, rules []L4ServiceRoute) *listenerv3.Listener {
+	var chains []*listenerv3.FilterChain
+	for i, rule := range rules {
+		if len(rule.SNIHostnames) == 0 || len(rule.Backends) == 0 {
+			continue
+		}
+		statPrefix := fmt.Sprintf("%s_%d", EdgeTLSListenerName(port), i)
+		clusters := l4BackendsToWeightedClusters(rule.Backends)
+		tcpProxy := buildWeightedTCPProxy(statPrefix, clusters)
+		if tcpProxy == nil {
+			continue
+		}
+		chains = append(chains, &listenerv3.FilterChain{
+			Name: fmt.Sprintf("%s_%d", EdgeTLSListenerName(port), i),
+			FilterChainMatch: &listenerv3.FilterChainMatch{
+				ServerNames:       rule.SNIHostnames,
+				TransportProtocol: "tls",
+			},
+			Filters: []*listenerv3.Filter{tcpProxy},
+		})
+	}
+	if len(chains) == 0 {
+		return nil
+	}
+	ln := &listenerv3.Listener{
+		Name: EdgeTLSListenerName(port),
+		Address: &corev3.Address{
+			Address: &corev3.Address_SocketAddress{
+				SocketAddress: &corev3.SocketAddress{
+					Protocol: corev3.SocketAddress_TCP,
+					Address:  defaultEdgeAddress,
+					PortSpecifier: &corev3.SocketAddress_PortValue{
+						PortValue: port,
+					},
+				},
+			},
+		},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		StatPrefix:                    EdgeTLSListenerName(port),
+		TrafficDirection:              corev3.TrafficDirection_INBOUND,
+		// The tls_inspector reads the ClientHello SNI so filter_chain_match.server_names
+		// works. No TLS termination: the SNI is for routing only; the raw mTLS stream
+		// passes through to the backend.
+		ListenerFilters: []*listenerv3.ListenerFilter{tlsInspector()},
+		FilterChains:    chains,
+	}
+	return ln
+}
 
 // BuildEdgeListener builds the edge proxy's public-facing HTTP listener: an HCM
 // on 0.0.0.0:<port> that routes external traffic to mesh services via RDS

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -6,6 +6,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	tcp_proxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
 	transport_sockets_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -146,4 +147,134 @@ func TestBuildEdgeRouteConfiguration(t *testing.T) {
 	assert.Equal(t, []string{"*"}, last.GetDomains())
 	require.Len(t, last.GetRoutes(), 1)
 	assert.Equal(t, uint32(404), last.GetRoutes()[0].GetDirectResponse().GetStatus())
+}
+
+// TestEdgeL4ListenerNames verifies the naming helpers are stable.
+func TestEdgeL4ListenerNames(t *testing.T) {
+	assert.Equal(t, "edge_tcp_5432", EdgeTCPListenerName(5432))
+	assert.Equal(t, "edge_tls_8443", EdgeTLSListenerName(8443))
+}
+
+// TestBuildEdgeTCPListener_SingleBackend verifies the TCP listener: INBOUND on 0.0.0.0,
+// one filter chain with a tcp_proxy (single-cluster form), no TLS transport socket.
+func TestBuildEdgeTCPListener_SingleBackend(t *testing.T) {
+	backends := []L4Backend{
+		{Service: "pg", Cluster: "tcp:pg.aether.internal", Weight: 1},
+	}
+	ln := BuildEdgeTCPListener(5432, backends)
+	require.NotNil(t, ln)
+
+	assert.Equal(t, "edge_tcp_5432", ln.GetName())
+	assert.Equal(t, corev3.TrafficDirection_INBOUND, ln.GetTrafficDirection())
+	addr := ln.GetAddress().GetSocketAddress()
+	assert.Equal(t, defaultEdgeAddress, addr.GetAddress())
+	assert.Equal(t, uint32(5432), addr.GetPortValue())
+
+	require.Len(t, ln.GetFilterChains(), 1)
+	fc := ln.GetFilterChains()[0]
+	assert.Nil(t, fc.GetTransportSocket(), "TCP listener: no downstream TLS (plain passthrough)")
+	assert.Nil(t, fc.GetFilterChainMatch(), "single-backend TCP listener: no filter chain match")
+
+	// The tcp_proxy must reference the backend cluster.
+	require.Len(t, fc.GetFilters(), 1)
+	tcpProxy := &tcp_proxyv3.TcpProxy{}
+	require.NoError(t, fc.GetFilters()[0].GetTypedConfig().UnmarshalTo(tcpProxy))
+	assert.Equal(t, "tcp:pg.aether.internal", tcpProxy.GetCluster())
+}
+
+// TestBuildEdgeTCPListener_WeightedBackends verifies weighted_clusters form when
+// multiple backends are present.
+func TestBuildEdgeTCPListener_WeightedBackends(t *testing.T) {
+	backends := []L4Backend{
+		{Service: "pg-v1", Cluster: "tcp:pg-v1.aether.internal", Weight: 90},
+		{Service: "pg-v2", Cluster: "tcp:pg-v2.aether.internal", Weight: 10},
+	}
+	ln := BuildEdgeTCPListener(5432, backends)
+	require.NotNil(t, ln)
+
+	fc := ln.GetFilterChains()[0]
+	tcpProxy := &tcp_proxyv3.TcpProxy{}
+	require.NoError(t, fc.GetFilters()[0].GetTypedConfig().UnmarshalTo(tcpProxy))
+	wc := tcpProxy.GetWeightedClusters()
+	require.NotNil(t, wc)
+	require.Len(t, wc.GetClusters(), 2)
+	assert.Equal(t, "tcp:pg-v1.aether.internal", wc.GetClusters()[0].GetName())
+	assert.Equal(t, uint32(90), wc.GetClusters()[0].GetWeight())
+	assert.Equal(t, "tcp:pg-v2.aether.internal", wc.GetClusters()[1].GetName())
+	assert.Equal(t, uint32(10), wc.GetClusters()[1].GetWeight())
+}
+
+// TestBuildEdgeTCPListener_EmptyBackends returns nil (no listener without backends).
+func TestBuildEdgeTCPListener_EmptyBackends(t *testing.T) {
+	assert.Nil(t, BuildEdgeTCPListener(5432, nil))
+	assert.Nil(t, BuildEdgeTCPListener(5432, []L4Backend{}))
+}
+
+// TestBuildEdgeTLSPassthroughListener_SNIRouting verifies the TLS passthrough listener:
+// tls_inspector listener filter, per-SNI filter chains (transport_protocol "tls",
+// server_names match), tcp_proxy filter.
+func TestBuildEdgeTLSPassthroughListener_SNIRouting(t *testing.T) {
+	rules := []L4ServiceRoute{
+		{
+			SNIHostnames: []string{"db.example.com"},
+			Backends:     []L4Backend{{Service: "db", Cluster: "tcp:db.aether.internal", Weight: 1}},
+		},
+		{
+			SNIHostnames: []string{"analytics.example.com", "bi.example.com"},
+			Backends:     []L4Backend{{Service: "analytics", Cluster: "tcp:analytics.aether.internal", Weight: 1}},
+		},
+	}
+	ln := BuildEdgeTLSPassthroughListener(5433, rules)
+	require.NotNil(t, ln)
+
+	assert.Equal(t, "edge_tls_5433", ln.GetName())
+	assert.Equal(t, corev3.TrafficDirection_INBOUND, ln.GetTrafficDirection())
+	assert.Equal(t, uint32(5433), ln.GetAddress().GetSocketAddress().GetPortValue())
+
+	// tls_inspector listener filter must be present.
+	require.Len(t, ln.GetListenerFilters(), 1)
+	assert.Equal(t, listenerFilterTLSInspectorName, ln.GetListenerFilters()[0].GetName())
+
+	// Two filter chains, one per rule.
+	require.Len(t, ln.GetFilterChains(), 2)
+
+	fc0 := ln.GetFilterChains()[0]
+	assert.Equal(t, []string{"db.example.com"}, fc0.GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, "tls", fc0.GetFilterChainMatch().GetTransportProtocol())
+	tcpProxy0 := &tcp_proxyv3.TcpProxy{}
+	require.NoError(t, fc0.GetFilters()[0].GetTypedConfig().UnmarshalTo(tcpProxy0))
+	assert.Equal(t, "tcp:db.aether.internal", tcpProxy0.GetCluster())
+
+	fc1 := ln.GetFilterChains()[1]
+	assert.Equal(t, []string{"analytics.example.com", "bi.example.com"}, fc1.GetFilterChainMatch().GetServerNames())
+}
+
+// TestBuildEdgeTLSPassthroughListener_EmptyRules returns nil.
+func TestBuildEdgeTLSPassthroughListener_EmptyRules(t *testing.T) {
+	assert.Nil(t, BuildEdgeTLSPassthroughListener(5433, nil))
+	assert.Nil(t, BuildEdgeTLSPassthroughListener(5433, []L4ServiceRoute{
+		{SNIHostnames: []string{"h"}, Backends: nil},
+	}))
+}
+
+// TestEdgeUpstreamTCPTransportSocket verifies the edge TCP transport socket uses
+// NO ALPN (not "h2" or "aether-tcp") and NO SNI so the destination inbound falls
+// to the TCP floor DEFAULT chain, while SDS is fetched from spire_agent (not ADS).
+func TestEdgeUpstreamTCPTransportSocket(t *testing.T) {
+	ts := EdgeUpstreamTCPTransportSocket(
+		"spiffe://aether.internal/ns/aether-ingress/sa/edge",
+		"spiffe://aether.internal",
+		nil,
+	)
+	utc := &transport_sockets_v3.UpstreamTlsContext{}
+	require.NoError(t, ts.GetTypedConfig().UnmarshalTo(utc))
+
+	common := utc.GetCommonTlsContext()
+	assert.Empty(t, common.GetAlpnProtocols(), "must advertise no ALPN (TCP floor default chain)")
+	assert.Empty(t, utc.GetSni(), "must send no SNI (TCP floor default chain)")
+
+	grpc := common.GetTlsCertificateSdsSecretConfigs()[0].GetSdsConfig().GetApiConfigSource().GetGrpcServices()
+	require.Len(t, grpc, 1)
+	assert.Equal(t, SpireAgentSDSClusterName, grpc[0].GetEnvoyGrpc().GetClusterName(),
+		"SDS must be fetched from spire_agent, not ADS")
 }

--- a/agent/internal/xds/proxy/transportsocket.go
+++ b/agent/internal/xds/proxy/transportsocket.go
@@ -82,6 +82,17 @@ func EdgeUpstreamTransportSocket(tlsCertificateSecretName string, validationCont
 	return upstreamTransportSocket(tlsCertificateSecretName, validationContextName, sanURIs, sni, config.SDSConfigSourceFromCluster(SpireAgentSDSClusterName))
 }
 
+// EdgeUpstreamTCPTransportSocket is EdgeUpstreamTransportSocket for TCP floor
+// clusters: it advertises NO ALPN (like the east-west UpstreamTCPTransportSocket)
+// and NO SNI so the destination inbound demuxes to the TCP floor's DEFAULT chain,
+// while still fetching the edge SVID and trust bundle directly from the SPIRE Agent
+// (not the agent's ADS stream). #304 removed the bespoke "aether-tcp" ALPN; #306
+// established that the SNI must be empty for the floor — a non-empty SNI would
+// hit the destination's per-port HCM chain instead of the floor default.
+func EdgeUpstreamTCPTransportSocket(tlsCertificateSecretName string, validationContextName string, sanURIs []string) *corev3.TransportSocket {
+	return upstreamTransportSocket(tlsCertificateSecretName, validationContextName, sanURIs, "" /* no SNI */, config.SDSConfigSourceFromCluster(SpireAgentSDSClusterName), "" /* no ALPN */)
+}
+
 // upstreamTransportSocket builds an upstream TLS context. With no alpnOverride the
 // ALPN is "h2" (HTTP/2 mesh transport). An alpnOverride of "" suppresses ALPN
 // entirely — the TCP floor path, so the destination inbound demuxes it as the

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.40.0-{GIT_COMMIT}"
+version: "0.41.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-rbac.yaml
+++ b/charts/aether/templates/edge-rbac.yaml
@@ -10,13 +10,14 @@ metadata:
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
 rules:
-  # Gateway API (proposal 018): read Gateways + HTTPRoutes (and their status) in
-  # the watched namespace.
+  # Gateway API (proposal 018): read Gateways + HTTPRoutes + TCPRoutes + TLSRoutes
+  # (and their status) in the watched namespace. TCPRoute/TLSRoute live in
+  # gateway.networking.k8s.io/v1alpha2 but share the same apiGroup label in RBAC.
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways", "httproutes"]
+    resources: ["gateways", "httproutes", "tcproutes", "tlsroutes"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gateways/status", "httproutes/status"]
+    resources: ["gateways/status", "httproutes/status", "tcproutes/status", "tlsroutes/status"]
     verbs: ["get", "update", "patch"]
   {{- if .Values.edge.tls.enabled }}
   # Read the kubernetes.io/tls Secrets a Gateway listener references (downstream

--- a/charts/aether/templates/edge-service.yaml
+++ b/charts/aether/templates/edge-service.yaml
@@ -25,4 +25,10 @@ spec:
       targetPort: https
       protocol: TCP
     {{- end }}
+    {{- range .Values.edge.service.extraPorts }}
+    - name: {{ .name }}
+      port: {{ .port }}
+      targetPort: {{ .port }}
+      protocol: {{ default "TCP" .protocol }}
+    {{- end }}
 {{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -233,6 +233,11 @@ edge:
     port: 80
     httpsPort: 443
     annotations: {}
+    # extraPorts declares additional TCP ports on the edge Service so the LoadBalancer
+    # exposes them. Each entry becomes a spec.ports item. Use this to expose the ports
+    # bound by Gateway TCP/TLS listeners (TCPRoute/TLSRoute parented to the edge Gateway).
+    # Example: [{name: postgres, port: 5432, protocol: TCP}]
+    extraPorts: []
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
## Summary

- **TCPRoute** (protocol: TCP): Gateway listener → `tcp_proxy` to weighted `tcp:<svc>.<meshDomain>` EDS clusters; edge upstream transport socket with **no ALPN + no SNI** so the destination inbound demuxes to the TCP floor DEFAULT chain (not the HCM)
- **TLSRoute** (mode: Passthrough): `tls_inspector` listener filter + per-SNI filter chains (`TransportProtocol: "tls"`, `ServerNames` from `spec.hostnames`) → `tcp_proxy`; raw stream passes through to backend, no termination at edge
- `EdgeUpstreamTCPTransportSocket`: single SDS identity from `spire_agent` cluster (not ADS); **no ALPN, no SNI** — aligned with `UpstreamTCPTransportSocket`'s no-ALPN/no-SNI floor design (PRs #304/#306 removed `AetherTCPALPN` and established empty SNI for the floor)
- L4 route backends are included in `SetStaticDependencies` via unified `rebuildEdgeDependencies()`, scoping registrar watch/cluster set correctly
- `gatewayListenerKey{Gateway, Port, Protocol}` enables port-scoped TCPRoute/TLSRoute parentRef matching; `gatewayParentPorts` handles both explicit-port and wildcard-port refs
- `attachedToOurGateway` refactored to accept `[]ParentReference` (reused from all route type paths)
- charts/aether: RBAC for `tcproutes`/`tlsroutes`/status, `edge.service.extraPorts` loop for additional L4 ports, version → `0.41.0`

## Rebase onto main

Rebased onto `10030ae` (post-#306). Conflicts resolved:

- `transportsocket.go`: dropped the branch's `EdgeUpstreamTCPTransportSocket` using the removed `AetherTCPALPN` constant; replaced with a new `EdgeUpstreamTCPTransportSocket` passing `""` ALPN and `""` SNI (no-ALPN, no-SNI), matching the east-west TCP floor semantics established by #304/#306
- `charts/aether/Chart.yaml`: took main's `0.40.0` base, bumped to `0.41.0`

## Test plan

- [x] `bazel build //...` clean (59/59 targets)
- [x] `bazel test //... --test_output=errors` — 59/59 pass
- [x] `bazel test //agent/internal/xds/proxy:proxy_test` — 7 new cases: `BuildEdgeTCPListener` (single/weighted/empty), `BuildEdgeTLSPassthroughListener` (SNI-routing/empty), `EdgeUpstreamTCPTransportSocket` (no-ALPN + no-SNI + spire_agent SDS), listener naming
- [x] `bazel test //agent/internal/edge/gatewayapi:gatewayapi_test` — 8 new cases: `buildL4Backends` (cluster name, weight, group skip), `attachedToOurGateway` L4 path, `gatewayParentPorts` (exact port, no-port wildcard, wrong protocol, unknown gateway)
- [x] `bazel run //:format` clean
- [ ] e2e on talos-main — TCP floor is now green (#304/#306 merged); run after merge:
  - Deploy a `Service` with TCP protocol + a `TCPRoute` parented to the edge `Gateway` on a new port; send raw TCP through the edge LB; expect connection to reach the backend pod
  - Deploy a `TLSRoute` (mode: Passthrough) on a TLS port; send a TLS ClientHello with the matching SNI; expect the raw TLS stream to reach the backend (no cert presented by edge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S