### PR TITLE
feat(agent): protocol-aware TCP-connect liveness for TCP-floor services

### DIFF
--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -7,7 +7,6 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/agent/types"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
-	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/common/telemetry"
 	"github.com/bpalermo/aether/registry"
 	"go.opentelemetry.io/otel"
@@ -96,21 +95,16 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, state *livenessState)
 			continue
 		}
 
-		// TCP floor services are reached as a raw mTLS passthrough, so the HTTP
-		// delegated app-health probe is inapplicable — treat them as healthy instead
-		// of leaving them perpetually UNHEALTHY (which, with the floor cluster's
-		// HealthyPanicThreshold of 0, gives it no host to dial). A protocol-aware
-		// TCP-connect liveness is a follow-up.
-		healthy, known := true, true
-		if pod.GetAnnotations()[constants.AnnotationEndpointProtocol] != constants.ProtocolTCP {
-			var err error
-			healthy, known, err = s.healthClient.appHealth(ctx, proxy.HealthProbeClusterName(pod))
-			if err != nil {
-				// The gateway itself is unreachable (proxy down / restarting): no
-				// probe this tick can succeed, abort instead of logging per pod.
-				s.log.DebugContext(ctx, "liveness: health gateway unreachable", "error", err)
-				return
-			}
+		// HTTP and TCP-floor services are liveness-probed the same way here: the
+		// gateway returns 200/503 by reflecting the per-pod probe cluster's
+		// membership, and that cluster runs the protocol-appropriate active check
+		// (HTTP GET for HTTP/gRPC, raw TCP connect for TCP — NewAppHealthProbeCluster).
+		healthy, known, err := s.healthClient.appHealth(ctx, proxy.HealthProbeClusterName(pod))
+		if err != nil {
+			// The gateway itself is unreachable (proxy down / restarting): no
+			// probe this tick can succeed, abort instead of logging per pod.
+			s.log.DebugContext(ctx, "liveness: health gateway unreachable", "error", err)
+			return
 		}
 		if !known {
 			continue // pod's gateway filter not yet programmed / propagated

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -211,10 +211,11 @@ func HealthProbeClusterName(cniPod *cniv1.CNIPod) string {
 // separate cluster, not on app_<pod>: an active HC removes failing/pending hosts
 // from load balancing, which would gate (break) the real delivery path through
 // app_<pod> at startup and whenever the probe fails.
-func NewAppHealthProbeCluster(name, netns string, port uint16, healthPath string) *clusterv3.Cluster {
-	// The active health check probes the app readiness path over HTTP/1.1
-	// (delegated liveness); h2 app ports are still liveness-probed on the
-	// primary port, so the probe cluster stays HTTP/1.1.
+func NewAppHealthProbeCluster(name, netns string, port uint16, healthPath string, tcp bool) *clusterv3.Cluster {
+	// The active health check probes the app's readiness (delegated liveness):
+	// HTTP/1.1 GET <healthPath> for HTTP/gRPC services, or a raw TCP connect for
+	// non-HTTP (TCP floor) services, which have no HTTP readiness surface. h2 app
+	// ports are still liveness-probed on the primary port, so HTTP probes stay HTTP/1.1.
 	c := NewAppCluster(name, netns, port, false)
 	// MUST stay per-pod (clear the inherited collapse): the health_check
 	// filter answers per-pod readiness by reading THIS cluster's
@@ -222,30 +223,38 @@ func NewAppHealthProbeCluster(name, netns string, port uint16, healthPath string
 	// outage). A shared alt_stat_name would merge every pod's membership into
 	// one gauge and one unhealthy pod would fail every pod's readiness.
 	c.AltStatName = ""
-	c.HealthChecks = []*corev3.HealthCheck{
-		{
-			Timeout:            durationpb.New(1 * time.Second),
-			Interval:           durationpb.New(5 * time.Second),
-			HealthyThreshold:   wrapperspb.UInt32(1),
-			UnhealthyThreshold: wrapperspb.UInt32(2),
-			// This cluster never carries routed traffic (see above), so without
-			// these Envoy applies its no-traffic HC cadence (default 60s) to every
-			// check after the immediate first one — measured as a 30-62s
-			// endpoint-promotion delay per new pod (e2e 2026-06-11): the first
-			// probe races app startup, loses, and the retry waits out the
-			// no-traffic interval. The healthy variant likewise delayed *demotion*
-			// of a dying app by up to 60s. Probing localhost is cheap; keep the
-			// configured cadence regardless of traffic.
-			NoTrafficInterval:        durationpb.New(5 * time.Second),
-			NoTrafficHealthyInterval: durationpb.New(5 * time.Second),
-			HealthChecker: &corev3.HealthCheck_HttpHealthCheck_{
-				HttpHealthCheck: &corev3.HealthCheck_HttpHealthCheck{
-					Host:            appHealthCheckHost,
-					Path:            healthPath,
-					CodecClientType: typev3.CodecClientType_HTTP1,
-				},
-			},
-		},
+	hc := &corev3.HealthCheck{
+		Timeout:            durationpb.New(1 * time.Second),
+		Interval:           durationpb.New(5 * time.Second),
+		HealthyThreshold:   wrapperspb.UInt32(1),
+		UnhealthyThreshold: wrapperspb.UInt32(2),
+		// This cluster never carries routed traffic (see above), so without
+		// these Envoy applies its no-traffic HC cadence (default 60s) to every
+		// check after the immediate first one — measured as a 30-62s
+		// endpoint-promotion delay per new pod (e2e 2026-06-11): the first
+		// probe races app startup, loses, and the retry waits out the
+		// no-traffic interval. The healthy variant likewise delayed *demotion*
+		// of a dying app by up to 60s. Probing localhost is cheap; keep the
+		// configured cadence regardless of traffic.
+		NoTrafficInterval:        durationpb.New(5 * time.Second),
+		NoTrafficHealthyInterval: durationpb.New(5 * time.Second),
 	}
+	if tcp {
+		// Connect-only (empty send/receive): a successful TCP connect to the app
+		// port = healthy. This replaces the inapplicable HTTP probe for TCP-floor
+		// services so they get real liveness instead of being assumed healthy.
+		hc.HealthChecker = &corev3.HealthCheck_TcpHealthCheck_{
+			TcpHealthCheck: &corev3.HealthCheck_TcpHealthCheck{},
+		}
+	} else {
+		hc.HealthChecker = &corev3.HealthCheck_HttpHealthCheck_{
+			HttpHealthCheck: &corev3.HealthCheck_HttpHealthCheck{
+				Host:            appHealthCheckHost,
+				Path:            healthPath,
+				CodecClientType: typev3.CodecClientType_HTTP1,
+			},
+		}
+	}
+	c.HealthChecks = []*corev3.HealthCheck{hc}
 	return c
 }

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -66,7 +66,10 @@ func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string, 
 	// liveness) on the primary port; keeping the HC off app_<pod> avoids gating
 	// the delivery path. Liveness stays pod-level (primary port), not per-port.
 	primary := AppPortFromPod(cniPod)
-	healthCluster = NewAppHealthProbeCluster(HealthProbeClusterName(cniPod), netns, primary, AppHealthPathFromPod(cniPod))
+	// TCP-floor (non-HTTP) services have no HTTP readiness surface: the probe is a
+	// raw TCP connect to the app port instead of an HTTP GET.
+	isTCP := cniPod.GetAnnotations()[constants.AnnotationEndpointProtocol] == constants.ProtocolTCP
+	healthCluster = NewAppHealthProbeCluster(HealthProbeClusterName(cniPod), netns, primary, AppHealthPathFromPod(cniPod), isTCP)
 
 	return inbound, outbound, appClusters, healthCluster, nil
 }

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -75,6 +75,25 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 	}
 }
 
+// TestNewAppHealthProbeCluster_CheckerType verifies the active health checker is a
+// raw TCP connect for TCP-floor services and an HTTP GET otherwise (proposal 018
+// Phase 3b TCP liveness).
+func TestNewAppHealthProbeCluster_CheckerType(t *testing.T) {
+	httpC := NewAppHealthProbeCluster("health_p", "/var/run/netns/x", 8080, "/-/-/ready", false)
+	require.Len(t, httpC.GetHealthChecks(), 1)
+	require.NotNil(t, httpC.GetHealthChecks()[0].GetHttpHealthCheck(), "HTTP service: HTTP health check")
+	assert.Nil(t, httpC.GetHealthChecks()[0].GetTcpHealthCheck())
+	assert.Equal(t, "/-/-/ready", httpC.GetHealthChecks()[0].GetHttpHealthCheck().GetPath())
+
+	tcpC := NewAppHealthProbeCluster("health_p", "/var/run/netns/x", 9000, "/-/-/ready", true)
+	require.Len(t, tcpC.GetHealthChecks(), 1)
+	require.NotNil(t, tcpC.GetHealthChecks()[0].GetTcpHealthCheck(), "TCP service: connect-only TCP health check")
+	assert.Nil(t, tcpC.GetHealthChecks()[0].GetHttpHealthCheck())
+	// Connect-only: no send/receive payloads.
+	assert.Empty(t, tcpC.GetHealthChecks()[0].GetTcpHealthCheck().GetSend())
+	assert.Empty(t, tcpC.GetHealthChecks()[0].GetTcpHealthCheck().GetReceive())
+}
+
 func TestGenerateOutboundHTTPListener(t *testing.T) {
 	tests := []struct {
 		name                     string


### PR DESCRIPTION
Replaces the #305 stopgap (force TCP endpoints HEALTHY) with real liveness. The whole health pipeline is protocol-agnostic above the probe — agent HTTP GET → health gateway → reflects the per-pod probe cluster's membership. Only the active checker changes: TCP services get a connect-only `TcpHealthCheck` to `127.0.0.1:<appPort>` instead of an HTTP GET; `liveness.go` drops the #305 skip. A dead TCP app is now detected. 🤖 Generated with [Claude Code](https://claude.com/claude-code)