### PR TITLE
fix(proxy): drop aether-tcp ALPN — TCP floor reuses the HTTP transport path

### DIFF
--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -20,12 +20,6 @@ import (
 // generated mesh-Service names) to the registry-backed service clusters.
 const CaptureHTTPRouteName = "cap_http"
 
-// AetherTCPALPN is the TLS ALPN token the capture/outbound tcp_proxy uses when
-// dialing a destination over mTLS. The destination inbound's filter-chain match
-// on application_protocols: ["aether-tcp"] selects the tcp_proxy floor chain;
-// any other ALPN (e.g. "h2" from the HCM) falls through to the HTTP chains.
-const AetherTCPALPN = "aether-tcp"
-
 const (
 	listenerFilterOriginalDstName   = "envoy.filters.listener.original_dst"
 	listenerFilterHTTPInspectorName = "envoy.filters.listener.http_inspector"

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -91,17 +91,16 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod b
 	}, nil
 }
 
-// buildInboundFilterChains builds the full set of inbound filter chains:
+// buildInboundFilterChains builds the full set of inbound filter chains, demuxed by
+// Envoy's match precedence (server_names > application_protocols > default):
 //
-//  1. TCP floor chain: matches application_protocols:["aether-tcp"] (set by the
-//     source proxy's tcp_proxy outbound path). Terminates mTLS and routes via
-//     tcp_proxy to the pod's primary app cluster on loopback. This chain is
-//     more specific than the HCM chains (has application_protocols) so Envoy
-//     selects it first for TCP-over-mTLS connections.
+//  1. HCM chains: one per served port (SNI-matched on the port number) plus a
+//     no-SNI chain matching application_protocols:["h2"] — the mesh HTTP/2 transport.
 //
-//  2. HCM chains: one per served port (SNI-matched on the port number) plus a
-//     default (no-SNI) chain for back-compat and no-SNI clients. These handle
-//     HTTP/2 (ALPN "h2") and any other ALPN not matched by the floor chain.
+//  2. TCP floor chain: the DEFAULT (no match). The source proxy's tcp_proxy egress
+//     sends NO ALPN, so it matches no HCM chain (no "h2", no port SNI) and lands
+//     here, terminating mTLS and routing via tcp_proxy to the pod's app on loopback.
+//     Demux is the standard "h2" ALPN for HTTP vs no-ALPN for TCP — no bespoke token.
 //
 // SNI is port routing only — identity stays the terminated mTLS SVID.
 func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) []*listenerv3.FilterChain {
@@ -127,20 +126,17 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 }
 
 // buildInboundTCPFloorFilterChain builds the mTLS-terminating TCP floor chain for
-// the inbound listener. It matches ALPN "aether-tcp" (set by the outbound
-// tcp_proxy's UpstreamTCPTransportSocket) and routes all bytes via tcp_proxy to
-// the pod's primary application cluster (app_<pod>_<defaultPort>) on loopback.
+// the inbound listener. It is the listener's DEFAULT chain (no match criteria): a
+// no-ALPN mTLS connection — the source proxy's tcp_proxy floor egress, which sends
+// no ALPN — matches nothing more specific (HTTP chains require "h2" or a port SNI)
+// and lands here, terminating mTLS and routing all bytes via tcp_proxy to the pod's
+// primary application cluster (app_<pod>_<defaultPort>) on loopback.
 func buildInboundTCPFloorFilterChain(cniPod *cniv1.CNIPod, defaultPort uint16, tlsCertificateSecretName, validationContextName string) *listenerv3.FilterChain {
 	appCluster := AppClusterName(cniPod, defaultPort)
 	return &listenerv3.FilterChain{
-		Name: fmt.Sprintf("in_tcp_%s", cniPod.GetName()),
-		FilterChainMatch: &listenerv3.FilterChainMatch{
-			// application_protocols is more specific than server_names in Envoy's
-			// filter-chain match order, so this chain wins over the HCM chains for
-			// any connection that negotiated the "aether-tcp" ALPN.
-			ApplicationProtocols: []string{AetherTCPALPN},
-		},
-		TransportSocket: DownstreamTransportSocket(tlsCertificateSecretName, validationContextName),
+		Name:             fmt.Sprintf("in_tcp_%s", cniPod.GetName()),
+		FilterChainMatch: nil, // default chain: no ALPN / no SNI → the TCP floor
+		TransportSocket:  DownstreamTransportSocket(tlsCertificateSecretName, validationContextName),
 		Filters: []*listenerv3.Filter{
 			buildTCPProxyNetworkFilter(fmt.Sprintf("%s_%s", inboundTCPFloorStatPrefix, cniPod.GetName()), appCluster),
 		},
@@ -175,7 +171,11 @@ func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16,
 	}
 
 	name := fmt.Sprintf("in_%s", cniPod.GetName())
-	var match *listenerv3.FilterChainMatch
+	// The no-SNI HCM chain matches application_protocols:["h2"] (the mesh's HTTP/2
+	// transport) so a no-ALPN mTLS connection — the TCP floor — falls through to the
+	// floor's default chain instead. Per-port chains match the port SNI (more
+	// specific than application_protocols, so they win for HTTP regardless of ALPN).
+	match := &listenerv3.FilterChainMatch{ApplicationProtocols: []string{"h2"}}
 	if sni != "" {
 		name = fmt.Sprintf("in_%s_%s", cniPod.GetName(), sni)
 		match = &listenerv3.FilterChainMatch{ServerNames: []string{sni}}

--- a/agent/internal/xds/proxy/ingress_test.go
+++ b/agent/internal/xds/proxy/ingress_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"strings"
 	"testing"
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
@@ -34,10 +35,10 @@ func TestNewInboundListener(t *testing.T) {
 	assert.Equal(t, "/var/run/netns/cni-a", sa.GetNetworkNamespaceFilepath())
 	assert.Equal(t, corev3.TrafficDirection_INBOUND, l.GetTrafficDirection())
 
-	// First chain is the TCP floor (application_protocols: ["aether-tcp"]).
+	// First chain is the TCP floor — the listener's default chain (no match): a
+	// no-ALPN mTLS connection (the source tcp_proxy egress) lands here.
 	tcpFloor := l.GetFilterChains()[0]
-	require.NotNil(t, tcpFloor.GetFilterChainMatch())
-	assert.Equal(t, []string{AetherTCPALPN}, tcpFloor.GetFilterChainMatch().GetApplicationProtocols())
+	assert.Nil(t, tcpFloor.GetFilterChainMatch(), "TCP floor is the default chain (no match)")
 	require.NotNil(t, tcpFloor.GetTransportSocket(), "TCP floor chain must terminate mTLS")
 	require.Len(t, tcpFloor.GetFilters(), 1)
 	assert.Equal(t, "envoy.filters.network.tcp_proxy", tcpFloor.GetFilters()[0].GetName())
@@ -131,17 +132,19 @@ func TestInboundFilterChains_MultiPort(t *testing.T) {
 	bySNI := map[string]*listenerv3.FilterChain{}
 	var defaultChain *listenerv3.FilterChain
 	for _, fc := range l.GetFilterChains() {
-		// Skip the TCP floor chain (matched on application_protocols only).
-		if fc.GetFilterChainMatch() != nil && len(fc.GetFilterChainMatch().GetApplicationProtocols()) > 0 {
+		m := fc.GetFilterChainMatch()
+		// The TCP floor is the only no-match (default) chain — skip it.
+		if m == nil {
 			continue
 		}
-		if fc.GetFilterChainMatch() == nil || len(fc.GetFilterChainMatch().GetServerNames()) == 0 {
-			defaultChain = fc
+		// Per-port HCM chains match a port SNI; the no-SNI HCM chain matches "h2".
+		if len(m.GetServerNames()) > 0 {
+			bySNI[m.GetServerNames()[0]] = fc
 			continue
 		}
-		bySNI[fc.GetFilterChainMatch().GetServerNames()[0]] = fc
+		defaultChain = fc
 	}
-	require.NotNil(t, defaultChain, "a default (no-SNI) chain must exist for back-compat")
+	require.NotNil(t, defaultChain, "a default (no-SNI, h2) HCM chain must exist for back-compat")
 	require.Contains(t, bySNI, "8080")
 	require.Contains(t, bySNI, "9090")
 
@@ -193,10 +196,9 @@ func TestInboundChainStatsFilter(t *testing.T) {
 	assert.False(t, fields["emit_pod"].GetBoolValue())
 }
 
-// TestInboundTCPFloorFilterChain verifies the ALPN-demuxed TCP floor chain on the
-// inbound :15008 listener (proposal 018, Phase 3a).
-// Expected: chain named "in_tcp_<pod>", matched on application_protocols=["aether-tcp"],
-// a single tcp_proxy network filter routing to the app cluster, and a transport socket.
+// TestInboundTCPFloorFilterChain verifies the TCP floor chain on the inbound :15008
+// listener (proposal 018, Phase 3a) — the DEFAULT chain (no match): a no-ALPN mTLS
+// connection lands here, with a single tcp_proxy network filter to the app cluster.
 func TestInboundTCPFloorFilterChain(t *testing.T) {
 	pod := &cniv1.CNIPod{
 		Name:             "svc-a",
@@ -208,17 +210,15 @@ func TestInboundTCPFloorFilterChain(t *testing.T) {
 	l, err := NewInboundListener(pod, "aether.internal", false)
 	require.NoError(t, err)
 
-	// Find the TCP floor chain.
+	// Find the TCP floor chain: the default chain (no match), named in_tcp_<pod>.
 	var tcpFloor *listenerv3.FilterChain
 	for _, fc := range l.GetFilterChains() {
-		if fc.GetFilterChainMatch() != nil &&
-			len(fc.GetFilterChainMatch().GetApplicationProtocols()) == 1 &&
-			fc.GetFilterChainMatch().GetApplicationProtocols()[0] == AetherTCPALPN {
+		if fc.GetFilterChainMatch() == nil && strings.HasPrefix(fc.GetName(), "in_tcp_") {
 			tcpFloor = fc
 			break
 		}
 	}
-	require.NotNil(t, tcpFloor, "TCP floor chain with application_protocols=[\"aether-tcp\"] must be present")
+	require.NotNil(t, tcpFloor, "TCP floor chain (default, in_tcp_<pod>) must be present")
 
 	// Chain name.
 	assert.Equal(t, "in_tcp_svc-a", tcpFloor.GetName())

--- a/agent/internal/xds/proxy/transportsocket.go
+++ b/agent/internal/xds/proxy/transportsocket.go
@@ -64,12 +64,13 @@ func UpstreamTransportSocket(tlsCertificateSecretName string, validationContextN
 
 // UpstreamTCPTransportSocket creates a TLS transport socket for TCP-proxy upstream
 // connections (proposal 018, Phase 3a TCP floor). It is identical to
-// UpstreamTransportSocket except that it advertises ALPN "aether-tcp" instead of
-// "h2". The destination inbound listener matches application_protocols:["aether-tcp"]
-// on its TCP floor chain, cleanly demultiplexing TCP from HTTP (which uses "h2").
+// UpstreamTransportSocket except that it advertises NO ALPN (vs HTTP's "h2"). The
+// destination inbound listener's HTTP chains match application_protocols:["h2"], so
+// a no-ALPN mTLS connection falls through to the inbound TCP floor's DEFAULT chain —
+// demultiplexing TCP from HTTP with the standard h2 ALPN instead of a bespoke token.
 // sanURIs and sni semantics are unchanged.
 func UpstreamTCPTransportSocket(tlsCertificateSecretName string, validationContextName string, sanURIs []string, sni string) *corev3.TransportSocket {
-	return upstreamTransportSocket(tlsCertificateSecretName, validationContextName, sanURIs, sni, config.XDSConfigSourceADS(), AetherTCPALPN)
+	return upstreamTransportSocket(tlsCertificateSecretName, validationContextName, sanURIs, sni, config.XDSConfigSourceADS(), "")
 }
 
 // EdgeUpstreamTransportSocket is UpstreamTransportSocket for the edge proxy: it
@@ -81,17 +82,22 @@ func EdgeUpstreamTransportSocket(tlsCertificateSecretName string, validationCont
 	return upstreamTransportSocket(tlsCertificateSecretName, validationContextName, sanURIs, sni, config.SDSConfigSourceFromCluster(SpireAgentSDSClusterName))
 }
 
-// upstreamTransportSocket builds an upstream TLS context. An optional alpnOverride
-// replaces the default "h2" ALPN (used by the TCP floor path to signal "aether-tcp"
-// to the destination inbound listener). If no override is supplied, ALPN is "h2".
+// upstreamTransportSocket builds an upstream TLS context. With no alpnOverride the
+// ALPN is "h2" (HTTP/2 mesh transport). An alpnOverride of "" suppresses ALPN
+// entirely — the TCP floor path, so the destination inbound demuxes it as the
+// default (non-h2) chain; any other override value sets that explicit ALPN list.
 func upstreamTransportSocket(tlsCertificateSecretName string, validationContextName string, sanURIs []string, sni string, sdsSource *corev3.ConfigSource, alpnOverride ...string) *corev3.TransportSocket {
 	alpn := []string{"h2"}
-	if len(alpnOverride) > 0 && alpnOverride[0] != "" {
-		alpn = alpnOverride
+	if len(alpnOverride) > 0 {
+		if alpnOverride[0] == "" {
+			alpn = nil // no ALPN (TCP floor): falls to the inbound default chain
+		} else {
+			alpn = alpnOverride
+		}
 	}
 	common := &transport_sockets_v3.CommonTlsContext{
-		// Clusters speak HTTP/2 upstream by default; the TCP floor overrides with
-		// "aether-tcp" so the destination inbound can demux to the tcp_proxy chain.
+		// Clusters speak HTTP/2 upstream ("h2"); the TCP floor sends no ALPN so the
+		// destination inbound demuxes it to the default tcp_proxy chain (HTTP matches "h2").
 		AlpnProtocols: alpn,
 		TlsCertificateSdsSecretConfigs: []*transport_sockets_v3.SdsSecretConfig{
 			sdsSecretConfigFrom(tlsCertificateSecretName, sdsSource),


### PR DESCRIPTION
The bespoke `aether-tcp` ALPN forced a duplicated TCP transport-socket stack where all three earlier fixes (#298/#299/#301) lived, yet `upstream_cx_total=0` persisted. Collapse onto the standard `h2` ALPN: egress TCP socket sends **no ALPN**, inbound no-SNI HCM matches `[h2]`, TCP floor becomes the **default** chain. Reuses the validated HTTP per-source mTLS path; removes the duplicated TCP stack + `AetherTCPALPN`. Validate: `echo-tcp` → 200.