### PR TITLE
feat(gamma,edge): gRPC RegularExpression method match + header-modifier filters

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -297,12 +297,13 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 		if p := firstBackendPort(rule.BackendRefs); p != 0 {
 			port = p
 		}
+		mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
 		if len(rule.Matches) == 0 {
-			vh.Routes = append(vh.Routes, cache.Route{Prefix: "/", Service: backend, Port: port})
+			vh.Routes = append(vh.Routes, cache.Route{Prefix: "/", Service: backend, Port: port, HeaderMutation: mutation})
 			continue
 		}
 		for _, m := range rule.Matches {
-			route := cache.Route{Service: backend, Port: port}
+			route := cache.Route{Service: backend, Port: port, HeaderMutation: mutation}
 			if m.Path != nil && m.Path.Value != nil {
 				switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
 				case gatewayv1.PathMatchExact:
@@ -463,4 +464,47 @@ func ptrType(p *gatewayv1.PathMatchType, def gatewayv1.PathMatchType) gatewayv1.
 		return def
 	}
 	return *p
+}
+
+// buildEdgeHTTPHeaderMutation merges all RequestHeaderModifier and
+// ResponseHeaderModifier filters in an edge HTTPRoute rule's filter list into a
+// single GammaHeaderMutation. Unknown filter types (redirect, rewrite, mirror)
+// are silently skipped. Returns nil when no modifier filter is present.
+func buildEdgeHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaHeaderMutation {
+	var m *proxy.GammaHeaderMutation
+	ensure := func() {
+		if m == nil {
+			m = &proxy.GammaHeaderMutation{}
+		}
+	}
+	for _, f := range filters {
+		switch f.Type {
+		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+			if f.RequestHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			for _, h := range f.RequestHeaderModifier.Set {
+				m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			for _, h := range f.RequestHeaderModifier.Add {
+				m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
+		case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+			if f.ResponseHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			for _, h := range f.ResponseHeaderModifier.Set {
+				m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			for _, h := range f.ResponseHeaderModifier.Add {
+				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
+			// Redirect, rewrite, mirror, extension: future items, silently skipped.
+		}
+	}
+	return m
 }

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -203,3 +203,101 @@ func TestBuildVirtualHost_ParentRefsRefactored(t *testing.T) {
 	hr.Spec.ParentRefs = []gatewayv1.ParentReference{{Name: "edge-gw"}}
 	assert.True(t, attachedToOurGateway(hr.Spec.ParentRefs, ours))
 }
+
+// TestBuildVirtualHost_RequestHeaderModifier: set/add/remove request header filters
+// on an edge HTTPRoute rule are projected into cache.Route.HeaderMutation.
+func TestBuildVirtualHost_RequestHeaderModifier(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/api"),
+			BackendRefs: backend("svc-1", 0),
+			Filters: []gatewayv1.HTTPRouteFilter{
+				{
+					Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+					RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+						Set:    []gatewayv1.HTTPHeader{{Name: "x-env", Value: "prod"}},
+						Add:    []gatewayv1.HTTPHeader{{Name: "x-trace", Value: "1"}},
+						Remove: []string{"x-debug"},
+					},
+				},
+			},
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+
+	require.Len(t, vh.Routes, 1)
+	m := vh.Routes[0].HeaderMutation
+	require.NotNil(t, m)
+	require.Len(t, m.SetRequest, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-env", Value: "prod"}, m.SetRequest[0])
+	require.Len(t, m.AddRequest, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-trace", Value: "1"}, m.AddRequest[0])
+	require.Len(t, m.RemoveRequest, 1)
+	assert.Equal(t, "x-debug", m.RemoveRequest[0])
+	assert.Empty(t, m.SetResponse, "no response modifiers in this rule")
+}
+
+// TestBuildVirtualHost_ResponseHeaderModifier: response header modifier filter is
+// projected into cache.Route.HeaderMutation.SetResponse / RemoveResponse.
+func TestBuildVirtualHost_ResponseHeaderModifier(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchExact, "/health"),
+			BackendRefs: backend("svc-1", 0),
+			Filters: []gatewayv1.HTTPRouteFilter{
+				{
+					Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+					ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+						Set:    []gatewayv1.HTTPHeader{{Name: "x-served-by", Value: "aether"}},
+						Remove: []string{"x-internal"},
+					},
+				},
+			},
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+
+	require.Len(t, vh.Routes, 1)
+	m := vh.Routes[0].HeaderMutation
+	require.NotNil(t, m)
+	assert.Empty(t, m.SetRequest, "no request modifiers")
+	require.Len(t, m.SetResponse, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-served-by", Value: "aether"}, m.SetResponse[0])
+	require.Len(t, m.RemoveResponse, 1)
+	assert.Equal(t, "x-internal", m.RemoveResponse[0])
+}
+
+// TestBuildVirtualHost_UnknownFilterSkipped: non-modifier filters produce a nil
+// HeaderMutation (redirect/rewrite are future items, must not panic).
+func TestBuildVirtualHost_UnknownFilterSkipped(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/"),
+			BackendRefs: backend("svc-1", 0),
+			Filters: []gatewayv1.HTTPRouteFilter{
+				{Type: gatewayv1.HTTPRouteFilterRequestRedirect},
+			},
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+	require.Len(t, vh.Routes, 1)
+	assert.Nil(t, vh.Routes[0].HeaderMutation, "unknown filter must not produce a mutation")
+}
+
+// TestBuildVirtualHost_NoMutationWhenNoFilters: a route with no filters has a nil
+// HeaderMutation (regression guard against allocating empty structs).
+func TestBuildVirtualHost_NoMutationWhenNoFilters(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/"),
+			BackendRefs: backend("svc-1", 0),
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+	require.Len(t, vh.Routes, 1)
+	assert.Nil(t, vh.Routes[0].HeaderMutation)
+}

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -257,7 +257,97 @@ func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule) proxy.GammaRo
 		}
 		gr.Matches = append(gr.Matches, gm)
 	}
+	gr.HeaderMutation = buildHTTPHeaderMutation(rule.Filters)
 	return gr
+}
+
+// buildHTTPHeaderMutation merges all RequestHeaderModifier and
+// ResponseHeaderModifier filters in an HTTPRoute rule's filter list into a single
+// GammaHeaderMutation. Unknown filter types are silently skipped so future
+// filter types (redirect, rewrite, mirror) can be added without breaking this
+// path. Returns nil when no modifier filter is present.
+func buildHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaHeaderMutation {
+	var m *proxy.GammaHeaderMutation
+	ensure := func() {
+		if m == nil {
+			m = &proxy.GammaHeaderMutation{}
+		}
+	}
+	for _, f := range filters {
+		switch f.Type {
+		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+			if f.RequestHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			for _, h := range f.RequestHeaderModifier.Set {
+				m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			for _, h := range f.RequestHeaderModifier.Add {
+				m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
+		case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+			if f.ResponseHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			for _, h := range f.ResponseHeaderModifier.Set {
+				m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			for _, h := range f.ResponseHeaderModifier.Add {
+				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
+			// Redirect, rewrite, mirror, and extension filter types are not handled
+			// here — they are future items and are silently skipped.
+		}
+	}
+	return m
+}
+
+// buildGRPCHeaderMutation merges all RequestHeaderModifier and
+// ResponseHeaderModifier filters in a GRPCRoute rule's filter list into a single
+// GammaHeaderMutation. The filter shape is identical to the HTTP variant
+// (HTTPHeaderFilter is shared); unknown types are silently skipped.
+// Returns nil when no modifier filter is present.
+func buildGRPCHeaderMutation(filters []gatewayv1.GRPCRouteFilter) *proxy.GammaHeaderMutation {
+	var m *proxy.GammaHeaderMutation
+	ensure := func() {
+		if m == nil {
+			m = &proxy.GammaHeaderMutation{}
+		}
+	}
+	for _, f := range filters {
+		switch f.Type {
+		case gatewayv1.GRPCRouteFilterRequestHeaderModifier:
+			if f.RequestHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			for _, h := range f.RequestHeaderModifier.Set {
+				m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			for _, h := range f.RequestHeaderModifier.Add {
+				m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
+		case gatewayv1.GRPCRouteFilterResponseHeaderModifier:
+			if f.ResponseHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			for _, h := range f.ResponseHeaderModifier.Set {
+				m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			for _, h := range f.ResponseHeaderModifier.Add {
+				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+			}
+			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
+			// Mirror and extension filter types are future items; skip silently.
+		}
+	}
+	return m
 }
 
 // buildGammaRouteFromGRPC translates a GRPCRouteRule into the same GammaRoute
@@ -295,13 +385,31 @@ func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule) proxy
 			if m.Method.Method != nil {
 				method = *m.Method.Method
 			}
-			// Only the Exact method-match type maps to a literal path (the
-			// GammaMatch vocabulary has no regex). svc+method = exact, svc = prefix.
-			exactType := m.Method.Type == nil || *m.Method.Type == gatewayv1.GRPCMethodMatchExact
-			if exactType && svc != "" && method != "" {
-				gm.Exact = fmt.Sprintf("/%s/%s", svc, method)
-			} else if exactType && svc != "" {
-				gm.Prefix = fmt.Sprintf("/%s/", svc)
+			matchType := gatewayv1.GRPCMethodMatchExact
+			if m.Method.Type != nil {
+				matchType = *m.Method.Type
+			}
+			switch matchType {
+			case gatewayv1.GRPCMethodMatchExact:
+				// svc+method = exact /svc/method; svc-only = prefix /svc/.
+				if svc != "" && method != "" {
+					gm.Exact = fmt.Sprintf("/%s/%s", svc, method)
+				} else if svc != "" {
+					gm.Prefix = fmt.Sprintf("/%s/", svc)
+				}
+			case gatewayv1.GRPCMethodMatchRegularExpression:
+				// Build a /<serviceRegex>/<methodRegex> safe_regex path. When a
+				// component is unset, use ".*" to match any value in that segment,
+				// mirroring the Exact service-only → prefix semantics.
+				svcPart := svc
+				if svcPart == "" {
+					svcPart = "[^/]+"
+				}
+				methodPart := method
+				if methodPart == "" {
+					methodPart = "[^/]+"
+				}
+				gm.Regex = fmt.Sprintf("/%s/%s", svcPart, methodPart)
 			}
 		}
 		for _, h := range m.Headers {
@@ -309,5 +417,6 @@ func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule) proxy
 		}
 		gr.Matches = append(gr.Matches, gm)
 	}
+	gr.HeaderMutation = buildGRPCHeaderMutation(rule.Filters)
 	return gr
 }

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -192,3 +192,159 @@ func TestBuildGammaRouteFromGRPC(t *testing.T) {
 	assert.Equal(t, "svc-2.aether.internal", gr.Backends[0].Cluster)
 	assert.Equal(t, uint32(7), gr.Backends[0].Weight)
 }
+
+// TestBuildGammaRouteFromGRPC_RegularExpression: GRPCMethodMatchRegularExpression
+// type produces a safe_regex path in GammaMatch.Regex.
+func TestBuildGammaRouteFromGRPC_RegularExpression(t *testing.T) {
+	r := &Reconciler{MeshDomain: "aether.internal"}
+	regexType := gatewayv1.GRPCMethodMatchRegularExpression
+
+	tests := []struct {
+		name      string
+		match     gatewayv1.GRPCMethodMatch
+		wantRegex string
+	}{
+		{
+			name:      "service+method regex",
+			match:     gatewayv1.GRPCMethodMatch{Type: &regexType, Service: ptr("foo\\..*"), Method: ptr("Get.*")},
+			wantRegex: "/foo\\..*/Get.*",
+		},
+		{
+			name:      "service-only regex",
+			match:     gatewayv1.GRPCMethodMatch{Type: &regexType, Service: ptr("my\\.svc")},
+			wantRegex: "/my\\.svc/[^/]+",
+		},
+		{
+			name:      "method-only regex",
+			match:     gatewayv1.GRPCMethodMatch{Type: &regexType, Method: ptr("Watch.*")},
+			wantRegex: "/[^/]+/Watch.*",
+		},
+		{
+			name:      "both unset regex",
+			match:     gatewayv1.GRPCMethodMatch{Type: &regexType},
+			wantRegex: "/[^/]+/[^/]+",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rule := gatewayv1.GRPCRouteRule{
+				Matches: []gatewayv1.GRPCRouteMatch{{Method: &tc.match}},
+				BackendRefs: []gatewayv1.GRPCBackendRef{
+					{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc"}}},
+				},
+			}
+			gr := r.buildGammaRouteFromGRPC(rule)
+			require.Len(t, gr.Matches, 1)
+			assert.Equal(t, tc.wantRegex, gr.Matches[0].Regex, "Regex field")
+			assert.Empty(t, gr.Matches[0].Exact, "Exact must be empty for regex match")
+			assert.Empty(t, gr.Matches[0].Prefix, "Prefix must be empty for regex match")
+		})
+	}
+}
+
+// TestBuildGammaRoute_RequestHeaderModifier: set/add/remove request header
+// filters on an HTTPRoute rule are projected into the GammaHeaderMutation.
+func TestBuildGammaRoute_RequestHeaderModifier(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	rule := gatewayv1.HTTPRouteRule{
+		Filters: []gatewayv1.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set:    []gatewayv1.HTTPHeader{{Name: "x-env", Value: "prod"}},
+					Add:    []gatewayv1.HTTPHeader{{Name: "x-trace", Value: "1"}},
+					Remove: []string{"x-debug"},
+				},
+			},
+		},
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
+		},
+	}
+	gr := r.buildGammaRoute(rule)
+
+	require.NotNil(t, gr.HeaderMutation)
+	require.Len(t, gr.HeaderMutation.SetRequest, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-env", Value: "prod"}, gr.HeaderMutation.SetRequest[0])
+	require.Len(t, gr.HeaderMutation.AddRequest, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-trace", Value: "1"}, gr.HeaderMutation.AddRequest[0])
+	require.Len(t, gr.HeaderMutation.RemoveRequest, 1)
+	assert.Equal(t, "x-debug", gr.HeaderMutation.RemoveRequest[0])
+	assert.Empty(t, gr.HeaderMutation.SetResponse)
+}
+
+// TestBuildGammaRoute_ResponseHeaderModifier: set/add/remove response header
+// filters on an HTTPRoute rule are projected into the GammaHeaderMutation.
+func TestBuildGammaRoute_ResponseHeaderModifier(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	rule := gatewayv1.HTTPRouteRule{
+		Filters: []gatewayv1.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set:    []gatewayv1.HTTPHeader{{Name: "x-served-by", Value: "aether"}},
+					Remove: []string{"x-internal"},
+				},
+			},
+		},
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
+		},
+	}
+	gr := r.buildGammaRoute(rule)
+
+	require.NotNil(t, gr.HeaderMutation)
+	assert.Empty(t, gr.HeaderMutation.SetRequest, "no request headers")
+	require.Len(t, gr.HeaderMutation.SetResponse, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-served-by", Value: "aether"}, gr.HeaderMutation.SetResponse[0])
+	require.Len(t, gr.HeaderMutation.RemoveResponse, 1)
+	assert.Equal(t, "x-internal", gr.HeaderMutation.RemoveResponse[0])
+}
+
+// TestBuildGammaRoute_UnknownFilterSkipped: non-modifier filters (e.g. redirect)
+// are silently ignored; HeaderMutation is nil when only unknown filters are present.
+func TestBuildGammaRoute_UnknownFilterSkipped(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	rule := gatewayv1.HTTPRouteRule{
+		Filters: []gatewayv1.HTTPRouteFilter{
+			{Type: gatewayv1.HTTPRouteFilterRequestRedirect},
+		},
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
+		},
+	}
+	gr := r.buildGammaRoute(rule)
+	assert.Nil(t, gr.HeaderMutation, "unknown filter type must not produce a mutation")
+}
+
+// TestBuildGammaRouteFromGRPC_HeaderModifier: GRPCRoute request/response header
+// modifier filters are projected into GammaHeaderMutation.
+func TestBuildGammaRouteFromGRPC_HeaderModifier(t *testing.T) {
+	r := &Reconciler{MeshDomain: "aether.internal"}
+	rule := gatewayv1.GRPCRouteRule{
+		Filters: []gatewayv1.GRPCRouteFilter{
+			{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{{Name: "x-grpc-env", Value: "prod"}},
+				},
+			},
+			{
+				Type: gatewayv1.GRPCRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Remove: []string{"x-grpc-debug"},
+				},
+			},
+		},
+		BackendRefs: []gatewayv1.GRPCBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-2"}}},
+		},
+	}
+	gr := r.buildGammaRouteFromGRPC(rule)
+
+	require.NotNil(t, gr.HeaderMutation)
+	require.Len(t, gr.HeaderMutation.SetRequest, 1)
+	assert.Equal(t, proxy.GammaHeaderKV{Name: "x-grpc-env", Value: "prod"}, gr.HeaderMutation.SetRequest[0])
+	require.Len(t, gr.HeaderMutation.RemoveResponse, 1)
+	assert.Equal(t, "x-grpc-debug", gr.HeaderMutation.RemoveResponse[0])
+}

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -27,11 +27,14 @@ type VirtualHost struct {
 
 // Route is one path-match -> backend rule within a VirtualHost. Exactly one of
 // Prefix/Exact is set; Port 0 means the service's default port.
+// HeaderMutation carries the merged request/response header modifier filters for
+// this rule (nil = no header mutations).
 type Route struct {
-	Prefix  string
-	Exact   string
-	Service string
-	Port    uint32
+	Prefix         string
+	Exact          string
+	Service        string
+	Port           uint32
+	HeaderMutation *proxy.GammaHeaderMutation
 }
 
 // EdgeTLSCert is raw certificate material for an edge downstream TLS secret,
@@ -132,7 +135,7 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 				continue
 			}
 			cluster := c.edgeClusterNameLocked(r.Service, r.Port)
-			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster))
+			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation))
 		}
 		if len(routes) == 0 {
 			continue
@@ -276,6 +279,54 @@ func (c *SnapshotCache) edgeTCPListeners() []types.Resource {
 	return out
 }
 
+// equalRoutes reports whether two Route slices are content-equal. Route carries
+// a *GammaHeaderMutation pointer, so we cannot rely on slices.Equal (pointer
+// identity) — we need a deep comparison.
+func equalRoutes(a, b []Route) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		ra, rb := a[i], b[i]
+		if ra.Prefix != rb.Prefix || ra.Exact != rb.Exact || ra.Service != rb.Service || ra.Port != rb.Port {
+			return false
+		}
+		if !equalHeaderMutation(ra.HeaderMutation, rb.HeaderMutation) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalHeaderMutation reports content equality for two *GammaHeaderMutation
+// values. Both nil = equal; one nil = not equal; otherwise fields are compared.
+func equalHeaderMutation(a, b *proxy.GammaHeaderMutation) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return slices.Equal(a.RemoveRequest, b.RemoveRequest) &&
+		slices.Equal(a.RemoveResponse, b.RemoveResponse) &&
+		equalHeaderKVs(a.SetRequest, b.SetRequest) &&
+		equalHeaderKVs(a.AddRequest, b.AddRequest) &&
+		equalHeaderKVs(a.SetResponse, b.SetResponse) &&
+		equalHeaderKVs(a.AddResponse, b.AddResponse)
+}
+
+func equalHeaderKVs(a, b []proxy.GammaHeaderKV) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // equalVirtualHosts reports whether two virtual-host slices are identical (order
 // and contents), so a no-op SetVirtualHosts call skips a snapshot rebuild.
 func equalVirtualHosts(a, b []VirtualHost) bool {
@@ -285,7 +336,7 @@ func equalVirtualHosts(a, b []VirtualHost) bool {
 	for i := range a {
 		if a[i].TLSSecret != b[i].TLSSecret ||
 			!slices.Equal(a[i].Hosts, b[i].Hosts) ||
-			!slices.Equal(a[i].Routes, b[i].Routes) {
+			!equalRoutes(a[i].Routes, b[i].Routes) {
 			return false
 		}
 	}

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -67,9 +67,12 @@ func equalGammaRoute(a, b proxy.GammaRoute) bool {
 	if timeoutNanos(a) != timeoutNanos(b) {
 		return false
 	}
+	if !equalGammaHeaderMutation(a.HeaderMutation, b.HeaderMutation) {
+		return false
+	}
 	for i := range a.Matches {
 		ma, mb := a.Matches[i], b.Matches[i]
-		if ma.Prefix != mb.Prefix || ma.Exact != mb.Exact || len(ma.Headers) != len(mb.Headers) {
+		if ma.Prefix != mb.Prefix || ma.Exact != mb.Exact || ma.Regex != mb.Regex || len(ma.Headers) != len(mb.Headers) {
 			return false
 		}
 		for j := range ma.Headers {
@@ -80,6 +83,54 @@ func equalGammaRoute(a, b proxy.GammaRoute) bool {
 	}
 	for i := range a.Backends {
 		if a.Backends[i] != b.Backends[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// equalGammaHeaderMutation compares two *GammaHeaderMutation values for content
+// equality. Used by the gamma route equality check to avoid constant snapshot
+// rebuilds when the reconciler allocates new (but equivalent) mutation structs.
+func equalGammaHeaderMutation(a, b *proxy.GammaHeaderMutation) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	if len(a.SetRequest) != len(b.SetRequest) || len(a.AddRequest) != len(b.AddRequest) ||
+		len(a.RemoveRequest) != len(b.RemoveRequest) || len(a.SetResponse) != len(b.SetResponse) ||
+		len(a.AddResponse) != len(b.AddResponse) || len(a.RemoveResponse) != len(b.RemoveResponse) {
+		return false
+	}
+	for i := range a.SetRequest {
+		if a.SetRequest[i] != b.SetRequest[i] {
+			return false
+		}
+	}
+	for i := range a.AddRequest {
+		if a.AddRequest[i] != b.AddRequest[i] {
+			return false
+		}
+	}
+	for i := range a.RemoveRequest {
+		if a.RemoveRequest[i] != b.RemoveRequest[i] {
+			return false
+		}
+	}
+	for i := range a.SetResponse {
+		if a.SetResponse[i] != b.SetResponse[i] {
+			return false
+		}
+	}
+	for i := range a.AddResponse {
+		if a.AddResponse[i] != b.AddResponse[i] {
+			return false
+		}
+	}
+	for i := range a.RemoveResponse {
+		if a.RemoveResponse[i] != b.RemoveResponse[i] {
 			return false
 		}
 	}

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -247,13 +247,16 @@ func buildEdgeRedirectRouteConfig() *routev3.RouteConfiguration {
 // BuildEdgeRoute builds one Envoy route for the edge: a path match forwarding to
 // the named cluster with the outbound retry policy. Exactly one of prefix/exact
 // is non-empty (exact takes precedence if both are set). Prefix "/" matches all.
-func BuildEdgeRoute(prefix, exact, cluster string) *routev3.Route {
+// mutation applies RequestHeaderModifier / ResponseHeaderModifier at the route
+// level; nil mutation = no header mutations.
+func BuildEdgeRoute(prefix, exact, cluster string, mutation *GammaHeaderMutation) *routev3.Route {
 	match := &routev3.RouteMatch{}
 	if exact != "" {
 		match.PathSpecifier = &routev3.RouteMatch_Path{Path: exact}
 	} else {
 		match.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: prefix}
 	}
+	reqAdd, respAdd, reqRemove, respRemove := headerMutationFields(mutation)
 	return &routev3.Route{
 		Match: match,
 		Action: &routev3.Route_Route{
@@ -262,6 +265,10 @@ func BuildEdgeRoute(prefix, exact, cluster string) *routev3.Route {
 				RetryPolicy:      outboundRetryPolicy(),
 			},
 		},
+		RequestHeadersToAdd:     reqAdd,
+		RequestHeadersToRemove:  reqRemove,
+		ResponseHeadersToAdd:    respAdd,
+		ResponseHeadersToRemove: respRemove,
 	}
 }
 

--- a/agent/internal/xds/proxy/gammaroute_test.go
+++ b/agent/internal/xds/proxy/gammaroute_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"testing"
 
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,4 +54,80 @@ func TestBuildOutboundServiceVirtualHost_Rules(t *testing.T) {
 	assert.Equal(t, "/", vh.Routes[2].GetMatch().GetPrefix())
 
 	_ = routev3.RouteMatch{} // keep import
+}
+
+// TestGammaRouteMatch_Regex: GammaMatch.Regex → Envoy safe_regex path specifier.
+func TestGammaRouteMatch_Regex(t *testing.T) {
+	m := gammaRouteMatch(GammaMatch{Regex: "/foo\\.Bar/Get.*"})
+	sr := m.GetSafeRegex()
+	require.NotNil(t, sr, "regex match must produce a safe_regex path specifier")
+	assert.Equal(t, "/foo\\.Bar/Get.*", sr.GetRegex())
+	// Exact and Prefix specifiers must be absent.
+	assert.Empty(t, m.GetPath(), "Exact must be empty")
+	assert.Empty(t, m.GetPrefix(), "Prefix must be empty")
+}
+
+// TestBuildOutboundServiceVirtualHost_RegexRule: a GammaRoute with a Regex match
+// produces an Envoy route with a safe_regex path specifier.
+func TestBuildOutboundServiceVirtualHost_RegexRule(t *testing.T) {
+	rules := []GammaRoute{
+		{
+			Matches:  []GammaMatch{{Regex: "/foo\\..*/.+"}},
+			Backends: []GammaBackend{{Cluster: "svc-foo.mesh", Weight: 1}},
+		},
+	}
+	vh := BuildOutboundServiceVirtualHost("svc-foo.mesh", []string{"svc-foo.mesh"}, rules)
+	require.GreaterOrEqual(t, len(vh.Routes), 1)
+	r0 := vh.Routes[0]
+	sr := r0.GetMatch().GetSafeRegex()
+	require.NotNil(t, sr, "regex GammaMatch must produce safe_regex in Envoy route")
+	assert.Equal(t, "/foo\\..*/.+", sr.GetRegex())
+}
+
+// TestBuildOutboundServiceVirtualHost_HeaderMutation: request/response header
+// mutations on a GammaRoute are emitted as Envoy route-level header mutations
+// with the correct AppendActions.
+func TestBuildOutboundServiceVirtualHost_HeaderMutation(t *testing.T) {
+	rules := []GammaRoute{
+		{
+			Matches:  []GammaMatch{{Prefix: "/"}},
+			Backends: []GammaBackend{{Cluster: "svc-1.mesh", Weight: 1}},
+			HeaderMutation: &GammaHeaderMutation{
+				SetRequest:     []GammaHeaderKV{{Name: "x-env", Value: "prod"}},
+				AddRequest:     []GammaHeaderKV{{Name: "x-trace", Value: "1"}},
+				RemoveRequest:  []string{"x-debug"},
+				SetResponse:    []GammaHeaderKV{{Name: "x-served-by", Value: "aether"}},
+				RemoveResponse: []string{"x-internal"},
+			},
+		},
+	}
+	vh := BuildOutboundServiceVirtualHost("svc-1.mesh", []string{"svc-1.mesh"}, rules)
+	// rule0 (1 match) + trailing catch-all = 2 routes.
+	require.GreaterOrEqual(t, len(vh.Routes), 1)
+	r0 := vh.Routes[0]
+
+	// Request headers to add: set → OVERWRITE_IF_EXISTS_OR_ADD, add → APPEND_IF_EXISTS_OR_ADD.
+	reqAdd := r0.GetRequestHeadersToAdd()
+	require.Len(t, reqAdd, 2)
+	assert.Equal(t, "x-env", reqAdd[0].GetHeader().GetKey())
+	assert.Equal(t, "prod", reqAdd[0].GetHeader().GetValue())
+	assert.Equal(t, corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD, reqAdd[0].GetAppendAction())
+	assert.Equal(t, "x-trace", reqAdd[1].GetHeader().GetKey())
+	assert.Equal(t, corev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD, reqAdd[1].GetAppendAction())
+
+	// Request headers to remove.
+	assert.Equal(t, []string{"x-debug"}, r0.GetRequestHeadersToRemove())
+
+	// Response headers to add.
+	respAdd := r0.GetResponseHeadersToAdd()
+	require.Len(t, respAdd, 1)
+	assert.Equal(t, "x-served-by", respAdd[0].GetHeader().GetKey())
+	assert.Equal(t, corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD, respAdd[0].GetAppendAction())
+
+	// Response headers to remove.
+	assert.Equal(t, []string{"x-internal"}, r0.GetResponseHeadersToRemove())
+
+	// The trailing catch-all has no mutations.
+	last := vh.Routes[len(vh.Routes)-1]
+	assert.Empty(t, last.GetRequestHeadersToAdd(), "catch-all route must have no header mutations")
 }

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	previoushostsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/retry/host/previous_hosts/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
@@ -164,19 +165,27 @@ func BuildOutboundClusterVirtualHost(clusterName string, domains []string) *rout
 
 // GAMMA east-west L7 routing (proposal 018, Phase 2). A GammaRoute is one resolved
 // HTTPRoute rule: ordered matches forwarding to one or more weighted backend
-// clusters, with an optional timeout. Backends are already resolved to data-plane
-// cluster names (<backend>.<meshDomain>) by the reconciler.
+// clusters, with an optional timeout and header mutations.
+// Backends are already resolved to data-plane cluster names (<backend>.<meshDomain>)
+// by the reconciler.
 type GammaRoute struct {
-	Matches  []GammaMatch
-	Backends []GammaBackend
-	Timeout  *durationpb.Duration
+	Matches        []GammaMatch
+	Backends       []GammaBackend
+	Timeout        *durationpb.Duration
+	HeaderMutation *GammaHeaderMutation
 }
 
-// GammaMatch is one HTTPRoute match: a path (prefix OR exact; empty = prefix "/")
-// and zero or more exact header matches (ANDed).
+// GammaMatch is one HTTPRoute match: a path (prefix OR exact OR regex; empty =
+// prefix "/") and zero or more exact header matches (ANDed). Exactly one of
+// Prefix, Exact, or Regex should be set; Exact takes precedence over Prefix, and
+// Regex is only used when neither Prefix nor Exact is set.
 type GammaMatch struct {
-	Prefix  string
-	Exact   string
+	Prefix string
+	Exact  string
+	// Regex is an RE2 safe_regex path match, used for gRPC RegularExpression method
+	// matches: the reconciler builds a /<serviceRegex>/<methodRegex> pattern and
+	// stores it here. Empty means no regex path match.
+	Regex   string
 	Headers []GammaHeaderMatch
 }
 
@@ -194,11 +203,37 @@ type GammaBackend struct {
 	Weight  uint32
 }
 
+// GammaHeaderMutation describes the header modifications carried by one
+// RequestHeaderModifier or ResponseHeaderModifier filter on a route rule.
+// Multiple filters merge (later set/add entries win for set, remove is additive).
+type GammaHeaderMutation struct {
+	// SetRequest are key/value pairs to set (overwrite) on the request.
+	SetRequest []GammaHeaderKV
+	// AddRequest are key/value pairs to append to the request.
+	AddRequest []GammaHeaderKV
+	// RemoveRequest are header names to strip from the request.
+	RemoveRequest []string
+	// SetResponse are key/value pairs to set (overwrite) on the response.
+	SetResponse []GammaHeaderKV
+	// AddResponse are key/value pairs to append to the response.
+	AddResponse []GammaHeaderKV
+	// RemoveResponse are header names to strip from the response.
+	RemoveResponse []string
+}
+
+// GammaHeaderKV is one header name+value pair for a header mutation action.
+type GammaHeaderKV struct {
+	Name  string
+	Value string
+}
+
 // BuildOutboundServiceVirtualHost builds a service's outbound virtual host enriched
 // with GAMMA rules: each rule's matches become Envoy routes to its weighted backend
-// cluster(s), with the outbound retry policy and an optional timeout. A trailing
-// catch-all routes anything the rules don't match to the service's own cluster
-// (name), so producer rules are additive. With no rules it is the passthrough vhost.
+// cluster(s), with the outbound retry policy, an optional timeout, and optional
+// header mutations (RequestHeaderModifier / ResponseHeaderModifier filters). A
+// trailing catch-all routes anything the rules don't match to the service's own
+// cluster (name), so producer rules are additive. With no rules it is the passthrough
+// vhost.
 func BuildOutboundServiceVirtualHost(name string, domains []string, rules []GammaRoute) *routev3.VirtualHost {
 	if len(rules) == 0 {
 		return BuildOutboundClusterVirtualHost(name, domains)
@@ -210,8 +245,17 @@ func BuildOutboundServiceVirtualHost(name string, domains []string, rules []Gamm
 		if len(matches) == 0 {
 			matches = []GammaMatch{{Prefix: "/"}}
 		}
+		reqAdd, respAdd, reqRemove, respRemove := headerMutationFields(rule.HeaderMutation)
 		for _, m := range matches {
-			routes = append(routes, &routev3.Route{Match: gammaRouteMatch(m), Action: action})
+			r := &routev3.Route{
+				Match:                   gammaRouteMatch(m),
+				Action:                  action,
+				RequestHeadersToAdd:     reqAdd,
+				RequestHeadersToRemove:  reqRemove,
+				ResponseHeadersToAdd:    respAdd,
+				ResponseHeadersToRemove: respRemove,
+			}
+			routes = append(routes, r)
 		}
 	}
 	routes = append(routes, &routev3.Route{
@@ -224,11 +268,56 @@ func BuildOutboundServiceVirtualHost(name string, domains []string, rules []Gamm
 	return &routev3.VirtualHost{Name: name, Domains: domains, Routes: routes}
 }
 
+// headerMutationFields converts a GammaHeaderMutation into the four Envoy route-level
+// header mutation slices. Returns nil slices when mutation is nil or empty (no
+// allocations for the common no-filter case).
+func headerMutationFields(m *GammaHeaderMutation) (
+	reqAdd []*corev3.HeaderValueOption,
+	respAdd []*corev3.HeaderValueOption,
+	reqRemove []string,
+	respRemove []string,
+) {
+	if m == nil {
+		return
+	}
+	for _, kv := range m.SetRequest {
+		reqAdd = append(reqAdd, &corev3.HeaderValueOption{
+			Header:       &corev3.HeaderValue{Key: kv.Name, Value: kv.Value},
+			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		})
+	}
+	for _, kv := range m.AddRequest {
+		reqAdd = append(reqAdd, &corev3.HeaderValueOption{
+			Header:       &corev3.HeaderValue{Key: kv.Name, Value: kv.Value},
+			AppendAction: corev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+		})
+	}
+	reqRemove = append(reqRemove, m.RemoveRequest...)
+	for _, kv := range m.SetResponse {
+		respAdd = append(respAdd, &corev3.HeaderValueOption{
+			Header:       &corev3.HeaderValue{Key: kv.Name, Value: kv.Value},
+			AppendAction: corev3.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+		})
+	}
+	for _, kv := range m.AddResponse {
+		respAdd = append(respAdd, &corev3.HeaderValueOption{
+			Header:       &corev3.HeaderValue{Key: kv.Name, Value: kv.Value},
+			AppendAction: corev3.HeaderValueOption_APPEND_IF_EXISTS_OR_ADD,
+		})
+	}
+	respRemove = append(respRemove, m.RemoveResponse...)
+	return
+}
+
 func gammaRouteMatch(m GammaMatch) *routev3.RouteMatch {
 	rm := &routev3.RouteMatch{}
 	switch {
 	case m.Exact != "":
 		rm.PathSpecifier = &routev3.RouteMatch_Path{Path: m.Exact}
+	case m.Regex != "":
+		rm.PathSpecifier = &routev3.RouteMatch_SafeRegex{
+			SafeRegex: &matcherv3.RegexMatcher{Regex: m.Regex},
+		}
 	case m.Prefix != "":
 		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: m.Prefix}
 	default:

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -31,8 +31,10 @@ e2e-validated on talos (aether 0.41.0).
 | Weighted backends (canary/split) | Supported | `WeightedClusters` |
 | Request timeout | Supported | HTTPRoute `timeouts.request` |
 | Request mirroring | Planned | |
-| Request/response header & redirect filters | Planned | |
-| RegularExpression matches | Partial | gRPC method RegularExpression type is not translated (Exact only) |
+| Request redirect / URL rewrite filters | Planned | |
+| `RequestHeaderModifier` filter | Supported | `set` → `OVERWRITE_IF_EXISTS_OR_ADD`; `add` → `APPEND_IF_EXISTS_OR_ADD`; `remove` → `request_headers_to_remove`; applied at route level on HTTPRoute (edge + GAMMA) and GRPCRoute |
+| `ResponseHeaderModifier` filter | Supported | same shape on `response_headers_to_add` / `response_headers_to_remove`; applied at route level on HTTPRoute (edge + GAMMA) and GRPCRoute |
+| RegularExpression matches | Supported | gRPC method `RegularExpression` type → Envoy `safe_regex` path (`/<serviceRegex>/<methodRegex>`); unset component uses `[^/]+` |
 
 ## Mesh & multi-cluster
 


### PR DESCRIPTION
## Summary

- **Feature 1 — gRPC `RegularExpression` method match**: `GRPCMethodMatchRegularExpression` was previously silently dropped (Exact-only). Now it builds a `/<serviceRegex>/<methodRegex>` RE2 pattern emitted as an Envoy `RouteMatch_SafeRegex` path specifier. An unset Service or Method component defaults to `[^/]+`. Conformance row: **Partial → Supported**.

- **Feature 2 — `RequestHeaderModifier` + `ResponseHeaderModifier` filters**: Implements the two core header-modifier filter types at the Envoy route level (per rule) for HTTPRoute (GAMMA east-west + edge north-south) and GRPCRoute. `set` → `OVERWRITE_IF_EXISTS_OR_ADD`; `add` → `APPEND_IF_EXISTS_OR_ADD`; `remove` → `request_headers_to_remove` / `response_headers_to_remove`. Unknown filter types (redirect, rewrite, mirror) are silently skipped. Conformance rows: **Planned → Supported** for both.

- **Conformance doc** (`docs/conformance/gateway-api-features.md`) updated to reflect the new status.

## Builders touched

| Builder | Change |
|---|---|
| `gamma/reconciler.go` | `buildGammaRoute` calls `buildHTTPHeaderMutation`; `buildGammaRouteFromGRPC` gains regex `switch`/`case` + calls `buildGRPCHeaderMutation` |
| `proxy/route.go` | `GammaMatch.Regex` field; `GammaRoute.HeaderMutation`; `GammaHeaderMutation`/`GammaHeaderKV` types; `gammaRouteMatch` handles `Regex`; `headerMutationFields` helper; `BuildOutboundServiceVirtualHost` emits header mutations per route |
| `proxy/edge.go` | `BuildEdgeRoute` gains `mutation *GammaHeaderMutation` parameter |
| `cache/edge.go` | `cache.Route.HeaderMutation`; `equalRoutes`/`equalHeaderMutation`/`equalHeaderKVs` for deep comparison (avoids snapshot churn); `virtualHostVhosts` passes mutation |
| `cache/gamma.go` | `equalGammaRoute` includes `Regex` and `HeaderMutation`; `equalGammaHeaderMutation` helper |
| `edge/gatewayapi/reconciler.go` | `buildVirtualHost` extracts filters via `buildEdgeHTTPHeaderMutation` per rule |

## Test plan

- `bazel test //agent/internal/gamma/... //agent/internal/xds/proxy/... //agent/internal/edge/... //agent/internal/xds/cache/...` — all 5 targets PASS
- Full suite `bazel test //...` — 60/60 tests PASS

New test cases added:
- `TestBuildGammaRouteFromGRPC_RegularExpression` — 4 sub-cases (svc+method, svc-only, method-only, both unset) verify `GammaMatch.Regex`
- `TestGammaRouteMatch_Regex` — Envoy safe_regex path specifier emitted
- `TestBuildOutboundServiceVirtualHost_RegexRule` — regex GammaRoute → Envoy safe_regex route
- `TestBuildOutboundServiceVirtualHost_HeaderMutation` — set/add/remove req+resp → correct Envoy header mutation fields + AppendActions
- `TestBuildGammaRoute_RequestHeaderModifier` / `_ResponseHeaderModifier` / `_UnknownFilterSkipped` — GAMMA HTTP path
- `TestBuildGammaRouteFromGRPC_HeaderModifier` — GRPCRoute filter path
- `TestBuildVirtualHost_RequestHeaderModifier` / `_ResponseHeaderModifier` / `_UnknownFilterSkipped` / `_NoMutationWhenNoFilters` — edge reconciler path

## e2e ideas

- **gRPC regex match**: deploy a GRPCRoute with `type: RegularExpression` method match (e.g. `service: "helloworld\\.Greeter"`, `method: "Say.*"`) against a gRPC service; verify traffic to `/helloworld.Greeter/SayHello` is routed to the correct backend, while `/other.Svc/Call` falls through to the default.

- **Header modifier**: deploy an HTTPRoute rule with `RequestHeaderModifier` (set `x-env: prod`) and `ResponseHeaderModifier` (remove `x-internal`); `curl -v` the route and confirm the upstream sees `x-env: prod` in the request (via an echo service that reflects headers) and the response does not contain `x-internal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S