### PR TITLE
fix(agent): don't HTTP-liveness-gate TCP floor services

### DIFF
--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -7,6 +7,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/agent/types"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/common/telemetry"
 	"github.com/bpalermo/aether/registry"
 	"go.opentelemetry.io/otel"
@@ -95,12 +96,21 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, state *livenessState)
 			continue
 		}
 
-		healthy, known, err := s.healthClient.appHealth(ctx, proxy.HealthProbeClusterName(pod))
-		if err != nil {
-			// The gateway itself is unreachable (proxy down / restarting): no
-			// probe this tick can succeed, abort instead of logging per pod.
-			s.log.DebugContext(ctx, "liveness: health gateway unreachable", "error", err)
-			return
+		// TCP floor services are reached as a raw mTLS passthrough, so the HTTP
+		// delegated app-health probe is inapplicable — treat them as healthy instead
+		// of leaving them perpetually UNHEALTHY (which, with the floor cluster's
+		// HealthyPanicThreshold of 0, gives it no host to dial). A protocol-aware
+		// TCP-connect liveness is a follow-up.
+		healthy, known := true, true
+		if pod.GetAnnotations()[constants.AnnotationEndpointProtocol] != constants.ProtocolTCP {
+			var err error
+			healthy, known, err = s.healthClient.appHealth(ctx, proxy.HealthProbeClusterName(pod))
+			if err != nil {
+				// The gateway itself is unreachable (proxy down / restarting): no
+				// probe this tick can succeed, abort instead of logging per pod.
+				s.log.DebugContext(ctx, "liveness: health gateway unreachable", "error", err)
+				return
+			}
 		}
 		if !known {
 			continue // pod's gateway filter not yet programmed / propagated

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -109,14 +109,12 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 
 	chains := make([]*listenerv3.FilterChain, 0, len(ports)+2)
 
-	// TCP floor chain: ALPN "aether-tcp" → tcp_proxy to primary app loopback port.
-	// Placed first so it is evaluated before the HCM chains when Envoy sorts chains
-	// by specificity (application_protocols is more specific than server_names).
+	// TCP floor chain: the DEFAULT (no match) → tcp_proxy to the primary app loopback
+	// port. A no-ALPN mTLS connection (the source tcp_proxy egress) lands here.
 	chains = append(chains, buildInboundTCPFloorFilterChain(cniPod, defaultPort, tlsCertificateSecretName, validationContextName))
 
-	// Default chain (no server_names): primary port. Matches no-SNI/no-ALPN clients
-	// and any SNI that doesn't match a port chain. Must come before per-port chains
-	// so it is tried after the TCP floor but before named-port chains.
+	// No-SNI HCM chain: matches application_protocols ["h2"] (the mesh HTTP/2
+	// transport) on the primary port. Per-port SNI chains follow.
 	chains = append(chains, buildInboundFilterChain(cniPod, "", defaultPort, tlsCertificateSecretName, validationContextName, emitStatsPod))
 	// One chain per served port, SNI-matched on the port number.
 	for _, port := range ports {


### PR DESCRIPTION
Definitive root cause of the TCP-floor 000: `tcp:<svc>` EDS endpoints were UNHEALTHY (aether's delegated liveness is an HTTP probe that can't pass for a raw-mTLS-passthrough TCP service), and `HealthyPanicThreshold:0` gives an all-unhealthy cluster zero traffic. The transport-socket fixes were red herrings. Fix: liveness loop treats `PROTOCOL_TCP` pods as healthy (TCP-connect liveness is a follow-up). Validate: `echo-tcp` → 200.