### PR TITLE
feat(agent,cni): UDPRoute data path — UDP capture listener + CNI UDP redirect (proposal 018 Phase 3b)

### DIFF
--- a/agent/internal/l4route/reconciler.go
+++ b/agent/internal/l4route/reconciler.go
@@ -167,13 +167,36 @@ func (r *Reconciler) buildTLSRoute(rule gatewayv1alpha2.TLSRouteRule, hostnames 
 }
 
 // buildUDPBackends translates a UDPRouteRule into a flat backend list.
+// UDP backends resolve to "udp:<svc>.<domain>" clusters (plain EDS, no mTLS)
+// rather than the TCP "tcp:<svc>.<domain>" clusters used by TCPRoute/TLSRoute.
 func (r *Reconciler) buildUDPBackends(rule gatewayv1alpha2.UDPRouteRule) []proxy.L4Backend {
-	return r.buildL4Backends(rule.BackendRefs)
+	return r.buildUDPL4Backends(rule.BackendRefs)
 }
 
 // buildL4Backends converts a BackendRef slice into L4Backends with resolved
 // TCP cluster names. Refs with a non-core group or non-Service kind are skipped.
 func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef) []proxy.L4Backend {
+	return r.buildBackendsWithCluster(refs, func(name string) string {
+		// TCP clusters share the same EDS endpoints as HTTP clusters but use
+		// ALPN "aether-tcp" (see TCPClusterName). The capture TCP floor chains
+		// already reference "tcp:<svc>.<domain>" clusters.
+		return proxy.TCPClusterName(name, r.MeshDomain)
+	})
+}
+
+// buildUDPL4Backends converts a BackendRef slice into L4Backends with resolved
+// UDP cluster names ("udp:<svc>.<domain>"). These clusters are plain EDS without
+// a transport socket — UDP traffic is not covered by mesh mTLS.
+func (r *Reconciler) buildUDPL4Backends(refs []gatewayv1alpha2.BackendRef) []proxy.L4Backend {
+	return r.buildBackendsWithCluster(refs, func(name string) string {
+		return proxy.UDPClusterName(name, r.MeshDomain)
+	})
+}
+
+// buildBackendsWithCluster converts a BackendRef slice into L4Backends, resolving
+// the cluster name via clusterNameFn. Refs with a non-core group or non-Service
+// kind are skipped.
+func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef, clusterNameFn func(name string) string) []proxy.L4Backend {
 	backends := make([]proxy.L4Backend, 0, len(refs))
 	for _, b := range refs {
 		if b.Group != nil && string(*b.Group) != "" {
@@ -192,10 +215,7 @@ func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef) []proxy.
 		}
 		backends = append(backends, proxy.L4Backend{
 			Service: name,
-			// TCP clusters share the same EDS endpoints as HTTP clusters but use
-			// ALPN "aether-tcp" (see TCPClusterName). The capture TCP floor chains
-			// already reference "tcp:<svc>.<domain>" clusters.
-			Cluster: proxy.TCPClusterName(name, r.MeshDomain),
+			Cluster: clusterNameFn(name),
 			Weight:  weight,
 		})
 	}

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -225,6 +225,12 @@ type listenerEntry struct {
 	// pod netns; routes CNI-redirected ClusterIP:18081 traffic by cluster.local
 	// authority over the cap_http route table.
 	capture types.Resource
+	// udpCapture is the per-pod UDP capture listener (proposal 018, Phase 3b):
+	// nil unless capture is enabled AND there are UDPRoute backends for this pod's
+	// upstream services. Bound to ProxyUDPCapturePort inside the pod netns; the
+	// CNI installs a UDP REDIRECT rule that steers outbound UDP to a mesh ClusterIP
+	// into this listener. No mTLS — UDP datagrams are forwarded in plaintext.
+	udpCapture types.Resource
 	// cniPod is the original CNIPod proto used to build this entry. Stored so
 	// the capture listener can be regenerated in-place when the TCP service set
 	// changes (per-pod capture listeners embed per-ClusterIP TCP floor chains).

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -12,6 +12,26 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
+// generateUDPCaptureListener builds a pod's per-pod UDP capture listener, or
+// returns nil when capture is disabled or no UDPRoute backends are in scope.
+// The listener is generated from the current udpServiceRoutes snapshot.
+func (c *SnapshotCache) generateUDPCaptureListener(cniPod *cniv1.CNIPod) (types.Resource, error) {
+	if !c.captureEnabled {
+		return nil, nil
+	}
+	udpRoutes := c.udpServiceRoutesSnapshot()
+	l, err := proxy.GenerateUDPCaptureListener(
+		cniPod.GetName(),
+		cniPod.GetNetworkNamespace(),
+		constants.ProxyUDPCapturePort,
+		udpRoutes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
 // generateCaptureListener builds a pod's transparent-capture listener, or returns
 // nil when capture is disabled (so the listenerEntry carries no capture resource).
 func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Resource, error) {
@@ -260,6 +280,45 @@ func (c *SnapshotCache) edgeTCPClusters() []types.Resource {
 		resources = append(resources, cl)
 	}
 	c.clusterMu.RUnlock()
+
+	return resources
+}
+
+// captureUDPClusters returns the UDP floor clusters for services with UDPRoute
+// backends as a resource slice. Each in-scope service that has at least one UDP
+// backend emits a "udp:<svc>.<domain>" EDS cluster — a plain EDS cluster with
+// no transport socket, since UDP traffic is not covered by mesh mTLS.
+//
+// SECURITY NOTE: these clusters forward datagrams in plaintext. This is a known
+// limitation of the UDP floor (proposal 018 Phase 3b).
+func (c *SnapshotCache) captureUDPClusters() []types.Resource {
+	if !c.captureEnabled {
+		return nil
+	}
+
+	udpRoutes := c.udpServiceRoutesSnapshot()
+	if len(udpRoutes) == 0 {
+		return nil
+	}
+
+	// Collect unique service names from the UDP route backends.
+	services := make(map[string]struct{}, len(udpRoutes))
+	for _, backends := range udpRoutes {
+		for _, b := range backends {
+			if b.Service != "" {
+				services[b.Service] = struct{}{}
+			}
+		}
+	}
+
+	resources := make([]types.Resource, 0, len(services))
+	for svc := range services {
+		udpName := proxy.UDPClusterName(svc, c.meshDomain)
+		// EDS service name is the bare service name — shared with the HTTP/TCP
+		// clusters so the same load assignment carries UDP backends.
+		cl := proxy.NewUDPServiceCluster(udpName, svc, svc)
+		resources = append(resources, cl)
+	}
 	return resources
 }
 

--- a/agent/internal/xds/cache/l4route.go
+++ b/agent/internal/xds/cache/l4route.go
@@ -42,18 +42,24 @@ func (c *SnapshotCache) SetTLSServiceRoutes(routes map[string][]proxy.L4ServiceR
 }
 
 // SetUDPServiceRoutes replaces the UDPRoute-derived per-service UDP routes
-// (proposal 018, Phase 3b). The cache does not generate a UDP capture listener
-// yet — UDP redirect requires a CNI follow-up; this stores the routes for when
-// it lands. On change, signals a snapshot rebuild to ensure the dependency set
-// includes UDP backend services.
+// (proposal 018, Phase 3b). On change, regenerates all per-pod UDP capture
+// listeners (each pod gets one UDP listener covering all services' UDP routes)
+// and triggers a full snapshot rebuild so Envoy picks up the new listeners and
+// their backend UDP clusters.
 func (c *SnapshotCache) SetUDPServiceRoutes(routes map[string][]proxy.L4Backend) {
 	c.depMu.Lock()
 	changed := !equalUDPRoutes(c.udpServiceRoutes, routes)
 	c.udpServiceRoutes = routes
 	c.depMu.Unlock()
-	if changed {
-		c.signalDependencyChange()
+	if !changed {
+		return
 	}
+	// Regenerate per-pod UDP capture listeners: the udp_proxy target cluster set
+	// changes when UDPRoute rules arrive or change.
+	if c.captureEnabled {
+		c.regenerateAllUDPCaptureListeners()
+	}
+	c.signalDependencyChange()
 }
 
 // tcpServiceRoutesSnapshot returns a shallow copy of the TCPRoute rules for
@@ -112,6 +118,27 @@ func (c *SnapshotCache) l4RouteBackendsLocked(service string, set map[string]str
 			set[b.Service] = struct{}{}
 		}
 	}
+}
+
+// regenerateAllUDPCaptureListeners rebuilds every per-pod UDP capture listener
+// in place. Called when UDPRoute rules change: the udp_proxy target cluster
+// is derived from the route map, so a change requires regenerating all listeners.
+func (c *SnapshotCache) regenerateAllUDPCaptureListeners() {
+	c.listenerMu.Lock()
+	for netns, entry := range c.listeners {
+		if entry.cniPod == nil {
+			continue
+		}
+		newUDP, err := c.generateUDPCaptureListener(entry.cniPod)
+		if err != nil {
+			c.log.Error("failed to regenerate UDP capture listener on UDPRoute change",
+				"netns", netns, "pod", entry.cniPod.GetName(), "error", err)
+			continue
+		}
+		entry.udpCapture = newUDP
+		c.listeners[netns] = entry
+	}
+	c.listenerMu.Unlock()
 }
 
 // regenerateAllCaptureListeners rebuilds every per-pod capture listener in place.

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -38,6 +38,10 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	if err != nil {
 		return err
 	}
+	udpCapture, err := c.generateUDPCaptureListener(cniPod)
+	if err != nil {
+		return err
+	}
 
 	c.listenerMu.Lock()
 	if c.listeners == nil {
@@ -47,6 +51,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 		inbound:       inbound,
 		outbound:      outbound,
 		capture:       capture,
+		udpCapture:    udpCapture,
 		cniPod:        cniPod,
 		appClusters:   clustersToResources(appClusters),
 		healthCluster: healthCluster,
@@ -123,6 +128,9 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 		resources = append(resources, entry.inbound, entry.outbound)
 		if entry.capture != nil {
 			resources = append(resources, entry.capture)
+		}
+		if entry.udpCapture != nil {
+			resources = append(resources, entry.udpCapture)
 		}
 		if hc, ok := entry.healthCluster.(*clusterv3.Cluster); ok && hc != nil {
 			probeClusters = append(probeClusters, hc.GetName())
@@ -210,10 +218,17 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 			errs = append(errs, captureErr)
 			continue
 		}
+		udpCapture, udpCaptureErr := c.generateUDPCaptureListener(pod)
+		if udpCaptureErr != nil {
+			c.log.ErrorContext(ctx, "failed to generate UDP capture listener for pod", "error", udpCaptureErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())
+			errs = append(errs, udpCaptureErr)
+			continue
+		}
 		c.listeners[netns] = listenerEntry{
 			inbound:       inbound,
 			outbound:      outbound,
 			capture:       capture,
+			udpCapture:    udpCapture,
 			cniPod:        pod,
 			appClusters:   clustersToResources(appClusters),
 			healthCluster: healthCluster,

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -70,6 +70,11 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 	if c.edge {
 		clusters = append(clusters, c.edgeTCPClusters()...)
 	}
+	// UDP floor clusters (proposal 018, Phase 3b): one per service with UDPRoute
+	// backends. These are plain EDS clusters with no transport socket — UDP datagrams
+	// are not protected by mesh mTLS (known limitation). Only emitted when capture is
+	// enabled and there are UDPRoute rules.
+	clusters = append(clusters, c.captureUDPClusters()...)
 
 	c.secretMu.RLock()
 	secrets := make([]types.Resource, 0, len(c.secrets))

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -44,6 +44,15 @@ func TCPClusterName(serviceName, meshDomain string) string {
 	return "tcp:" + ServiceClusterName(serviceName, meshDomain)
 }
 
+// UDPClusterName returns the data-plane name of a service's UDP-floor cluster:
+// "udp:<service>.<meshDomain>". This cluster carries the same backend endpoints
+// as the HTTP cluster but is a plain EDS cluster with no transport socket (UDP
+// datagrams are not wrapped in mTLS — mesh mTLS is a TCP/TLS construct and
+// DTLS is not supported). The udp_proxy capture listener references this cluster.
+func UDPClusterName(serviceName, meshDomain string) string {
+	return "udp:" + ServiceClusterName(serviceName, meshDomain)
+}
+
 // ServiceFromClusterName maps a data-plane cluster name (a mesh authority,
 // <service>.<meshDomain>) back to the bare service name. ok is false when the
 // name is not under the mesh domain or the remainder is not a single DNS
@@ -286,6 +295,47 @@ func NewTCPServiceCluster(name, edsServiceName, altStatName string, perDownstrea
 		},
 		CloseConnectionsOnHostHealthFailure: true,
 		IgnoreHealthOnHostRemoval:           true,
+	}
+}
+
+// NewUDPServiceCluster builds a plain EDS cluster for a UDPRoute's backend
+// (proposal 018, Phase 3b). It is intentionally transport-socket-free — UDP
+// datagrams are not wrapped in mTLS (mTLS is a TCP/TLS construct; DTLS is not
+// implemented in this mesh). Traffic forwarded via this cluster is PLAINTEXT.
+//
+// SECURITY NOTE: mesh mTLS does NOT cover the UDP floor. All datagrams
+// forwarded to backends via this cluster travel without encryption or mutual
+// authentication. This is a known limitation; see proposal 018 Phase 3b.
+//
+// The cluster uses EDS (bare service name) to discover backends, outlier
+// detection for fast failure, and no subset routing (not meaningful for UDP).
+func NewUDPServiceCluster(name, edsServiceName, altStatName string) *clusterv3.Cluster {
+	return &clusterv3.Cluster{
+		Name:                          name,
+		AltStatName:                   altStatName,
+		ConnectTimeout:                durationpb.New(2 * time.Second),
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_EDS,
+		},
+		EdsClusterConfig: &clusterv3.Cluster_EdsClusterConfig{
+			EdsConfig:   config.XDSConfigSourceADS(),
+			ServiceName: edsServiceName,
+		},
+		// No TypedExtensionProtocolOptions: udp_proxy speaks raw UDP upstream.
+		// No LbSubsetConfig: subset routing is not meaningful for UDP.
+		// No TransportSocket: UDP is plaintext — see security note above.
+		CommonLbConfig: &clusterv3.Cluster_CommonLbConfig{
+			HealthyPanicThreshold: &typev3.Percent{Value: 0},
+		},
+		OutlierDetection: &clusterv3.OutlierDetection{
+			SplitExternalLocalOriginErrors: true,
+			ConsecutiveLocalOriginFailure:  wrapperspb.UInt32(3),
+			BaseEjectionTime:               durationpb.New(30 * time.Second),
+			MaxEjectionPercent:             wrapperspb.UInt32(50),
+			Interval:                       durationpb.New(10 * time.Second),
+		},
+		IgnoreHealthOnHostRemoval: true,
 	}
 }
 

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -294,3 +294,56 @@ func TestSubsetSelectors_MultiKey(t *testing.T) {
 		}
 	}
 }
+
+// TestNewUDPServiceCluster verifies the UDP floor cluster shape: plain EDS,
+// no h2 protocol options, no transport socket, no subset routing.
+//
+// The absence of a transport socket is the key invariant — UDP datagrams are
+// forwarded in plaintext (no mesh mTLS). Any regression that injects a
+// transport socket would silently break every UDP route by wrapping datagrams
+// in a TLS session the backend is not expecting.
+func TestNewUDPServiceCluster(t *testing.T) {
+	c := NewUDPServiceCluster("udp:svc-a.aether.internal", "svc-a", "svc-a")
+
+	assert.Equal(t, "udp:svc-a.aether.internal", c.GetName())
+	assert.Equal(t, "svc-a", c.GetAltStatName())
+	assert.Equal(t, "svc-a", c.GetEdsClusterConfig().GetServiceName())
+	assert.Equal(t, clusterv3.Cluster_EDS, c.GetType())
+
+	// No per-downstream pool needed for UDP (no connection-level identity).
+	assert.False(t, c.GetConnectionPoolPerDownstreamConnection())
+
+	// No HTTP/2 protocol options: udp_proxy speaks raw UDP upstream.
+	assert.Empty(t, c.GetTypedExtensionProtocolOptions(), "UDP cluster must not configure h2 upstream protocol")
+
+	// No transport socket: UDP datagrams are plaintext (no mesh mTLS for UDP).
+	assert.Nil(t, c.GetTransportSocket(), "UDP cluster must not have a transport socket")
+	assert.Nil(t, c.GetTransportSocketMatcher(), "UDP cluster must not have a transport socket matcher")
+
+	// No subset routing: not meaningful for UDP.
+	assert.Nil(t, c.GetLbSubsetConfig(), "UDP cluster must not configure subset routing")
+
+	// Outlier detection present for fast failure.
+	od := c.GetOutlierDetection()
+	require.NotNil(t, od)
+	assert.True(t, od.GetSplitExternalLocalOriginErrors())
+	assert.Equal(t, uint32(3), od.GetConsecutiveLocalOriginFailure().GetValue())
+	assert.Equal(t, uint32(50), od.GetMaxEjectionPercent().GetValue())
+
+	// EDS removals honoured immediately (same as TCP/HTTP clusters).
+	assert.True(t, c.GetIgnoreHealthOnHostRemoval())
+}
+
+// TestUDPClusterName verifies the naming scheme and that it does not collide with
+// the TCP or HTTP cluster names for the same service.
+func TestUDPClusterName(t *testing.T) {
+	udp := UDPClusterName("payments", "aether.internal")
+	tcp := TCPClusterName("payments", "aether.internal")
+	http := ServiceClusterName("payments", "aether.internal")
+
+	assert.Equal(t, "udp:payments.aether.internal", udp)
+	assert.Equal(t, "tcp:payments.aether.internal", tcp)
+	assert.Equal(t, "payments.aether.internal", http)
+	assert.NotEqual(t, udp, tcp, "UDP and TCP clusters must have distinct names")
+	assert.NotEqual(t, udp, http, "UDP and HTTP clusters must have distinct names")
+}

--- a/agent/internal/xds/proxy/l4route.go
+++ b/agent/internal/xds/proxy/l4route.go
@@ -14,11 +14,14 @@ package proxy
 // TCP clusters. No TLS termination — the mTLS between proxies stays intact; the
 // SNI is the app's TLS SNI on the raw captured stream.
 //
-// UDPRoute (parentRef=Service): the control-plane side is implemented here
-// (per-pod UDP listener + udp_proxy with weighted clusters). The CNI UDP redirect
-// is NOT yet wired: the nftables rule in cni/internal/plugin/capture.go only
-// redirects TCP. See the note in GenerateUDPCaptureListener. Plan to add the UDP
-// redirect in a follow-up CNI change.
+// UDPRoute (parentRef=Service): per-pod UDP capture listener + udp_proxy. The
+// CNI installs an nftables REDIRECT rule for outbound UDP to a mesh ClusterIP
+// (in cni/internal/plugin/capture.go, programCaptureRedirect). Backends use
+// "udp:<svc>.<domain>" EDS clusters (plain, no mTLS — see NewUDPServiceCluster).
+//
+// SECURITY NOTE: mesh mTLS does NOT cover the UDP floor. Datagrams are forwarded
+// to backends in plaintext. This is a known limitation of the UDP floor (proposal
+// 018 Phase 3b); DTLS is not implemented.
 
 import (
 	"fmt"
@@ -167,18 +170,14 @@ func CaptureUDPListenerName(podName string) string {
 // routing (proposal 018, Phase 3b). It binds to captureUDPPort inside the pod
 // netns and routes via udp_proxy to the service's backends.
 //
-// IMPORTANT — PARTIAL IMPLEMENTATION: the CNI redirect for UDP is NOT yet wired.
-// cni/internal/plugin/capture.go only installs an nftables rule for TCP
-// (meta l4proto tcp). To activate UDP capture, a follow-up CNI change must add:
+// The CNI installs a matching nftables REDIRECT rule (programCaptureRedirect in
+// cni/internal/plugin/capture.go) that steers outbound UDP destined for a mesh
+// ClusterIP:meshPort into this listener when --l4-routes is enabled.
 //
-//	meta l4proto udp
-//	ip daddr & 255.0.0.0 != 127.0.0.0
-//	udp dport <meshPort>
-//	redirect to :<captureUDPPort>
-//
-// Until that lands, this listener will be generated in the snapshot but will
-// receive no traffic (no iptables/nftables rule redirects UDP to it). It is safe
-// to include: the listener binds a UDP socket that receives nothing.
+// SECURITY NOTE: datagrams forwarded via this listener are NOT protected by
+// mesh mTLS. mTLS is a TCP/TLS construct; DTLS is not implemented. Backend
+// clusters are plain EDS with no transport socket. This is a known limitation
+// of the UDP floor (proposal 018 Phase 3b).
 //
 // Returns nil if udpRoutes is empty (no listener generated until there are routes).
 func GenerateUDPCaptureListener(podName, netns string, captureUDPPort uint32, udpRoutes map[string][]L4Backend) (*listenerv3.Listener, error) {

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -32,10 +32,24 @@ func installCaptureRedirect(netnsPath string, logger *zap.Logger) error {
 	return withPodNetns(netnsPath, func() error { return programCaptureRedirect(logger) })
 }
 
-// programCaptureRedirect adds the nat/output REDIRECT rule in the CURRENT netns.
+// programCaptureRedirect adds the nat/output REDIRECT rules in the CURRENT netns:
+// one for outbound TCP and one for outbound UDP, both destined for the mesh
+// port (ProxyOutboundPort). TCP redirects to ProxyCapturePort (the capture
+// listener); UDP redirects to ProxyUDPCapturePort (the UDP capture listener,
+// proposal 018 Phase 3b). Both rules share the loopback exclusion so the
+// pod-local explicit fast-lane (127.x:meshPort) is never intercepted.
+//
+// NOTE: the UDP redirect only takes effect when --l4-routes is enabled (the
+// agent only generates the UDP capture listener when UDPRoute backends exist).
+// The nft rule itself is always installed when capture is on — the absence of a
+// bound UDP socket on ProxyUDPCapturePort means redirected packets are silently
+// dropped until the agent creates the listener, which is correct behaviour
+// (UDPRoute without --l4-routes = no listener = datagrams discarded rather than
+// sent to an unexpected destination).
 func programCaptureRedirect(logger *zap.Logger) error {
 	meshPort := uint16(commonconstants.ProxyOutboundPort)
-	capturePort := uint16(commonconstants.ProxyCapturePort)
+	tcpCapturePort := uint16(commonconstants.ProxyCapturePort)
+	udpCapturePort := uint16(commonconstants.ProxyUDPCapturePort)
 
 	c, err := nftables.New()
 	if err != nil {
@@ -50,35 +64,53 @@ func programCaptureRedirect(logger *zap.Logger) error {
 		Hooknum:  nftables.ChainHookOutput,
 		Priority: nftables.ChainPriorityNATDest,
 	})
+	// TCP: outbound TCP to ClusterIP:meshPort → capturePort (Phase 3a).
 	c.AddRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,
-		Exprs: captureRedirectExprs(meshPort, capturePort),
+		Exprs: captureRedirectExprs(unix.IPPROTO_TCP, meshPort, tcpCapturePort),
+	})
+	// UDP: outbound UDP to ClusterIP:meshPort → udpCapturePort (Phase 3b).
+	// Datagrams arriving at ProxyUDPCapturePort are handled by the udp_proxy
+	// capture listener generated for each pod when UDPRoute backends are present.
+	// No mesh mTLS — UDP is forwarded in plaintext (known limitation; no DTLS).
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: captureRedirectExprs(unix.IPPROTO_UDP, meshPort, udpCapturePort),
 	})
 
 	if err := c.Flush(); err != nil {
 		return fmt.Errorf("apply capture redirect (nft flush): %w", err)
 	}
 	logger.Info("installed transparent-capture redirect",
-		zap.Uint16("mesh_port", meshPort), zap.Uint16("capture_port", capturePort))
+		zap.Uint16("mesh_port", meshPort),
+		zap.Uint16("tcp_capture_port", tcpCapturePort),
+		zap.Uint16("udp_capture_port", udpCapturePort))
 	return nil
 }
 
 // captureRedirectExprs builds the rule:
 //
-//	meta l4proto tcp
-//	ip daddr & 255.0.0.0 != 127.0.0.0      (skip the loopback fast-lane)
-//	tcp dport <meshPort>
+//	meta l4proto <proto>                         (tcp or udp)
+//	ip daddr & 255.0.0.0 != 127.0.0.0           (skip the loopback fast-lane)
+//	<proto> dport <meshPort>                     (transport dport, offset 2)
 //	redirect to :<capturePort>
-func captureRedirectExprs(meshPort, capturePort uint16) []expr.Any {
+//
+// The transport dest port is at the same offset (2, len 2) for both TCP and UDP,
+// so the same expression shape applies to both protocols — matching the approach
+// used in dns.go for the mesh-DNS DNAT. The proto byte controls which L4 traffic
+// is matched (unix.IPPROTO_TCP or unix.IPPROTO_UDP).
+func captureRedirectExprs(proto byte, meshPort, capturePort uint16) []expr.Any {
 	return []expr.Any{
 		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
-		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{proto}},
 		// ip daddr (IPv4 dest = offset 16, len 4), masked to /8, != 127.0.0.0
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 16, Len: 4},
 		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: []byte{0xff, 0x00, 0x00, 0x00}, Xor: []byte{0x00, 0x00, 0x00, 0x00}},
 		&expr.Cmp{Op: expr.CmpOpNeq, Register: 1, Data: []byte{127, 0, 0, 0}},
-		// tcp dport == meshPort (transport dest = offset 2, len 2, big-endian)
+		// <proto> dport == meshPort (transport dest = offset 2, len 2, big-endian;
+		// this offset is identical for TCP and UDP headers).
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(meshPort)},
 		// redirect to capturePort

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -10,13 +10,13 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// TestCaptureRedirectExprs verifies the nft rule: tcp + non-loopback daddr +
-// dport meshPort -> redirect to capturePort. A wrong loopback exclusion or port
-// would silently break the explicit fast-lane or fail to capture.
-func TestCaptureRedirectExprs(t *testing.T) {
+// TestCaptureRedirectExprs_TCP verifies the nft rule for TCP: tcp + non-loopback
+// daddr + dport meshPort -> redirect to tcpCapturePort. A wrong loopback
+// exclusion or port would silently break the explicit fast-lane or fail to capture.
+func TestCaptureRedirectExprs_TCP(t *testing.T) {
 	mesh := uint16(commonconstants.ProxyOutboundPort) // 18081
 	cap := uint16(commonconstants.ProxyCapturePort)   // 18001
-	exprs := captureRedirectExprs(mesh, cap)
+	exprs := captureRedirectExprs(unix.IPPROTO_TCP, mesh, cap)
 	require.Len(t, exprs, 9)
 
 	// l4proto == tcp
@@ -40,5 +40,39 @@ func TestCaptureRedirectExprs(t *testing.T) {
 	// redirect to 18001
 	require.IsType(t, &expr.Immediate{}, exprs[7])
 	assert.Equal(t, []byte{0x46, 0x51}, exprs[7].(*expr.Immediate).Data) // 18001
+	assert.IsType(t, &expr.Redir{}, exprs[8])
+}
+
+// TestCaptureRedirectExprs_UDP verifies the nft rule for UDP: udp + non-loopback
+// daddr + dport meshPort -> redirect to udpCapturePort. The transport header dport
+// is at the same offset (2) for UDP as for TCP, so the expression shape is identical
+// except for the l4proto byte and the redirect target port.
+func TestCaptureRedirectExprs_UDP(t *testing.T) {
+	mesh := uint16(commonconstants.ProxyOutboundPort)  // 18081
+	cap := uint16(commonconstants.ProxyUDPCapturePort) // 18002
+	exprs := captureRedirectExprs(unix.IPPROTO_UDP, mesh, cap)
+	require.Len(t, exprs, 9)
+
+	// l4proto == udp
+	require.IsType(t, &expr.Meta{}, exprs[0])
+	assert.Equal(t, expr.MetaKeyL4PROTO, exprs[0].(*expr.Meta).Key)
+	require.IsType(t, &expr.Cmp{}, exprs[1])
+	assert.Equal(t, []byte{unix.IPPROTO_UDP}, exprs[1].(*expr.Cmp).Data)
+
+	// loopback exclusion unchanged
+	require.IsType(t, &expr.Bitwise{}, exprs[3])
+	assert.Equal(t, []byte{0xff, 0x00, 0x00, 0x00}, exprs[3].(*expr.Bitwise).Mask)
+	require.IsType(t, &expr.Cmp{}, exprs[4])
+	assert.Equal(t, expr.CmpOpNeq, exprs[4].(*expr.Cmp).Op)
+	assert.Equal(t, []byte{127, 0, 0, 0}, exprs[4].(*expr.Cmp).Data)
+
+	// udp dport == 18081 (big-endian)
+	require.IsType(t, &expr.Cmp{}, exprs[6])
+	assert.Equal(t, expr.CmpOpEq, exprs[6].(*expr.Cmp).Op)
+	assert.Equal(t, []byte{0x46, 0xA1}, exprs[6].(*expr.Cmp).Data) // 18081
+
+	// redirect to 18002
+	require.IsType(t, &expr.Immediate{}, exprs[7])
+	assert.Equal(t, []byte{0x46, 0x52}, exprs[7].(*expr.Immediate).Data) // 18002
 	assert.IsType(t, &expr.Redir{}, exprs[8])
 }

--- a/common/constants/proxy.go
+++ b/common/constants/proxy.go
@@ -12,6 +12,17 @@ const (
 	// In aether's 18xxx range (with ProxyOutboundPort) to avoid colliding with
 	// Istio's 15001 outbound-capture port if both meshes share a node.
 	ProxyCapturePort = 18001
+	// ProxyUDPCapturePort is the port the per-pod UDP capture listener binds
+	// inside the pod netns (proposal 018, Phase 3b UDPRoute). The CNI REDIRECTs
+	// outbound UDP to a mesh ClusterIP:ProxyOutboundPort here; the udp_proxy
+	// filter routes to the UDPRoute backends. Default off (gated behind
+	// --l4-routes). In aether's 18xxx range alongside ProxyCapturePort (TCP).
+	//
+	// SECURITY NOTE: UDP datagrams routed via this listener are NOT protected
+	// by mesh mTLS. mTLS is a TCP/TLS construct; DTLS is not implemented in this
+	// mesh. UDP traffic is forwarded in plaintext to the backend pods. This is a
+	// known limitation of the UDP floor — see proposal 018 Phase 3b.
+	ProxyUDPCapturePort = 18002
 	// ProxyDNSResolverPort is the host port the node agent's in-process mesh-DNS
 	// resolver listens on (UDP+TCP) at HOST_IP (proposal 018, mesh-global FQDN). The
 	// CNI DNATs each pod's outbound :53 straight to HOST_IP:ProxyDNSResolverPort. In


### PR DESCRIPTION
## Summary

Wires the UDPRoute data plane end-to-end. The control-plane (l4route reconciler + cache) already stored UDPRoute backends but never emitted Envoy resources or CNI rules for them. This PR completes the floor.

- **`ProxyUDPCapturePort = 18002`** — new constant in `common/constants/proxy.go`, in the aether 18xxx range, distinct from TCP capture (18001).
- **`UDPClusterName` + `NewUDPServiceCluster`** — `"udp:<svc>.<domain>"` EDS clusters with no transport socket (plaintext — see security note below). `proxy/egress.go`.
- **UDP capture listener** — `GenerateUDPCaptureListener` (already existed in `proxy/l4route.go`) is now wired into the cache: `listenerEntry.udpCapture`, `generateUDPCaptureListener`, `captureUDPClusters`, `regenerateAllUDPCaptureListeners`, `Listeners()`, `AddPod`, `LoadListenersFromStorage`, `generateSnapshot`.
- **`SetUDPServiceRoutes`** — now regenerates UDP capture listeners on change, matching the TCPRoute pattern.
- **l4route reconciler** — UDP backends now resolve to `UDPClusterName` (not `TCPClusterName`); refactored to `buildBackendsWithCluster` shared helper.
- **CNI UDP redirect** — `captureRedirectExprs` gains a `proto` byte parameter; `programCaptureRedirect` installs two rules: TCP→18001 (unchanged) and UDP→18002 (new). The UDP dport offset in the transport header is the same (offset 2) as TCP, so the nft expression shape is identical.

## Security note: no mesh mTLS for UDP

UDP datagrams forwarded via the `udp_proxy` listener travel **in plaintext** to backend pods. mTLS is a TCP/TLS construct; DTLS is not implemented in this mesh. This is a **known limitation** of the UDP floor (proposal 018 Phase 3b). The feature is off by default (`--l4-routes`). The `NewUDPServiceCluster` docstring, `ProxyUDPCapturePort` constant, and `GenerateUDPCaptureListener` doc all call this out explicitly.

## Gating

Fully behind the existing `--l4-routes` flag (default: false). No chart changes (no new flags surface via values).

## Tests

- `TestCaptureRedirectExprs_TCP` / `TestCaptureRedirectExprs_UDP` — both CNI nft rule shapes
- `TestNewUDPServiceCluster` — cluster shape: no transport socket, no h2, no subset routing
- `TestUDPClusterName` — naming scheme, no collision with tcp:/http clusters
- Existing `TestGenerateUDPCaptureListener_*` already covered the listener
- All 59 tests pass: `Executed 59 out of 59 tests: 59 tests pass.`

## e2e on talos — what to check

1. Deploy a UDP backend service (e.g. a simple UDP echo at `containerPort: 9000/UDP`).
2. Register it in the mesh registry (or let the agent discover it).
3. Create a `UDPRoute` with `parentRef: kind: Service, name: <svc>` and `backendRefs: [{name: udp-echo, port: 9000}]`, with `--l4-routes` enabled on the agent.
4. From a client pod, send a UDP datagram to `<ClusterIP>:18081` (the mesh port).
5. Assert: datagram arrives at the backend pod's port 9000; no TLS handshake; `envoy_listener_udp_downstream_session_rx_datagrams_total` increments on the UDP capture listener; `envoy_cluster_upstream_rq_total` increments on the `udp:<svc>.aether.internal` cluster.
6. Confirm: no regression on TCP capture (TCP routes still use 18001, TCP clusters still have mTLS transport socket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)