### PR TITLE
feat(agent,edge): ReferenceGrant enforcement for cross-namespace backendRefs

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials",
     ],

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // edgeName is the controller/logging name for the edge proxy control plane.
@@ -126,6 +127,11 @@ func runEdge(ctx context.Context) (retErr error) {
 	// TCPRoute/TLSRoute live in v1alpha2 (not yet promoted to v1 in gateway-api v1.5.1).
 	if err := gatewayv1alpha2.Install(scheme); err != nil {
 		return fmt.Errorf("register gateway.networking.k8s.io/v1alpha2 scheme: %w", err)
+	}
+	// ReferenceGrant is served as v1beta1 (the storage version) — needed to admit
+	// cross-namespace backendRefs.
+	if err := gatewayv1beta1.Install(scheme); err != nil {
+		return fmt.Errorf("register gateway.networking.k8s.io/v1beta1 scheme: %w", err)
 	}
 
 	result, err := manager.Bootstrap(ctx, cfg.Config, edgeName, Version, func(o *ctrl.Options) { o.Scheme = scheme })

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -60,6 +60,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 const (
@@ -356,6 +357,10 @@ func runAgent(ctx context.Context) (retErr error) {
 		if err = gatewayv1.Install(m.GetScheme()); err != nil {
 			return fmt.Errorf("register gateway.networking.k8s.io scheme: %w", err)
 		}
+		// ReferenceGrant (v1beta1) gates cross-namespace backendRefs on GAMMA routes.
+		if err = gatewayv1beta1.Install(m.GetScheme()); err != nil {
+			return fmt.Errorf("register gateway.networking.k8s.io/v1beta1 scheme: %w", err)
+		}
 		gammaReconciler := &gamma.Reconciler{
 			Client:     m.GetClient(),
 			Sink:       snapshotCache,
@@ -375,6 +380,13 @@ func runAgent(ctx context.Context) (retErr error) {
 	if cfg.L4Routes {
 		if err = gatewayv1alpha2.Install(m.GetScheme()); err != nil {
 			return fmt.Errorf("register gateway.networking.k8s.io v1alpha2 scheme: %w", err)
+		}
+		// v1 (TLSRoute) + v1beta1 (ReferenceGrant) types the l4 reconciler reads.
+		if err = gatewayv1.Install(m.GetScheme()); err != nil {
+			return fmt.Errorf("register gateway.networking.k8s.io scheme: %w", err)
+		}
+		if err = gatewayv1beta1.Install(m.GetScheme()); err != nil {
+			return fmt.Errorf("register gateway.networking.k8s.io/v1beta1 scheme: %w", err)
 		}
 		l4Reconciler := &l4route.Reconciler{
 			Client:     m.GetClient(),

--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//agent/internal/edge/secret",
         "//agent/internal/gatewaystatus",
+        "//agent/internal/referencegrant",
         "//agent/internal/xds/cache",
         "//agent/internal/xds/proxy",
         "//api/aether/config/v1:config",
@@ -26,6 +27,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@io_k8s_sigs_gateway_api//pkg/features",
     ],
 )
@@ -53,5 +55,6 @@ go_test(
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
     ],
 )

--- a/agent/internal/edge/gatewayapi/features.go
+++ b/agent/internal/edge/gatewayapi/features.go
@@ -16,15 +16,23 @@ import (
 // (sigs.k8s.io/gateway-api/pkg/features).
 //
 //   - Gateway / GatewayPort8080 — north-south Gateways on the standard test port.
+//
 //   - HTTPRoute / GRPCRoute — both route types (edge HTTPRoute, GAMMA HTTPRoute+GRPCRoute).
+//
 //   - HTTPRouteMethodMatching — gRPC method match → path; HTTP method match.
+//
 //   - HTTPRouteResponseHeaderModification — ResponseHeaderModifier filter (route level).
+//
 //   - HTTPRouteRequestTimeout — HTTPRoute timeouts.request.
+//
+//   - ReferenceGrant — cross-namespace backendRef admission + status enforcement
+//     (ungranted cross-ns refs report ResolvedRefs=False/RefNotPermitted and are
+//     dropped). Resolution stays namespace-blind today (proposal 020 Part 1).
 //
 // Path match (Exact/PathPrefix), header match (Exact), weighted backends, and the
 // RequestHeaderModifier filter are part of HTTPRoute *core* conformance and carry
-// no separate feature flag. Redirect/rewrite/mirror and ReferenceGrant are
-// deliberately omitted (not implemented) so their suites skip.
+// no separate feature flag. Redirect/rewrite/mirror are deliberately omitted (not
+// implemented) so their suites skip.
 var aetherSupportedFeaturesList = []features.FeatureName{
 	features.SupportGateway,
 	features.SupportGatewayPort8080,
@@ -33,6 +41,7 @@ var aetherSupportedFeaturesList = []features.FeatureName{
 	features.SupportHTTPRouteMethodMatching,
 	features.SupportHTTPRouteRequestTimeout,
 	features.SupportHTTPRouteResponseHeaderModification,
+	features.SupportReferenceGrant,
 }
 
 // aetherSupportedFeatures returns the supportedFeatures to publish on the

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/bpalermo/aether/agent/internal/edge/secret"
+	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
@@ -24,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // RouteSink receives the projected virtual hosts, TLS certs, and L4 routes
@@ -79,6 +81,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&gatewayv1.Gateway{}, resync).
 		Watches(&gatewayv1alpha2.TCPRoute{}, resync).
 		Watches(&gatewayv1.TLSRoute{}, resync).
+		// ReferenceGrant (v1beta1): a grant change can flip a cross-namespace
+		// backendRef between permitted and RefNotPermitted, so re-project everything.
+		Watches(&gatewayv1beta1.ReferenceGrant{}, resync).
 		Named("gatewayapi")
 	if r.Secrets != nil {
 		b = b.Watches(&corev1.Secret{}, resync)
@@ -96,6 +101,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs (drop +
+	// RefNotPermitted). The edge cache is cluster-wide (post-#323).
+	grantList := &gatewayv1beta1.ReferenceGrantList{}
+	if err := r.List(ctx, grantList); err != nil {
+		return reconcile.Result{}, err
+	}
+	grants := grantList.Items
 
 	// --- HTTPRoutes (cluster-wide) ---
 	httpRoutes := &gatewayv1.HTTPRouteList{}
@@ -116,7 +129,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		if !attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways) {
 			continue
 		}
-		vh := r.buildVirtualHost(hr, hostCerts)
+		vh := r.buildVirtualHost(hr, hostCerts, grants)
 		if len(vh.Hosts) == 0 || len(vh.Routes) == 0 {
 			continue
 		}
@@ -134,7 +147,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		ports := gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, gatewayListeners)
 		for _, port := range ports {
 			for _, rule := range tr.Spec.Rules {
-				tcpByPort[port] = append(tcpByPort[port], r.buildL4Backends(rule.BackendRefs)...)
+				tcpByPort[port] = append(tcpByPort[port], r.buildL4Backends(rule.BackendRefs, tr.Namespace, "TCPRoute", grants)...)
 			}
 		}
 	}
@@ -169,7 +182,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			for _, rule := range tr.Spec.Rules {
 				tlsByPort[port] = append(tlsByPort[port], proxy.L4ServiceRoute{
 					SNIHostnames: hostnames,
-					Backends:     r.buildL4Backends(rule.BackendRefs),
+					Backends:     r.buildL4Backends(rule.BackendRefs, tr.Namespace, "TLSRoute", grants),
 				})
 			}
 		}
@@ -211,7 +224,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// retries. The GatewayClass, Gateways, and routes we own all get conditions.
 	r.writeGatewayClassStatus(ctx)
 	r.writeGatewayStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners)
-	r.writeRouteStatuses(ctx, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners)
+	r.writeRouteStatuses(ctx, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, grants)
 	return reconcile.Result{}, nil
 }
 
@@ -308,7 +321,7 @@ func (r *Reconciler) resolveGateways(ctx context.Context) (map[gatewayKey]struct
 //
 // Rules with a RequestRedirect filter emit a redirect route (no backend required).
 // Rules with a URLRewrite filter apply host/path rewriting on the forwarding route.
-func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[string]string) cache.VirtualHost {
+func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[string]string, grants []gatewayv1beta1.ReferenceGrant) cache.VirtualHost {
 	vh := cache.VirtualHost{}
 	for _, h := range hr.Spec.Hostnames {
 		vh.Hosts = append(vh.Hosts, string(h))
@@ -317,13 +330,13 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 		redirect := buildHTTPRedirect(rule.Filters)
 		urlRewrite := buildHTTPURLRewrite(rule.Filters)
 
-		backend := firstBackendService(rule.BackendRefs)
+		backend := firstBackendService(rule.BackendRefs, hr.Namespace, grants)
 		// A rule must have either a backend or a redirect to produce a route.
 		if backend == "" && redirect == nil {
 			continue
 		}
 		var port uint32
-		if p := firstBackendPort(rule.BackendRefs); p != 0 {
+		if p := firstBackendPort(rule.BackendRefs, hr.Namespace, grants); p != 0 {
 			port = p
 		}
 		mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
@@ -455,8 +468,10 @@ func gatewayParentPorts(
 }
 
 // buildL4Backends converts a BackendRef slice into L4Backends with resolved TCP
-// cluster names. Refs with a non-core group or non-Service kind are skipped.
-func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef) []proxy.L4Backend {
+// cluster names. Refs with a non-core group or non-Service kind are skipped, as are
+// ungranted cross-namespace refs (RefNotPermitted: dropped from the data plane).
+// routeKind is the referring route's kind (TCPRoute/TLSRoute).
+func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
 	backends := make([]proxy.L4Backend, 0, len(refs))
 	for _, b := range refs {
 		if b.Group != nil && string(*b.Group) != "" {
@@ -467,6 +482,9 @@ func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef) []proxy.L4Back
 		}
 		name := string(b.Name)
 		if name == "" {
+			continue
+		}
+		if !backendPermitted(b.Namespace, routeNamespace, routeKind, name, grants) {
 			continue
 		}
 		weight := uint32(1)
@@ -482,7 +500,12 @@ func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef) []proxy.L4Back
 	return backends
 }
 
-func firstBackendService(refs []gatewayv1.HTTPBackendRef) string {
+// firstBackendService returns the name of the first core-Service backendRef that is
+// admissible: a same-namespace ref, or a cross-namespace ref permitted by a
+// ReferenceGrant. Ungranted cross-namespace refs are skipped (RefNotPermitted →
+// dropped from the data plane), so a rule whose only backend is ungranted yields no
+// backend (and, with no redirect, no route).
+func firstBackendService(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) string {
 	for _, b := range refs {
 		if b.Group != nil && string(*b.Group) != "" {
 			continue // only core Services in Phase 1
@@ -490,18 +513,53 @@ func firstBackendService(refs []gatewayv1.HTTPBackendRef) string {
 		if b.Kind != nil && string(*b.Kind) != "Service" {
 			continue
 		}
+		if !backendPermitted(b.Namespace, routeNamespace, "HTTPRoute", string(b.Name), grants) {
+			continue
+		}
 		return string(b.Name)
 	}
 	return ""
 }
 
-func firstBackendPort(refs []gatewayv1.HTTPBackendRef) uint32 {
+// firstBackendPort returns the port of the first admissible (same-namespace or
+// granted cross-namespace) backendRef, so the port matches the backend
+// firstBackendService selects.
+func firstBackendPort(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) uint32 {
 	for _, b := range refs {
+		if b.Group != nil && string(*b.Group) != "" {
+			continue
+		}
+		if b.Kind != nil && string(*b.Kind) != "Service" {
+			continue
+		}
+		if !backendPermitted(b.Namespace, routeNamespace, "HTTPRoute", string(b.Name), grants) {
+			continue
+		}
 		if b.Port != nil {
 			return uint32(*b.Port)
 		}
 	}
 	return 0
+}
+
+// derefBackendNamespace returns the backendRef namespace ("" when unset).
+func derefBackendNamespace(ns *gatewayv1.Namespace) string {
+	if ns == nil {
+		return ""
+	}
+	return string(*ns)
+}
+
+// backendPermitted reports whether a backendRef is allowed onto the data plane: a
+// same-namespace ref always is; a cross-namespace ref needs a matching ReferenceGrant
+// in the backend's namespace whose from matches the route and whose to allows the
+// Service. routeKind is the referring route's kind (HTTPRoute/TCPRoute/TLSRoute).
+func backendPermitted(backendNamespace *gatewayv1.Namespace, routeNamespace, routeKind, name string, grants []gatewayv1beta1.ReferenceGrant) bool {
+	ns := derefBackendNamespace(backendNamespace)
+	if !referencegrant.CrossNamespace(ns, routeNamespace) {
+		return true
+	}
+	return referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, name)
 }
 
 // certForHosts picks the SDS cert for a vhost: an exact hostname listener match

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -47,7 +48,7 @@ func TestBuildVirtualHost(t *testing.T) {
 		{Matches: pathMatch(gatewayv1.PathMatchExact, "/exact"), BackendRefs: backend("svc-2", 8080)},
 		{BackendRefs: backend("svc-1", 0)}, // no match → default "/"
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 
 	assert.Equal(t, []string{"api.example.com"}, vh.Hosts)
 	assert.Equal(t, []cache.Route{
@@ -64,10 +65,10 @@ func TestBuildVirtualHost_TLS(t *testing.T) {
 	r := &Reconciler{}
 	hostCerts := map[string]string{"*.example.com": "kubernetes/wild", "": "kubernetes/default"}
 
-	wild := r.buildVirtualHost(httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{{BackendRefs: backend("svc-1", 0)}}), hostCerts)
+	wild := r.buildVirtualHost(httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{{BackendRefs: backend("svc-1", 0)}}), hostCerts, nil)
 	assert.Equal(t, "kubernetes/wild", wild.TLSSecret, "wildcard listener covers the host")
 
-	other := r.buildVirtualHost(httpRoute([]string{"foo.other.com"}, []gatewayv1.HTTPRouteRule{{BackendRefs: backend("svc-1", 0)}}), hostCerts)
+	other := r.buildVirtualHost(httpRoute([]string{"foo.other.com"}, []gatewayv1.HTTPRouteRule{{BackendRefs: backend("svc-1", 0)}}), hostCerts, nil)
 	assert.Equal(t, "kubernetes/default", other.TLSSecret, "falls back to the catch-all listener")
 }
 
@@ -93,8 +94,24 @@ func TestAttachedToOurGateway_ExplicitNamespace(t *testing.T) {
 }
 
 func TestFirstBackendService(t *testing.T) {
-	assert.Equal(t, "echo", firstBackendService(backend("echo", 0)))
-	assert.Empty(t, firstBackendService(nil))
+	assert.Equal(t, "echo", firstBackendService(backend("echo", 0), "ns", nil))
+	assert.Empty(t, firstBackendService(nil, "ns", nil))
+
+	// A cross-namespace backendRef without a grant is skipped (RefNotPermitted).
+	otherNs := gatewayv1.Namespace("other")
+	crossRefs := []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+		BackendObjectReference: gatewayv1.BackendObjectReference{Name: "echo", Namespace: &otherNs},
+	}}}
+	assert.Empty(t, firstBackendService(crossRefs, "ns", nil), "ungranted cross-ns backend dropped")
+
+	grants := []gatewayv1beta1.ReferenceGrant{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other"},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: "ns"}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+		},
+	}}
+	assert.Equal(t, "echo", firstBackendService(crossRefs, "ns", grants), "granted cross-ns backend kept")
 }
 
 // --- L4 edge helpers ---
@@ -125,7 +142,7 @@ func TestBuildL4Backends(t *testing.T) {
 		tcpBackendRef("pg", 1),
 		tcpBackendRef("cache", 2),
 	}
-	backends := r.buildL4Backends(refs)
+	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 2)
 	assert.Equal(t, "pg", backends[0].Service)
 	assert.Equal(t, proxy.TCPClusterName("pg", "aether.internal"), backends[0].Cluster)
@@ -143,7 +160,7 @@ func TestBuildL4Backends_ForeignGroupSkipped(t *testing.T) {
 		}},
 		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "keep"}},
 	}
-	backends := r.buildL4Backends(refs)
+	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 1)
 	assert.Equal(t, "keep", backends[0].Service)
 }
@@ -242,7 +259,7 @@ func TestBuildVirtualHost_RequestHeaderModifier(t *testing.T) {
 			},
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 
 	require.Len(t, vh.Routes, 1)
 	m := vh.Routes[0].HeaderMutation
@@ -275,7 +292,7 @@ func TestBuildVirtualHost_ResponseHeaderModifier(t *testing.T) {
 			},
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 
 	require.Len(t, vh.Routes, 1)
 	m := vh.Routes[0].HeaderMutation
@@ -302,7 +319,7 @@ func TestBuildVirtualHost_UnknownFilterSkipped(t *testing.T) {
 			},
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 	require.Len(t, vh.Routes, 1)
 	assert.Nil(t, vh.Routes[0].HeaderMutation, "unknown/nil-body filter must not produce a header mutation")
 	assert.Nil(t, vh.Routes[0].Redirect, "nil-body redirect filter must produce nil Redirect")
@@ -328,7 +345,7 @@ func TestBuildVirtualHost_RequestRedirect(t *testing.T) {
 			},
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 	require.Len(t, vh.Routes, 1, "redirect rule with no backend must still produce a route")
 	rt := vh.Routes[0]
 	assert.Equal(t, "/old", rt.Prefix)
@@ -362,7 +379,7 @@ func TestBuildVirtualHost_URLRewrite(t *testing.T) {
 			},
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 	require.Len(t, vh.Routes, 1)
 	rt := vh.Routes[0]
 	assert.Equal(t, "/api", rt.Prefix)
@@ -396,7 +413,7 @@ func TestBuildVirtualHost_URLRewrite_ReplaceFullPath(t *testing.T) {
 			},
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 	require.Len(t, vh.Routes, 1)
 	require.NotNil(t, vh.Routes[0].URLRewrite)
 	assert.Equal(t, "ReplaceFullPath", vh.Routes[0].URLRewrite.PathType)
@@ -413,7 +430,7 @@ func TestBuildVirtualHost_NoMutationWhenNoFilters(t *testing.T) {
 			BackendRefs: backend("svc-1", 0),
 		},
 	})
-	vh := r.buildVirtualHost(hr, nil)
+	vh := r.buildVirtualHost(hr, nil, nil)
 	require.Len(t, vh.Routes, 1)
 	assert.Nil(t, vh.Routes[0].HeaderMutation)
 }

--- a/agent/internal/edge/gatewayapi/status.go
+++ b/agent/internal/edge/gatewayapi/status.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
+	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // writeGatewayClassStatus sets Accepted=True and the supportedFeatures list on the
@@ -269,23 +271,24 @@ func (r *Reconciler) writeRouteStatuses(
 	tlsRoutes []gatewayv1.TLSRoute,
 	gateways map[gatewayKey]struct{},
 	listenerKeys map[gatewayListenerKey]struct{},
+	grants []gatewayv1beta1.ReferenceGrant,
 ) {
 	for i := range httpRoutes {
 		hr := &httpRoutes[i]
 		accepted := attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways)
-		resolved, reason, msg := r.backendsResolveHTTP(ctx, hr.Namespace, hr.Spec.Rules)
+		resolved, reason, msg := r.backendsResolveHTTP(ctx, hr.Namespace, hr.Spec.Rules, grants)
 		r.writeRouteParentStatus(ctx, hr, hr.Generation, &hr.Status.RouteStatus, ourGatewayParentRefs(hr.Spec.ParentRefs, hr.Namespace, gateways), accepted, resolved, reason, msg, "HTTPRoute")
 	}
 	for i := range tcpRoutes {
 		tr := &tcpRoutes[i]
 		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, listenerKeys)) > 0
-		resolved, reason, msg := r.backendsResolveL4(ctx, tr.Namespace, l4BackendObjectRefs(tr.Spec.Rules))
+		resolved, reason, msg := r.backendsResolveL4(ctx, tr.Namespace, "TCPRoute", l4BackendObjectRefs(tr.Spec.Rules), grants)
 		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, resolved, reason, msg, "TCPRoute")
 	}
 	for i := range tlsRoutes {
 		tr := &tlsRoutes[i]
 		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, listenerKeys)) > 0
-		resolved, reason, msg := r.backendsResolveTLS(ctx, tr.Namespace, tr.Spec.Rules)
+		resolved, reason, msg := r.backendsResolveTLS(ctx, tr.Namespace, tr.Spec.Rules, grants)
 		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, resolved, reason, msg, "TLSRoute")
 	}
 }
@@ -367,24 +370,24 @@ func (r *Reconciler) writeRouteParentStatus(
 	}
 }
 
-func (r *Reconciler) backendsResolveHTTP(ctx context.Context, ns string, rules []gatewayv1.HTTPRouteRule) (bool, string, string) {
+func (r *Reconciler) backendsResolveHTTP(ctx context.Context, ns string, rules []gatewayv1.HTTPRouteRule, grants []gatewayv1beta1.ReferenceGrant) (bool, string, string) {
 	var refs []gatewayv1.BackendObjectReference
 	for _, rule := range rules {
 		for _, b := range rule.BackendRefs {
 			refs = append(refs, b.BackendObjectReference)
 		}
 	}
-	return r.backendsResolveL4(ctx, ns, refs)
+	return r.backendsResolveL4(ctx, ns, "HTTPRoute", refs, grants)
 }
 
-func (r *Reconciler) backendsResolveTLS(ctx context.Context, ns string, rules []gatewayv1.TLSRouteRule) (bool, string, string) {
+func (r *Reconciler) backendsResolveTLS(ctx context.Context, ns string, rules []gatewayv1.TLSRouteRule, grants []gatewayv1beta1.ReferenceGrant) (bool, string, string) {
 	var refs []gatewayv1.BackendObjectReference
 	for _, rule := range rules {
 		for _, b := range rule.BackendRefs {
 			refs = append(refs, b.BackendObjectReference)
 		}
 	}
-	return r.backendsResolveL4(ctx, ns, refs)
+	return r.backendsResolveL4(ctx, ns, "TLSRoute", refs, grants)
 }
 
 func l4BackendObjectRefs(rules []gatewayv1alpha2.TCPRouteRule) []gatewayv1.BackendObjectReference {
@@ -404,13 +407,18 @@ func l4BackendObjectRefs(rules []gatewayv1alpha2.TCPRouteRule) []gatewayv1.Backe
 // A valid core Service-kind ref with a non-empty name is therefore resolved here; a
 // genuinely-absent backend surfaces at runtime as no endpoints / 503, not a static
 // ResolvedRefs failure. Only the ref *shape* is validated.
-func (r *Reconciler) backendsResolveL4(_ context.Context, _ string, refs []gatewayv1.BackendObjectReference) (bool, string, string) {
+func (r *Reconciler) backendsResolveL4(_ context.Context, routeNamespace, routeKind string, refs []gatewayv1.BackendObjectReference, grants []gatewayv1beta1.ReferenceGrant) (bool, string, string) {
 	for _, ref := range refs {
 		if (ref.Group != nil && string(*ref.Group) != "") || (ref.Kind != nil && string(*ref.Kind) != "Service") {
 			return false, string(gatewayv1.RouteReasonInvalidKind), fmt.Sprintf("backendRef %q is not a core Service", ref.Name)
 		}
 		if string(ref.Name) == "" {
 			return false, string(gatewayv1.RouteReasonBackendNotFound), "backendRef has an empty name"
+		}
+		if ns := derefBackendNamespace(ref.Namespace); referencegrant.CrossNamespace(ns, routeNamespace) &&
+			!referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, string(ref.Name)) {
+			return false, string(gatewayv1.RouteReasonRefNotPermitted),
+				fmt.Sprintf("cross-namespace backendRef to Service %q in namespace %q is not permitted by any ReferenceGrant", ref.Name, ns)
 		}
 	}
 	return true, string(gatewayv1.RouteReasonResolvedRefs), "All backend references resolved"

--- a/agent/internal/edge/gatewayapi/status_test.go
+++ b/agent/internal/edge/gatewayapi/status_test.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type statusFakeSink struct{}
@@ -38,6 +39,7 @@ func statusScheme(t *testing.T) *runtime.Scheme {
 	require.NoError(t, clientgoscheme.AddToScheme(s))
 	require.NoError(t, gatewayv1.Install(s))
 	require.NoError(t, gatewayv1alpha2.Install(s))
+	require.NoError(t, gatewayv1beta1.Install(s))
 	return s
 }
 
@@ -116,6 +118,73 @@ func TestReconcile_GatewayAndRouteStatus(t *testing.T) {
 	rres := meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
 	require.NotNil(t, rres)
 	assert.Equal(t, metav1.ConditionTrue, rres.Status)
+}
+
+// TestReconcile_CrossNamespaceBackend_RefNotPermitted: an HTTPRoute in ns A whose
+// backendRef targets a Service in ns B with NO ReferenceGrant gets ResolvedRefs=
+// False/RefNotPermitted; adding a matching grant flips it to True.
+func TestReconcile_CrossNamespaceBackend_RefNotPermitted(t *testing.T) {
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge", Namespace: "ns-a", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners:        []gatewayv1.Listener{{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+		},
+	}
+	nsB := gatewayv1.Namespace("ns-b")
+	hr := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "ns-a", Generation: 1},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{
+				{Kind: ptr(gatewayv1.Kind("Gateway")), Name: "edge"},
+			}},
+			Hostnames: []gatewayv1.Hostname{"api.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-b", Namespace: &nsB, Port: ptr(gatewayv1.PortNumber(8080))},
+				}}},
+			}},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(gc, gw, hr).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "ns-a", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotHR := &gatewayv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns-a", Name: "r1"}, gotHR))
+	require.Len(t, gotHR.Status.Parents, 1)
+	rres := meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+	require.NotNil(t, rres)
+	assert.Equal(t, metav1.ConditionFalse, rres.Status, "ungranted cross-ns backend → ResolvedRefs False")
+	assert.Equal(t, string(gatewayv1.RouteReasonRefNotPermitted), rres.Reason)
+
+	// Add a matching ReferenceGrant in ns-b → ResolvedRefs flips to True.
+	grant := &gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Name: "g", Namespace: "ns-b"},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: "ns-a"}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+		},
+	}
+	require.NoError(t, c.Create(context.Background(), grant))
+
+	_, err = r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns-a", Name: "r1"}, gotHR))
+	rres = meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
+	require.NotNil(t, rres)
+	assert.Equal(t, metav1.ConditionTrue, rres.Status, "granted cross-ns backend → ResolvedRefs True")
 }
 
 // TestReconcile_GatewayInNonEdgeNamespace: a Gateway of our class living in a
@@ -213,7 +282,9 @@ func TestReconcile_GatewayClassSupportedFeatures(t *testing.T) {
 	assert.Contains(t, names, "HTTPRoute")
 	assert.Contains(t, names, "GRPCRoute")
 	assert.Contains(t, names, "HTTPRouteRequestTimeout")
+	// ReferenceGrant is now implemented (cross-namespace backendRef admission +
+	// status) and therefore advertised so the suite runs those tests.
+	assert.Contains(t, names, "ReferenceGrant")
 	// Unsupported features must NOT be advertised (so their suites skip).
 	assert.NotContains(t, names, "HTTPRouteRequestMirror")
-	assert.NotContains(t, names, "ReferenceGrant")
 }

--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//agent:__subpackages__"],
     deps = [
         "//agent/internal/gatewaystatus",
+        "//agent/internal/referencegrant",
         "//agent/internal/xds/proxy",
         "//common/log",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
@@ -15,6 +16,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/handler",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
@@ -37,5 +39,6 @@ go_test(
         "@io_k8s_sigs_controller_runtime//pkg/client/fake",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
     ],
 )

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
+	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	commonlog "github.com/bpalermo/aether/common/log"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -21,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // RouteSink receives the projected per-service GAMMA rules (the snapshot cache).
@@ -55,6 +57,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.HTTPRoute{}).
 		Watches(&gatewayv1.GRPCRoute{}, enqueueAll).
+		// ReferenceGrant (v1beta1, the served storage version): a change to any grant
+		// can flip a cross-namespace backendRef between permitted and RefNotPermitted,
+		// so re-project + re-status on every grant change. Cluster-wide cache (post-#323).
+		Watches(&gatewayv1beta1.ReferenceGrant{}, enqueueAll).
 		Named("gamma").
 		Complete(r)
 }
@@ -70,13 +76,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err := r.List(ctx, grpcList); err != nil {
 		return reconcile.Result{}, err
 	}
+	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs.
+	grantList := &gatewayv1beta1.ReferenceGrantList{}
+	if err := r.List(ctx, grantList); err != nil {
+		return reconcile.Result{}, err
+	}
+	grants := grantList.Items
 
 	routes := map[string][]proxy.GammaRoute{}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
 		for _, svc := range serviceParents(hr.Spec.ParentRefs) {
 			for _, rule := range hr.Spec.Rules {
-				routes[svc] = append(routes[svc], r.buildGammaRoute(rule))
+				routes[svc] = append(routes[svc], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants))
 			}
 		}
 	}
@@ -84,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		gr := &grpcList.Items[i]
 		for _, svc := range serviceParents(gr.Spec.ParentRefs) {
 			for _, rule := range gr.Spec.Rules {
-				routes[svc] = append(routes[svc], r.buildGammaRouteFromGRPC(rule))
+				routes[svc] = append(routes[svc], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants))
 			}
 		}
 	}
@@ -99,14 +111,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// projected); the next reconcile retries.
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
-		resolved, reason, msg := r.backendsResolve(ctx, hr.Namespace, httpBackendRefs(hr.Spec.Rules))
+		resolved, reason, msg := r.backendsResolve(ctx, hr.Namespace, "HTTPRoute", httpBackendRefs(hr.Spec.Rules), grants)
 		if err := r.writeRouteStatus(ctx, hr, hr.Generation, &hr.Status.RouteStatus, hr.Spec.ParentRefs, resolved, reason, msg); err != nil {
 			r.Log.WarnContext(ctx, "failed to write HTTPRoute status", "route", hr.Name, "namespace", hr.Namespace, "error", err.Error())
 		}
 	}
 	for i := range grpcList.Items {
 		gr := &grpcList.Items[i]
-		resolved, reason, msg := r.backendsResolve(ctx, gr.Namespace, grpcBackendRefs(gr.Spec.Rules))
+		resolved, reason, msg := r.backendsResolve(ctx, gr.Namespace, "GRPCRoute", grpcBackendRefs(gr.Spec.Rules), grants)
 		if err := r.writeRouteStatus(ctx, gr, gr.Generation, &gr.Status.RouteStatus, gr.Spec.ParentRefs, resolved, reason, msg); err != nil {
 			r.Log.WarnContext(ctx, "failed to write GRPCRoute status", "route", gr.Name, "namespace", gr.Namespace, "error", err.Error())
 		}
@@ -168,8 +180,10 @@ func (r *Reconciler) writeRouteStatus(
 // ref with a non-empty name is resolved here; a genuinely-absent backend surfaces at
 // runtime as no endpoints / 503, not a static ResolvedRefs failure. A k8s Service Get
 // would be a false negative (the registry, not a k8s Service, backs the route). Only
-// the ref *shape* is validated.
-func (r *Reconciler) backendsResolve(_ context.Context, _ string, refs []gatewayv1.BackendObjectReference) (bool, string, string) {
+// the ref *shape* — and, for cross-namespace refs, ReferenceGrant permission — is
+// validated. routeKind is the referring route's kind (HTTPRoute/GRPCRoute), used to
+// match a grant's spec.from.kind.
+func (r *Reconciler) backendsResolve(_ context.Context, routeNamespace, routeKind string, refs []gatewayv1.BackendObjectReference, grants []gatewayv1beta1.ReferenceGrant) (bool, string, string) {
 	for _, ref := range refs {
 		if (ref.Group != nil && string(*ref.Group) != "") || (ref.Kind != nil && string(*ref.Kind) != "Service") {
 			return false, string(gatewayv1.RouteReasonInvalidKind), fmt.Sprintf("backendRef %q is not a core Service", ref.Name)
@@ -177,8 +191,33 @@ func (r *Reconciler) backendsResolve(_ context.Context, _ string, refs []gateway
 		if string(ref.Name) == "" {
 			return false, string(gatewayv1.RouteReasonBackendNotFound), "backendRef has an empty name"
 		}
+		if ns := derefBackendNamespace(ref.Namespace); referencegrant.CrossNamespace(ns, routeNamespace) &&
+			!referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, string(ref.Name)) {
+			return false, string(gatewayv1.RouteReasonRefNotPermitted),
+				fmt.Sprintf("cross-namespace backendRef to Service %q in namespace %q is not permitted by any ReferenceGrant", ref.Name, ns)
+		}
 	}
 	return true, string(gatewayv1.RouteReasonResolvedRefs), "All backend references resolved"
+}
+
+// derefBackendNamespace returns the backendRef namespace ("" when unset).
+func derefBackendNamespace(ns *gatewayv1.Namespace) string {
+	if ns == nil {
+		return ""
+	}
+	return string(*ns)
+}
+
+// backendPermitted reports whether a backendRef is allowed onto the data plane: a
+// same-namespace ref always is; a cross-namespace ref needs a matching ReferenceGrant.
+// Non-permitted cross-namespace backends are dropped from the built route (the rest of
+// the route still applies), mirroring the RefNotPermitted status.
+func backendPermitted(backendNamespace *gatewayv1.Namespace, routeNamespace, routeKind, name string, grants []gatewayv1beta1.ReferenceGrant) bool {
+	ns := derefBackendNamespace(backendNamespace)
+	if !referencegrant.CrossNamespace(ns, routeNamespace) {
+		return true
+	}
+	return referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, name)
 }
 
 func httpBackendRefs(rules []gatewayv1.HTTPRouteRule) []gatewayv1.BackendObjectReference {
@@ -217,7 +256,7 @@ func serviceParents(refs []gatewayv1.ParentReference) []string {
 	return svcs
 }
 
-func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule) proxy.GammaRoute {
+func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) proxy.GammaRoute {
 	gr := proxy.GammaRoute{}
 	if rule.Timeouts != nil && rule.Timeouts.Request != nil {
 		// HTTPRoute timeouts are GEP-2257 duration strings (a subset of Go's).
@@ -233,6 +272,11 @@ func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule) proxy.GammaRo
 			continue
 		}
 		name := string(b.Name)
+		// Drop ungranted cross-namespace backends (RefNotPermitted): they are removed
+		// from the data plane, but the rest of the route still applies.
+		if !backendPermitted(b.Namespace, routeNamespace, routeKind, name, grants) {
+			continue
+		}
 		weight := uint32(1)
 		if b.Weight != nil {
 			weight = uint32(*b.Weight)
@@ -430,7 +474,7 @@ func buildGRPCHeaderMutation(filters []gatewayv1.GRPCRouteFilter) *proxy.GammaHe
 // method match becomes a path match (service+method = exact /svc/method; service-only
 // = prefix /svc/), and gRPC header matches map to request-header matches. GRPCRoute
 // has no per-rule timeout. The backends are identical (weighted Service refs).
-func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule) proxy.GammaRoute {
+func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) proxy.GammaRoute {
 	gr := proxy.GammaRoute{}
 	for _, b := range rule.BackendRefs {
 		if b.Group != nil && string(*b.Group) != "" {
@@ -440,6 +484,9 @@ func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule) proxy
 			continue
 		}
 		name := string(b.Name)
+		if !backendPermitted(b.Namespace, routeNamespace, routeKind, name, grants) {
+			continue
+		}
 		weight := uint32(1)
 		if b.Weight != nil {
 			weight = uint32(*b.Weight)

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -31,6 +32,7 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	s := runtime.NewScheme()
 	require.NoError(t, clientgoscheme.AddToScheme(s))
 	require.NoError(t, gatewayv1.Install(s))
+	require.NoError(t, gatewayv1beta1.Install(s))
 	return s
 }
 
@@ -111,22 +113,72 @@ func TestBackendsResolve_Shapes(t *testing.T) {
 	svcKind := gatewayv1.Kind("Service")
 	otherKind := gatewayv1.Kind("Foo")
 
-	ok, _, _ := r.backendsResolve(context.Background(), "ns", []gatewayv1.BackendObjectReference{
+	ok, _, _ := r.backendsResolve(context.Background(), "ns", "HTTPRoute", []gatewayv1.BackendObjectReference{
 		{Name: "svc-1", Kind: &svcKind},
-	})
+	}, nil)
 	assert.True(t, ok, "valid Service-kind ref resolves")
 
-	ok, reason, _ := r.backendsResolve(context.Background(), "ns", []gatewayv1.BackendObjectReference{
+	ok, reason, _ := r.backendsResolve(context.Background(), "ns", "HTTPRoute", []gatewayv1.BackendObjectReference{
 		{Name: "x", Kind: &otherKind},
-	})
+	}, nil)
 	assert.False(t, ok)
 	assert.Equal(t, string(gatewayv1.RouteReasonInvalidKind), reason)
 
-	ok, reason, _ = r.backendsResolve(context.Background(), "ns", []gatewayv1.BackendObjectReference{
+	ok, reason, _ = r.backendsResolve(context.Background(), "ns", "HTTPRoute", []gatewayv1.BackendObjectReference{
 		{Name: ""},
-	})
+	}, nil)
 	assert.False(t, ok)
 	assert.Equal(t, string(gatewayv1.RouteReasonBackendNotFound), reason)
+
+	// Cross-namespace ref with no ReferenceGrant → RefNotPermitted.
+	otherNs := gatewayv1.Namespace("other")
+	ok, reason, _ = r.backendsResolve(context.Background(), "ns", "HTTPRoute", []gatewayv1.BackendObjectReference{
+		{Name: "svc-1", Kind: &svcKind, Namespace: &otherNs},
+	}, nil)
+	assert.False(t, ok)
+	assert.Equal(t, string(gatewayv1.RouteReasonRefNotPermitted), reason)
+
+	// Cross-namespace ref WITH a matching grant → resolved.
+	grants := []gatewayv1beta1.ReferenceGrant{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other"},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: "ns"}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+		},
+	}}
+	ok, _, _ = r.backendsResolve(context.Background(), "ns", "HTTPRoute", []gatewayv1.BackendObjectReference{
+		{Name: "svc-1", Kind: &svcKind, Namespace: &otherNs},
+	}, grants)
+	assert.True(t, ok, "granted cross-namespace ref resolves")
+}
+
+// TestBuildGammaRoute_DropsUngrantedCrossNamespaceBackend: an ungranted
+// cross-namespace backendRef is dropped from the built route; a same-namespace one
+// (and a granted cross-ns one) stays.
+func TestBuildGammaRoute_DropsUngrantedCrossNamespaceBackend(t *testing.T) {
+	r := &Reconciler{MeshDomain: "mesh"}
+	otherNs := gatewayv1.Namespace("other")
+	rule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "local"}}},
+			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "remote", Namespace: &otherNs}}},
+		},
+	}
+	// No grants: the cross-ns "remote" backend is dropped.
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
+	require.Len(t, gr.Backends, 1)
+	assert.Equal(t, "local", gr.Backends[0].Service)
+
+	// With a matching grant: both backends are kept.
+	grants := []gatewayv1beta1.ReferenceGrant{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other"},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "HTTPRoute", Namespace: "ns"}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service", Name: ptr(gatewayv1.ObjectName("remote"))}},
+		},
+	}}
+	gr = r.buildGammaRoute(rule, "ns", "HTTPRoute", grants)
+	require.Len(t, gr.Backends, 2)
 }
 
 func TestServiceParents(t *testing.T) {
@@ -155,7 +207,7 @@ func TestBuildGammaRoute(t *testing.T) {
 		},
 		Timeouts: &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))},
 	}
-	gr := r.buildGammaRoute(rule)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 
 	require.Len(t, gr.Matches, 1)
 	assert.Equal(t, "/admin", gr.Matches[0].Exact)
@@ -183,7 +235,7 @@ func TestBuildGammaRouteFromGRPC(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-2"}, Weight: w}},
 		},
 	}
-	gr := r.buildGammaRouteFromGRPC(rule)
+	gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil)
 	require.Len(t, gr.Matches, 2)
 	assert.Equal(t, "/foo.Bar/Baz", gr.Matches[0].Exact, "service+method -> exact path")
 	assert.Equal(t, "/foo.Bar/", gr.Matches[1].Prefix, "service-only -> prefix path")
@@ -233,7 +285,7 @@ func TestBuildGammaRouteFromGRPC_RegularExpression(t *testing.T) {
 					{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc"}}},
 				},
 			}
-			gr := r.buildGammaRouteFromGRPC(rule)
+			gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil)
 			require.Len(t, gr.Matches, 1)
 			assert.Equal(t, tc.wantRegex, gr.Matches[0].Regex, "Regex field")
 			assert.Empty(t, gr.Matches[0].Exact, "Exact must be empty for regex match")
@@ -261,7 +313,7 @@ func TestBuildGammaRoute_RequestHeaderModifier(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 
 	require.NotNil(t, gr.HeaderMutation)
 	require.Len(t, gr.HeaderMutation.SetRequest, 1)
@@ -291,7 +343,7 @@ func TestBuildGammaRoute_ResponseHeaderModifier(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 
 	require.NotNil(t, gr.HeaderMutation)
 	assert.Empty(t, gr.HeaderMutation.SetRequest, "no request headers")
@@ -314,7 +366,7 @@ func TestBuildGammaRoute_UnknownFilterSkipped(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 	assert.Nil(t, gr.HeaderMutation, "redirect filter type must not produce a HeaderMutation")
 }
 
@@ -378,7 +430,7 @@ func TestBuildGammaRoute_RequestRedirect(t *testing.T) {
 					{Type: gatewayv1.HTTPRouteFilterRequestRedirect, RequestRedirect: &f},
 				},
 			}
-			gr := r.buildGammaRoute(rule)
+			gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 			require.NotNil(t, gr.Redirect, "RequestRedirect filter must produce GammaRoute.Redirect")
 			assert.Nil(t, gr.URLRewrite, "RequestRedirect must not produce URLRewrite")
 			assert.Equal(t, tc.wantScheme, gr.Redirect.Scheme)
@@ -441,7 +493,7 @@ func TestBuildGammaRoute_URLRewrite(t *testing.T) {
 					{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 				},
 			}
-			gr := r.buildGammaRoute(rule)
+			gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 			require.NotNil(t, gr.URLRewrite, "URLRewrite filter must produce GammaRoute.URLRewrite")
 			assert.Nil(t, gr.Redirect, "URLRewrite must not produce Redirect")
 			assert.Equal(t, tc.wantHost, gr.URLRewrite.Hostname)
@@ -460,7 +512,7 @@ func TestBuildGammaRoute_NilRedirectWhenNoFilter(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 	assert.Nil(t, gr.Redirect, "no filter must produce nil Redirect")
 	assert.Nil(t, gr.URLRewrite, "no filter must produce nil URLRewrite")
 }
@@ -488,7 +540,7 @@ func TestBuildGammaRouteFromGRPC_HeaderModifier(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-2"}}},
 		},
 	}
-	gr := r.buildGammaRouteFromGRPC(rule)
+	gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil)
 
 	require.NotNil(t, gr.HeaderMutation)
 	require.Len(t, gr.HeaderMutation.SetRequest, 1)

--- a/agent/internal/l4route/BUILD.bazel
+++ b/agent/internal/l4route/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//agent:__subpackages__"],
     deps = [
         "//agent/internal/gatewaystatus",
+        "//agent/internal/referencegrant",
         "//agent/internal/xds/proxy",
         "//common/log",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
@@ -16,6 +17,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
     ],
 )
 
@@ -41,5 +43,6 @@ go_test(
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
     ],
 )

--- a/agent/internal/l4route/reconciler.go
+++ b/agent/internal/l4route/reconciler.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
+	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	commonlog "github.com/bpalermo/aether/common/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // L4RouteSink receives the projected L4 service routes and UDP routes from this
@@ -65,6 +67,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&gatewayv1alpha2.TCPRoute{}).
 		Watches(&gatewayv1.TLSRoute{}, enqueueAll).
 		Watches(&gatewayv1alpha2.UDPRoute{}, enqueueAll).
+		// ReferenceGrant (v1beta1): a grant change can flip a cross-namespace backendRef
+		// between permitted and RefNotPermitted, so re-project + re-status on any change.
+		Watches(&gatewayv1beta1.ReferenceGrant{}, enqueueAll).
 		Named("l4route").
 		Complete(r)
 }
@@ -85,13 +90,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err := r.List(ctx, udpList); err != nil {
 		return reconcile.Result{}, err
 	}
+	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs.
+	grantList := &gatewayv1beta1.ReferenceGrantList{}
+	if err := r.List(ctx, grantList); err != nil {
+		return reconcile.Result{}, err
+	}
+	grants := grantList.Items
 
 	tcpRoutes := map[string][]proxy.L4ServiceRoute{}
 	for i := range tcpList.Items {
 		tr := &tcpList.Items[i]
 		for _, svc := range serviceParents(tr.Spec.ParentRefs) {
 			for _, rule := range tr.Spec.Rules {
-				tcpRoutes[svc] = append(tcpRoutes[svc], r.buildTCPRoute(rule))
+				tcpRoutes[svc] = append(tcpRoutes[svc], r.buildTCPRoute(rule, tr.Namespace, "TCPRoute", grants))
 			}
 		}
 	}
@@ -105,7 +116,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 				hostnames = append(hostnames, string(h))
 			}
 			for _, rule := range tr.Spec.Rules {
-				tlsRoutes[svc] = append(tlsRoutes[svc], r.buildTLSRoute(rule, hostnames))
+				tlsRoutes[svc] = append(tlsRoutes[svc], r.buildTLSRoute(rule, hostnames, tr.Namespace, "TLSRoute", grants))
 			}
 		}
 	}
@@ -115,7 +126,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		ur := &udpList.Items[i]
 		for _, svc := range serviceParents(ur.Spec.ParentRefs) {
 			for _, rule := range ur.Spec.Rules {
-				udpRoutes[svc] = append(udpRoutes[svc], r.buildUDPBackends(rule)...)
+				udpRoutes[svc] = append(udpRoutes[svc], r.buildUDPBackends(rule, ur.Namespace, "UDPRoute", grants)...)
 			}
 		}
 	}
@@ -139,21 +150,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// reconcile retries.
 	for i := range tcpList.Items {
 		tr := &tcpList.Items[i]
-		resolved, reason, msg := r.backendsResolve(ctx, tr.Namespace, tcpBackendRefs(tr.Spec.Rules))
+		resolved, reason, msg := r.backendsResolve(ctx, tr.Namespace, "TCPRoute", tcpBackendRefs(tr.Spec.Rules), grants)
 		if err := r.writeRouteStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, tr.Spec.ParentRefs, resolved, reason, msg); err != nil {
 			r.Log.WarnContext(ctx, "failed to write TCPRoute status", "route", tr.Name, "namespace", tr.Namespace, "error", err.Error())
 		}
 	}
 	for i := range tlsList.Items {
 		tr := &tlsList.Items[i]
-		resolved, reason, msg := r.backendsResolve(ctx, tr.Namespace, tlsBackendRefs(tr.Spec.Rules))
+		resolved, reason, msg := r.backendsResolve(ctx, tr.Namespace, "TLSRoute", tlsBackendRefs(tr.Spec.Rules), grants)
 		if err := r.writeRouteStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, tr.Spec.ParentRefs, resolved, reason, msg); err != nil {
 			r.Log.WarnContext(ctx, "failed to write TLSRoute status", "route", tr.Name, "namespace", tr.Namespace, "error", err.Error())
 		}
 	}
 	for i := range udpList.Items {
 		ur := &udpList.Items[i]
-		resolved, reason, msg := r.backendsResolve(ctx, ur.Namespace, udpBackendRefs(ur.Spec.Rules))
+		resolved, reason, msg := r.backendsResolve(ctx, ur.Namespace, "UDPRoute", udpBackendRefs(ur.Spec.Rules), grants)
 		if err := r.writeRouteStatus(ctx, ur, ur.Generation, &ur.Status.RouteStatus, ur.Spec.ParentRefs, resolved, reason, msg); err != nil {
 			r.Log.WarnContext(ctx, "failed to write UDPRoute status", "route", ur.Name, "namespace", ur.Namespace, "error", err.Error())
 		}
@@ -217,8 +228,9 @@ func (r *Reconciler) writeRouteStatus(
 // ref with a non-empty name is resolved here; a genuinely-absent backend surfaces at
 // runtime as no endpoints / 503, not a static ResolvedRefs failure. A k8s Service Get
 // would be a false negative (the registry, not a k8s Service, backs the route). Only
-// the ref *shape* is validated.
-func (r *Reconciler) backendsResolve(_ context.Context, _ string, refs []gatewayv1.BackendObjectReference) (bool, string, string) {
+// the ref *shape* — and, for cross-namespace refs, ReferenceGrant permission — is
+// validated. routeKind is the referring route's kind (TCPRoute/TLSRoute/UDPRoute).
+func (r *Reconciler) backendsResolve(_ context.Context, routeNamespace, routeKind string, refs []gatewayv1.BackendObjectReference, grants []gatewayv1beta1.ReferenceGrant) (bool, string, string) {
 	for _, ref := range refs {
 		if (ref.Group != nil && string(*ref.Group) != "") || (ref.Kind != nil && string(*ref.Kind) != "Service") {
 			return false, string(gatewayv1.RouteReasonInvalidKind), fmt.Sprintf("backendRef %q is not a core Service", ref.Name)
@@ -226,8 +238,32 @@ func (r *Reconciler) backendsResolve(_ context.Context, _ string, refs []gateway
 		if string(ref.Name) == "" {
 			return false, string(gatewayv1.RouteReasonBackendNotFound), "backendRef has an empty name"
 		}
+		if ns := derefBackendNamespace(ref.Namespace); referencegrant.CrossNamespace(ns, routeNamespace) &&
+			!referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, string(ref.Name)) {
+			return false, string(gatewayv1.RouteReasonRefNotPermitted),
+				fmt.Sprintf("cross-namespace backendRef to Service %q in namespace %q is not permitted by any ReferenceGrant", ref.Name, ns)
+		}
 	}
 	return true, string(gatewayv1.RouteReasonResolvedRefs), "All backend references resolved"
+}
+
+// derefBackendNamespace returns the backendRef namespace ("" when unset).
+func derefBackendNamespace(ns *gatewayv1.Namespace) string {
+	if ns == nil {
+		return ""
+	}
+	return string(*ns)
+}
+
+// backendPermitted reports whether a backendRef is allowed onto the data plane: a
+// same-namespace ref always is; a cross-namespace ref needs a matching ReferenceGrant.
+// Non-permitted cross-namespace backends are dropped from the built route.
+func backendPermitted(backendNamespace *gatewayv1.Namespace, routeNamespace, routeKind, name string, grants []gatewayv1beta1.ReferenceGrant) bool {
+	ns := derefBackendNamespace(backendNamespace)
+	if !referencegrant.CrossNamespace(ns, routeNamespace) {
+		return true
+	}
+	return referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, name)
 }
 
 func tcpBackendRefs(rules []gatewayv1alpha2.TCPRouteRule) []gatewayv1.BackendObjectReference {
@@ -278,33 +314,33 @@ func serviceParents(refs []gatewayv1alpha2.ParentReference) []string {
 
 // buildTCPRoute translates a TCPRouteRule into an L4ServiceRoute (no SNI match).
 // Backends without a valid Service name (foreign group/kind) are skipped.
-func (r *Reconciler) buildTCPRoute(rule gatewayv1alpha2.TCPRouteRule) proxy.L4ServiceRoute {
+func (r *Reconciler) buildTCPRoute(rule gatewayv1alpha2.TCPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) proxy.L4ServiceRoute {
 	return proxy.L4ServiceRoute{
-		Backends: r.buildL4Backends(rule.BackendRefs),
+		Backends: r.buildL4Backends(rule.BackendRefs, routeNamespace, routeKind, grants),
 	}
 }
 
 // buildTLSRoute translates a TLSRouteRule + the route's hostname list into an
 // L4ServiceRoute. Hostnames map to filter_chain_match.server_names on the
 // capture listener.
-func (r *Reconciler) buildTLSRoute(rule gatewayv1.TLSRouteRule, hostnames []string) proxy.L4ServiceRoute {
+func (r *Reconciler) buildTLSRoute(rule gatewayv1.TLSRouteRule, hostnames []string, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) proxy.L4ServiceRoute {
 	return proxy.L4ServiceRoute{
 		SNIHostnames: hostnames,
-		Backends:     r.buildL4Backends(rule.BackendRefs),
+		Backends:     r.buildL4Backends(rule.BackendRefs, routeNamespace, routeKind, grants),
 	}
 }
 
 // buildUDPBackends translates a UDPRouteRule into a flat backend list.
 // UDP backends resolve to "udp:<svc>.<domain>" clusters (plain EDS, no mTLS)
 // rather than the TCP "tcp:<svc>.<domain>" clusters used by TCPRoute/TLSRoute.
-func (r *Reconciler) buildUDPBackends(rule gatewayv1alpha2.UDPRouteRule) []proxy.L4Backend {
-	return r.buildUDPL4Backends(rule.BackendRefs)
+func (r *Reconciler) buildUDPBackends(rule gatewayv1alpha2.UDPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
+	return r.buildUDPL4Backends(rule.BackendRefs, routeNamespace, routeKind, grants)
 }
 
 // buildL4Backends converts a BackendRef slice into L4Backends with resolved
 // TCP cluster names. Refs with a non-core group or non-Service kind are skipped.
-func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef) []proxy.L4Backend {
-	return r.buildBackendsWithCluster(refs, func(name string) string {
+func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
+	return r.buildBackendsWithCluster(refs, routeNamespace, routeKind, grants, func(name string) string {
 		// TCP clusters share the same EDS endpoints as HTTP clusters but use
 		// ALPN "aether-tcp" (see TCPClusterName). The capture TCP floor chains
 		// already reference "tcp:<svc>.<domain>" clusters.
@@ -315,16 +351,17 @@ func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef) []proxy.
 // buildUDPL4Backends converts a BackendRef slice into L4Backends with resolved
 // UDP cluster names ("udp:<svc>.<domain>"). These clusters are plain EDS without
 // a transport socket — UDP traffic is not covered by mesh mTLS.
-func (r *Reconciler) buildUDPL4Backends(refs []gatewayv1alpha2.BackendRef) []proxy.L4Backend {
-	return r.buildBackendsWithCluster(refs, func(name string) string {
+func (r *Reconciler) buildUDPL4Backends(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
+	return r.buildBackendsWithCluster(refs, routeNamespace, routeKind, grants, func(name string) string {
 		return proxy.UDPClusterName(name, r.MeshDomain)
 	})
 }
 
 // buildBackendsWithCluster converts a BackendRef slice into L4Backends, resolving
 // the cluster name via clusterNameFn. Refs with a non-core group or non-Service
-// kind are skipped.
-func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef, clusterNameFn func(name string) string) []proxy.L4Backend {
+// kind are skipped, as are ungranted cross-namespace refs (RefNotPermitted: dropped
+// from the data plane, mirroring the route's ResolvedRefs status).
+func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, clusterNameFn func(name string) string) []proxy.L4Backend {
 	backends := make([]proxy.L4Backend, 0, len(refs))
 	for _, b := range refs {
 		if b.Group != nil && string(*b.Group) != "" {
@@ -335,6 +372,9 @@ func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef,
 		}
 		name := string(b.Name)
 		if name == "" {
+			continue
+		}
+		if !backendPermitted(b.Namespace, routeNamespace, routeKind, name, grants) {
 			continue
 		}
 		weight := uint32(1)

--- a/agent/internal/l4route/reconciler_test.go
+++ b/agent/internal/l4route/reconciler_test.go
@@ -6,8 +6,10 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 func ptr[T any](v T) *T { return &v }
@@ -35,7 +37,7 @@ func TestBuildTCPRoute_SingleBackend(t *testing.T) {
 			},
 		},
 	}
-	route := r.buildTCPRoute(rule)
+	route := r.buildTCPRoute(rule, "ns", "TCPRoute", nil)
 	assert.Empty(t, route.SNIHostnames, "TCPRoute must not set SNI hostnames")
 	require.Len(t, route.Backends, 1)
 	assert.Equal(t, "svc-a", route.Backends[0].Service)
@@ -52,7 +54,7 @@ func TestBuildTCPRoute_WeightedBackends(t *testing.T) {
 			{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-v2"}, Weight: ptr(int32(10))},
 		},
 	}
-	route := r.buildTCPRoute(rule)
+	route := r.buildTCPRoute(rule, "ns", "TCPRoute", nil)
 	require.Len(t, route.Backends, 2)
 	assert.Equal(t, "tcp:svc-v1.mesh", route.Backends[0].Cluster)
 	assert.Equal(t, uint32(90), route.Backends[0].Weight)
@@ -69,7 +71,7 @@ func TestBuildTLSRoute_WithHostnames(t *testing.T) {
 		},
 	}
 	hostnames := []string{"a.example.com", "b.example.com"}
-	route := r.buildTLSRoute(rule, hostnames)
+	route := r.buildTLSRoute(rule, hostnames, "ns", "TLSRoute", nil)
 	assert.Equal(t, hostnames, route.SNIHostnames)
 	require.Len(t, route.Backends, 1)
 	assert.Equal(t, proxy.TCPClusterName("svc-b", "aether.internal"), route.Backends[0].Cluster)
@@ -83,7 +85,7 @@ func TestBuildUDPBackends(t *testing.T) {
 			{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-c"}, Weight: ptr(int32(5))},
 		},
 	}
-	backends := r.buildUDPBackends(rule)
+	backends := r.buildUDPBackends(rule, "ns", "UDPRoute", nil)
 	require.Len(t, backends, 1)
 	assert.Equal(t, "svc-c", backends[0].Service)
 	assert.Equal(t, uint32(5), backends[0].Weight)
@@ -102,7 +104,7 @@ func TestBuildL4Backends_ForeignGroupSkipped(t *testing.T) {
 		}},
 		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "keep-me"}},
 	}
-	backends := r.buildL4Backends(refs)
+	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 1)
 	assert.Equal(t, "keep-me", backends[0].Service)
 }
@@ -113,7 +115,34 @@ func TestBuildL4Backends_DefaultWeight(t *testing.T) {
 	refs := []gatewayv1.BackendRef{
 		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-d"}},
 	}
-	backends := r.buildL4Backends(refs)
+	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 1)
 	assert.Equal(t, uint32(1), backends[0].Weight, "nil weight should default to 1")
+}
+
+// TestBuildL4Backends_DropsUngrantedCrossNamespace verifies that an ungranted
+// cross-namespace backendRef is dropped (RefNotPermitted), while a matching grant
+// keeps it.
+func TestBuildL4Backends_DropsUngrantedCrossNamespace(t *testing.T) {
+	r := &Reconciler{MeshDomain: "aether.internal"}
+	otherNs := gatewayv1.Namespace("other")
+	refs := []gatewayv1.BackendRef{
+		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "local"}},
+		{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "remote", Namespace: &otherNs}},
+	}
+	// No grants: cross-ns "remote" dropped.
+	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
+	require.Len(t, backends, 1)
+	assert.Equal(t, "local", backends[0].Service)
+
+	// Matching grant: both kept.
+	grants := []gatewayv1beta1.ReferenceGrant{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "other"},
+		Spec: gatewayv1beta1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{Group: gatewayv1.GroupName, Kind: "TCPRoute", Namespace: "ns"}},
+			To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+		},
+	}}
+	backends = r.buildL4Backends(refs, "ns", "TCPRoute", grants)
+	require.Len(t, backends, 2)
 }

--- a/agent/internal/l4route/status_test.go
+++ b/agent/internal/l4route/status_test.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 type fakeSink struct{}
@@ -33,6 +34,7 @@ func l4Scheme(t *testing.T) *runtime.Scheme {
 	require.NoError(t, clientgoscheme.AddToScheme(s))
 	require.NoError(t, gatewayv1.Install(s))
 	require.NoError(t, gatewayv1alpha2.Install(s))
+	require.NoError(t, gatewayv1beta1.Install(s))
 	return s
 }
 

--- a/agent/internal/referencegrant/BUILD.bazel
+++ b/agent/internal/referencegrant/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "referencegrant",
+    srcs = ["referencegrant.go"],
+    importpath = "github.com/bpalermo/aether/agent/internal/referencegrant",
+    visibility = ["//agent:__subpackages__"],
+    deps = [
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
+    ],
+)
+
+go_test(
+    name = "referencegrant_test",
+    srcs = ["referencegrant_test.go"],
+    embed = [":referencegrant"],
+    deps = [
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
+    ],
+)

--- a/agent/internal/referencegrant/referencegrant.go
+++ b/agent/internal/referencegrant/referencegrant.go
@@ -1,0 +1,87 @@
+// Package referencegrant implements the Gateway API ReferenceGrant check used to
+// admit cross-namespace backendRefs (conformance item: GATEWAY-HTTP core,
+// cross-namespace route tests).
+//
+// A backendRef whose namespace is set and differs from the referring route's
+// namespace is "cross-namespace". Per the Gateway API spec it is permitted ONLY
+// when a ReferenceGrant exists IN THE BACKEND'S namespace whose spec.from includes
+// {group: gateway.networking.k8s.io, kind: <route kind>, namespace: <route ns>} and
+// whose spec.to includes {group: "", kind: Service} (optionally a specific name).
+// Without a matching grant the reference MUST NOT be permitted.
+//
+// CAVEAT: aether resolves backends by NAME via the registry and is namespace-blind
+// today (the data-plane cluster name is <svc>.<meshDomain>; proposal 020 Part 1 will
+// make it <ns>/<svc>). So this is admission + status enforcement, NOT a change to the
+// resolution path: an ungranted cross-namespace backendRef reports
+// ResolvedRefs=False / RefNotPermitted and is DROPPED from the route; a granted one
+// resolves exactly as today.
+package referencegrant
+
+import (
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// PermitsBackend reports whether the given set of ReferenceGrants (which the caller
+// should list cluster-wide) permits a cross-namespace reference from a route of kind
+// fromKind/fromGroup in fromNamespace to a Service named toName in toNamespace.
+//
+// A grant matches when it lives in toNamespace AND has a spec.from entry matching
+// {fromGroup, fromKind, fromNamespace} AND a spec.to entry matching the core Service
+// {group: "", kind: Service} whose name is empty (all Services) or equal to toName.
+//
+// Callers must only invoke this for genuinely cross-namespace refs; same-namespace
+// refs are always permitted and need no grant (see CrossNamespace).
+func PermitsBackend(
+	grants []gatewayv1beta1.ReferenceGrant,
+	fromGroup, fromKind, fromNamespace string,
+	toNamespace, toName string,
+) bool {
+	for i := range grants {
+		g := &grants[i]
+		if g.Namespace != toNamespace {
+			continue
+		}
+		if !fromMatches(g.Spec.From, fromGroup, fromKind, fromNamespace) {
+			continue
+		}
+		if toMatches(g.Spec.To, toName) {
+			return true
+		}
+	}
+	return false
+}
+
+// fromMatches reports whether any spec.from entry trusts {group, kind, namespace}.
+func fromMatches(from []gatewayv1.ReferenceGrantFrom, group, kind, namespace string) bool {
+	for _, f := range from {
+		if string(f.Group) == group && string(f.Kind) == kind && string(f.Namespace) == namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// toMatches reports whether any spec.to entry allows the core Service named toName.
+// A to-entry with no Name matches every Service of the kind; a named entry matches
+// only that Service.
+func toMatches(to []gatewayv1.ReferenceGrantTo, toName string) bool {
+	for _, t := range to {
+		// Only the core ("") group Service kind is a valid backend target here.
+		if string(t.Group) != "" || string(t.Kind) != "Service" {
+			continue
+		}
+		if t.Name == nil || string(*t.Name) == "" || string(*t.Name) == toName {
+			return true
+		}
+	}
+	return false
+}
+
+// CrossNamespace reports whether a backendRef namespace (the dereferenced
+// backendRef.Namespace, "" when unset) makes the reference cross-namespace relative
+// to the referring route's namespace. An unset or equal namespace is same-namespace
+// (always permitted, no grant required).
+func CrossNamespace(backendNamespace, routeNamespace string) bool {
+	return backendNamespace != "" && backendNamespace != routeNamespace
+}

--- a/agent/internal/referencegrant/referencegrant_test.go
+++ b/agent/internal/referencegrant/referencegrant_test.go
@@ -1,0 +1,187 @@
+package referencegrant
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// grant builds a ReferenceGrant in toNamespace with the given from + to entries.
+func grant(toNamespace string, from []gatewayv1.ReferenceGrantFrom, to []gatewayv1.ReferenceGrantTo) gatewayv1beta1.ReferenceGrant {
+	return gatewayv1beta1.ReferenceGrant{
+		ObjectMeta: metav1.ObjectMeta{Namespace: toNamespace, Name: "g"},
+		Spec:       gatewayv1beta1.ReferenceGrantSpec{From: from, To: to},
+	}
+}
+
+func from(group, kind, ns string) gatewayv1.ReferenceGrantFrom {
+	return gatewayv1.ReferenceGrantFrom{
+		Group:     gatewayv1.Group(group),
+		Kind:      gatewayv1.Kind(kind),
+		Namespace: gatewayv1.Namespace(ns),
+	}
+}
+
+func to(group, kind string, name *string) gatewayv1.ReferenceGrantTo {
+	t := gatewayv1.ReferenceGrantTo{Group: gatewayv1.Group(group), Kind: gatewayv1.Kind(kind)}
+	if name != nil {
+		on := gatewayv1.ObjectName(*name)
+		t.Name = &on
+	}
+	return t
+}
+
+func strp(s string) *string { return &s }
+
+func TestCrossNamespace(t *testing.T) {
+	cases := []struct {
+		name             string
+		backendNamespace string
+		routeNamespace   string
+		want             bool
+	}{
+		{"unset is same-namespace", "", "ns-a", false},
+		{"equal is same-namespace", "ns-a", "ns-a", false},
+		{"different is cross-namespace", "ns-b", "ns-a", true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := CrossNamespace(c.backendNamespace, c.routeNamespace); got != c.want {
+				t.Fatalf("CrossNamespace(%q,%q)=%v want %v", c.backendNamespace, c.routeNamespace, got, c.want)
+			}
+		})
+	}
+}
+
+func TestPermitsBackend(t *testing.T) {
+	const grp = gatewayv1.GroupName // gateway.networking.k8s.io
+
+	cases := []struct {
+		name   string
+		grants []gatewayv1beta1.ReferenceGrant
+		want   bool
+	}{
+		{
+			name:   "no grants",
+			grants: nil,
+			want:   false,
+		},
+		{
+			name: "matching grant, to with no name (all Services)",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", nil)},
+				),
+			},
+			want: true,
+		},
+		{
+			name: "matching grant, to scoped to the exact Service name",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", strp("backend"))},
+				),
+			},
+			want: true,
+		},
+		{
+			name: "to scoped to a DIFFERENT Service name",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", strp("other"))},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "grant in the WRONG namespace (not the backend's)",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-c",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", nil)},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "from with the WRONG route kind",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "TCPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", nil)},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "from with the WRONG route namespace",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-x")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", nil)},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "from with the WRONG group",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from("example.com", "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Service", nil)},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "to with a non-core group is not a Service target",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("example.com", "Service", nil)},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "to with a non-Service kind",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{from(string(grp), "HTTPRoute", "ns-a")},
+					[]gatewayv1.ReferenceGrantTo{to("", "Secret", nil)},
+				),
+			},
+			want: false,
+		},
+		{
+			name: "one of several from/to entries matches",
+			grants: []gatewayv1beta1.ReferenceGrant{
+				grant("ns-b",
+					[]gatewayv1.ReferenceGrantFrom{
+						from(string(grp), "TCPRoute", "ns-a"),
+						from(string(grp), "HTTPRoute", "ns-a"),
+					},
+					[]gatewayv1.ReferenceGrantTo{
+						to("", "Service", strp("nope")),
+						to("", "Service", strp("backend")),
+					},
+				),
+			},
+			want: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := PermitsBackend(c.grants, string(grp), "HTTPRoute", "ns-a", "ns-b", "backend")
+			if got != c.want {
+				t.Fatalf("PermitsBackend=%v want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.43.0-{GIT_COMMIT}"
+version: "0.44.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -33,6 +33,14 @@ rules:
     resources: ["tcproutes/status", "tlsroutes/status", "udproutes/status"]
     verbs: ["get", "update", "patch"]
   {{- end }}
+  {{- if or .Values.agent.gamma .Values.agent.l4Routes }}
+  # ReferenceGrant (v1beta1): admit cross-namespace backendRefs on GAMMA/L4 routes.
+  # Read-only; a grant's presence gates whether a cross-ns backend is served +
+  # surfaced as ResolvedRefs (RefNotPermitted otherwise). Cluster-wide.
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["referencegrants"]
+    verbs: ["list", "get", "watch"]
+  {{- end }}
   {{- if or .Values.agent.transparentCapture .Values.agent.meshDns .Values.agent.gamma .Values.agent.l4Routes }}
   # Transparent capture (Phase 3a) / mesh DNS (mesh-global FQDN): watch the generated
   # mesh Services for their cluster.local authorities + ClusterIPs. GAMMA + l4route also

--- a/charts/aether/templates/edge-rbac.yaml
+++ b/charts/aether/templates/edge-rbac.yaml
@@ -29,6 +29,12 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["gatewayclasses/status"]
     verbs: ["get", "update", "patch"]
+  # ReferenceGrant (v1beta1): admit cross-namespace backendRefs. Read-only; the
+  # presence/absence of a grant gates whether a cross-ns backend is served +
+  # surfaced as ResolvedRefs (RefNotPermitted otherwise).
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["referencegrants"]
+    verbs: ["get", "list", "watch"]
   # Resolve backendRef Services cluster-wide for the ResolvedRefs condition.
   - apiGroups: [""]
     resources: ["services"]

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -44,7 +44,7 @@ e2e-validated on talos (aether 0.41.0).
 | GAMMA Mesh profile (parentRef=Service) | Supported | producer routes; consumer (per-namespace) overrides Planned |
 | GAMMA rules on the transparent-capture path | Supported | applies to clients dialing `<svc>.<meshDomain>` (the default path) |
 | East-west L4 on the transparent-capture path | Supported | TCPRoute/TLSRoute/UDPRoute (parentRef=Service) project onto the capture floor; gated behind `--l4-routes` |
-| `ReferenceGrant` (cross-namespace backendRefs) | N/A → Planned | aether's data-plane cluster name is namespace-free (`<svc>.<meshDomain>`), so cross-namespace backend references are not part of the routing model today; grant enforcement is a conformance-only follow-up |
+| `ReferenceGrant` (cross-namespace backendRefs) | Supported (admission + status; namespace-blind resolution pending 020 Part 1) | A cross-namespace backendRef (namespace set and != the route's) is admitted only when a `ReferenceGrant` in the backend's namespace has a `from` matching `{group: gateway.networking.k8s.io, kind: <route kind>, namespace: <route ns>}` and a `to` matching `{group: "", kind: Service}` (optionally `name`). Without a grant the route's `ResolvedRefs` is `False`/`RefNotPermitted` and the backend is DROPPED from the data plane (rest of the route still applies). Enforced on edge HTTPRoute/TCPRoute/TLSRoute and east-west GAMMA HTTPRoute/GRPCRoute + L4 TCPRoute/TLSRoute/UDPRoute. CAVEAT: aether's data-plane cluster name is still namespace-free (`<svc>.<meshDomain>`), so a *granted* cross-ns ref resolves by name exactly as today; proper per-namespace resolution lands with proposal 020 Part 1 |
 | MCS `ServiceExport`/`ServiceImport`, `clusterset.local` | Planned | registry-backed (proposal 006), DNS strictly local |
 
 ## Transport / security
@@ -67,10 +67,12 @@ The GatewayClass also publishes a machine-readable `status.supportedFeatures` li
 the suite skips (rather than fails) the features aether does not implement. The
 advertised set is: `Gateway`, `GatewayPort8080`, `HTTPRoute`, `GRPCRoute`,
 `HTTPRouteMethodMatching`, `HTTPRouteRequestTimeout`,
-`HTTPRouteResponseHeaderModification`. Path/header/method match, weighted backends,
-and the `RequestHeaderModifier` filter are part of HTTPRoute *core* and carry no
-separate feature flag. Redirect/rewrite/mirror and `ReferenceGrant` are deliberately
-omitted (not implemented).
+`HTTPRouteResponseHeaderModification`, `ReferenceGrant`. Path/header/method match,
+weighted backends, and the `RequestHeaderModifier` filter are part of HTTPRoute *core*
+and carry no separate feature flag. Redirect/rewrite/mirror are deliberately omitted
+(not implemented). `ReferenceGrant` is advertised now that cross-namespace backendRef
+admission + status enforcement is implemented (resolution stays namespace-blind until
+proposal 020 Part 1).
 
 ### Data-plane / addressing gap
 


### PR DESCRIPTION
## What

Implements Gateway API **ReferenceGrant** enforcement for cross-namespace `backendRef`s — ranked conformance item #4 (GATEWAY-HTTP core, the cross-namespace route tests), now reachable since the edge reconciles cluster-wide (#323).

This is **admission + status enforcement**, not a change to the resolution path (see caveat below).

## from/to matching

A `backendRef` whose `namespace` is set and differs from the route's namespace is *cross-namespace*. It is permitted only if a `ReferenceGrant` exists **in the backend's namespace** whose:
- `spec.from` includes `{group: gateway.networking.k8s.io, kind: <the route's kind>, namespace: <route's namespace>}`, **and**
- `spec.to` includes `{group: "", kind: Service}` (optionally a specific `name`).

Same-namespace refs (namespace unset or `== route ns`) are always allowed — no grant needed.

Shared helper: `agent/internal/referencegrant.PermitsBackend(grants, fromGroup, fromKind, fromNamespace, toNamespace, toName)` (+ `CrossNamespace`). The served API version is **`v1beta1`** (`sigs.k8s.io/gateway-api/apis/v1beta1.ReferenceGrant`, the storage version; its spec types alias v1).

## drop-and-RefNotPermitted behavior

When any cross-ns backendRef is ungranted:
- the route's parent **`ResolvedRefs`** condition is set `False` / reason `RefNotPermitted`, and
- that backend is **dropped** from the built data plane (the rest of the route still applies; if it was the only backend, the rule has no backend).

The existing `ResolvedRefs` logic (True / `InvalidKind` / `BackendNotFound`) is extended, not replaced.

## Wiring

- **Watch** `gatewayv1beta1.ReferenceGrant` added to `SetupWithManager` in the edge (`agent/internal/edge/gatewayapi`), GAMMA (`agent/internal/gamma`), and l4route (`agent/internal/l4route`) reconcilers — a grant change re-projects + re-statuses (caches are cluster-wide post-#323). Scheme registration (`gatewayv1beta1.Install`) added for the edge command and both agent reconciler paths.
- Backend builders skip non-permitted cross-ns backends; `backendsResolve*` feeds the `RefNotPermitted` result into `ResolvedRefs`. Covers edge HTTPRoute/TCPRoute/TLSRoute and east-west GAMMA HTTPRoute/GRPCRoute + L4 TCPRoute/TLSRoute/UDPRoute.

## Namespace-blind-resolution caveat

aether resolves backends **by name via the registry** and is namespace-blind today (cluster name is `<svc>.<meshDomain>`). So a **granted** cross-ns ref resolves by name exactly as today; proper per-namespace resolution lands with **proposal 020 Part 1**. This PR is exactly the "conformance-only follow-up" the features doc describes.

## RBAC + chart bump

- `referencegrants` `get/list/watch` added to the cluster-wide agent and edge `ClusterRole`s.
- Template change → `charts/aether/Chart.yaml` base `0.43.0-{GIT_COMMIT}` → **`0.44.0-{GIT_COMMIT}`**.

## supportedFeatures

`ReferenceGrant` added to the GatewayClass `supportedFeatures` advertisement (edge `features.go`) now that it's implemented, so the conformance suite runs those tests.

## Tests

- New `referencegrant` package unit tests (from/to matching edge cases: wrong from-kind, wrong from-namespace, wrong group, to-name scoping, grant-in-wrong-namespace, multi-entry).
- Per-reconciler: same-ns allowed (no grant); cross-ns without grant → `RefNotPermitted` + backend dropped; cross-ns with matching grant → resolved. Edge has an end-to-end Reconcile test (route ns A → Service ns B: `ResolvedRefs=False` without a grant, `True` after creating one).
- `bazel build //...` green; affected + full `bazel test //...` green; `bazel run //:format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)