### PR TITLE
fix(agent): UDP capture listener — udp_proxy is a listener filter, not a filter chain

### DIFF
--- a/agent/internal/xds/proxy/l4route.go
+++ b/agent/internal/xds/proxy/l4route.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"net"
 
+	"github.com/bpalermo/aether/agent/internal/xds/config"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	tcp_proxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
@@ -208,7 +209,11 @@ func GenerateUDPCaptureListener(podName, netns string, captureUDPPort uint32, ud
 		return nil, nil
 	}
 
-	udpFilter := networkFilter("envoy.filters.udp_listener.udp_proxy", &udp_proxyv3.UdpProxyConfig{
+	// udp_proxy is a UDP *listener filter*, not a network filter in a filter chain.
+	// A connection-less UDP listener must carry NO filter_chains — Envoy rejects it
+	// with "N filter chain(s) specified for connection-less UDP listener" — so the
+	// proxy config goes in listener_filters instead.
+	udpProxyConfig := config.TypedConfig(&udp_proxyv3.UdpProxyConfig{
 		StatPrefix: fmt.Sprintf("capture_udp_%s", podName),
 		RouteSpecifier: &udp_proxyv3.UdpProxyConfig_Cluster{
 			Cluster: primaryCluster,
@@ -231,11 +236,10 @@ func GenerateUDPCaptureListener(podName, netns string, captureUDPPort uint32, ud
 		},
 		StatPrefix:       fmt.Sprintf("capture_udp_%s", podName),
 		TrafficDirection: corev3.TrafficDirection_OUTBOUND,
-		ListenerFilters:  []*listenerv3.ListenerFilter{},
-		FilterChains: []*listenerv3.FilterChain{
+		ListenerFilters: []*listenerv3.ListenerFilter{
 			{
-				Name:    fmt.Sprintf("capture_udp_%s", podName),
-				Filters: []*listenerv3.Filter{udpFilter},
+				Name:       "envoy.filters.udp_listener.udp_proxy",
+				ConfigType: &listenerv3.ListenerFilter_TypedConfig{TypedConfig: udpProxyConfig},
 			},
 		},
 	}, nil

--- a/agent/internal/xds/proxy/l4route_test.go
+++ b/agent/internal/xds/proxy/l4route_test.go
@@ -204,8 +204,11 @@ func TestGenerateUDPCaptureListener_WithRoutes(t *testing.T) {
 	require.NotNil(t, sa)
 	assert.Equal(t, corev3.SocketAddress_UDP, sa.Protocol)
 	assert.Equal(t, uint32(18082), sa.GetPortValue())
-	require.Len(t, l.FilterChains, 1)
-	assert.Equal(t, "envoy.filters.udp_listener.udp_proxy", l.FilterChains[0].Filters[0].Name)
+	// A connection-less UDP listener carries NO filter chains; udp_proxy is a
+	// listener filter (Envoy rejects filter_chains on a UDP listener).
+	assert.Empty(t, l.FilterChains, "UDP listener must have no filter chains")
+	require.Len(t, l.ListenerFilters, 1)
+	assert.Equal(t, "envoy.filters.udp_listener.udp_proxy", l.ListenerFilters[0].Name)
 }
 
 // TestL4RulesToWeightedClusters_DefaultWeight verifies weight=0 becomes 1.


### PR DESCRIPTION
Envoy NACKed every UDP capture listener: `1 filter chain(s) specified for connection-less UDP listener`. `udp_proxy` is a UDP **listener filter**; a UDP listener must have no filter_chains. The rejected listener never bound, so captured UDP datagrams were dropped despite a correct `udp:<svc>` cluster + projected route. Move udp_proxy to `listener_filters`. 🤖 Generated with [Claude Code](https://claude.com/claude-code)