### PR TITLE
fix(agent): TCP floor egress must send no SNI (was hitting the inbound HCM → 503)

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -176,8 +176,13 @@ func (c *SnapshotCache) captureTCPClusters() []types.Resource {
 		}
 		tcpName := proxy.TCPClusterName(e.serviceName, c.meshDomain)
 		cl := proxy.NewTCPServiceCluster(tcpName, e.serviceName, e.serviceName, c.perDownstreamConnectionPool())
-		// sni = same as HTTP cluster for this service (port routing on destination inbound)
-		proxy.InjectUpstreamTCPMTLS(cl, netnsToID, ids, nodeSpiffeID, validationContextName, sanURIs, httpEntry.sni)
+		// NO SNI for the TCP floor: the egress floor connection must NOT carry the
+		// destination port as SNI, or the peer's inbound per-port HCM chain
+		// (server_names:[port]) would win over the inbound TCP floor's default chain
+		// (server_names > application_protocols > default) — the connection lands on
+		// the HCM, which can't parse the raw TCP stream and 503s. An empty SNI lets it
+		// fall through to the inbound default floor chain (tcp_proxy to the app).
+		proxy.InjectUpstreamTCPMTLS(cl, netnsToID, ids, nodeSpiffeID, validationContextName, sanURIs, "")
 		resources = append(resources, cl)
 	}
 	c.clusterMu.RUnlock()


### PR DESCRIPTION
With endpoints healthy (#305) and the floor connecting, echo-tcp still 503'd because the inbound **HCM** handled the connection, not the TCP floor. Cause: `captureTCPClusters` passed the destination port as SNI (`8080`), so the inbound per-port HCM chain (`server_names:[8080]`) out-ranked the inbound floor's default chain. Fix: empty SNI → the no-ALPN floor connection falls to the inbound default floor chain (tcp_proxy → app). Last piece of the floor data path. Validate: `echo-tcp` → 200.