### PR TITLE
refactor(agent,cni): collapse UDP capture onto the TCP capture port (drop 18002)

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -227,9 +227,10 @@ type listenerEntry struct {
 	capture types.Resource
 	// udpCapture is the per-pod UDP capture listener (proposal 018, Phase 3b):
 	// nil unless capture is enabled AND there are UDPRoute backends for this pod's
-	// upstream services. Bound to ProxyUDPCapturePort inside the pod netns; the
-	// CNI installs a UDP REDIRECT rule that steers outbound UDP to a mesh ClusterIP
-	// into this listener. No mTLS — UDP datagrams are forwarded in plaintext.
+	// upstream services. Bound to ProxyCapturePort (UDP socket, same port as the
+	// TCP capture listener) inside the pod netns; the CNI installs a UDP REDIRECT
+	// rule that steers outbound UDP to a mesh ClusterIP into this listener.
+	// No mTLS — UDP datagrams are forwarded in plaintext.
 	udpCapture types.Resource
 	// cniPod is the original CNIPod proto used to build this entry. Stored so
 	// the capture listener can be regenerated in-place when the TCP service set

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -24,7 +24,7 @@ func (c *SnapshotCache) generateUDPCaptureListener(cniPod *cniv1.CNIPod) (types.
 	l, err := proxy.GenerateUDPCaptureListener(
 		cniPod.GetName(),
 		cniPod.GetNetworkNamespace(),
-		constants.ProxyUDPCapturePort,
+		constants.ProxyCapturePort,
 		udpRoutes,
 	)
 	if err != nil {

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -34,22 +34,22 @@ func installCaptureRedirect(netnsPath string, logger *zap.Logger) error {
 
 // programCaptureRedirect adds the nat/output REDIRECT rules in the CURRENT netns:
 // one for outbound TCP and one for outbound UDP, both destined for the mesh
-// port (ProxyOutboundPort). TCP redirects to ProxyCapturePort (the capture
-// listener); UDP redirects to ProxyUDPCapturePort (the UDP capture listener,
-// proposal 018 Phase 3b). Both rules share the loopback exclusion so the
+// port (ProxyOutboundPort). Both protocols redirect to ProxyCapturePort — the
+// TCP and UDP listeners bind the SAME port number on independent sockets (TCP
+// and UDP are separate socket families; the kernel routes by (protocol, port),
+// so there is no collision). Both rules share the loopback exclusion so the
 // pod-local explicit fast-lane (127.x:meshPort) is never intercepted.
 //
 // NOTE: the UDP redirect only takes effect when --l4-routes is enabled (the
 // agent only generates the UDP capture listener when UDPRoute backends exist).
 // The nft rule itself is always installed when capture is on — the absence of a
-// bound UDP socket on ProxyUDPCapturePort means redirected packets are silently
+// bound UDP socket on ProxyCapturePort means redirected packets are silently
 // dropped until the agent creates the listener, which is correct behaviour
 // (UDPRoute without --l4-routes = no listener = datagrams discarded rather than
 // sent to an unexpected destination).
 func programCaptureRedirect(logger *zap.Logger) error {
 	meshPort := uint16(commonconstants.ProxyOutboundPort)
-	tcpCapturePort := uint16(commonconstants.ProxyCapturePort)
-	udpCapturePort := uint16(commonconstants.ProxyUDPCapturePort)
+	capturePort := uint16(commonconstants.ProxyCapturePort)
 
 	c, err := nftables.New()
 	if err != nil {
@@ -68,16 +68,17 @@ func programCaptureRedirect(logger *zap.Logger) error {
 	c.AddRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,
-		Exprs: captureRedirectExprs(unix.IPPROTO_TCP, meshPort, tcpCapturePort),
+		Exprs: captureRedirectExprs(unix.IPPROTO_TCP, meshPort, capturePort),
 	})
-	// UDP: outbound UDP to ClusterIP:meshPort → udpCapturePort (Phase 3b).
-	// Datagrams arriving at ProxyUDPCapturePort are handled by the udp_proxy
+	// UDP: outbound UDP to ClusterIP:meshPort → capturePort (Phase 3b).
+	// Datagrams arriving at ProxyCapturePort:UDP are handled by the udp_proxy
 	// capture listener generated for each pod when UDPRoute backends are present.
+	// The TCP and UDP listeners coexist on :18001 via independent protocol sockets.
 	// No mesh mTLS — UDP is forwarded in plaintext (known limitation; no DTLS).
 	c.AddRule(&nftables.Rule{
 		Table: table,
 		Chain: chain,
-		Exprs: captureRedirectExprs(unix.IPPROTO_UDP, meshPort, udpCapturePort),
+		Exprs: captureRedirectExprs(unix.IPPROTO_UDP, meshPort, capturePort),
 	})
 
 	if err := c.Flush(); err != nil {
@@ -85,8 +86,7 @@ func programCaptureRedirect(logger *zap.Logger) error {
 	}
 	logger.Info("installed transparent-capture redirect",
 		zap.Uint16("mesh_port", meshPort),
-		zap.Uint16("tcp_capture_port", tcpCapturePort),
-		zap.Uint16("udp_capture_port", udpCapturePort))
+		zap.Uint16("capture_port", capturePort))
 	return nil
 }
 

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -44,12 +44,14 @@ func TestCaptureRedirectExprs_TCP(t *testing.T) {
 }
 
 // TestCaptureRedirectExprs_UDP verifies the nft rule for UDP: udp + non-loopback
-// daddr + dport meshPort -> redirect to udpCapturePort. The transport header dport
-// is at the same offset (2) for UDP as for TCP, so the expression shape is identical
-// except for the l4proto byte and the redirect target port.
+// daddr + dport meshPort -> redirect to ProxyCapturePort (same port as TCP).
+// The transport header dport is at the same offset (2) for UDP as for TCP, so
+// the expression shape is identical except for the l4proto byte. Both TCP and
+// UDP redirect to the same port number (18001) — the kernel differentiates them
+// at the socket layer by protocol, so the listeners do not collide.
 func TestCaptureRedirectExprs_UDP(t *testing.T) {
-	mesh := uint16(commonconstants.ProxyOutboundPort)  // 18081
-	cap := uint16(commonconstants.ProxyUDPCapturePort) // 18002
+	mesh := uint16(commonconstants.ProxyOutboundPort) // 18081
+	cap := uint16(commonconstants.ProxyCapturePort)   // 18001 (shared with TCP)
 	exprs := captureRedirectExprs(unix.IPPROTO_UDP, mesh, cap)
 	require.Len(t, exprs, 9)
 
@@ -71,8 +73,8 @@ func TestCaptureRedirectExprs_UDP(t *testing.T) {
 	assert.Equal(t, expr.CmpOpEq, exprs[6].(*expr.Cmp).Op)
 	assert.Equal(t, []byte{0x46, 0xA1}, exprs[6].(*expr.Cmp).Data) // 18081
 
-	// redirect to 18002
+	// redirect to 18001 (ProxyCapturePort, shared with TCP listener)
 	require.IsType(t, &expr.Immediate{}, exprs[7])
-	assert.Equal(t, []byte{0x46, 0x52}, exprs[7].(*expr.Immediate).Data) // 18002
+	assert.Equal(t, []byte{0x46, 0x51}, exprs[7].(*expr.Immediate).Data) // 18001
 	assert.IsType(t, &expr.Redir{}, exprs[8])
 }

--- a/common/constants/proxy.go
+++ b/common/constants/proxy.go
@@ -5,24 +5,22 @@ const (
 	// binds inside each pod's network namespace. The CNI plugin probes this
 	// address (from within the netns) to confirm the data plane is serving.
 	ProxyOutboundPort = 18081
-	// ProxyCapturePort is the port the per-pod transparent-capture listener binds
-	// inside the pod netns (proposal 018, Phase 3a). The CNI redirects outbound
-	// TCP to a mesh ClusterIP:ProxyOutboundPort here; the listener recovers the
-	// original ClusterIP and routes by cluster.local authority. Default off.
-	// In aether's 18xxx range (with ProxyOutboundPort) to avoid colliding with
-	// Istio's 15001 outbound-capture port if both meshes share a node.
-	ProxyCapturePort = 18001
-	// ProxyUDPCapturePort is the port the per-pod UDP capture listener binds
-	// inside the pod netns (proposal 018, Phase 3b UDPRoute). The CNI REDIRECTs
-	// outbound UDP to a mesh ClusterIP:ProxyOutboundPort here; the udp_proxy
-	// filter routes to the UDPRoute backends. Default off (gated behind
-	// --l4-routes). In aether's 18xxx range alongside ProxyCapturePort (TCP).
+	// ProxyCapturePort is the port both the per-pod TCP and UDP capture listeners
+	// bind inside the pod netns (proposal 018, Phase 3a/3b). TCP and UDP are
+	// independent at the socket layer — a UDP socket and a TCP socket can both
+	// bind the same port number — so a single port serves both protocols (like
+	// HTTP/3 running TCP+QUIC on :443). The CNI redirects outbound TCP to a mesh
+	// ClusterIP:ProxyOutboundPort to this port (Phase 3a, TCP listener); it also
+	// redirects outbound UDP to this same port (Phase 3b, UDP listener). Default
+	// off. In aether's 18xxx range (with ProxyOutboundPort) to avoid colliding
+	// with Istio's 15001 outbound-capture port if both meshes share a node.
 	//
-	// SECURITY NOTE: UDP datagrams routed via this listener are NOT protected
-	// by mesh mTLS. mTLS is a TCP/TLS construct; DTLS is not implemented in this
-	// mesh. UDP traffic is forwarded in plaintext to the backend pods. This is a
-	// known limitation of the UDP floor — see proposal 018 Phase 3b.
-	ProxyUDPCapturePort = 18002
+	// SECURITY NOTE: UDP datagrams routed via the UDP capture listener are NOT
+	// protected by mesh mTLS. mTLS is a TCP/TLS construct; DTLS is not
+	// implemented in this mesh. UDP traffic is forwarded in plaintext to the
+	// backend pods. This is a known limitation of the UDP floor — see proposal
+	// 018 Phase 3b.
+	ProxyCapturePort = 18001
 	// ProxyDNSResolverPort is the host port the node agent's in-process mesh-DNS
 	// resolver listens on (UDP+TCP) at HOST_IP (proposal 018, mesh-global FQDN). The
 	// CNI DNATs each pod's outbound :53 straight to HOST_IP:ProxyDNSResolverPort. In


### PR DESCRIPTION
## Summary

- Remove `ProxyUDPCapturePort` (18002) and consolidate all transparent-capture redirect targets onto `ProxyCapturePort` (18001) for both TCP and UDP.
- TCP and UDP are independent at the socket layer — the kernel routes by `(protocol, port)`, so a TCP socket and a UDP socket bound to the same port number do not collide. This is the same principle as HTTP/3 running TCP+QUIC on :443.
- The two Envoy listeners remain distinct: `capture_<pod>` (TCP, `SocketAddress_TCP`, :18001) and `capture_udp_<pod>` (UDP, `SocketAddress_UDP`, :18001). Only the port number is shared.

## Files changed

| File | Change |
|---|---|
| `common/constants/proxy.go` | Remove `ProxyUDPCapturePort`; expand `ProxyCapturePort` comment to document shared TCP+UDP use and retain the UDP mTLS security note |
| `cni/internal/plugin/capture.go` | Single `capturePort` variable for both nftables REDIRECT rules; updated log field name |
| `agent/internal/xds/cache/capture.go` | Pass `ProxyCapturePort` (not the removed constant) to `GenerateUDPCaptureListener` |
| `agent/internal/xds/cache/cache.go` | Update `udpCapture` field comment |
| `cni/internal/plugin/capture_test.go` | Update `TestCaptureRedirectExprs_UDP` to assert `0x46,0x51` (18001) instead of old 18002 |

## Dual-bind caveat — talos e2e required

Unit tests **cannot** verify Envoy's runtime listener-manager acceptance of two listeners sharing a port by protocol. Modern Envoy (7.x) supports TCP+UDP listeners on the same address:port via distinct socket types, but this must be confirmed empirically.

**Before merging**, run a talos e2e with `--l4-routes` enabled and verify:
1. The LDS push for both `capture_<pod>` (TCP :18001) and `capture_udp_<pod>` (UDP :18001) is **ACKed**, not NACKed with a "duplicate address" or "listener already exists on port" error.
2. Both listeners appear in `envoy admin /listeners` output.
3. Captured TCP traffic (TCPRoute) and captured UDP traffic (UDPRoute) both reach their backends.

If Envoy NACKs the dual-bind, revert by restoring `ProxyUDPCapturePort = 18002` and the original call sites.

## No chart changes

`ProxyCapturePort` / `ProxyUDPCapturePort` are agent/CNI-internal constants; no Helm values or chart templates reference them. No `Chart.yaml` bump required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)