### PR TITLE
fix(mcs): distinct clusterset.local VIP (re-bump 0.40.0, supersedes #300)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.38.0-{GIT_COMMIT}"
+version: "0.39.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/common/constants/labels.go
+++ b/common/constants/labels.go
@@ -32,6 +32,21 @@ const (
 	// (LabelMeshService) so the two projections never clobber each other.
 	LabelClustersetService = aetherLabelPrefix + "/clusterset-service"
 
+	// AnnotationClustersetImport links a generated clusterset VIP Service back to
+	// the MCS ServiceImport (and the same-named mesh service) it provides the
+	// ClusterSetIP for. The registrar reads it to copy the K8s-allocated ClusterIP
+	// onto the ServiceImport's spec.IPs, so <svc>.<ns>.svc.clusterset.local
+	// resolves to the clusterset VIP rather than the per-cluster mesh VIP.
+	AnnotationClustersetImport = aetherLabelPrefix + "/clusterset-import"
+
+	// ClustersetServiceNameSuffix is appended to the mesh service name to derive
+	// the distinct name of the generated clusterset VIP Service. The clusterset VIP
+	// is a SEPARATE k8s Service (its own ClusterIP) from the per-cluster mesh VIP
+	// (the same-named transparent-capture Service), so the two coexist: the mesh
+	// Service backs <svc>.<ns>.svc.cluster.local, the clusterset VIP backs the
+	// ServiceImport's <svc>.<ns>.svc.clusterset.local address.
+	ClustersetServiceNameSuffix = "-clusterset"
+
 	// LabelManagedServiceImport marks a ServiceImport materialized by the
 	// registrar from the registry's clusterset-wide export view. The registrar
 	// owns these — it lists/prunes ServiceImports by this label, never touching

--- a/registrar/internal/mcs/BUILD.bazel
+++ b/registrar/internal/mcs/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake",
+        "@io_k8s_sigs_controller_runtime//pkg/client/interceptor",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_mcs_api//pkg/apis/v1alpha1",
     ],

--- a/registrar/internal/mcs/export_controller.go
+++ b/registrar/internal/mcs/export_controller.go
@@ -8,10 +8,13 @@
 //     import the service. It reconciles ServiceExport status (Valid/Ready).
 //   - ImportGenerator reads the clusterset-wide export view back out of the
 //     registry and materializes, in THIS cluster, a ServiceImport (ClusterSetIP)
-//     plus a LOCAL selectorless clusterset.local Service (the clusterset VIP) —
-//     mirroring the registrar's mesh-Service generator. No EndpointSlice import:
-//     endpoints stay in the registry; the proxy resolves cross-cluster endpoints
-//     via registry EDS at dial time (a later phase — out of scope here).
+//     plus a LOCAL selectorless clusterset VIP Service (a DISTINCT <svc>-clusterset
+//     object with its own ClusterIP, so it coexists with the same-named per-cluster
+//     mesh Service) — mirroring the registrar's mesh-Service generator. The VIP's
+//     ClusterIP is stamped onto the ServiceImport's spec.IPs (the
+//     <svc>.<ns>.svc.clusterset.local address). No EndpointSlice import: endpoints
+//     stay in the registry; the proxy resolves cross-cluster endpoints via registry
+//     EDS at dial time (a later phase — out of scope here).
 //
 // DNS stays STRICTLY LOCAL: each cluster materializes its own clusterset VIP from
 // its own registry view. Both runnables are leader-elected (single writer) and

--- a/registrar/internal/mcs/import_generator.go
+++ b/registrar/internal/mcs/import_generator.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/bpalermo/aether/common/constants"
@@ -20,12 +21,19 @@ import (
 
 // ImportGenerator reconciles the registry's clusterset-wide export view into, in
 // THIS cluster: a ServiceImport (type ClusterSetIP) per exported service, and a
-// LOCAL selectorless clusterset.local Service (the ClusterSet VIP) — mirroring
-// the registrar's mesh-Service generator. No EndpointSlice import: endpoints stay
-// in the registry, and the proxy resolves cross-cluster endpoints via registry
-// EDS at dial time (a later phase). Each clusterset Service is annotated with the
-// mesh service + mesh port so the agent maps the captured ClusterIP back to the
-// registry-backed EDS cluster, exactly like a per-cluster mesh VIP.
+// LOCAL selectorless clusterset VIP Service — mirroring the registrar's
+// mesh-Service generator. No EndpointSlice import: endpoints stay in the registry,
+// and the proxy resolves cross-cluster endpoints via registry EDS at dial time
+// (a later phase). Each clusterset Service is annotated with the mesh service +
+// mesh port so the agent maps the captured ClusterIP back to the registry-backed
+// EDS cluster, exactly like a per-cluster mesh VIP.
+//
+// The clusterset VIP Service has a DISTINCT name (<svc>-clusterset) so it
+// coexists with the same-named per-cluster mesh Service (<svc>): the mesh VIP
+// backs <svc>.<ns>.svc.cluster.local, the clusterset VIP its own ClusterIP. The
+// generator copies the K8s-allocated ClusterIP of the clusterset Service onto the
+// ServiceImport's spec.IPs, which is what an MCS DNS controller publishes for
+// <svc>.<ns>.svc.clusterset.local.
 //
 // It is a leader-elected manager Runnable: only the leader writes. It reads the
 // export view on a ticker (the etcd registry's view changes when any cluster's
@@ -100,9 +108,18 @@ func (g *ImportGenerator) reconcile(ctx context.Context) {
 	g.pruneServiceImports(ctx, desired)
 	g.pruneClustersetServices(ctx, desired)
 	for _, d := range desired {
-		g.applyServiceImport(ctx, d)
-		g.applyClustersetService(ctx, d)
+		// Apply the clusterset VIP Service FIRST so K8s allocates its ClusterIP,
+		// then stamp that IP onto the ServiceImport (the MCS ClusterSetIP VIP).
+		vip := g.applyClustersetService(ctx, d)
+		g.applyServiceImport(ctx, d, vip)
 	}
+}
+
+// clustersetServiceName is the distinct name of the generated clusterset VIP
+// Service for a mesh service: <svc>-clusterset. A separate object (its own
+// ClusterIP) from the same-named per-cluster mesh Service, so the two coexist.
+func clustersetServiceName(service string) string {
+	return service + constants.ClustersetServiceNameSuffix
 }
 
 // pruneServiceImports deletes managed ServiceImports whose service no longer has
@@ -137,7 +154,15 @@ func (g *ImportGenerator) pruneClustersetServices(ctx context.Context, desired m
 	for i := range managed.Items {
 		s := &managed.Items[i]
 		key := client.ObjectKeyFromObject(s)
-		if _, ok := desired[key]; ok {
+		// The clusterset Service name is <svc>-clusterset; the import key is keyed
+		// by the mesh service name, recorded on the Service's clusterset-import
+		// annotation (fall back to trimming the suffix off the name).
+		importName := s.Annotations[constants.AnnotationClustersetImport]
+		if importName == "" {
+			importName = strings.TrimSuffix(s.Name, constants.ClustersetServiceNameSuffix)
+		}
+		importKey := client.ObjectKey{Namespace: s.Namespace, Name: importName}
+		if _, ok := desired[importKey]; ok {
 			continue
 		}
 		if err := g.Delete(ctx, s); err != nil && !apierrors.IsNotFound(err) {
@@ -149,13 +174,16 @@ func (g *ImportGenerator) pruneClustersetServices(ctx context.Context, desired m
 }
 
 // applyServiceImport creates or updates the ServiceImport (ClusterSetIP) for one
-// exported service. It never touches a ServiceImport it does not own.
-func (g *ImportGenerator) applyServiceImport(ctx context.Context, d *desiredImport) {
+// exported service. vip is the K8s-allocated ClusterIP of the clusterset VIP
+// Service (the MCS ClusterSetIP), set on spec.IPs; empty if not yet allocated.
+// It never touches a ServiceImport it does not own.
+func (g *ImportGenerator) applyServiceImport(ctx context.Context, d *desiredImport, vip string) {
 	key := client.ObjectKey{Namespace: d.namespace, Name: d.service}
 	clusters := make([]mcsv1alpha1.ClusterStatus, 0, len(d.clusters))
 	for _, c := range d.clusters {
 		clusters = append(clusters, mcsv1alpha1.ClusterStatus{Cluster: c})
 	}
+	ips := clustersetIPs(vip)
 
 	existing := &mcsv1alpha1.ServiceImport{}
 	if err := g.Get(ctx, key, existing); err == nil {
@@ -165,6 +193,7 @@ func (g *ImportGenerator) applyServiceImport(ctx context.Context, d *desiredImpo
 		}
 		existing.Spec.Type = mcsv1alpha1.ClusterSetIP
 		existing.Spec.Ports = g.importPorts()
+		existing.Spec.IPs = ips
 		if err := g.Update(ctx, existing); err != nil {
 			g.Log.ErrorContext(ctx, "update ServiceImport failed", "import", key.String(), "error", err)
 			return
@@ -185,14 +214,25 @@ func (g *ImportGenerator) applyServiceImport(ctx context.Context, d *desiredImpo
 		Spec: mcsv1alpha1.ServiceImportSpec{
 			Type:  mcsv1alpha1.ClusterSetIP,
 			Ports: g.importPorts(),
+			IPs:   ips,
 		},
 	}
 	if err := g.Create(ctx, si); err != nil && !apierrors.IsAlreadyExists(err) {
 		g.Log.ErrorContext(ctx, "create ServiceImport failed", "import", key.String(), "error", err)
 		return
 	}
-	g.Log.InfoContext(ctx, "created ServiceImport (ClusterSetIP)", "import", key.String(), "clusters", d.clusters)
+	g.Log.InfoContext(ctx, "created ServiceImport (ClusterSetIP)", "import", key.String(), "clusters", d.clusters, "vip", vip)
 	g.setImportClusters(ctx, si, clusters)
+}
+
+// clustersetIPs is the ServiceImport spec.IPs for a clusterset VIP. The MCS API
+// caps IPs at 2 entries; a single ClusterIP is the common case. A headless/none
+// ClusterIP yields no spec.IPs (the import is published but addressless).
+func clustersetIPs(vip string) []string {
+	if vip == "" || vip == corev1.ClusterIPNone {
+		return nil
+	}
+	return []string{vip}
 }
 
 // setImportClusters records the exporting clusters on the ServiceImport status.
@@ -216,43 +256,48 @@ func (g *ImportGenerator) importPorts() []mcsv1alpha1.ServicePort {
 }
 
 // applyClustersetService creates or updates the selectorless clusterset VIP
-// Service for one exported service. Mirrors the mesh-Service generator: a pure
-// ClusterIP + name handle, endpoints stay in the registry. It never touches a
-// Service it does not own.
-func (g *ImportGenerator) applyClustersetService(ctx context.Context, d *desiredImport) {
-	key := client.ObjectKey{Namespace: d.namespace, Name: d.service}
+// Service for one exported service and returns its K8s-allocated ClusterIP
+// (empty if unallocated). It has a DISTINCT name (<svc>-clusterset) so it
+// coexists with the same-named per-cluster mesh Service — a separate ClusterIP
+// backing the ServiceImport's <svc>.<ns>.svc.clusterset.local address. Mirrors
+// the mesh-Service generator: a pure ClusterIP + name handle, endpoints stay in
+// the registry. It never touches a Service it does not own.
+func (g *ImportGenerator) applyClustersetService(ctx context.Context, d *desiredImport) string {
+	name := clustersetServiceName(d.service)
+	key := client.ObjectKey{Namespace: d.namespace, Name: name}
 
 	existing := &corev1.Service{}
 	if err := g.Get(ctx, key, existing); err == nil {
 		if existing.Labels[constants.LabelClustersetService] != "true" {
 			g.Log.WarnContext(ctx, "a non-aether Service owns this name; skipping clusterset VIP", "service", key.String())
-			return
+			return ""
 		}
-		return // converged (selectorless VIP is static)
+		return clusterIP(existing) // converged (selectorless VIP is static)
 	} else if !apierrors.IsNotFound(err) {
 		g.Log.ErrorContext(ctx, "get clusterset Service failed", "service", key.String(), "error", err)
-		return
+		return ""
 	}
 
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      d.service,
+			Name:      name,
 			Namespace: d.namespace,
 			Labels: map[string]string{
 				constants.LabelClustersetService: "true",
 				constants.LabelMeshService:       "true",
 			},
 			Annotations: map[string]string{
-				constants.AnnotationMeshService: d.service,
-				constants.AnnotationMeshPort:    strconv.Itoa(int(g.MeshPort)),
+				constants.AnnotationMeshService:      d.service,
+				constants.AnnotationMeshPort:         strconv.Itoa(int(g.MeshPort)),
+				constants.AnnotationClustersetImport: d.service,
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
-			// Selectorless ClusterSet VIP: a cluster.local name + VIP handle.
-			// Endpoints stay in the aether registry; the agent maps this ClusterIP
-			// to the registry-backed EDS cluster, which resolves cross-cluster
-			// endpoints at dial time.
+			// Selectorless ClusterSet VIP: its own ClusterIP + name handle, distinct
+			// from the per-cluster mesh VIP. Endpoints stay in the aether registry;
+			// the agent maps this ClusterIP to the registry-backed EDS cluster, which
+			// resolves cross-cluster endpoints at dial time.
 			Ports: []corev1.ServicePort{{
 				Name:       "mesh",
 				Port:       g.MeshPort,
@@ -263,9 +308,25 @@ func (g *ImportGenerator) applyClustersetService(ctx context.Context, d *desired
 	}
 	if err := g.Create(ctx, svc); err != nil && !apierrors.IsAlreadyExists(err) {
 		g.Log.ErrorContext(ctx, "create clusterset Service failed", "service", key.String(), "error", err)
-		return
+		return ""
 	}
-	g.Log.InfoContext(ctx, "created clusterset Service (ClusterSet VIP)", "service", key.String())
+	// Re-read so we observe the ClusterIP the apiserver allocated on create.
+	if err := g.Get(ctx, key, svc); err != nil {
+		g.Log.WarnContext(ctx, "get clusterset Service after create failed", "service", key.String(), "error", err)
+		return ""
+	}
+	vip := clusterIP(svc)
+	g.Log.InfoContext(ctx, "created clusterset Service (ClusterSet VIP)", "service", key.String(), "vip", vip)
+	return vip
+}
+
+// clusterIP returns the Service's allocated ClusterIP, or "" if none/unallocated
+// ("None" headless or empty pending allocation).
+func clusterIP(svc *corev1.Service) string {
+	if svc.Spec.ClusterIP == corev1.ClusterIPNone {
+		return ""
+	}
+	return svc.Spec.ClusterIP
 }
 
 // dedupe returns xs with consecutive duplicates removed; xs must be sorted.

--- a/registrar/internal/mcs/mcs_test.go
+++ b/registrar/internal/mcs/mcs_test.go
@@ -2,6 +2,7 @@ package mcs
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"sync"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
@@ -78,6 +80,30 @@ func newClient(t *testing.T, objs ...client.Object) client.Client {
 		WithScheme(scheme(t)).
 		WithObjects(objs...).
 		WithStatusSubresource(&mcsv1alpha1.ServiceExport{}, &mcsv1alpha1.ServiceImport{}).
+		Build()
+}
+
+// newIPAllocatingClient mimics the apiserver's ClusterIP allocator: it assigns a
+// deterministic ClusterIP to every ClusterIP Service on Create (the fake client
+// otherwise leaves spec.ClusterIP empty), so the import generator observes a VIP.
+func newIPAllocatingClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	var n int
+	return fake.NewClientBuilder().
+		WithScheme(scheme(t)).
+		WithObjects(objs...).
+		WithStatusSubresource(&mcsv1alpha1.ServiceExport{}, &mcsv1alpha1.ServiceImport{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if svc, ok := obj.(*corev1.Service); ok &&
+					svc.Spec.ClusterIP == "" && svc.Spec.Type == corev1.ServiceTypeClusterIP {
+					n++
+					svc.Spec.ClusterIP = fmt.Sprintf("10.96.0.%d", n)
+					svc.Spec.ClusterIPs = []string{svc.Spec.ClusterIP}
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
 		Build()
 }
 
@@ -163,7 +189,7 @@ func newImportGen(c client.Client, exp *fakeExporter) *ImportGenerator {
 
 func TestImportGenerator_MaterializesImportAndVIP(t *testing.T) {
 	ctx := context.Background()
-	c := newClient(t)
+	c := newIPAllocatingClient(t)
 	exp := newFakeExporter("cluster-1")
 	exp.seeded = []export.ServiceExport{
 		{Service: "svc-1", Namespace: "team-a", Cluster: "cluster-2"},
@@ -171,23 +197,56 @@ func TestImportGenerator_MaterializesImportAndVIP(t *testing.T) {
 	g := newImportGen(c, exp)
 	g.reconcile(ctx)
 
+	// The clusterset VIP Service has a DISTINCT name (<svc>-clusterset) so it
+	// coexists with the same-named per-cluster mesh Service.
+	svc := &corev1.Service{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1-clusterset", Namespace: "team-a"}, svc))
+	assert.Equal(t, "true", svc.Labels[constants.LabelClustersetService])
+	assert.Empty(t, svc.Spec.Selector, "selectorless clusterset VIP: endpoints stay in the registry")
+	assert.Equal(t, "svc-1", svc.Annotations[constants.AnnotationMeshService])
+	assert.Equal(t, "svc-1", svc.Annotations[constants.AnnotationClustersetImport])
+	assert.Equal(t, "18081", svc.Annotations[constants.AnnotationMeshPort])
+	require.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, int32(18081), svc.Spec.Ports[0].Port)
+	require.NotEmpty(t, svc.Spec.ClusterIP, "the clusterset VIP gets its own ClusterIP")
+
+	// No same-named clusterset Service collides with the mesh Service name.
+	notClusterset := &corev1.Service{}
+	err := c.Get(ctx, types.NamespacedName{Name: "svc-1", Namespace: "team-a"}, notClusterset)
+	assert.True(t, apierrors.IsNotFound(err), "the clusterset VIP does NOT take the mesh Service name")
+
 	si := &mcsv1alpha1.ServiceImport{}
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1", Namespace: "team-a"}, si))
 	assert.Equal(t, "true", si.Labels[constants.LabelManagedServiceImport])
 	assert.Equal(t, mcsv1alpha1.ClusterSetIP, si.Spec.Type)
 	require.Len(t, si.Spec.Ports, 1)
 	assert.Equal(t, int32(18081), si.Spec.Ports[0].Port)
+	require.Len(t, si.Spec.IPs, 1, "the ServiceImport VIP is the clusterset Service ClusterIP")
+	assert.Equal(t, svc.Spec.ClusterIP, si.Spec.IPs[0])
 	require.Len(t, si.Status.Clusters, 1)
 	assert.Equal(t, "cluster-2", si.Status.Clusters[0].Cluster)
+}
+
+func TestImportGenerator_SingleClusterExportGetsVIP(t *testing.T) {
+	ctx := context.Background()
+	c := newIPAllocatingClient(t)
+	// Only a LOCAL export (this cluster) — single-cluster MCS must still produce a
+	// ServiceImport with a real clusterset VIP, distinct from the mesh VIP.
+	exp := newFakeExporter("cluster-1")
+	require.NoError(t, exp.SetExport(ctx, "svc-1", "team-a"))
+	g := newImportGen(c, exp)
+	g.reconcile(ctx)
 
 	svc := &corev1.Service{}
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1", Namespace: "team-a"}, svc))
-	assert.Equal(t, "true", svc.Labels[constants.LabelClustersetService])
-	assert.Empty(t, svc.Spec.Selector, "selectorless clusterset VIP: endpoints stay in the registry")
-	assert.Equal(t, "svc-1", svc.Annotations[constants.AnnotationMeshService])
-	assert.Equal(t, "18081", svc.Annotations[constants.AnnotationMeshPort])
-	require.Len(t, svc.Spec.Ports, 1)
-	assert.Equal(t, int32(18081), svc.Spec.Ports[0].Port)
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1-clusterset", Namespace: "team-a"}, svc))
+	require.NotEmpty(t, svc.Spec.ClusterIP)
+
+	si := &mcsv1alpha1.ServiceImport{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1", Namespace: "team-a"}, si))
+	require.Len(t, si.Spec.IPs, 1)
+	assert.Equal(t, svc.Spec.ClusterIP, si.Spec.IPs[0], "single-cluster ServiceImport carries the clusterset VIP")
+	require.Len(t, si.Status.Clusters, 1)
+	assert.Equal(t, "cluster-1", si.Status.Clusters[0].Cluster)
 }
 
 func TestImportGenerator_MergesMultiClusterExports(t *testing.T) {
@@ -216,10 +275,11 @@ func TestImportGenerator_PrunesStale(t *testing.T) {
 		Labels: map[string]string{constants.LabelManagedServiceImport: "true"},
 	}}
 	staleSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{
-		Name: "gone", Namespace: "team-a",
-		Labels: map[string]string{constants.LabelClustersetService: "true"},
+		Name: "gone-clusterset", Namespace: "team-a",
+		Labels:      map[string]string{constants.LabelClustersetService: "true"},
+		Annotations: map[string]string{constants.AnnotationClustersetImport: "gone"},
 	}}
-	c := newClient(t, staleSI, staleSvc)
+	c := newIPAllocatingClient(t, staleSI, staleSvc)
 	exp := newFakeExporter("cluster-1")
 	exp.seeded = []export.ServiceExport{{Service: "svc-1", Namespace: "team-a", Cluster: "cluster-2"}}
 	g := newImportGen(c, exp)
@@ -227,7 +287,7 @@ func TestImportGenerator_PrunesStale(t *testing.T) {
 
 	err := c.Get(ctx, types.NamespacedName{Name: "gone", Namespace: "team-a"}, &mcsv1alpha1.ServiceImport{})
 	assert.True(t, apierrors.IsNotFound(err), "ServiceImport for a vanished export is pruned")
-	err = c.Get(ctx, types.NamespacedName{Name: "gone", Namespace: "team-a"}, &corev1.Service{})
+	err = c.Get(ctx, types.NamespacedName{Name: "gone-clusterset", Namespace: "team-a"}, &corev1.Service{})
 	assert.True(t, apierrors.IsNotFound(err), "clusterset VIP for a vanished export is pruned")
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1", Namespace: "team-a"}, &mcsv1alpha1.ServiceImport{}))
 }
@@ -238,11 +298,13 @@ func TestImportGenerator_DoesNotClobberUserObjects(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "team-a"}, // no managed label
 		Spec:       mcsv1alpha1.ServiceImportSpec{Type: mcsv1alpha1.Headless},
 	}
-	userSvc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: "svc-1", Namespace: "team-a"},
-		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "svc-1"}},
+	// A user's Service occupies the clusterset VIP's DISTINCT name (svc-1-clusterset):
+	// the generator must skip it, not clobber it.
+	userClustersetName := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-1-clusterset", Namespace: "team-a"},
+		Spec:       corev1.ServiceSpec{Selector: map[string]string{"app": "owned-by-user"}},
 	}
-	c := newClient(t, userSI, userSvc)
+	c := newIPAllocatingClient(t, userSI, userClustersetName)
 	exp := newFakeExporter("cluster-1")
 	exp.seeded = []export.ServiceExport{{Service: "svc-1", Namespace: "team-a", Cluster: "cluster-2"}}
 	g := newImportGen(c, exp)
@@ -253,8 +315,8 @@ func TestImportGenerator_DoesNotClobberUserObjects(t *testing.T) {
 	assert.Equal(t, mcsv1alpha1.Headless, si.Spec.Type, "a user's ServiceImport is left untouched")
 
 	svc := &corev1.Service{}
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1", Namespace: "team-a"}, svc))
-	assert.Equal(t, map[string]string{"app": "svc-1"}, svc.Spec.Selector, "a user's Service is left untouched")
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Name: "svc-1-clusterset", Namespace: "team-a"}, svc))
+	assert.Equal(t, map[string]string{"app": "owned-by-user"}, svc.Spec.Selector, "a user's Service on the clusterset name is left untouched")
 }
 
 func hasTrueCondition(conds []metav1.Condition, t string) bool {


### PR DESCRIPTION
MCS clusterset VIP coexistence fix (was #300): a distinct `<svc>-clusterset` Service with its own ClusterIP stamped onto the ServiceImport, so it no longer collides with the per-cluster mesh Service and the import gets a real VIP. Re-bumped 0.39.0→0.40.0 (the 0.39.0 collision with #301). Supersedes #300.