### PR TITLE
fix(agent): UDP floor cluster must target the backend app port, not :15008

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/bpalermo/aether/agent/internal/capture"
 	"github.com/bpalermo/aether/agent/internal/meshdns"
@@ -311,12 +312,26 @@ func (c *SnapshotCache) captureUDPClusters() []types.Resource {
 		}
 	}
 
+	c.clusterMu.RLock()
+	defer c.clusterMu.RUnlock()
 	resources := make([]types.Resource, 0, len(services))
 	for svc := range services {
+		entry, ok := c.clusters[svc]
+		if !ok || entry.loadAssignment == nil {
+			// Backend service not in scope yet; skip until its cluster/EDS exists.
+			continue
+		}
+		// entry.sni carries the backend's registered application port. The UDP floor
+		// has no inbound mTLS hop, so udp_proxy must reach that app port directly (not
+		// the mesh inbound :15008 the shared bare-name EDS carries) — build an inline
+		// app-port UDP load assignment from the service's endpoints.
+		port, err := strconv.Atoi(entry.sni)
+		if err != nil || port <= 0 || port > 65535 {
+			continue
+		}
 		udpName := proxy.UDPClusterName(svc, c.meshDomain)
-		// EDS service name is the bare service name — shared with the HTTP/TCP
-		// clusters so the same load assignment carries UDP backends.
-		cl := proxy.NewUDPServiceCluster(udpName, svc, svc)
+		la := proxy.UDPLoadAssignment(entry.loadAssignment, udpName, uint32(port))
+		cl := proxy.NewUDPServiceCluster(udpName, svc, la)
 		resources = append(resources, cl)
 	}
 	return resources

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -12,6 +12,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -307,21 +308,20 @@ func NewTCPServiceCluster(name, edsServiceName, altStatName string, perDownstrea
 // forwarded to backends via this cluster travel without encryption or mutual
 // authentication. This is a known limitation; see proposal 018 Phase 3b.
 //
-// The cluster uses EDS (bare service name) to discover backends, outlier
-// detection for fast failure, and no subset routing (not meaningful for UDP).
-func NewUDPServiceCluster(name, edsServiceName, altStatName string) *clusterv3.Cluster {
+// The cluster is STATIC with an inline load assignment rather than EDS: the UDP
+// floor has no inbound mTLS hop, so udp_proxy must reach the backend's application
+// UDP port directly — not the mesh inbound :15008 that the shared bare-name EDS
+// carries. Callers pass a load assignment from UDPLoadAssignment (app-port endpoints).
+func NewUDPServiceCluster(name, altStatName string, loadAssignment *endpointv3.ClusterLoadAssignment) *clusterv3.Cluster {
 	return &clusterv3.Cluster{
 		Name:                          name,
 		AltStatName:                   altStatName,
 		ConnectTimeout:                durationpb.New(2 * time.Second),
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		ClusterDiscoveryType: &clusterv3.Cluster_Type{
-			Type: clusterv3.Cluster_EDS,
+			Type: clusterv3.Cluster_STATIC,
 		},
-		EdsClusterConfig: &clusterv3.Cluster_EdsClusterConfig{
-			EdsConfig:   config.XDSConfigSourceADS(),
-			ServiceName: edsServiceName,
-		},
+		LoadAssignment: loadAssignment,
 		// No TypedExtensionProtocolOptions: udp_proxy speaks raw UDP upstream.
 		// No LbSubsetConfig: subset routing is not meaningful for UDP.
 		// No TransportSocket: UDP is plaintext — see security note above.
@@ -337,6 +337,30 @@ func NewUDPServiceCluster(name, edsServiceName, altStatName string) *clusterv3.C
 		},
 		IgnoreHealthOnHostRemoval: true,
 	}
+}
+
+// UDPLoadAssignment derives an inline UDP load assignment from a service's existing
+// (TCP-inbound, :15008) load assignment: it clones it and rewrites every endpoint to
+// the backend's application UDP port and UDP protocol. The UDP floor has no inbound
+// mTLS proxy, so udp_proxy reaches the application port directly. Returns nil if src
+// is nil.
+func UDPLoadAssignment(src *endpointv3.ClusterLoadAssignment, clusterName string, port uint32) *endpointv3.ClusterLoadAssignment {
+	if src == nil {
+		return nil
+	}
+	la, _ := proto.Clone(src).(*endpointv3.ClusterLoadAssignment)
+	la.ClusterName = clusterName
+	for _, lle := range la.GetEndpoints() {
+		for _, lb := range lle.GetLbEndpoints() {
+			sa := lb.GetEndpoint().GetAddress().GetSocketAddress()
+			if sa == nil {
+				continue
+			}
+			sa.Protocol = corev3.SocketAddress_UDP
+			sa.PortSpecifier = &corev3.SocketAddress_PortValue{PortValue: port}
+		}
+	}
+	return la
 }
 
 // InjectUpstreamTCPMTLS is InjectUpstreamMTLS for TCP floor clusters: it injects

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -7,6 +7,7 @@ import (
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -303,12 +304,34 @@ func TestSubsetSelectors_MultiKey(t *testing.T) {
 // transport socket would silently break every UDP route by wrapping datagrams
 // in a TLS session the backend is not expecting.
 func TestNewUDPServiceCluster(t *testing.T) {
-	c := NewUDPServiceCluster("udp:svc-a.aether.internal", "svc-a", "svc-a")
+	// Source LA mirrors a service's bare-name EDS: endpoints on the mesh inbound
+	// :15008 (TCP). UDPLoadAssignment must rewrite them to the app UDP port.
+	src := &endpointv3.ClusterLoadAssignment{
+		ClusterName: "svc-a",
+		Endpoints: []*endpointv3.LocalityLbEndpoints{{
+			LbEndpoints: []*endpointv3.LbEndpoint{{
+				HostIdentifier: &endpointv3.LbEndpoint_Endpoint{Endpoint: &endpointv3.Endpoint{
+					Address: &corev3.Address{Address: &corev3.Address_SocketAddress{SocketAddress: &corev3.SocketAddress{
+						Protocol:      corev3.SocketAddress_TCP,
+						Address:       "10.0.0.9",
+						PortSpecifier: &corev3.SocketAddress_PortValue{PortValue: 15008},
+					}}},
+				}},
+			}},
+		}},
+	}
+	la := UDPLoadAssignment(src, "udp:svc-a.aether.internal", 9000)
+	c := NewUDPServiceCluster("udp:svc-a.aether.internal", "svc-a", la)
 
 	assert.Equal(t, "udp:svc-a.aether.internal", c.GetName())
 	assert.Equal(t, "svc-a", c.GetAltStatName())
-	assert.Equal(t, "svc-a", c.GetEdsClusterConfig().GetServiceName())
-	assert.Equal(t, clusterv3.Cluster_EDS, c.GetType())
+	assert.Equal(t, clusterv3.Cluster_STATIC, c.GetType())
+	// Inline LA reaches the backend's app UDP port directly (not the mesh inbound).
+	sa := c.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, corev3.SocketAddress_UDP, sa.GetProtocol())
+	assert.Equal(t, uint32(9000), sa.GetPortValue())
+	// The source LA is not mutated (clone).
+	assert.Equal(t, uint32(15008), src.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress().GetPortValue())
 
 	// No per-downstream pool needed for UDP (no connection-level identity).
 	assert.False(t, c.GetConnectionPoolPerDownstreamConnection())


### PR DESCRIPTION
The `udp:<svc>` cluster shared the bare-name EDS (endpoints on the mesh inbound `:15008`), but the UDP floor has no inbound proxy hop — udp_proxy must hit the backend's app UDP port directly. Captured datagrams went to `<pod>:15008` (no UDP there) and were dropped. Make the UDP cluster STATIC with an inline load assignment (`UDPLoadAssignment`) that rewrites endpoints to the registered app port + UDP protocol. 🤖 Generated with [Claude Code](https://claude.com/claude-code)