### PR TITLE
feat(edge): namespace-agnostic Gateway reconcile + status + GatewayClass supportedFeatures

### DIFF
--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -19,7 +19,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
@@ -99,16 +98,21 @@ func runEdge(ctx context.Context) (retErr error) {
 		}()
 	}
 
-	// Watch Gateways/HTTPRoutes in the edge's own namespace (or an override). Scope
-	// the manager's informer cache to that namespace so the edge needs only
-	// namespaced RBAC, not cluster-wide.
+	// Watch Gateway API objects CLUSTER-WIDE. The edge reconciles every Gateway of
+	// our GatewayClass wherever it lives (namespace-agnostic): the conformance suite
+	// creates its Gateways/Routes in its own namespaces, so a namespace-scoped cache
+	// would never see them and they would never reach Accepted/Programmed. Leaving
+	// CacheOptions nil makes the manager cache every watched kind across all
+	// namespaces; the ClusterRoles grant the matching cluster-wide list/watch.
+	//
+	// routeNamespace is still resolved (the edge's own namespace) and used as the
+	// default namespace for the Secret provider's TLS cert lookups — Gateway TLS
+	// secrets are expected alongside the edge by default.
 	routeNamespace := cfg.RouteNamespace
 	if routeNamespace == "" {
 		routeNamespace = currentNamespace()
 	}
-	cfg.CacheOptions = &ctrlcache.Options{
-		DefaultNamespaces: map[string]ctrlcache.Config{routeNamespace: {}},
-	}
+	cfg.CacheOptions = nil
 
 	// Manager scheme = client-go built-ins + the Gateway API types so the
 	// reconciler reads typed Gateways/HTTPRoutes (no unstructured).

--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "gatewayapi",
     srcs = [
+        "features.go",
         "reconciler.go",
         "status.go",
     ],
@@ -25,6 +26,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
+        "@io_k8s_sigs_gateway_api//pkg/features",
     ],
 )
 

--- a/agent/internal/edge/gatewayapi/features.go
+++ b/agent/internal/edge/gatewayapi/features.go
@@ -1,0 +1,66 @@
+package gatewayapi
+
+import (
+	"slices"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	"sigs.k8s.io/gateway-api/pkg/features"
+)
+
+// aetherSupportedFeaturesList is the honest set of Gateway API conformance
+// features the aether edge implements (docs/conformance/gateway-api-features.md).
+// The upstream conformance suite reads GatewayClass.status.supportedFeatures to
+// decide which suites to run vs skip, so advertising ONLY what we implement makes
+// unsupported tests (redirect/rewrite/mirror, ReferenceGrant) skip cleanly instead
+// of failing. The named feature constants come from the pinned gateway-api module
+// (sigs.k8s.io/gateway-api/pkg/features).
+//
+//   - Gateway / GatewayPort8080 — north-south Gateways on the standard test port.
+//   - HTTPRoute / GRPCRoute — both route types (edge HTTPRoute, GAMMA HTTPRoute+GRPCRoute).
+//   - HTTPRouteMethodMatching — gRPC method match → path; HTTP method match.
+//   - HTTPRouteResponseHeaderModification — ResponseHeaderModifier filter (route level).
+//   - HTTPRouteRequestTimeout — HTTPRoute timeouts.request.
+//
+// Path match (Exact/PathPrefix), header match (Exact), weighted backends, and the
+// RequestHeaderModifier filter are part of HTTPRoute *core* conformance and carry
+// no separate feature flag. Redirect/rewrite/mirror and ReferenceGrant are
+// deliberately omitted (not implemented) so their suites skip.
+var aetherSupportedFeaturesList = []features.FeatureName{
+	features.SupportGateway,
+	features.SupportGatewayPort8080,
+	features.SupportGRPCRoute,
+	features.SupportHTTPRoute,
+	features.SupportHTTPRouteMethodMatching,
+	features.SupportHTTPRouteRequestTimeout,
+	features.SupportHTTPRouteResponseHeaderModification,
+}
+
+// aetherSupportedFeatures returns the supportedFeatures to publish on the
+// GatewayClass status, sorted ascending by name (the API requires the list be
+// sorted in ascending alphabetical order by the Name key).
+func aetherSupportedFeatures() []gatewayv1.SupportedFeature {
+	names := make([]string, 0, len(aetherSupportedFeaturesList))
+	for _, f := range aetherSupportedFeaturesList {
+		names = append(names, string(f))
+	}
+	slices.Sort(names)
+	out := make([]gatewayv1.SupportedFeature, 0, len(names))
+	for _, n := range names {
+		out = append(out, gatewayv1.SupportedFeature{Name: gatewayv1.FeatureName(n)})
+	}
+	return out
+}
+
+// supportedFeaturesEqual reports whether two supportedFeatures lists carry the
+// same set of feature names (used to avoid no-op status writes / reconcile loops).
+func supportedFeaturesEqual(a, b []gatewayv1.SupportedFeature) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].Name != b[i].Name {
+			return false
+		}
+	}
+	return true
+}

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -36,22 +36,26 @@ type RouteSink interface {
 }
 
 // Reconciler watches Gateway API HTTPRoutes, TCPRoutes, and TLSRoutes (and the
-// Gateways/Secrets they depend on) in a namespace and projects, on any change,
-// the complete virtual-host and L4 route sets into the cache. Level-based: each
+// Gateways/Secrets they depend on) CLUSTER-WIDE and projects, on any change, the
+// complete virtual-host and L4 route sets into the cache. Level-based: each
 // reconcile re-lists, so adds/updates/deletes converge without delta tracking —
-// the same model as the VirtualHost reconciler.
+// the same model as the VirtualHost reconciler. It is namespace-agnostic: a
+// Gateway of our class in any namespace is reconciled and gets status, which is
+// what the upstream conformance suite (running in its own namespaces) requires.
 type Reconciler struct {
 	client.Client
 
 	// APIReader is an uncached reader (mgr.GetAPIReader) used to fetch the
-	// cluster-scoped GatewayClass for status: the edge's cache is namespace-scoped
-	// (DefaultNamespaces), so a cached Get on the cluster-scoped GatewayClass misses
-	// and returns NotFound, leaving its Accepted status stuck at the CRD default.
+	// cluster-scoped GatewayClass for status (a cached Get on a cluster-scoped
+	// resource can miss before its informer has synced and return NotFound).
 	APIReader client.Reader
 
 	// Sink receives the projected virtual hosts/certs and L4 routes (the snapshot cache).
 	Sink RouteSink
-	// Namespace is the namespace Gateways/HTTPRoutes/TCPRoutes/TLSRoutes live in.
+	// Namespace is the edge's own namespace. It is used only as the default
+	// namespace for the TLS Secret provider's cert lookups; Gateways/Routes are
+	// listed and reconciled CLUSTER-WIDE (namespace-agnostic), so this field no
+	// longer scopes the route/Gateway lists.
 	Namespace string
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves.
 	GatewayClassName string
@@ -93,19 +97,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
-	// --- HTTPRoutes ---
+	// --- HTTPRoutes (cluster-wide) ---
 	httpRoutes := &gatewayv1.HTTPRouteList{}
-	if err := r.List(ctx, httpRoutes, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.List(ctx, httpRoutes); err != nil {
 		return reconcile.Result{}, err
 	}
-	// Deterministic order so keep-first host-dedup in the cache is stable.
+	// Deterministic order so keep-first host-dedup in the cache is stable. Sort by
+	// namespace+name now that routes may span namespaces.
 	slices.SortFunc(httpRoutes.Items, func(a, b gatewayv1.HTTPRoute) int {
+		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
 		return strings.Compare(a.Name, b.Name)
 	})
 	vhosts := make([]cache.VirtualHost, 0, len(httpRoutes.Items))
 	for i := range httpRoutes.Items {
 		hr := &httpRoutes.Items[i]
-		if !attachedToOurGateway(hr.Spec.ParentRefs, gateways) {
+		if !attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways) {
 			continue
 		}
 		vh := r.buildVirtualHost(hr, hostCerts)
@@ -115,15 +123,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		vhosts = append(vhosts, vh)
 	}
 
-	// --- TCPRoutes ---
+	// --- TCPRoutes (cluster-wide) ---
 	tcpRouteList := &gatewayv1alpha2.TCPRouteList{}
-	if err := r.List(ctx, tcpRouteList, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.List(ctx, tcpRouteList); err != nil {
 		return reconcile.Result{}, err
 	}
 	tcpByPort := make(map[uint32][]proxy.L4Backend)
 	for i := range tcpRouteList.Items {
 		tr := &tcpRouteList.Items[i]
-		ports := gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TCPProtocolType, gatewayListeners)
+		ports := gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, gatewayListeners)
 		for _, port := range ports {
 			for _, rule := range tr.Spec.Rules {
 				tcpByPort[port] = append(tcpByPort[port], r.buildL4Backends(rule.BackendRefs)...)
@@ -144,15 +152,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return 0
 	})
 
-	// --- TLSRoutes ---
+	// --- TLSRoutes (cluster-wide) ---
 	tlsRouteList := &gatewayv1.TLSRouteList{}
-	if err := r.List(ctx, tlsRouteList, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.List(ctx, tlsRouteList); err != nil {
 		return reconcile.Result{}, err
 	}
 	tlsByPort := make(map[uint32][]proxy.L4ServiceRoute)
 	for i := range tlsRouteList.Items {
 		tr := &tlsRouteList.Items[i]
-		ports := gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TLSProtocolType, gatewayListeners)
+		ports := gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, gatewayListeners)
 		hostnames := make([]string, 0, len(tr.Spec.Hostnames))
 		for _, h := range tr.Spec.Hostnames {
 			hostnames = append(hostnames, string(h))
@@ -207,25 +215,38 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	return reconcile.Result{}, nil
 }
 
-// gatewayListenerKey identifies a listener within a gateway by name+protocol+port.
-// Used to scope TCPRoute/TLSRoute parentRef port matching.
+// gatewayKey identifies a Gateway by namespace+name. Since the edge now
+// reconciles cluster-wide, Gateway names alone are no longer unique (two
+// namespaces may each have a Gateway "edge"), so route attachment must match on
+// the full namespaced name.
+type gatewayKey struct {
+	Namespace string
+	Name      string
+}
+
+// gatewayListenerKey identifies a listener within a gateway by
+// namespace+name+protocol+port. Used to scope TCPRoute/TLSRoute parentRef port
+// matching.
 type gatewayListenerKey struct {
-	Gateway  string
+	Gateway  gatewayKey
 	Port     uint32
 	Protocol gatewayv1.ProtocolType
 }
 
-// resolveGateways lists the Gateways of our GatewayClass and resolves each TLS
-// listener's cert. It returns the set of our Gateway names, the Gateway objects
-// themselves (for status), a set of listener keys (for TCPRoute/TLSRoute port
-// matching), a hostname→SDS-name map for HTTP cert selection, and the
-// SDS-name→bytes map to push.
-func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, []gatewayv1.Gateway, map[gatewayListenerKey]struct{}, map[string]string, map[string]cache.EdgeTLSCert, error) {
+// resolveGateways lists the Gateways of our GatewayClass CLUSTER-WIDE and resolves
+// each TLS listener's cert. It returns the set of our Gateways (by namespaced
+// name), the Gateway objects themselves (for status), a set of listener keys (for
+// TCPRoute/TLSRoute port matching), a hostname→SDS-name map for HTTP cert
+// selection, and the SDS-name→bytes map to push. Selection is by
+// GatewayClassName: every Gateway whose gatewayClassName is the class this edge
+// serves (whose controllerName is gateway.aether.io/edge) is ours, regardless of
+// namespace.
+func (r *Reconciler) resolveGateways(ctx context.Context) (map[gatewayKey]struct{}, []gatewayv1.Gateway, map[gatewayListenerKey]struct{}, map[string]string, map[string]cache.EdgeTLSCert, error) {
 	list := &gatewayv1.GatewayList{}
-	if err := r.List(ctx, list, client.InNamespace(r.Namespace)); err != nil {
+	if err := r.List(ctx, list); err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	gateways := map[string]struct{}{}
+	gateways := map[gatewayKey]struct{}{}
 	var ourGateways []gatewayv1.Gateway
 	listenerKeys := map[gatewayListenerKey]struct{}{}
 	hostCerts := map[string]string{} // listener hostname ("" = catch-all) -> SDS name
@@ -235,11 +256,12 @@ func (r *Reconciler) resolveGateways(ctx context.Context) (map[string]struct{}, 
 		if string(gw.Spec.GatewayClassName) != r.GatewayClassName {
 			continue
 		}
-		gateways[gw.Name] = struct{}{}
+		gk := gatewayKey{Namespace: gw.Namespace, Name: gw.Name}
+		gateways[gk] = struct{}{}
 		ourGateways = append(ourGateways, *gw)
 		for _, ln := range gw.Spec.Listeners {
 			listenerKeys[gatewayListenerKey{
-				Gateway:  gw.Name,
+				Gateway:  gk,
 				Port:     uint32(ln.Port),
 				Protocol: ln.Protocol,
 			}] = struct{}{}
@@ -343,29 +365,53 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 	return vh
 }
 
-// attachedToOurGateway reports whether the given parentRefs include a reference
-// to one of our Gateways (same namespace; Gateway kind/group).
-func attachedToOurGateway(parentRefs []gatewayv1.ParentReference, gateways map[string]struct{}) bool {
+// attachedToOurGateway reports whether the given parentRefs (belonging to a route
+// in routeNamespace) include a reference to one of our Gateways. A parentRef's
+// namespace defaults to the route's own namespace when unset (per the Gateway API
+// spec), so cross-namespace attachment is matched correctly.
+func attachedToOurGateway(parentRefs []gatewayv1.ParentReference, routeNamespace string, gateways map[gatewayKey]struct{}) bool {
 	for _, p := range parentRefs {
-		if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
+		if !parentRefIsGateway(p) {
 			continue
 		}
-		if p.Kind != nil && string(*p.Kind) != "Gateway" {
-			continue
-		}
-		if _, ok := gateways[string(p.Name)]; ok {
+		key := gatewayKey{Namespace: parentRefNamespace(p.Namespace, routeNamespace), Name: string(p.Name)}
+		if _, ok := gateways[key]; ok {
 			return true
 		}
 	}
 	return false
 }
 
+// parentRefIsGateway reports whether a parentRef targets a Gateway (the default
+// group/kind, or explicitly the Gateway API Gateway kind).
+func parentRefIsGateway(p gatewayv1.ParentReference) bool {
+	if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
+		return false
+	}
+	if p.Kind != nil && string(*p.Kind) != "Gateway" {
+		return false
+	}
+	return true
+}
+
+// parentRefNamespace resolves a parentRef namespace, defaulting to the referring
+// route's namespace when the ref leaves it unset (Gateway API local-default rule).
+func parentRefNamespace(ns *gatewayv1.Namespace, routeNamespace string) string {
+	if ns != nil && *ns != "" {
+		return string(*ns)
+	}
+	return routeNamespace
+}
+
 // gatewayParentPorts returns the distinct ports of our Gateway listeners that
-// match the given protocol and are referenced by the given parentRefs. Used to
-// scope TCPRoute/TLSRoute attachments to the exact Gateway listener ports.
+// match the given protocol and are referenced by the given parentRefs (belonging
+// to a route in routeNamespace). Used to scope TCPRoute/TLSRoute attachments to
+// the exact Gateway listener ports. A parentRef namespace defaults to the route's
+// own namespace when unset.
 func gatewayParentPorts(
 	parentRefs []gatewayv1alpha2.ParentReference,
-	gateways map[string]struct{},
+	routeNamespace string,
+	gateways map[gatewayKey]struct{},
 	protocol gatewayv1.ProtocolType,
 	listenerKeys map[gatewayListenerKey]struct{},
 ) []uint32 {
@@ -378,15 +424,15 @@ func gatewayParentPorts(
 		if p.Kind != nil && string(*p.Kind) != "Gateway" {
 			continue
 		}
-		gwName := string(p.Name)
-		if _, ok := gateways[gwName]; !ok {
+		gk := gatewayKey{Namespace: parentRefNamespace(p.Namespace, routeNamespace), Name: string(p.Name)}
+		if _, ok := gateways[gk]; !ok {
 			continue
 		}
 		// If a sectionName (listener name) is specified, match only that listener;
 		// otherwise match all listeners of the given protocol on this gateway.
 		if p.Port != nil {
 			port := uint32(*p.Port)
-			key := gatewayListenerKey{Gateway: gwName, Port: port, Protocol: protocol}
+			key := gatewayListenerKey{Gateway: gk, Port: port, Protocol: protocol}
 			if _, ok := listenerKeys[key]; ok {
 				if _, dup := seen[port]; !dup {
 					seen[port] = struct{}{}
@@ -397,7 +443,7 @@ func gatewayParentPorts(
 		}
 		// No port specified: include all matching-protocol listeners on this gateway.
 		for k := range listenerKeys {
-			if k.Gateway == gwName && k.Protocol == protocol {
+			if k.Gateway == gk && k.Protocol == protocol {
 				if _, dup := seen[k.Port]; !dup {
 					seen[k.Port] = struct{}{}
 					ports = append(ports, k.Port)

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -72,12 +72,24 @@ func TestBuildVirtualHost_TLS(t *testing.T) {
 }
 
 // TestAttachedToOurGateway: only routes with a parentRef to one of our Gateways
-// project.
+// project. parentRef namespace defaults to the route's namespace.
 func TestAttachedToOurGateway(t *testing.T) {
-	ours := map[string]struct{}{"edge-gw": {}}
-	assert.True(t, attachedToOurGateway(httpRoute(nil, nil, "edge-gw").Spec.ParentRefs, ours))
-	assert.False(t, attachedToOurGateway(httpRoute(nil, nil, "other-gw").Spec.ParentRefs, ours))
-	assert.False(t, attachedToOurGateway(httpRoute(nil, nil).Spec.ParentRefs, ours), "no parentRef")
+	ours := map[gatewayKey]struct{}{{Namespace: "ns", Name: "edge-gw"}: {}}
+	assert.True(t, attachedToOurGateway(httpRoute(nil, nil, "edge-gw").Spec.ParentRefs, "ns", ours))
+	assert.False(t, attachedToOurGateway(httpRoute(nil, nil, "other-gw").Spec.ParentRefs, "ns", ours))
+	assert.False(t, attachedToOurGateway(httpRoute(nil, nil).Spec.ParentRefs, "ns", ours), "no parentRef")
+	// Same gateway name in a DIFFERENT namespace must not match.
+	assert.False(t, attachedToOurGateway(httpRoute(nil, nil, "edge-gw").Spec.ParentRefs, "other-ns", ours), "name match in wrong namespace")
+}
+
+// TestAttachedToOurGateway_ExplicitNamespace: a parentRef with an explicit
+// namespace matches the Gateway in that namespace regardless of the route's.
+func TestAttachedToOurGateway_ExplicitNamespace(t *testing.T) {
+	ours := map[gatewayKey]struct{}{{Namespace: "gw-ns", Name: "edge-gw"}: {}}
+	ns := gatewayv1.Namespace("gw-ns")
+	hr := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "route-ns"}}
+	hr.Spec.ParentRefs = []gatewayv1.ParentReference{{Name: "edge-gw", Namespace: &ns}}
+	assert.True(t, attachedToOurGateway(hr.Spec.ParentRefs, "route-ns", ours))
 }
 
 func TestFirstBackendService(t *testing.T) {
@@ -139,45 +151,51 @@ func TestBuildL4Backends_ForeignGroupSkipped(t *testing.T) {
 // TestAttachedToOurGateway_L4 verifies the refactored attachedToOurGateway accepts
 // a []ParentReference slice directly (used by TCPRoute/TLSRoute path).
 func TestAttachedToOurGateway_L4(t *testing.T) {
-	ours := map[string]struct{}{"edge-gw": {}}
+	ours := map[gatewayKey]struct{}{{Namespace: "ns", Name: "edge-gw"}: {}}
 	refs := []gatewayv1.ParentReference{
 		{Name: "edge-gw"},
 	}
-	assert.True(t, attachedToOurGateway(refs, ours))
-	assert.False(t, attachedToOurGateway([]gatewayv1.ParentReference{{Name: "other"}}, ours))
+	assert.True(t, attachedToOurGateway(refs, "ns", ours))
+	assert.False(t, attachedToOurGateway([]gatewayv1.ParentReference{{Name: "other"}}, "ns", ours))
 }
 
 // TestGatewayParentPorts_WithPort verifies port-scoped parentRefs are matched
 // against the listener key set.
 func TestGatewayParentPorts_WithPort(t *testing.T) {
-	gateways := map[string]struct{}{"edge-gw": {}}
+	gk := gatewayKey{Namespace: "ns", Name: "edge-gw"}
+	gateways := map[gatewayKey]struct{}{gk: {}}
 	keys := map[gatewayListenerKey]struct{}{
-		{Gateway: "edge-gw", Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
-		{Gateway: "edge-gw", Port: 8443, Protocol: gatewayv1.TLSProtocolType}: {},
+		{Gateway: gk, Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: gk, Port: 8443, Protocol: gatewayv1.TLSProtocolType}: {},
 	}
 
 	tcpRefs := []gatewayv1alpha2.ParentReference{gatewayParentRef("edge-gw", 5432)}
-	ports := gatewayParentPorts(tcpRefs, gateways, gatewayv1.TCPProtocolType, keys)
+	ports := gatewayParentPorts(tcpRefs, "ns", gateways, gatewayv1.TCPProtocolType, keys)
 	assert.Equal(t, []uint32{5432}, ports)
 
 	// Wrong protocol: TLS ref not matched as TCP.
 	wrongProto := []gatewayv1alpha2.ParentReference{gatewayParentRef("edge-gw", 8443)}
-	tcpPorts := gatewayParentPorts(wrongProto, gateways, gatewayv1.TCPProtocolType, keys)
+	tcpPorts := gatewayParentPorts(wrongProto, "ns", gateways, gatewayv1.TCPProtocolType, keys)
 	assert.Empty(t, tcpPorts)
+
+	// Right name+port but wrong route namespace (no explicit ref ns): no match.
+	wrongNs := gatewayParentPorts(tcpRefs, "other-ns", gateways, gatewayv1.TCPProtocolType, keys)
+	assert.Empty(t, wrongNs)
 }
 
 // TestGatewayParentPorts_NoPort verifies that a parentRef with no port matches
 // all listeners of the given protocol on the gateway.
 func TestGatewayParentPorts_NoPort(t *testing.T) {
-	gateways := map[string]struct{}{"edge-gw": {}}
+	gk := gatewayKey{Namespace: "ns", Name: "edge-gw"}
+	gateways := map[gatewayKey]struct{}{gk: {}}
 	keys := map[gatewayListenerKey]struct{}{
-		{Gateway: "edge-gw", Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
-		{Gateway: "edge-gw", Port: 5433, Protocol: gatewayv1.TCPProtocolType}: {},
-		{Gateway: "edge-gw", Port: 8443, Protocol: gatewayv1.TLSProtocolType}: {},
+		{Gateway: gk, Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: gk, Port: 5433, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: gk, Port: 8443, Protocol: gatewayv1.TLSProtocolType}: {},
 	}
 	// No port: should match all TCP listeners.
 	refs := []gatewayv1alpha2.ParentReference{gatewayParentRef("edge-gw", 0)}
-	ports := gatewayParentPorts(refs, gateways, gatewayv1.TCPProtocolType, keys)
+	ports := gatewayParentPorts(refs, "ns", gateways, gatewayv1.TCPProtocolType, keys)
 	assert.Len(t, ports, 2)
 	for _, p := range ports {
 		assert.True(t, p == 5432 || p == 5433)
@@ -186,22 +204,22 @@ func TestGatewayParentPorts_NoPort(t *testing.T) {
 
 // TestGatewayParentPorts_UnknownGateway verifies refs to unknown gateways are ignored.
 func TestGatewayParentPorts_UnknownGateway(t *testing.T) {
-	gateways := map[string]struct{}{"edge-gw": {}}
+	gateways := map[gatewayKey]struct{}{{Namespace: "ns", Name: "edge-gw"}: {}}
 	keys := map[gatewayListenerKey]struct{}{
-		{Gateway: "other-gw", Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
+		{Gateway: gatewayKey{Namespace: "ns", Name: "other-gw"}, Port: 5432, Protocol: gatewayv1.TCPProtocolType}: {},
 	}
 	refs := []gatewayv1alpha2.ParentReference{gatewayParentRef("other-gw", 5432)}
-	ports := gatewayParentPorts(refs, gateways, gatewayv1.TCPProtocolType, keys)
+	ports := gatewayParentPorts(refs, "ns", gateways, gatewayv1.TCPProtocolType, keys)
 	assert.Empty(t, ports)
 }
 
 // TestBuildVirtualHost_ParentRefsRefactored verifies the refactored
 // attachedToOurGateway still works for HTTPRoutes.
 func TestBuildVirtualHost_ParentRefsRefactored(t *testing.T) {
-	ours := map[string]struct{}{"edge-gw": {}}
-	hr := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "r"}}
+	ours := map[gatewayKey]struct{}{{Namespace: "ns", Name: "edge-gw"}: {}}
+	hr := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"}}
 	hr.Spec.ParentRefs = []gatewayv1.ParentReference{{Name: "edge-gw"}}
-	assert.True(t, attachedToOurGateway(hr.Spec.ParentRefs, ours))
+	assert.True(t, attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, ours))
 }
 
 // TestBuildVirtualHost_RequestHeaderModifier: set/add/remove request header filters

--- a/agent/internal/edge/gatewayapi/status.go
+++ b/agent/internal/edge/gatewayapi/status.go
@@ -13,13 +13,15 @@ import (
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 )
 
-// writeGatewayClassStatus sets Accepted=True on the GatewayClass whose
-// controllerName is the edge controller and whose name is the one we serve. It
-// is a no-op for any other class (we MUST only touch classes we control).
+// writeGatewayClassStatus sets Accepted=True and the supportedFeatures list on the
+// GatewayClass whose controllerName is the edge controller and whose name is the
+// one we serve. It is a no-op for any other class (we MUST only touch classes we
+// control). supportedFeatures is what the upstream conformance suite reads to
+// decide which test suites to run vs skip.
 func (r *Reconciler) writeGatewayClassStatus(ctx context.Context) {
 	gc := &gatewayv1.GatewayClass{}
-	// Uncached read: GatewayClass is cluster-scoped and the manager cache is
-	// namespace-scoped, so r.Get (cached) would miss and return NotFound.
+	// Uncached read: GatewayClass is cluster-scoped and a cached Get can race the
+	// informer sync and return NotFound on the first reconcile.
 	if err := r.APIReader.Get(ctx, types.NamespacedName{Name: r.GatewayClassName}, gc); err != nil {
 		if !apierrors.IsNotFound(err) {
 			r.Log.WarnContext(ctx, "failed to get GatewayClass for status", "gatewayClass", r.GatewayClassName, "error", err.Error())
@@ -29,16 +31,21 @@ func (r *Reconciler) writeGatewayClassStatus(ctx context.Context) {
 	if gc.Spec.ControllerName != gatewaystatus.EdgeControllerName {
 		return
 	}
-	conds, changed := gatewaystatus.MergeConditions(gc.Status.Conditions, gc.Generation, gatewaystatus.Condition{
+	conds, condChanged := gatewaystatus.MergeConditions(gc.Status.Conditions, gc.Generation, gatewaystatus.Condition{
 		Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
 		Status:  metav1.ConditionTrue,
 		Reason:  string(gatewayv1.GatewayClassReasonAccepted),
 		Message: "GatewayClass accepted by the aether edge controller",
 	})
-	if !changed {
+
+	features := aetherSupportedFeatures()
+	featChanged := !supportedFeaturesEqual(gc.Status.SupportedFeatures, features)
+
+	if !condChanged && !featChanged {
 		return
 	}
 	gc.Status.Conditions = conds
+	gc.Status.SupportedFeatures = features
 	if err := r.Status().Update(ctx, gc); err != nil {
 		r.Log.WarnContext(ctx, "failed to write GatewayClass status", "gatewayClass", gc.Name, "error", err.Error())
 	}
@@ -54,7 +61,7 @@ func (r *Reconciler) writeGatewayStatuses(
 	httpRoutes []gatewayv1.HTTPRoute,
 	tcpRoutes []gatewayv1alpha2.TCPRoute,
 	tlsRoutes []gatewayv1.TLSRoute,
-	gateways map[string]struct{},
+	gateways map[gatewayKey]struct{},
 	listenerKeys map[gatewayListenerKey]struct{},
 ) {
 	for i := range ourGateways {
@@ -79,7 +86,7 @@ func (r *Reconciler) writeGatewayStatuses(
 
 		listeners := make([]gatewayv1.ListenerStatus, 0, len(gw.Spec.Listeners))
 		for _, ln := range gw.Spec.Listeners {
-			attached := r.attachedRoutesForListener(gw.Name, ln, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys)
+			attached := r.attachedRoutesForListener(gw.Namespace, gw.Name, ln, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys)
 			lc, _ := gatewaystatus.MergeConditions(existingListenerConditions(gw.Status.Listeners, ln.Name), gw.Generation,
 				gatewaystatus.Condition{
 					Type:    string(gatewayv1.ListenerConditionAccepted),
@@ -124,12 +131,12 @@ func (r *Reconciler) writeGatewayStatuses(
 // gateway; TCP/TLS listeners accept TCP/TLSRoutes whose parentRef resolves to
 // that listener's port (via gatewayParentPorts).
 func (r *Reconciler) attachedRoutesForListener(
-	gwName string,
+	gwNamespace, gwName string,
 	ln gatewayv1.Listener,
 	httpRoutes []gatewayv1.HTTPRoute,
 	tcpRoutes []gatewayv1alpha2.TCPRoute,
 	tlsRoutes []gatewayv1.TLSRoute,
-	gateways map[string]struct{},
+	gateways map[gatewayKey]struct{},
 	listenerKeys map[gatewayListenerKey]struct{},
 ) int32 {
 	var count int32
@@ -137,14 +144,14 @@ func (r *Reconciler) attachedRoutesForListener(
 	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
 		for i := range httpRoutes {
 			hr := &httpRoutes[i]
-			if httpRouteAttachesToListener(hr.Spec.ParentRefs, gwName, ln) {
+			if httpRouteAttachesToListener(hr.Spec.ParentRefs, hr.Namespace, gwNamespace, gwName, ln) {
 				count++
 			}
 		}
 	case gatewayv1.TCPProtocolType:
 		for i := range tcpRoutes {
 			tr := &tcpRoutes[i]
-			ports := gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TCPProtocolType, listenerKeys)
+			ports := gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, listenerKeys)
 			if containsPort(ports, uint32(ln.Port)) {
 				count++
 			}
@@ -152,7 +159,7 @@ func (r *Reconciler) attachedRoutesForListener(
 	case gatewayv1.TLSProtocolType:
 		for i := range tlsRoutes {
 			tr := &tlsRoutes[i]
-			ports := gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TLSProtocolType, listenerKeys)
+			ports := gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, listenerKeys)
 			if containsPort(ports, uint32(ln.Port)) {
 				count++
 			}
@@ -161,10 +168,11 @@ func (r *Reconciler) attachedRoutesForListener(
 	return count
 }
 
-// httpRouteAttachesToListener reports whether an HTTPRoute's parentRefs attach to
-// the given gateway listener. A parentRef with no sectionName/port attaches to
-// every HTTP/HTTPS listener; a sectionName or port narrows it to that listener.
-func httpRouteAttachesToListener(parentRefs []gatewayv1.ParentReference, gwName string, ln gatewayv1.Listener) bool {
+// httpRouteAttachesToListener reports whether an HTTPRoute (in routeNamespace)
+// attaches to the given gateway listener. A parentRef with no sectionName/port
+// attaches to every HTTP/HTTPS listener; a sectionName or port narrows it to that
+// listener. The parentRef namespace defaults to the route's namespace.
+func httpRouteAttachesToListener(parentRefs []gatewayv1.ParentReference, routeNamespace, gwNamespace, gwName string, ln gatewayv1.Listener) bool {
 	for _, p := range parentRefs {
 		if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
 			continue
@@ -172,7 +180,7 @@ func httpRouteAttachesToListener(parentRefs []gatewayv1.ParentReference, gwName 
 		if p.Kind != nil && string(*p.Kind) != "Gateway" {
 			continue
 		}
-		if string(p.Name) != gwName {
+		if string(p.Name) != gwName || parentRefNamespace(p.Namespace, routeNamespace) != gwNamespace {
 			continue
 		}
 		if p.SectionName != nil && *p.SectionName != ln.Name {
@@ -259,32 +267,33 @@ func (r *Reconciler) writeRouteStatuses(
 	httpRoutes []gatewayv1.HTTPRoute,
 	tcpRoutes []gatewayv1alpha2.TCPRoute,
 	tlsRoutes []gatewayv1.TLSRoute,
-	gateways map[string]struct{},
+	gateways map[gatewayKey]struct{},
 	listenerKeys map[gatewayListenerKey]struct{},
 ) {
 	for i := range httpRoutes {
 		hr := &httpRoutes[i]
-		accepted := attachedToOurGateway(hr.Spec.ParentRefs, gateways)
+		accepted := attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways)
 		resolved, reason, msg := r.backendsResolveHTTP(ctx, hr.Namespace, hr.Spec.Rules)
-		r.writeRouteParentStatus(ctx, hr, hr.Generation, &hr.Status.RouteStatus, ourGatewayParentRefs(hr.Spec.ParentRefs, gateways), accepted, resolved, reason, msg, "HTTPRoute")
+		r.writeRouteParentStatus(ctx, hr, hr.Generation, &hr.Status.RouteStatus, ourGatewayParentRefs(hr.Spec.ParentRefs, hr.Namespace, gateways), accepted, resolved, reason, msg, "HTTPRoute")
 	}
 	for i := range tcpRoutes {
 		tr := &tcpRoutes[i]
-		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TCPProtocolType, listenerKeys)) > 0
+		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, listenerKeys)) > 0
 		resolved, reason, msg := r.backendsResolveL4(ctx, tr.Namespace, l4BackendObjectRefs(tr.Spec.Rules))
-		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, gateways), accepted, resolved, reason, msg, "TCPRoute")
+		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, resolved, reason, msg, "TCPRoute")
 	}
 	for i := range tlsRoutes {
 		tr := &tlsRoutes[i]
-		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, gateways, gatewayv1.TLSProtocolType, listenerKeys)) > 0
+		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, listenerKeys)) > 0
 		resolved, reason, msg := r.backendsResolveTLS(ctx, tr.Namespace, tr.Spec.Rules)
-		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, gateways), accepted, resolved, reason, msg, "TLSRoute")
+		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, resolved, reason, msg, "TLSRoute")
 	}
 }
 
-// ourGatewayParentRefs returns the parentRefs of a route that point at one of our
-// Gateways — the only entries we own status for.
-func ourGatewayParentRefs(parentRefs []gatewayv1.ParentReference, gateways map[string]struct{}) []gatewayv1.ParentReference {
+// ourGatewayParentRefs returns the parentRefs of a route (in routeNamespace) that
+// point at one of our Gateways — the only entries we own status for. The parentRef
+// namespace defaults to the route's namespace.
+func ourGatewayParentRefs(parentRefs []gatewayv1.ParentReference, routeNamespace string, gateways map[gatewayKey]struct{}) []gatewayv1.ParentReference {
 	var out []gatewayv1.ParentReference
 	for _, p := range parentRefs {
 		if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
@@ -293,7 +302,8 @@ func ourGatewayParentRefs(parentRefs []gatewayv1.ParentReference, gateways map[s
 		if p.Kind != nil && string(*p.Kind) != "Gateway" {
 			continue
 		}
-		if _, ok := gateways[string(p.Name)]; !ok {
+		key := gatewayKey{Namespace: parentRefNamespace(p.Namespace, routeNamespace), Name: string(p.Name)}
+		if _, ok := gateways[key]; !ok {
 			continue
 		}
 		out = append(out, p)

--- a/agent/internal/edge/gatewayapi/status_test.go
+++ b/agent/internal/edge/gatewayapi/status_test.go
@@ -3,6 +3,7 @@ package gatewayapi
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"testing"
 
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
@@ -115,4 +116,104 @@ func TestReconcile_GatewayAndRouteStatus(t *testing.T) {
 	rres := meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
 	require.NotNil(t, rres)
 	assert.Equal(t, metav1.ConditionTrue, rres.Status)
+}
+
+// TestReconcile_GatewayInNonEdgeNamespace: a Gateway of our class living in a
+// namespace OTHER than the edge's own (r.Namespace) is reconciled cluster-wide and
+// reaches Accepted=True + Programmed=True, with its attached HTTPRoute (also in a
+// foreign namespace) getting Accepted=True under our controller. This is the
+// conformance unlock — the suite creates its objects in its own namespaces.
+func TestReconcile_GatewayInNonEdgeNamespace(t *testing.T) {
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+	// Gateway + Route in "gateway-conformance-infra", NOT the edge namespace ("aether-ingress").
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "conformance-gw", Namespace: "gateway-conformance-infra", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name:     "http",
+				Port:     80,
+				Protocol: gatewayv1.HTTPProtocolType,
+			}},
+		},
+	}
+	hr := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "infra-route", Namespace: "gateway-conformance-infra", Generation: 1},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{
+				{Kind: ptr(gatewayv1.Kind("Gateway")), Name: "conformance-gw"},
+			}},
+			Hostnames: []gatewayv1.Hostname{"infra.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "infra-backend", Port: ptr(gatewayv1.PortNumber(8080))},
+				}}},
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(gc, gw, hr).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
+		Build()
+	// Edge's own namespace is aether-ingress; the Gateway lives elsewhere.
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "aether-ingress", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotGW := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "gateway-conformance-infra", Name: "conformance-gw"}, gotGW))
+	acc := meta.FindStatusCondition(gotGW.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionTrue, acc.Status)
+	prog := meta.FindStatusCondition(gotGW.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+	require.NotNil(t, prog)
+	assert.Equal(t, metav1.ConditionTrue, prog.Status)
+	require.Len(t, gotGW.Status.Listeners, 1)
+	assert.Equal(t, int32(1), gotGW.Status.Listeners[0].AttachedRoutes)
+
+	gotHR := &gatewayv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "gateway-conformance-infra", Name: "infra-route"}, gotHR))
+	require.Len(t, gotHR.Status.Parents, 1)
+	racc := meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, racc)
+	assert.Equal(t, metav1.ConditionTrue, racc.Status)
+}
+
+// TestReconcile_GatewayClassSupportedFeatures: the GatewayClass status carries the
+// advertised supportedFeatures, sorted ascending and including HTTPRoute/GRPCRoute,
+// and omitting features aether does not implement.
+func TestReconcile_GatewayClassSupportedFeatures(t *testing.T) {
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(gc).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "aether-ingress", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotGC := &gatewayv1.GatewayClass{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "aether"}, gotGC))
+	require.NotEmpty(t, gotGC.Status.SupportedFeatures)
+
+	names := make([]string, 0, len(gotGC.Status.SupportedFeatures))
+	for _, f := range gotGC.Status.SupportedFeatures {
+		names = append(names, string(f.Name))
+	}
+	assert.True(t, sort.StringsAreSorted(names), "supportedFeatures must be ascending by name")
+	assert.Contains(t, names, "HTTPRoute")
+	assert.Contains(t, names, "GRPCRoute")
+	assert.Contains(t, names, "HTTPRouteRequestTimeout")
+	// Unsupported features must NOT be advertised (so their suites skip).
+	assert.NotContains(t, names, "HTTPRouteRequestMirror")
+	assert.NotContains(t, names, "ReferenceGrant")
 }

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.42.0-{GIT_COMMIT}"
+version: "0.43.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-rbac.yaml
+++ b/charts/aether/templates/edge-rbac.yaml
@@ -1,17 +1,19 @@
 {{- if .Values.edge.enabled }}
-{{- $routeNamespace := default (include "aether.edge.namespace" .) .Values.edge.routeNamespace }}
-# Namespaced: the edge only reads Gateways/HTTPRoutes (and their status) in the
-# namespace it watches. No cluster-wide access — exposure is delegable per namespace.
+# Cluster-scoped: the edge is now namespace-agnostic. It reconciles every Gateway
+# of its GatewayClass wherever it lives and publishes status (Accepted/Programmed/
+# ResolvedRefs) on those Gateways and their Routes — the upstream conformance suite
+# creates its objects in its OWN namespaces, so a namespace-scoped Role would never
+# see them. The cluster-wide list/watch + status here is what unblocks the
+# north-south profile. GatewayClass is itself a cluster resource.
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: {{ include "aether.edge.fullname" . }}
-  namespace: {{ $routeNamespace }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
 rules:
   # Gateway API (proposal 018): read Gateways + HTTPRoutes + TCPRoutes + TLSRoutes
-  # (and their status) in the watched namespace. TCPRoute/TLSRoute live in
+  # (and write their status) CLUSTER-WIDE. TCPRoute/TLSRoute live in
   # gateway.networking.k8s.io/v1alpha2 but share the same apiGroup label in RBAC.
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways", "httproutes", "tcproutes", "tlsroutes"]
@@ -19,8 +21,15 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gateways/status", "httproutes/status", "tcproutes/status", "tlsroutes/status"]
     verbs: ["get", "update", "patch"]
-  # Resolve backendRef Services in the watched namespace for the ResolvedRefs
-  # condition on routes.
+  # GatewayClass (cluster resource): read it and set its Accepted status +
+  # supportedFeatures (conformance).
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gatewayclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gatewayclasses/status"]
+    verbs: ["get", "update", "patch"]
+  # Resolve backendRef Services cluster-wide for the ResolvedRefs condition.
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["get", "list", "watch"]
@@ -33,47 +42,15 @@ rules:
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ include "aether.edge.fullname" . }}
-  namespace: {{ $routeNamespace }}
-  labels:
-    {{- include "aether.edge.labels" . | nindent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ include "aether.edge.fullname" . }}
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "aether.edge.serviceAccountName" . }}
-    namespace: {{ include "aether.edge.namespace" . }}
----
-# Cluster-scoped: GatewayClass is a cluster resource, so the edge needs a
-# ClusterRole to read it and set its Accepted status condition (conformance).
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "aether.edge.fullname" . }}-gatewayclass
-  labels:
-    {{- include "aether.edge.labels" . | nindent 4 }}
-rules:
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["gateway.networking.k8s.io"]
-    resources: ["gatewayclasses/status"]
-    verbs: ["get", "update", "patch"]
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "aether.edge.fullname" . }}-gatewayclass
+  name: {{ include "aether.edge.fullname" . }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "aether.edge.fullname" . }}-gatewayclass
+  name: {{ include "aether.edge.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "aether.edge.serviceAccountName" . }}

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -58,4 +58,25 @@ e2e-validated on talos (aether 0.41.0).
 ## Status reporting
 
 GatewayClass/Gateway/Route status-condition reporting (Accepted/Programmed/ResolvedRefs)
-and a machine-readable supported-features report are a Planned conformance follow-up.
+is **Supported**: the edge controller is namespace-agnostic — it reconciles every
+Gateway of its GatewayClass in ANY namespace and publishes the Gateway/Route status
+conditions and per-listener `attachedRoutes`, which is what the upstream conformance
+suite's `NamespacesMustBeReady` gate requires before any test runs.
+
+The GatewayClass also publishes a machine-readable `status.supportedFeatures` list so
+the suite skips (rather than fails) the features aether does not implement. The
+advertised set is: `Gateway`, `GatewayPort8080`, `HTTPRoute`, `GRPCRoute`,
+`HTTPRouteMethodMatching`, `HTTPRouteRequestTimeout`,
+`HTTPRouteResponseHeaderModification`. Path/header/method match, weighted backends,
+and the `RequestHeaderModifier` filter are part of HTTPRoute *core* and carry no
+separate feature flag. Redirect/rewrite/mirror and `ReferenceGrant` are deliberately
+omitted (not implemented).
+
+### Data-plane / addressing gap
+
+The status/reconcile unlock is namespace-agnostic, but the edge data plane is still a
+single Deployment on a single LoadBalancer address. A Gateway in another namespace is
+reconciled and reaches `Accepted`/`Programmed`, and its routes are served through that
+one shared edge address — there is no per-Gateway address allocation. Tests that assert
+each Gateway has its OWN distinct address are not yet satisfied; multi-Gateway
+addressing is the next item.


### PR DESCRIPTION
## Conformance unlock

The upstream **GATEWAY-HTTP** profile ran **0 tests** because the edge controller's cache + lists were scoped to a single namespace (`aether-ingress`). The conformance suite creates its Gateways/Routes in its **own** namespaces (e.g. `gateway-conformance-infra`), so those Gateways never reached `Accepted`/`Programmed` and the suite's `NamespacesMustBeReady` gate timed out **before a single test ran**. (Backends came up fine — CNI/capture doesn't block.)

This makes the edge Gateway controller **namespace-agnostic** and advertises **GatewayClass `supportedFeatures`**.

## What changed

1. **Cluster-wide cache** (`agent/internal/cmd/edge.go`) — `CacheOptions` left `nil`, so the manager caches every watched Gateway-API kind (+ Services/Secrets) across all namespaces. `routeNamespace` is still resolved as the default namespace for the TLS Secret provider's cert lookups.

2. **Cluster-wide reconcile** (`reconciler.go`) — drops `client.InNamespace` on the Gateway/HTTPRoute/TCPRoute/TLSRoute lists and selects ours by `gatewayClassName` across all namespaces. Gateways are now keyed by **namespace+name** (`gatewayKey`); route attachment resolves each parentRef's namespace (defaulting to the route's own), so duplicate Gateway names across namespaces don't cross-match.

3. **GatewayClass `supportedFeatures`** (`status.go` + new `features.go`) — `writeGatewayClassStatus` publishes the honest feature set from the pinned `sigs.k8s.io/gateway-api/pkg/features`, sorted ascending: `Gateway`, `GatewayPort8080`, `GRPCRoute`, `HTTPRoute`, `HTTPRouteMethodMatching`, `HTTPRouteRequestTimeout`, `HTTPRouteResponseHeaderModification`. Path/header/method match, weighted backends, and `RequestHeaderModifier` are HTTPRoute **core** (no separate flag). Redirect/rewrite/mirror and `ReferenceGrant` are **omitted** so their suites **skip** cleanly instead of failing.

4. **RBAC** (`charts/aether/templates/edge-rbac.yaml`) — the per-namespace `Role`/`RoleBinding` become a cluster-wide `ClusterRole`/`ClusterRoleBinding` (Gateway-API kinds + their `/status`, Services, Secrets, GatewayClass). Chart **0.42.0 → 0.43.0**.

## Data-plane / addressing gap (key finding for what's next)

The status/reconcile unlock is namespace-agnostic, but the edge data plane is still **one Deployment on one LoadBalancer address** (`192.168.100.101`). A Gateway in another namespace is reconciled and reaches `Accepted`/`Programmed`, and its routes are served through that **single shared address** — there is **no per-Gateway address allocation**. Tests that assert each Gateway has its **own** distinct address are not yet satisfied. Multi-Gateway addressing is the next item; this PR is the controller/status unlock, which is what lets the route tests execute through the edge's data plane.

## Build / test

- `make gazelle`; `bazel build //...` ✅
- `bazel test //... --test_output=errors` ✅ (chart-lint "failures" seen only when `-test.short` is forced onto the helm lint binary; they pass normally)
- `bazel run //:format` (no changes)
- New tests: a Gateway of class `aether` in a **non-edge** namespace → `Accepted`/`Programmed`=True + attached route accepted; GatewayClass status carries `supportedFeatures` (sorted, includes HTTPRoute/GRPCRoute, excludes mirror/ReferenceGrant); namespaced gateway-key matching guards.

## e2e to check

- Apply a Gateway of class `aether` in a fresh namespace → it reaches `Accepted=True` / `Programmed=True`, its HTTPRoute gets `Accepted=True`/`ResolvedRefs=True` under `gateway.aether.io/edge`.
- `kubectl get gatewayclass aether -o jsonpath='{.status.supportedFeatures}'` is populated.
- Existing `aether-ingress/edge` Gateway + `api` HTTPRoute still serve exactly as before (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)