### PR TITLE
fix(agent): GatewayClass status never written — MergeConditions changed-detection aliasing

### DIFF
--- a/agent/internal/gatewaystatus/status.go
+++ b/agent/internal/gatewaystatus/status.go
@@ -112,16 +112,20 @@ func MergeConditions(
 	result = make([]metav1.Condition, len(current))
 	copy(result, current)
 	for _, c := range conditions {
-		before := meta.FindStatusCondition(result, c.Type)
-		meta.SetStatusCondition(&result, metav1.Condition{
+		// meta.SetStatusCondition mutates the matching element in place and returns
+		// whether anything changed; use that return directly. The previous
+		// before/after comparison captured `before` as a pointer INTO result, which
+		// SetStatusCondition then mutates in place — so before and after aliased the
+		// same (already-updated) element and a transition on a PRE-EXISTING condition
+		// (e.g. a GatewayClass that ships a default Accepted=Unknown/Pending
+		// condition) was misdetected as no-change, and the status was never written.
+		if meta.SetStatusCondition(&result, metav1.Condition{
 			Type:               c.Type,
 			Status:             c.Status,
 			Reason:             c.Reason,
 			Message:            c.Message,
 			ObservedGeneration: observedGeneration,
-		})
-		after := meta.FindStatusCondition(result, c.Type)
-		if before == nil || !conditionSemanticEqual(*before, *after) {
+		}) {
 			changed = true
 		}
 	}

--- a/agent/internal/gatewaystatus/status_test.go
+++ b/agent/internal/gatewaystatus/status_test.go
@@ -83,3 +83,38 @@ func TestMergeConditions(t *testing.T) {
 	})
 	assert.False(t, changed2)
 }
+
+// TestMergeConditions_TransitionOnPreExisting is the GatewayClass regression: a
+// CRD ships a default Accepted=Unknown/Pending condition, and the controller must
+// flip it to True. The previous before/after pointer comparison aliased the same
+// (already-mutated) element, so the transition was misdetected as no-change and the
+// status was never written. The merge MUST report changed for a status flip.
+func TestMergeConditions_TransitionOnPreExisting(t *testing.T) {
+	current := []metav1.Condition{{
+		Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+		Status:  metav1.ConditionUnknown,
+		Reason:  "Pending",
+		Message: "Waiting for controller",
+	}}
+	result, changed := MergeConditions(current, 2, Condition{
+		Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayv1.GatewayClassReasonAccepted),
+		Message: "GatewayClass accepted by the aether edge controller",
+	})
+	require.True(t, changed, "Unknown/Pending -> True must report changed")
+	acc := meta.FindStatusCondition(result, string(gatewayv1.GatewayClassConditionStatusAccepted))
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionTrue, acc.Status)
+	assert.Equal(t, string(gatewayv1.GatewayClassReasonAccepted), acc.Reason)
+	assert.Equal(t, int64(2), acc.ObservedGeneration)
+
+	// A reason-only change on a pre-existing condition is also a real change.
+	_, changed2 := MergeConditions(result, 2, Condition{
+		Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  "Reconciled",
+		Message: "GatewayClass accepted by the aether edge controller",
+	})
+	assert.True(t, changed2, "reason change on a pre-existing condition must report changed")
+}


### PR DESCRIPTION
The edge GatewayClass `aether` stayed `Accepted=Unknown(Pending)` (epoch-zero lastTransitionTime) despite `writeGatewayClassStatus` running every reconcile. Root cause was **not** the APIReader Get — it's an aliasing bug in `MergeConditions`: `meta.FindStatusCondition` returns a pointer **into** the slice and `meta.SetStatusCondition` mutates it **in place**, so `before`/`after` aliased the same already-updated struct → `changed` stayed false for any **pre-existing** condition. Gateways/Routes start empty (worked); the GatewayClass ships a default Pending condition, so its Unknown→True flip was misdetected as no-change and `if !changed { return }` skipped the write. Fix: use `meta.SetStatusCondition`'s own correct `changed` return. Adds a regression test (fails on old code). Verified on talos. 🤖 Generated with [Claude Code](https://claude.com/claude-code)