### PR TITLE
feat(gamma,edge): HTTPRoute RequestRedirect + URLRewrite filters

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -283,14 +283,21 @@ func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, 
 // the vhost domains, each rule's path match + first backendRef becomes a Route, and
 // the matching Gateway listener cert (by hostname, falling back to a catch-all
 // listener) sets the downstream TLS.
+//
+// Rules with a RequestRedirect filter emit a redirect route (no backend required).
+// Rules with a URLRewrite filter apply host/path rewriting on the forwarding route.
 func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[string]string) cache.VirtualHost {
 	vh := cache.VirtualHost{}
 	for _, h := range hr.Spec.Hostnames {
 		vh.Hosts = append(vh.Hosts, string(h))
 	}
 	for _, rule := range hr.Spec.Rules {
+		redirect := buildHTTPRedirect(rule.Filters)
+		urlRewrite := buildHTTPURLRewrite(rule.Filters)
+
 		backend := firstBackendService(rule.BackendRefs)
-		if backend == "" {
+		// A rule must have either a backend or a redirect to produce a route.
+		if backend == "" && redirect == nil {
 			continue
 		}
 		var port uint32
@@ -299,11 +306,24 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 		}
 		mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
 		if len(rule.Matches) == 0 {
-			vh.Routes = append(vh.Routes, cache.Route{Prefix: "/", Service: backend, Port: port, HeaderMutation: mutation})
+			vh.Routes = append(vh.Routes, cache.Route{
+				Prefix:         "/",
+				Service:        backend,
+				Port:           port,
+				HeaderMutation: mutation,
+				Redirect:       redirect,
+				URLRewrite:     urlRewrite,
+			})
 			continue
 		}
 		for _, m := range rule.Matches {
-			route := cache.Route{Service: backend, Port: port, HeaderMutation: mutation}
+			route := cache.Route{
+				Service:        backend,
+				Port:           port,
+				HeaderMutation: mutation,
+				Redirect:       redirect,
+				URLRewrite:     urlRewrite,
+			}
 			if m.Path != nil && m.Path.Value != nil {
 				switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
 				case gatewayv1.PathMatchExact:
@@ -466,6 +486,77 @@ func ptrType(p *gatewayv1.PathMatchType, def gatewayv1.PathMatchType) gatewayv1.
 	return *p
 }
 
+// buildHTTPRedirect extracts the first RequestRedirect filter and converts it to a
+// GammaRedirect. Returns nil when no redirect filter is present.
+func buildHTTPRedirect(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaRedirect {
+	for _, f := range filters {
+		if f.Type != gatewayv1.HTTPRouteFilterRequestRedirect || f.RequestRedirect == nil {
+			continue
+		}
+		rd := f.RequestRedirect
+		r := &proxy.GammaRedirect{}
+		if rd.Scheme != nil {
+			r.Scheme = *rd.Scheme
+		}
+		if rd.Hostname != nil {
+			r.Hostname = string(*rd.Hostname)
+		}
+		if rd.Port != nil {
+			r.Port = uint32(*rd.Port)
+		}
+		if rd.StatusCode != nil {
+			r.StatusCode = *rd.StatusCode
+		}
+		if rd.Path != nil {
+			switch rd.Path.Type {
+			case gatewayv1.FullPathHTTPPathModifier:
+				if rd.Path.ReplaceFullPath != nil {
+					r.PathType = "ReplaceFullPath"
+					r.PathValue = *rd.Path.ReplaceFullPath
+				}
+			case gatewayv1.PrefixMatchHTTPPathModifier:
+				if rd.Path.ReplacePrefixMatch != nil {
+					r.PathType = "ReplacePrefixMatch"
+					r.PathValue = *rd.Path.ReplacePrefixMatch
+				}
+			}
+		}
+		return r
+	}
+	return nil
+}
+
+// buildHTTPURLRewrite extracts the first URLRewrite filter and converts it to a
+// GammaURLRewrite. Returns nil when no URLRewrite filter is present.
+func buildHTTPURLRewrite(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaURLRewrite {
+	for _, f := range filters {
+		if f.Type != gatewayv1.HTTPRouteFilterURLRewrite || f.URLRewrite == nil {
+			continue
+		}
+		rw := f.URLRewrite
+		r := &proxy.GammaURLRewrite{}
+		if rw.Hostname != nil {
+			r.Hostname = string(*rw.Hostname)
+		}
+		if rw.Path != nil {
+			switch rw.Path.Type {
+			case gatewayv1.FullPathHTTPPathModifier:
+				if rw.Path.ReplaceFullPath != nil {
+					r.PathType = "ReplaceFullPath"
+					r.PathValue = *rw.Path.ReplaceFullPath
+				}
+			case gatewayv1.PrefixMatchHTTPPathModifier:
+				if rw.Path.ReplacePrefixMatch != nil {
+					r.PathType = "ReplacePrefixMatch"
+					r.PathValue = *rw.Path.ReplacePrefixMatch
+				}
+			}
+		}
+		return r
+	}
+	return nil
+}
+
 // buildEdgeHTTPHeaderMutation merges all RequestHeaderModifier and
 // ResponseHeaderModifier filters in an edge HTTPRoute rule's filter list into a
 // single GammaHeaderMutation. Unknown filter types (redirect, rewrite, mirror)
@@ -503,7 +594,7 @@ func buildEdgeHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.Gam
 				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
 			}
 			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
-			// Redirect, rewrite, mirror, extension: future items, silently skipped.
+			// Redirect, rewrite, mirror: handled by dedicated builders above; skip here.
 		}
 	}
 	return m

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -270,7 +270,8 @@ func TestBuildVirtualHost_ResponseHeaderModifier(t *testing.T) {
 }
 
 // TestBuildVirtualHost_UnknownFilterSkipped: non-modifier filters produce a nil
-// HeaderMutation (redirect/rewrite are future items, must not panic).
+// HeaderMutation. A bare RequestRedirect filter (no nil RequestRedirect field)
+// with no backendRef still yields no route (nil filter body → skipped).
 func TestBuildVirtualHost_UnknownFilterSkipped(t *testing.T) {
 	r := &Reconciler{}
 	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
@@ -278,13 +279,110 @@ func TestBuildVirtualHost_UnknownFilterSkipped(t *testing.T) {
 			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/"),
 			BackendRefs: backend("svc-1", 0),
 			Filters: []gatewayv1.HTTPRouteFilter{
+				// nil RequestRedirect body → buildHTTPRedirect returns nil → treated as header modifier skip
 				{Type: gatewayv1.HTTPRouteFilterRequestRedirect},
 			},
 		},
 	})
 	vh := r.buildVirtualHost(hr, nil)
 	require.Len(t, vh.Routes, 1)
-	assert.Nil(t, vh.Routes[0].HeaderMutation, "unknown filter must not produce a mutation")
+	assert.Nil(t, vh.Routes[0].HeaderMutation, "unknown/nil-body filter must not produce a header mutation")
+	assert.Nil(t, vh.Routes[0].Redirect, "nil-body redirect filter must produce nil Redirect")
+}
+
+// TestBuildVirtualHost_RequestRedirect: a RequestRedirect filter on an edge
+// HTTPRoute rule is projected into cache.Route.Redirect and no backend is needed.
+func TestBuildVirtualHost_RequestRedirect(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches: pathMatch(gatewayv1.PathMatchPathPrefix, "/old"),
+			// No backendRefs — redirect filter provides the action.
+			Filters: []gatewayv1.HTTPRouteFilter{
+				{
+					Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+					RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+						Scheme:     ptr("https"),
+						Hostname:   ptr(gatewayv1.PreciseHostname("new.example.com")),
+						StatusCode: ptr(301),
+					},
+				},
+			},
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+	require.Len(t, vh.Routes, 1, "redirect rule with no backend must still produce a route")
+	rt := vh.Routes[0]
+	assert.Equal(t, "/old", rt.Prefix)
+	assert.Empty(t, rt.Service, "redirect route must have no backend service")
+	require.NotNil(t, rt.Redirect)
+	assert.Equal(t, "https", rt.Redirect.Scheme)
+	assert.Equal(t, "new.example.com", rt.Redirect.Hostname)
+	assert.Equal(t, 301, rt.Redirect.StatusCode)
+	assert.Nil(t, rt.URLRewrite, "redirect rule must not set URLRewrite")
+}
+
+// TestBuildVirtualHost_URLRewrite: a URLRewrite filter on an edge HTTPRoute rule is
+// projected into cache.Route.URLRewrite while the backend is still used.
+func TestBuildVirtualHost_URLRewrite(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/api"),
+			BackendRefs: backend("svc-1", 8080),
+			Filters: []gatewayv1.HTTPRouteFilter{
+				{
+					Type: gatewayv1.HTTPRouteFilterURLRewrite,
+					URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+						Hostname: ptr(gatewayv1.PreciseHostname("backend.internal")),
+						Path: &gatewayv1.HTTPPathModifier{
+							Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+							ReplacePrefixMatch: ptr("/v2"),
+						},
+					},
+				},
+			},
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+	require.Len(t, vh.Routes, 1)
+	rt := vh.Routes[0]
+	assert.Equal(t, "/api", rt.Prefix)
+	assert.Equal(t, "svc-1", rt.Service)
+	assert.Equal(t, uint32(8080), rt.Port)
+	require.NotNil(t, rt.URLRewrite)
+	assert.Equal(t, "backend.internal", rt.URLRewrite.Hostname)
+	assert.Equal(t, "ReplacePrefixMatch", rt.URLRewrite.PathType)
+	assert.Equal(t, "/v2", rt.URLRewrite.PathValue)
+	assert.Nil(t, rt.Redirect, "URLRewrite rule must not set Redirect")
+}
+
+// TestBuildVirtualHost_URLRewrite_ReplaceFullPath: URLRewrite with ReplaceFullPath
+// is projected into PathType="ReplaceFullPath".
+func TestBuildVirtualHost_URLRewrite_ReplaceFullPath(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/"),
+			BackendRefs: backend("svc-1", 0),
+			Filters: []gatewayv1.HTTPRouteFilter{
+				{
+					Type: gatewayv1.HTTPRouteFilterURLRewrite,
+					URLRewrite: &gatewayv1.HTTPURLRewriteFilter{
+						Path: &gatewayv1.HTTPPathModifier{
+							Type:            gatewayv1.FullPathHTTPPathModifier,
+							ReplaceFullPath: ptr("/fixed"),
+						},
+					},
+				},
+			},
+		},
+	})
+	vh := r.buildVirtualHost(hr, nil)
+	require.Len(t, vh.Routes, 1)
+	require.NotNil(t, vh.Routes[0].URLRewrite)
+	assert.Equal(t, "ReplaceFullPath", vh.Routes[0].URLRewrite.PathType)
+	assert.Equal(t, "/fixed", vh.Routes[0].URLRewrite.PathValue)
 }
 
 // TestBuildVirtualHost_NoMutationWhenNoFilters: a route with no filters has a nil

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -258,14 +258,15 @@ func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule) proxy.GammaRo
 		gr.Matches = append(gr.Matches, gm)
 	}
 	gr.HeaderMutation = buildHTTPHeaderMutation(rule.Filters)
+	gr.Redirect = buildHTTPRedirect(rule.Filters)
+	gr.URLRewrite = buildHTTPURLRewrite(rule.Filters)
 	return gr
 }
 
 // buildHTTPHeaderMutation merges all RequestHeaderModifier and
 // ResponseHeaderModifier filters in an HTTPRoute rule's filter list into a single
-// GammaHeaderMutation. Unknown filter types are silently skipped so future
-// filter types (redirect, rewrite, mirror) can be added without breaking this
-// path. Returns nil when no modifier filter is present.
+// GammaHeaderMutation. Unknown filter types (redirect, rewrite, mirror) are silently
+// skipped. Returns nil when no modifier filter is present.
 func buildHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaHeaderMutation {
 	var m *proxy.GammaHeaderMutation
 	ensure := func() {
@@ -299,11 +300,85 @@ func buildHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaHe
 				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
 			}
 			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
-			// Redirect, rewrite, mirror, and extension filter types are not handled
-			// here — they are future items and are silently skipped.
+			// Redirect, rewrite, mirror: handled by dedicated builders below; skip here.
 		}
 	}
 	return m
+}
+
+// buildHTTPRedirect extracts the first RequestRedirect filter from an HTTPRoute
+// rule's filter list and converts it to a GammaRedirect. Returns nil when no
+// redirect filter is present. A rule with a RequestRedirect filter yields a redirect
+// route (no backend cluster) per the Gateway API spec.
+func buildHTTPRedirect(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaRedirect {
+	for _, f := range filters {
+		if f.Type != gatewayv1.HTTPRouteFilterRequestRedirect || f.RequestRedirect == nil {
+			continue
+		}
+		rd := f.RequestRedirect
+		r := &proxy.GammaRedirect{}
+		if rd.Scheme != nil {
+			r.Scheme = *rd.Scheme
+		}
+		if rd.Hostname != nil {
+			r.Hostname = string(*rd.Hostname)
+		}
+		if rd.Port != nil {
+			r.Port = uint32(*rd.Port)
+		}
+		if rd.StatusCode != nil {
+			r.StatusCode = *rd.StatusCode
+		}
+		if rd.Path != nil {
+			switch rd.Path.Type {
+			case gatewayv1.FullPathHTTPPathModifier:
+				if rd.Path.ReplaceFullPath != nil {
+					r.PathType = "ReplaceFullPath"
+					r.PathValue = *rd.Path.ReplaceFullPath
+				}
+			case gatewayv1.PrefixMatchHTTPPathModifier:
+				if rd.Path.ReplacePrefixMatch != nil {
+					r.PathType = "ReplacePrefixMatch"
+					r.PathValue = *rd.Path.ReplacePrefixMatch
+				}
+			}
+		}
+		return r
+	}
+	return nil
+}
+
+// buildHTTPURLRewrite extracts the first URLRewrite filter from an HTTPRoute
+// rule's filter list and converts it to a GammaURLRewrite. Returns nil when no
+// URLRewrite filter is present. URLRewrite is applied on the RouteAction (the
+// request still proxies to the backend).
+func buildHTTPURLRewrite(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaURLRewrite {
+	for _, f := range filters {
+		if f.Type != gatewayv1.HTTPRouteFilterURLRewrite || f.URLRewrite == nil {
+			continue
+		}
+		rw := f.URLRewrite
+		r := &proxy.GammaURLRewrite{}
+		if rw.Hostname != nil {
+			r.Hostname = string(*rw.Hostname)
+		}
+		if rw.Path != nil {
+			switch rw.Path.Type {
+			case gatewayv1.FullPathHTTPPathModifier:
+				if rw.Path.ReplaceFullPath != nil {
+					r.PathType = "ReplaceFullPath"
+					r.PathValue = *rw.Path.ReplaceFullPath
+				}
+			case gatewayv1.PrefixMatchHTTPPathModifier:
+				if rw.Path.ReplacePrefixMatch != nil {
+					r.PathType = "ReplacePrefixMatch"
+					r.PathValue = *rw.Path.ReplacePrefixMatch
+				}
+			}
+		}
+		return r
+	}
+	return nil
 }
 
 // buildGRPCHeaderMutation merges all RequestHeaderModifier and

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -302,7 +302,8 @@ func TestBuildGammaRoute_ResponseHeaderModifier(t *testing.T) {
 }
 
 // TestBuildGammaRoute_UnknownFilterSkipped: non-modifier filters (e.g. redirect)
-// are silently ignored; HeaderMutation is nil when only unknown filters are present.
+// are silently ignored by buildHTTPHeaderMutation; HeaderMutation is nil when only
+// redirect/rewrite filters are present.
 func TestBuildGammaRoute_UnknownFilterSkipped(t *testing.T) {
 	r := &Reconciler{MeshDomain: "mesh"}
 	rule := gatewayv1.HTTPRouteRule{
@@ -314,7 +315,154 @@ func TestBuildGammaRoute_UnknownFilterSkipped(t *testing.T) {
 		},
 	}
 	gr := r.buildGammaRoute(rule)
-	assert.Nil(t, gr.HeaderMutation, "unknown filter type must not produce a mutation")
+	assert.Nil(t, gr.HeaderMutation, "redirect filter type must not produce a HeaderMutation")
+}
+
+// TestBuildGammaRoute_RequestRedirect: a RequestRedirect filter on an HTTPRoute rule
+// is projected into GammaRoute.Redirect with all fields mapped correctly.
+func TestBuildGammaRoute_RequestRedirect(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	tests := []struct {
+		name       string
+		filter     gatewayv1.HTTPRequestRedirectFilter
+		wantScheme string
+		wantHost   string
+		wantPort   uint32
+		wantStatus int
+		wantPType  string
+		wantPValue string
+	}{
+		{
+			name: "scheme+host+port+301",
+			filter: gatewayv1.HTTPRequestRedirectFilter{
+				Scheme:     ptr("https"),
+				Hostname:   ptr(gatewayv1.PreciseHostname("new.example.com")),
+				Port:       ptr(gatewayv1.PortNumber(8443)),
+				StatusCode: ptr(301),
+			},
+			wantScheme: "https",
+			wantHost:   "new.example.com",
+			wantPort:   8443,
+			wantStatus: 301,
+		},
+		{
+			name: "302 ReplaceFullPath",
+			filter: gatewayv1.HTTPRequestRedirectFilter{
+				StatusCode: ptr(302),
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:            gatewayv1.FullPathHTTPPathModifier,
+					ReplaceFullPath: ptr("/new-path"),
+				},
+			},
+			wantStatus: 302,
+			wantPType:  "ReplaceFullPath",
+			wantPValue: "/new-path",
+		},
+		{
+			name: "ReplacePrefixMatch",
+			filter: gatewayv1.HTTPRequestRedirectFilter{
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: ptr("/api/v2"),
+				},
+			},
+			wantPType:  "ReplacePrefixMatch",
+			wantPValue: "/api/v2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := tc.filter
+			rule := gatewayv1.HTTPRouteRule{
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{Type: gatewayv1.HTTPRouteFilterRequestRedirect, RequestRedirect: &f},
+				},
+			}
+			gr := r.buildGammaRoute(rule)
+			require.NotNil(t, gr.Redirect, "RequestRedirect filter must produce GammaRoute.Redirect")
+			assert.Nil(t, gr.URLRewrite, "RequestRedirect must not produce URLRewrite")
+			assert.Equal(t, tc.wantScheme, gr.Redirect.Scheme)
+			assert.Equal(t, tc.wantHost, gr.Redirect.Hostname)
+			assert.Equal(t, tc.wantPort, gr.Redirect.Port)
+			assert.Equal(t, tc.wantStatus, gr.Redirect.StatusCode)
+			assert.Equal(t, tc.wantPType, gr.Redirect.PathType)
+			assert.Equal(t, tc.wantPValue, gr.Redirect.PathValue)
+		})
+	}
+}
+
+// TestBuildGammaRoute_URLRewrite: a URLRewrite filter on an HTTPRoute rule is
+// projected into GammaRoute.URLRewrite with all fields mapped correctly.
+func TestBuildGammaRoute_URLRewrite(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	tests := []struct {
+		name       string
+		filter     gatewayv1.HTTPURLRewriteFilter
+		wantHost   string
+		wantPType  string
+		wantPValue string
+	}{
+		{
+			name:     "hostname rewrite",
+			filter:   gatewayv1.HTTPURLRewriteFilter{Hostname: ptr(gatewayv1.PreciseHostname("backend.internal"))},
+			wantHost: "backend.internal",
+		},
+		{
+			name: "ReplaceFullPath",
+			filter: gatewayv1.HTTPURLRewriteFilter{
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:            gatewayv1.FullPathHTTPPathModifier,
+					ReplaceFullPath: ptr("/fixed"),
+				},
+			},
+			wantPType:  "ReplaceFullPath",
+			wantPValue: "/fixed",
+		},
+		{
+			name: "ReplacePrefixMatch",
+			filter: gatewayv1.HTTPURLRewriteFilter{
+				Path: &gatewayv1.HTTPPathModifier{
+					Type:               gatewayv1.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: ptr("/api/v2"),
+				},
+			},
+			wantPType:  "ReplacePrefixMatch",
+			wantPValue: "/api/v2",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := tc.filter
+			rule := gatewayv1.HTTPRouteRule{
+				Filters: []gatewayv1.HTTPRouteFilter{
+					{Type: gatewayv1.HTTPRouteFilterURLRewrite, URLRewrite: &f},
+				},
+				BackendRefs: []gatewayv1.HTTPBackendRef{
+					{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
+				},
+			}
+			gr := r.buildGammaRoute(rule)
+			require.NotNil(t, gr.URLRewrite, "URLRewrite filter must produce GammaRoute.URLRewrite")
+			assert.Nil(t, gr.Redirect, "URLRewrite must not produce Redirect")
+			assert.Equal(t, tc.wantHost, gr.URLRewrite.Hostname)
+			assert.Equal(t, tc.wantPType, gr.URLRewrite.PathType)
+			assert.Equal(t, tc.wantPValue, gr.URLRewrite.PathValue)
+		})
+	}
+}
+
+// TestBuildGammaRoute_NilRedirectWhenNoFilter: no redirect/rewrite filter means
+// GammaRoute.Redirect and URLRewrite are nil (regression guard).
+func TestBuildGammaRoute_NilRedirectWhenNoFilter(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	rule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
+		},
+	}
+	gr := r.buildGammaRoute(rule)
+	assert.Nil(t, gr.Redirect, "no filter must produce nil Redirect")
+	assert.Nil(t, gr.URLRewrite, "no filter must produce nil URLRewrite")
 }
 
 // TestBuildGammaRouteFromGRPC_HeaderModifier: GRPCRoute request/response header

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -29,12 +29,16 @@ type VirtualHost struct {
 // Prefix/Exact is set; Port 0 means the service's default port.
 // HeaderMutation carries the merged request/response header modifier filters for
 // this rule (nil = no header mutations).
+// When Redirect is non-nil the route returns a redirect response (no backend).
+// When URLRewrite is non-nil the route rewrites the request URL before forwarding.
 type Route struct {
 	Prefix         string
 	Exact          string
 	Service        string
 	Port           uint32
 	HeaderMutation *proxy.GammaHeaderMutation
+	Redirect       *proxy.GammaRedirect
+	URLRewrite     *proxy.GammaURLRewrite
 }
 
 // EdgeTLSCert is raw certificate material for an edge downstream TLS secret,
@@ -131,11 +135,14 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 		}
 		routes := make([]*routev3.Route, 0, len(v.Routes))
 		for _, r := range v.Routes {
-			if r.Service == "" {
+			if r.Redirect == nil && r.Service == "" {
 				continue
 			}
-			cluster := c.edgeClusterNameLocked(r.Service, r.Port)
-			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation))
+			cluster := ""
+			if r.Service != "" {
+				cluster = c.edgeClusterNameLocked(r.Service, r.Port)
+			}
+			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
 		}
 		if len(routes) == 0 {
 			continue
@@ -280,8 +287,8 @@ func (c *SnapshotCache) edgeTCPListeners() []types.Resource {
 }
 
 // equalRoutes reports whether two Route slices are content-equal. Route carries
-// a *GammaHeaderMutation pointer, so we cannot rely on slices.Equal (pointer
-// identity) — we need a deep comparison.
+// pointer fields (*GammaHeaderMutation, *GammaRedirect, *GammaURLRewrite), so we
+// cannot rely on slices.Equal (pointer identity) — we need a deep comparison.
 func equalRoutes(a, b []Route) bool {
 	if len(a) != len(b) {
 		return false
@@ -294,8 +301,36 @@ func equalRoutes(a, b []Route) bool {
 		if !equalHeaderMutation(ra.HeaderMutation, rb.HeaderMutation) {
 			return false
 		}
+		if !equalRouteRedirect(ra.Redirect, rb.Redirect) {
+			return false
+		}
+		if !equalRouteURLRewrite(ra.URLRewrite, rb.URLRewrite) {
+			return false
+		}
 	}
 	return true
+}
+
+// equalRouteRedirect reports content equality for two *proxy.GammaRedirect values.
+func equalRouteRedirect(a, b *proxy.GammaRedirect) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// equalRouteURLRewrite reports content equality for two *proxy.GammaURLRewrite values.
+func equalRouteURLRewrite(a, b *proxy.GammaURLRewrite) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // equalHeaderMutation reports content equality for two *GammaHeaderMutation

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -70,6 +70,12 @@ func equalGammaRoute(a, b proxy.GammaRoute) bool {
 	if !equalGammaHeaderMutation(a.HeaderMutation, b.HeaderMutation) {
 		return false
 	}
+	if !equalGammaRedirect(a.Redirect, b.Redirect) {
+		return false
+	}
+	if !equalGammaURLRewrite(a.URLRewrite, b.URLRewrite) {
+		return false
+	}
 	for i := range a.Matches {
 		ma, mb := a.Matches[i], b.Matches[i]
 		if ma.Prefix != mb.Prefix || ma.Exact != mb.Exact || ma.Regex != mb.Regex || len(ma.Headers) != len(mb.Headers) {
@@ -87,6 +93,28 @@ func equalGammaRoute(a, b proxy.GammaRoute) bool {
 		}
 	}
 	return true
+}
+
+// equalGammaRedirect reports content equality for two *GammaRedirect values.
+func equalGammaRedirect(a, b *proxy.GammaRedirect) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+// equalGammaURLRewrite reports content equality for two *GammaURLRewrite values.
+func equalGammaURLRewrite(a, b *proxy.GammaURLRewrite) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }
 
 // equalGammaHeaderMutation compares two *GammaHeaderMutation values for content

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/tcp_proxy/v3:tcp_proxy",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/matching/common_inputs/transport_socket/v3:transport_socket",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
+        "@com_github_envoyproxy_go_control_plane_envoy//type/matcher/v3:matcher",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -244,12 +244,14 @@ func buildEdgeRedirectRouteConfig() *routev3.RouteConfiguration {
 	}
 }
 
-// BuildEdgeRoute builds one Envoy route for the edge: a path match forwarding to
-// the named cluster with the outbound retry policy. Exactly one of prefix/exact
+// BuildEdgeRoute builds one Envoy route for the edge. Exactly one of prefix/exact
 // is non-empty (exact takes precedence if both are set). Prefix "/" matches all.
-// mutation applies RequestHeaderModifier / ResponseHeaderModifier at the route
-// level; nil mutation = no header mutations.
-func BuildEdgeRoute(prefix, exact, cluster string, mutation *GammaHeaderMutation) *routev3.Route {
+// mutation applies RequestHeaderModifier / ResponseHeaderModifier at the route level.
+//
+// When redirect is non-nil the route emits a Route_Redirect (no cluster). When
+// urlRewrite is non-nil the route rewrite fields are applied before forwarding to
+// cluster. Both nil → plain forwarding route.
+func BuildEdgeRoute(prefix, exact, cluster string, mutation *GammaHeaderMutation, redirect *GammaRedirect, urlRewrite *GammaURLRewrite) *routev3.Route {
 	match := &routev3.RouteMatch{}
 	if exact != "" {
 		match.PathSpecifier = &routev3.RouteMatch_Path{Path: exact}
@@ -257,19 +259,24 @@ func BuildEdgeRoute(prefix, exact, cluster string, mutation *GammaHeaderMutation
 		match.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: prefix}
 	}
 	reqAdd, respAdd, reqRemove, respRemove := headerMutationFields(mutation)
-	return &routev3.Route{
-		Match: match,
-		Action: &routev3.Route_Route{
-			Route: &routev3.RouteAction{
-				ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: cluster},
-				RetryPolicy:      outboundRetryPolicy(),
-			},
-		},
+	r := &routev3.Route{
+		Match:                   match,
 		RequestHeadersToAdd:     reqAdd,
 		RequestHeadersToRemove:  reqRemove,
 		ResponseHeadersToAdd:    respAdd,
 		ResponseHeadersToRemove: respRemove,
 	}
+	if redirect != nil {
+		r.Action = gammaRedirectAction(redirect)
+	} else {
+		ra := &routev3.RouteAction{
+			ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: cluster},
+			RetryPolicy:      outboundRetryPolicy(),
+		}
+		applyURLRewrite(ra, urlRewrite)
+		r.Action = &routev3.Route_Route{Route: ra}
+	}
+	return r
 }
 
 // BuildEdgeVirtualHost builds one edge virtual host: the given external domains

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -257,6 +257,62 @@ func TestBuildEdgeTLSPassthroughListener_EmptyRules(t *testing.T) {
 	}))
 }
 
+// TestBuildEdgeRoute_Redirect: BuildEdgeRoute with a non-nil GammaRedirect emits a
+// Route_Redirect action (no cluster) with the correct fields.
+func TestBuildEdgeRoute_Redirect(t *testing.T) {
+	rd := &GammaRedirect{
+		Scheme:     "https",
+		Hostname:   "new.example.com",
+		Port:       8443,
+		StatusCode: 301,
+		PathType:   "ReplaceFullPath",
+		PathValue:  "/new-path",
+	}
+	r := BuildEdgeRoute("/old", "", "", nil, rd, nil)
+
+	require.NotNil(t, r, "BuildEdgeRoute must return a route")
+	assert.Nil(t, r.GetRoute(), "redirect route must not have a RouteAction")
+	rdr := r.GetRedirect()
+	require.NotNil(t, rdr, "redirect route must have a RedirectAction")
+	assert.Equal(t, routev3.RedirectAction_MOVED_PERMANENTLY, rdr.GetResponseCode())
+	assert.Equal(t, "https", rdr.GetSchemeRedirect())
+	assert.Equal(t, "new.example.com", rdr.GetHostRedirect())
+	assert.Equal(t, uint32(8443), rdr.GetPortRedirect())
+	assert.Equal(t, "/new-path", rdr.GetPathRedirect())
+}
+
+// TestBuildEdgeRoute_URLRewrite: BuildEdgeRoute with a non-nil GammaURLRewrite sets
+// the rewrite fields on the RouteAction (cluster is still used).
+func TestBuildEdgeRoute_URLRewrite(t *testing.T) {
+	rw := &GammaURLRewrite{
+		Hostname:  "backend.internal",
+		PathType:  "ReplacePrefixMatch",
+		PathValue: "/v2",
+	}
+	r := BuildEdgeRoute("/api", "", "svc-1.aether.internal", nil, nil, rw)
+
+	require.NotNil(t, r)
+	ra := r.GetRoute()
+	require.NotNil(t, ra, "URLRewrite route must have a RouteAction")
+	assert.Nil(t, r.GetRedirect(), "URLRewrite route must not be a redirect")
+	assert.Equal(t, "svc-1.aether.internal", ra.GetCluster())
+	assert.Equal(t, "backend.internal", ra.GetHostRewriteLiteral())
+	assert.Equal(t, "/v2", ra.GetPrefixRewrite())
+}
+
+// TestBuildEdgeRoute_URLRewrite_FullPath: ReplaceFullPath URLRewrite uses RegexRewrite.
+func TestBuildEdgeRoute_URLRewrite_FullPath(t *testing.T) {
+	rw := &GammaURLRewrite{PathType: "ReplaceFullPath", PathValue: "/fixed"}
+	r := BuildEdgeRoute("/", "", "svc-1.aether.internal", nil, nil, rw)
+
+	ra := r.GetRoute()
+	require.NotNil(t, ra)
+	rr := ra.GetRegexRewrite()
+	require.NotNil(t, rr, "ReplaceFullPath must produce a RegexRewrite")
+	assert.Equal(t, ".*", rr.GetPattern().GetRegex())
+	assert.Equal(t, "/fixed", rr.GetSubstitution())
+}
+
 // TestEdgeUpstreamTCPTransportSocket verifies the edge TCP transport socket uses
 // NO ALPN (not "h2" or "aether-tcp") and NO SNI so the destination inbound falls
 // to the TCP floor DEFAULT chain, while SDS is fetched from spire_agent (not ADS).

--- a/agent/internal/xds/proxy/gammaroute_test.go
+++ b/agent/internal/xds/proxy/gammaroute_test.go
@@ -5,6 +5,7 @@ import (
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,4 +131,163 @@ func TestBuildOutboundServiceVirtualHost_HeaderMutation(t *testing.T) {
 	// The trailing catch-all has no mutations.
 	last := vh.Routes[len(vh.Routes)-1]
 	assert.Empty(t, last.GetRequestHeadersToAdd(), "catch-all route must have no header mutations")
+}
+
+// TestBuildOutboundServiceVirtualHost_Redirect: a GammaRoute with a Redirect emits
+// a Route_Redirect action (no cluster) instead of a RouteAction.
+func TestBuildOutboundServiceVirtualHost_Redirect(t *testing.T) {
+	tests := []struct {
+		name       string
+		redirect   GammaRedirect
+		wantScheme string
+		wantHost   string
+		wantPort   uint32
+		wantCode   routev3.RedirectAction_RedirectResponseCode
+		wantPath   string // expected PathRedirect value, empty = no path rewrite
+		wantPrefix string // expected PrefixRewrite value, empty = no prefix rewrite
+	}{
+		{
+			name:       "301 host+scheme redirect",
+			redirect:   GammaRedirect{Scheme: "https", Hostname: "new.example.com", StatusCode: 301},
+			wantScheme: "https",
+			wantHost:   "new.example.com",
+			wantCode:   routev3.RedirectAction_MOVED_PERMANENTLY,
+		},
+		{
+			name:     "302 redirect default code when unset",
+			redirect: GammaRedirect{StatusCode: 302},
+			wantCode: routev3.RedirectAction_FOUND,
+		},
+		{
+			name:     "default 301 when StatusCode=0",
+			redirect: GammaRedirect{Hostname: "other.example.com"},
+			wantHost: "other.example.com",
+			wantCode: routev3.RedirectAction_MOVED_PERMANENTLY,
+		},
+		{
+			name:     "port redirect",
+			redirect: GammaRedirect{Port: 8443},
+			wantPort: 8443,
+			wantCode: routev3.RedirectAction_MOVED_PERMANENTLY,
+		},
+		{
+			name:     "ReplaceFullPath",
+			redirect: GammaRedirect{PathType: "ReplaceFullPath", PathValue: "/new/path"},
+			wantPath: "/new/path",
+			wantCode: routev3.RedirectAction_MOVED_PERMANENTLY,
+		},
+		{
+			name:       "ReplacePrefixMatch",
+			redirect:   GammaRedirect{PathType: "ReplacePrefixMatch", PathValue: "/api/v2"},
+			wantPrefix: "/api/v2",
+			wantCode:   routev3.RedirectAction_MOVED_PERMANENTLY,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rd := tc.redirect // copy
+			rules := []GammaRoute{
+				{
+					Matches:  []GammaMatch{{Prefix: "/"}},
+					Redirect: &rd,
+					// No backends — redirect takes precedence.
+				},
+			}
+			vh := BuildOutboundServiceVirtualHost("svc-1.mesh", []string{"svc-1.mesh"}, rules)
+			// rule0 (1 match, redirect) + trailing catch-all = 2 routes.
+			require.GreaterOrEqual(t, len(vh.Routes), 1)
+			r0 := vh.Routes[0]
+
+			// Must be a redirect action, not a route action.
+			rdr := r0.GetRedirect()
+			require.NotNil(t, rdr, "redirect rule must produce Route_Redirect, not Route_Route")
+			assert.Nil(t, r0.GetRoute(), "redirect rule must not have a RouteAction")
+
+			assert.Equal(t, tc.wantCode, rdr.GetResponseCode())
+			if tc.wantScheme != "" {
+				assert.Equal(t, tc.wantScheme, rdr.GetSchemeRedirect())
+			}
+			if tc.wantHost != "" {
+				assert.Equal(t, tc.wantHost, rdr.GetHostRedirect())
+			}
+			if tc.wantPort != 0 {
+				assert.Equal(t, tc.wantPort, rdr.GetPortRedirect())
+			}
+			if tc.wantPath != "" {
+				assert.Equal(t, tc.wantPath, rdr.GetPathRedirect())
+			}
+			if tc.wantPrefix != "" {
+				assert.Equal(t, tc.wantPrefix, rdr.GetPrefixRewrite())
+			}
+		})
+	}
+}
+
+// TestBuildOutboundServiceVirtualHost_URLRewrite: a GammaRoute with a URLRewrite
+// sets the appropriate rewrite fields on the RouteAction (cluster is still used).
+func TestBuildOutboundServiceVirtualHost_URLRewrite(t *testing.T) {
+	tests := []struct {
+		name       string
+		rewrite    GammaURLRewrite
+		cluster    string
+		wantHost   string
+		wantPrefix string
+		wantRegex  *matcherv3.RegexMatchAndSubstitute
+	}{
+		{
+			name:     "hostname rewrite",
+			rewrite:  GammaURLRewrite{Hostname: "backend.internal"},
+			cluster:  "svc-1.mesh",
+			wantHost: "backend.internal",
+		},
+		{
+			name:       "ReplacePrefixMatch",
+			rewrite:    GammaURLRewrite{PathType: "ReplacePrefixMatch", PathValue: "/api/v2"},
+			cluster:    "svc-1.mesh",
+			wantPrefix: "/api/v2",
+		},
+		{
+			name:    "ReplaceFullPath",
+			rewrite: GammaURLRewrite{PathType: "ReplaceFullPath", PathValue: "/fixed"},
+			cluster: "svc-1.mesh",
+			wantRegex: &matcherv3.RegexMatchAndSubstitute{
+				Pattern:      &matcherv3.RegexMatcher{Regex: ".*"},
+				Substitution: "/fixed",
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := tc.rewrite
+			rules := []GammaRoute{
+				{
+					Matches:    []GammaMatch{{Prefix: "/"}},
+					Backends:   []GammaBackend{{Cluster: tc.cluster, Weight: 1}},
+					URLRewrite: &rw,
+				},
+			}
+			vh := BuildOutboundServiceVirtualHost(tc.cluster, []string{tc.cluster}, rules)
+			require.GreaterOrEqual(t, len(vh.Routes), 1)
+			r0 := vh.Routes[0]
+
+			// Must be a forward route, not a redirect.
+			ra := r0.GetRoute()
+			require.NotNil(t, ra, "URLRewrite rule must produce a RouteAction")
+			assert.Nil(t, r0.GetRedirect(), "URLRewrite rule must not be a redirect")
+			assert.Equal(t, tc.cluster, ra.GetCluster())
+
+			if tc.wantHost != "" {
+				assert.Equal(t, tc.wantHost, ra.GetHostRewriteLiteral())
+			}
+			if tc.wantPrefix != "" {
+				assert.Equal(t, tc.wantPrefix, ra.GetPrefixRewrite())
+			}
+			if tc.wantRegex != nil {
+				rr := ra.GetRegexRewrite()
+				require.NotNil(t, rr, "ReplaceFullPath must produce a RegexRewrite")
+				assert.Equal(t, tc.wantRegex.GetPattern().GetRegex(), rr.GetPattern().GetRegex())
+				assert.Equal(t, tc.wantRegex.GetSubstitution(), rr.GetSubstitution())
+			}
+		})
+	}
 }

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -165,7 +165,7 @@ func BuildOutboundClusterVirtualHost(clusterName string, domains []string) *rout
 
 // GAMMA east-west L7 routing (proposal 018, Phase 2). A GammaRoute is one resolved
 // HTTPRoute rule: ordered matches forwarding to one or more weighted backend
-// clusters, with an optional timeout and header mutations.
+// clusters, with an optional timeout, header mutations, redirect, and URL rewrite.
 // Backends are already resolved to data-plane cluster names (<backend>.<meshDomain>)
 // by the reconciler.
 type GammaRoute struct {
@@ -173,6 +173,42 @@ type GammaRoute struct {
 	Backends       []GammaBackend
 	Timeout        *durationpb.Duration
 	HeaderMutation *GammaHeaderMutation
+	// Redirect, when non-nil, makes this route return a redirect response instead
+	// of forwarding to a backend. Coexists with Matches; takes precedence over
+	// Backends per the Gateway API spec.
+	Redirect *GammaRedirect
+	// URLRewrite, when non-nil, rewrites the request URL (host and/or path) before
+	// forwarding. Applied on top of the normal RouteAction (Backends still used).
+	URLRewrite *GammaURLRewrite
+}
+
+// GammaRedirect describes a RequestRedirect filter: it replaces the route action
+// with an Envoy RedirectAction instead of forwarding to a backend cluster.
+type GammaRedirect struct {
+	// Scheme is the target scheme ("http" or "https"). Empty = unchanged.
+	Scheme string
+	// Hostname is the target hostname. Empty = unchanged.
+	Hostname string
+	// Port is the target port (0 = unchanged).
+	Port uint32
+	// StatusCode is the HTTP redirect code (301 or 302; default 301).
+	StatusCode int
+	// PathType selects how to rewrite the path (empty = no path rewrite).
+	// "ReplaceFullPath" → Envoy PathRedirect; "ReplacePrefixMatch" → PrefixRewrite.
+	PathType  string
+	PathValue string
+}
+
+// GammaURLRewrite describes a URLRewrite filter: rewrites the request host
+// and/or path before forwarding to the backend. Applied within the RouteAction.
+type GammaURLRewrite struct {
+	// Hostname is the Host header to rewrite to. Empty = unchanged.
+	Hostname string
+	// PathType selects how to rewrite the path (empty = no path rewrite).
+	// "ReplaceFullPath" → Envoy RegexRewrite (.*) → value.
+	// "ReplacePrefixMatch" → Envoy PrefixRewrite.
+	PathType  string
+	PathValue string
 }
 
 // GammaMatch is one HTTPRoute match: a path (prefix OR exact OR regex; empty =
@@ -234,13 +270,16 @@ type GammaHeaderKV struct {
 // trailing catch-all routes anything the rules don't match to the service's own
 // cluster (name), so producer rules are additive. With no rules it is the passthrough
 // vhost.
+//
+// Rules with a Redirect field produce a redirect route (Route_Redirect) with no
+// backend cluster. Rules with a URLRewrite field apply host/path rewriting on the
+// RouteAction before forwarding to the backend.
 func BuildOutboundServiceVirtualHost(name string, domains []string, rules []GammaRoute) *routev3.VirtualHost {
 	if len(rules) == 0 {
 		return BuildOutboundClusterVirtualHost(name, domains)
 	}
 	var routes []*routev3.Route
 	for _, rule := range rules {
-		action := gammaRouteAction(name, rule)
 		matches := rule.Matches
 		if len(matches) == 0 {
 			matches = []GammaMatch{{Prefix: "/"}}
@@ -249,11 +288,15 @@ func BuildOutboundServiceVirtualHost(name string, domains []string, rules []Gamm
 		for _, m := range matches {
 			r := &routev3.Route{
 				Match:                   gammaRouteMatch(m),
-				Action:                  action,
 				RequestHeadersToAdd:     reqAdd,
 				RequestHeadersToRemove:  reqRemove,
 				ResponseHeadersToAdd:    respAdd,
 				ResponseHeadersToRemove: respRemove,
+			}
+			if rule.Redirect != nil {
+				r.Action = gammaRedirectAction(rule.Redirect)
+			} else {
+				r.Action = gammaRouteAction(name, rule)
 			}
 			routes = append(routes, r)
 		}
@@ -356,5 +399,56 @@ func gammaRouteAction(serviceCluster string, rule GammaRoute) *routev3.Route_Rou
 		}
 		ra.ClusterSpecifier = &routev3.RouteAction_WeightedClusters{WeightedClusters: weighted}
 	}
+	applyURLRewrite(ra, rule.URLRewrite)
 	return &routev3.Route_Route{Route: ra}
+}
+
+// gammaRedirectAction converts a GammaRedirect into an Envoy Route_Redirect action.
+// The returned action replaces the RouteAction entirely — no backend cluster is used.
+func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
+	a := &routev3.RedirectAction{}
+	if rd.Scheme != "" {
+		a.SchemeRewriteSpecifier = &routev3.RedirectAction_SchemeRedirect{SchemeRedirect: rd.Scheme}
+	}
+	if rd.Hostname != "" {
+		a.HostRedirect = rd.Hostname
+	}
+	if rd.Port != 0 {
+		a.PortRedirect = rd.Port
+	}
+	switch rd.StatusCode {
+	case 302:
+		a.ResponseCode = routev3.RedirectAction_FOUND
+	default:
+		// 301 is the Gateway API default; also covers 0 (unset).
+		a.ResponseCode = routev3.RedirectAction_MOVED_PERMANENTLY
+	}
+	switch rd.PathType {
+	case "ReplaceFullPath":
+		a.PathRewriteSpecifier = &routev3.RedirectAction_PathRedirect{PathRedirect: rd.PathValue}
+	case "ReplacePrefixMatch":
+		a.PathRewriteSpecifier = &routev3.RedirectAction_PrefixRewrite{PrefixRewrite: rd.PathValue}
+	}
+	return &routev3.Route_Redirect{Redirect: a}
+}
+
+// applyURLRewrite writes URLRewrite fields onto an existing RouteAction.
+// hostname → HostRewriteLiteral; ReplacePrefixMatch → PrefixRewrite;
+// ReplaceFullPath → RegexRewrite matching .* → the new path.
+func applyURLRewrite(ra *routev3.RouteAction, rw *GammaURLRewrite) {
+	if rw == nil {
+		return
+	}
+	if rw.Hostname != "" {
+		ra.HostRewriteSpecifier = &routev3.RouteAction_HostRewriteLiteral{HostRewriteLiteral: rw.Hostname}
+	}
+	switch rw.PathType {
+	case "ReplacePrefixMatch":
+		ra.PrefixRewrite = rw.PathValue
+	case "ReplaceFullPath":
+		ra.RegexRewrite = &matcherv3.RegexMatchAndSubstitute{
+			Pattern:      &matcherv3.RegexMatcher{Regex: ".*"},
+			Substitution: rw.PathValue,
+		}
+	}
 }

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -31,7 +31,8 @@ e2e-validated on talos (aether 0.41.0).
 | Weighted backends (canary/split) | Supported | `WeightedClusters` |
 | Request timeout | Supported | HTTPRoute `timeouts.request` |
 | Request mirroring | Planned | |
-| Request redirect / URL rewrite filters | Planned | |
+| `RequestRedirect` filter | Supported | `scheme` → `SchemeRedirect`; `hostname` → `HostRedirect`; `port` → `PortRedirect`; `statusCode` 301/302 → `MOVED_PERMANENTLY`/`FOUND`; `path.ReplaceFullPath` → `PathRedirect`; `path.ReplacePrefixMatch` → `PrefixRewrite`; yields `Route_Redirect` (no backend); applied on HTTPRoute (edge + GAMMA) |
+| `URLRewrite` filter | Supported | `hostname` → `HostRewriteLiteral`; `path.ReplacePrefixMatch` → `PrefixRewrite`; `path.ReplaceFullPath` → `RegexRewrite` (`.*` → value); applied on HTTPRoute (edge + GAMMA) |
 | `RequestHeaderModifier` filter | Supported | `set` → `OVERWRITE_IF_EXISTS_OR_ADD`; `add` → `APPEND_IF_EXISTS_OR_ADD`; `remove` → `request_headers_to_remove`; applied at route level on HTTPRoute (edge + GAMMA) and GRPCRoute |
 | `ResponseHeaderModifier` filter | Supported | same shape on `response_headers_to_add` / `response_headers_to_remove`; applied at route level on HTTPRoute (edge + GAMMA) and GRPCRoute |
 | RegularExpression matches | Supported | gRPC method `RegularExpression` type → Envoy `safe_regex` path (`/<serviceRegex>/<methodRegex>`); unset component uses `[^/]+` |


### PR DESCRIPTION
## Summary

- Implements `RequestRedirect` and `URLRewrite` HTTPRoute filters on both the GAMMA east-west path (parentRef=Service) and the edge north-south path (parentRef=Gateway), targeting the `MeshHTTPRouteRedirectHostAndStatus` conformance test gap.
- `RequestRedirect` maps to Envoy `Route_Redirect` (replaces RouteAction entirely; no backend cluster needed): `scheme` → `SchemeRedirect`, `hostname` → `HostRedirect`, `port` → `PortRedirect`, `statusCode` 301/302 → `MOVED_PERMANENTLY`/`FOUND` (default 301), `path.ReplaceFullPath` → `PathRedirect`, `path.ReplacePrefixMatch` → `PrefixRewrite`.
- `URLRewrite` applies rewrite fields on the existing `RouteAction` before forwarding to the backend: `hostname` → `HostRewriteLiteral`, `path.ReplacePrefixMatch` → `PrefixRewrite`, `path.ReplaceFullPath` → `RegexRewrite` (`.*` → value) since Envoy has no direct full-path rewrite field.
- New `GammaRedirect` and `GammaURLRewrite` structs plumbed through `GammaRoute`, `cache.Route`, and their deep equality comparisons to avoid spurious snapshot churn. `BuildEdgeRoute` gains `redirect`/`urlRewrite` params; `virtualHostVhosts` loosens the `service==""` skip guard so redirect-only routes (no backendRef) still project.
- Conformance doc updated: `RequestRedirect` and `URLRewrite` rows moved from `Planned` to `Supported`. `RequestMirror` remains `Planned`.

## Test plan

- [x] `bazel test //agent/internal/xds/proxy/... //agent/internal/gamma/... //agent/internal/edge/... //agent/internal/xds/cache/...` — 5/5 pass
- [x] `bazel test //... --test_arg=-test.short` — 57/57 Go tests pass (3 pre-existing Helm lint test failures unrelated to this change)
- [x] `make format` — no diff
- Unit tests added:
  - `proxy/gammaroute_test.go`: `TestBuildOutboundServiceVirtualHost_Redirect` (6 sub-cases: scheme/host/port/301/302/ReplaceFullPath/ReplacePrefixMatch), `TestBuildOutboundServiceVirtualHost_URLRewrite` (3 sub-cases: hostname / ReplacePrefixMatch / ReplaceFullPath)
  - `gamma/reconciler_test.go`: `TestBuildGammaRoute_RequestRedirect`, `TestBuildGammaRoute_URLRewrite`, `TestBuildGammaRoute_NilRedirectWhenNoFilter`
  - `edge/gatewayapi/reconciler_test.go`: `TestBuildVirtualHost_RequestRedirect`, `TestBuildVirtualHost_URLRewrite`, `TestBuildVirtualHost_URLRewrite_ReplaceFullPath`
  - `proxy/edge_test.go`: `TestBuildEdgeRoute_Redirect`, `TestBuildEdgeRoute_URLRewrite`, `TestBuildEdgeRoute_URLRewrite_FullPath`
- E2e idea: apply an `HTTPRoute` with `RequestRedirect` (scheme=https, statusCode=302) on a GAMMA service — `curl -v http://svc.mesh/...` should receive `302 Found` with a `Location: https://...` header and no upstream dial. For `URLRewrite`: apply a prefix-rewrite filter on an edge route — the upstream backend's access log should show the rewritten path, not the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S