### PR TITLE
feat(edge): publish Gateway status.addresses (021 Phase 1, shared edge LB IP)

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -113,6 +113,13 @@ type AgentConfig struct {
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves.
 	GatewayClassName string
 
+	// EdgeServiceName is the name of the edge's own LoadBalancer Service (in the
+	// edge's namespace). The edge resolves its assigned LB address from that
+	// Service's status and publishes it as every class-aether Gateway's
+	// status.addresses (proposal 021 Phase 1, shared edge address). Empty disables
+	// address publication (edge subcommand only).
+	EdgeServiceName string
+
 	// EdgeTLS enables downstream TLS termination: the edge serves an HTTPS
 	// listener on EdgeHTTPSPort (certs per Gateway listener via SDS) and an
 	// HTTP->HTTPS redirect on the plain port (edge subcommand only).

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -55,6 +55,7 @@ func init() {
 	edgeCmd.Flags().BoolVar(&cfg.EdgeTLS, "edge-tls", false, "Terminate downstream TLS: serve an HTTPS listener (certs per Gateway listener via SDS) + an HTTP->HTTPS redirect")
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPSPort, "edge-https-port", cfg.EdgeHTTPSPort, "Port the edge TLS listener binds when --edge-tls is set")
 	edgeCmd.Flags().StringVar(&cfg.GatewayClassName, "gateway-class", cfg.GatewayClassName, "GatewayClass name whose Gateways this edge serves")
+	edgeCmd.Flags().StringVar(&cfg.EdgeServiceName, "edge-service-name", "", "Name of the edge's own LoadBalancer Service (in the edge namespace); its assigned LB address is published as every class-aether Gateway's status.addresses. Empty disables address publication")
 }
 
 // runEdge initializes and runs the Aether edge proxy control plane. It is a
@@ -236,6 +237,7 @@ func runEdge(ctx context.Context) (retErr error) {
 		APIReader:        m.GetAPIReader(),
 		Sink:             snapshotCache,
 		Namespace:        routeNamespace,
+		EdgeServiceName:  cfg.EdgeServiceName,
 		GatewayClassName: cfg.GatewayClassName,
 		MeshDomain:       cfg.MeshDomain,
 		Secrets:          secretRegistry,

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -54,11 +54,18 @@ type Reconciler struct {
 
 	// Sink receives the projected virtual hosts/certs and L4 routes (the snapshot cache).
 	Sink RouteSink
-	// Namespace is the edge's own namespace. It is used only as the default
-	// namespace for the TLS Secret provider's cert lookups; Gateways/Routes are
-	// listed and reconciled CLUSTER-WIDE (namespace-agnostic), so this field no
-	// longer scopes the route/Gateway lists.
+	// Namespace is the edge's own namespace. It is used as the default namespace
+	// for the TLS Secret provider's cert lookups and as the namespace of the edge
+	// LoadBalancer Service (EdgeServiceName) from which the published Gateway
+	// status.addresses is resolved; Gateways/Routes are listed and reconciled
+	// CLUSTER-WIDE (namespace-agnostic), so this field does not scope the
+	// route/Gateway lists.
 	Namespace string
+	// EdgeServiceName is the name of the edge's own LoadBalancer Service (in
+	// Namespace). Its status.loadBalancer.ingress address is published as every
+	// class-aether Gateway's status.addresses (proposal 021 Phase 1 — the shared
+	// edge address). Empty disables address publication.
+	EdgeServiceName string
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves.
 	GatewayClassName string
 	// Secrets resolves Gateway listener TLS cert material; nil disables TLS.

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -13,8 +13,6 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-func ptr[T any](v T) *T { return &v }
-
 func httpRoute(hosts []string, rules []gatewayv1.HTTPRouteRule, parents ...string) *gatewayv1.HTTPRoute {
 	hr := &gatewayv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "r"}}
 	for _, h := range hosts {

--- a/agent/internal/edge/gatewayapi/status.go
+++ b/agent/internal/edge/gatewayapi/status.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
 	"github.com/bpalermo/aether/agent/internal/referencegrant"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,9 +55,10 @@ func (r *Reconciler) writeGatewayClassStatus(ctx context.Context) {
 }
 
 // writeGatewayStatuses sets, for each of our Gateways, top-level Accepted=True +
-// Programmed=True and a per-listener status (supportedKinds, attachedRoutes,
-// Programmed/Accepted/ResolvedRefs=True). attachedRoutes is computed from the
-// routes the reconciler already listed.
+// Programmed=True, a per-listener status (supportedKinds, attachedRoutes,
+// Programmed/Accepted/ResolvedRefs=True), and status.addresses (proposal 021
+// Phase 1: the shared edge LB IP). attachedRoutes is computed from the routes the
+// reconciler already listed.
 func (r *Reconciler) writeGatewayStatuses(
 	ctx context.Context,
 	ourGateways []gatewayv1.Gateway,
@@ -66,6 +68,12 @@ func (r *Reconciler) writeGatewayStatuses(
 	gateways map[gatewayKey]struct{},
 	listenerKeys map[gatewayListenerKey]struct{},
 ) {
+	// Proposal 021 Phase 1: resolve the shared edge LoadBalancer address once and
+	// publish it on every class-aether Gateway. Resolved at runtime (robust to
+	// MetalLB assignment): if the LB hasn't been assigned an address yet, addrs is
+	// empty and we leave status.addresses untouched this reconcile — the Service
+	// watch re-triggers us once MetalLB assigns it.
+	addrs := r.resolveGatewayAddresses(ctx)
 	for i := range ourGateways {
 		gw := &ourGateways[i]
 		desired := *gw.DeepCopy()
@@ -119,13 +127,85 @@ func (r *Reconciler) writeGatewayStatuses(
 
 		listenersChanged := !listenerStatusesEqual(gw.Status.Listeners, listeners)
 		desired.Status.Listeners = listeners
-		if !topChanged && !listenersChanged {
+
+		// Only publish addresses once the LB IP is resolved; never overwrite a
+		// previously-published address with an empty list (which would regress the
+		// Gateway to "no address"). The address write participates in the same
+		// no-op-skip change detection as the conditions so we don't hot-loop.
+		addrsChanged := false
+		if len(addrs) > 0 {
+			addrsChanged = !gatewayAddressesEqual(gw.Status.Addresses, addrs)
+			desired.Status.Addresses = addrs
+		}
+
+		if !topChanged && !listenersChanged && !addrsChanged {
 			continue
 		}
 		if err := r.Status().Update(ctx, &desired); err != nil {
 			r.Log.WarnContext(ctx, "failed to write Gateway status", "gateway", gw.Name, "error", err.Error())
 		}
 	}
+}
+
+// resolveGatewayAddresses returns the edge's shared LoadBalancer address as a
+// single Gateway status address (proposal 021 Phase 1). It Gets the edge's own
+// LoadBalancer Service (EdgeServiceName in Namespace) and reads
+// status.loadBalancer.ingress[0].ip, falling back to .hostname when the ingress
+// is hostname-based. It returns nil (skip publication) when EdgeServiceName is
+// unset, the Service is missing, or no LB address has been assigned yet — the
+// Service watch re-triggers reconciliation once MetalLB assigns one.
+func (r *Reconciler) resolveGatewayAddresses(ctx context.Context) []gatewayv1.GatewayStatusAddress {
+	if r.EdgeServiceName == "" {
+		return nil
+	}
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: r.Namespace, Name: r.EdgeServiceName}, svc); err != nil {
+		if !apierrors.IsNotFound(err) {
+			r.Log.WarnContext(ctx, "failed to get edge Service for Gateway addresses",
+				"service", r.EdgeServiceName, "namespace", r.Namespace, "error", err.Error())
+		}
+		return nil
+	}
+	for _, ing := range svc.Status.LoadBalancer.Ingress {
+		if ing.IP != "" {
+			return []gatewayv1.GatewayStatusAddress{{
+				Type:  ptr(gatewayv1.IPAddressType),
+				Value: ing.IP,
+			}}
+		}
+		if ing.Hostname != "" {
+			return []gatewayv1.GatewayStatusAddress{{
+				Type:  ptr(gatewayv1.HostnameAddressType),
+				Value: ing.Hostname,
+			}}
+		}
+	}
+	return nil
+}
+
+// ptr returns a pointer to v (for optional Gateway API fields).
+func ptr[T any](v T) *T { return &v }
+
+// gatewayAddressesEqual reports whether two Gateway status address slices are
+// equivalent (same type+value in order) — the no-op-skip guard for the address
+// write.
+func gatewayAddressesEqual(a, b []gatewayv1.GatewayStatusAddress) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		at, bt := "", ""
+		if a[i].Type != nil {
+			at = string(*a[i].Type)
+		}
+		if b[i].Type != nil {
+			bt = string(*b[i].Type)
+		}
+		if at != bt || a[i].Value != b[i].Value {
+			return false
+		}
+	}
+	return true
 }
 
 // attachedRoutesForListener counts the routes (with Accepted=True) attached to a

--- a/agent/internal/edge/gatewayapi/status_test.go
+++ b/agent/internal/edge/gatewayapi/status_test.go
@@ -253,6 +253,97 @@ func TestReconcile_GatewayInNonEdgeNamespace(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, racc.Status)
 }
 
+// TestReconcile_GatewayStatusAddresses: a reconciled class-aether Gateway (in any
+// namespace) gets status.addresses = the edge LoadBalancer Service's assigned IP
+// (proposal 021 Phase 1, shared edge address), resolved at runtime from the edge
+// Service's status.loadBalancer.ingress.
+func TestReconcile_GatewayStatusAddresses(t *testing.T) {
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+	// Gateway in a foreign namespace — it still shares the one edge address.
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "conformance-gw", Namespace: "gateway-conformance-infra", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners:        []gatewayv1.Listener{{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+		},
+	}
+	// The edge's own LoadBalancer Service, with MetalLB having assigned an IP.
+	edgeSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether-edge", Namespace: "aether-ingress"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		Status: corev1.ServiceStatus{LoadBalancer: corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{{IP: "192.168.100.101"}},
+		}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(gc, gw, edgeSvc).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}).
+		Build()
+	r := &Reconciler{
+		Client: c, APIReader: c, Sink: statusFakeSink{},
+		Namespace: "aether-ingress", EdgeServiceName: "aether-edge",
+		GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default(),
+	}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotGW := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "gateway-conformance-infra", Name: "conformance-gw"}, gotGW))
+	require.Len(t, gotGW.Status.Addresses, 1)
+	require.NotNil(t, gotGW.Status.Addresses[0].Type)
+	assert.Equal(t, gatewayv1.IPAddressType, *gotGW.Status.Addresses[0].Type)
+	assert.Equal(t, "192.168.100.101", gotGW.Status.Addresses[0].Value)
+}
+
+// TestReconcile_GatewayStatusAddresses_NoLBIP: when the edge LoadBalancer Service
+// has no assigned ingress address yet (MetalLB pending), no status.addresses is
+// written — the Gateway is left address-less rather than getting an empty/garbage
+// address. (The Service watch re-triggers reconciliation once the IP lands.)
+func TestReconcile_GatewayStatusAddresses_NoLBIP(t *testing.T) {
+	gc := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "edge", Namespace: "aether-ingress", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners:        []gatewayv1.Listener{{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+		},
+	}
+	// Edge Service exists but MetalLB hasn't assigned an IP (empty Ingress).
+	edgeSvc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether-edge", Namespace: "aether-ingress"},
+		Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(gc, gw, edgeSvc).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}).
+		Build()
+	r := &Reconciler{
+		Client: c, APIReader: c, Sink: statusFakeSink{},
+		Namespace: "aether-ingress", EdgeServiceName: "aether-edge",
+		GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default(),
+	}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotGW := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "aether-ingress", Name: "edge"}, gotGW))
+	// Conditions are still published; addresses are not (LB IP unset).
+	prog := meta.FindStatusCondition(gotGW.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+	require.NotNil(t, prog)
+	assert.Equal(t, metav1.ConditionTrue, prog.Status)
+	assert.Empty(t, gotGW.Status.Addresses, "no LB IP assigned → no status.addresses")
+}
+
 // TestReconcile_GatewayClassSupportedFeatures: the GatewayClass status carries the
 // advertised supportedFeatures, sorted ascending and including HTTPRoute/GRPCRoute,
 // and omitting features aether does not implement.

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.44.0-{GIT_COMMIT}"
+version: "0.45.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -74,6 +74,10 @@ spec:
             {{- if ne .Values.edge.gatewayClassName "aether" }}
             - "--gateway-class={{ .Values.edge.gatewayClassName }}"
             {{- end }}
+            # Publish this edge's shared LoadBalancer address as every class-aether
+            # Gateway's status.addresses (proposal 021 Phase 1). The edge Gets this
+            # Service in its own namespace and reads status.loadBalancer.ingress.
+            - "--edge-service-name={{ include "aether.edge.fullname" . }}"
             {{- if .Values.edge.tls.enabled }}
             - "--edge-tls"
             {{- if ne (int .Values.edge.httpsPort) 443 }}

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -63,6 +63,14 @@ Gateway of its GatewayClass in ANY namespace and publishes the Gateway/Route sta
 conditions and per-listener `attachedRoutes`, which is what the upstream conformance
 suite's `NamespacesMustBeReady` gate requires before any test runs.
 
+Every class-`aether` Gateway also gets `status.addresses` (one `IPAddress` entry =
+the shared edge LoadBalancer IP), so the suite's "wait for at least one IP address in
+status" setup step passes and the GATEWAY-HTTP *traffic* tests run (proposal 021 Phase
+1). The address is resolved at runtime from the edge's own LoadBalancer Service status
+(robust to MetalLB assignment): until the LB IP is assigned the address is omitted
+rather than written empty. All class-`aether` Gateways currently share the one edge
+address; distinct per-Gateway addresses are proposal 021 Phase 2.
+
 The GatewayClass also publishes a machine-readable `status.supportedFeatures` list so
 the suite skips (rather than fails) the features aether does not implement. The
 advertised set is: `Gateway`, `GatewayPort8080`, `HTTPRoute`, `GRPCRoute`,
@@ -76,9 +84,10 @@ proposal 020 Part 1).
 
 ### Data-plane / addressing gap
 
-The status/reconcile unlock is namespace-agnostic, but the edge data plane is still a
-single Deployment on a single LoadBalancer address. A Gateway in another namespace is
-reconciled and reaches `Accepted`/`Programmed`, and its routes are served through that
-one shared edge address — there is no per-Gateway address allocation. Tests that assert
-each Gateway has its OWN distinct address are not yet satisfied; multi-Gateway
-addressing is the next item.
+The edge data plane is still a single Deployment on a single LoadBalancer address.
+Every class-`aether` Gateway now publishes that shared address in `status.addresses`
+(proposal 021 Phase 1), which unblocks the address-dependent GATEWAY-HTTP traffic
+tests; routes are served through the one shared address (demuxed by listener
+hostname/port). Tests that assert each Gateway has its OWN *distinct* address are not
+yet satisfied — distinct per-Gateway addressing (per-Gateway LoadBalancer Service +
+internal-port demux) is proposal 021 Phase 2.


### PR DESCRIPTION
## What

Phase 1 of [proposal 021 (per-Gateway addressing)](docs/proposals/021_per-gateway-addressing.md): publish `status.addresses` on every class-`aether` Gateway the edge reconciles, set to one `IPAddress` entry = the **shared edge LoadBalancer IP**.

After #323 the edge reconciles class-`aether` Gateways cluster-wide and publishes `Accepted`/`Programmed`, but never set `status.addresses`. Conformance rev2 (GATEWAY-HTTP) now runs, but ~20 traffic tests fail at setup with `"error waiting for Gateway to have at least one IP address in status"`. This fixes that.

## How

- **Runtime address resolution** (robust to MetalLB assignment): the edge Gets its own LoadBalancer Service (`--edge-service-name`, set by the chart to `aether.edge.fullname`, in the edge's own namespace) and reads `status.loadBalancer.ingress[0].ip`, falling back to `.hostname`. Re-read each reconcile; Services are watched cluster-wide (post-#323).
- **Skip-when-unset**: if the LB IP isn't assigned yet, `status.addresses` is left untouched (never written empty/garbage). The Service watch re-triggers reconciliation once MetalLB assigns it.
- The address write participates in the **same no-op-skip change detection** as the conditions (`gatewayAddressesEqual`), so it doesn't hot-loop.
- Applies to **every** class-`aether` Gateway including conformance Gateways in other namespaces (they all share the one edge address in Phase 1) and the existing `aether-ingress/edge` Gateway (no regression).
- No `192.168.100.101` hardcode — resolved entirely at runtime.

## RBAC / chart

- RBAC already grants `services` `get`/`list`/`watch` cluster-wide on the edge ClusterRole (#323/#324) — verified, no change.
- Chart bumped `0.44.0` → `0.45.0` (changed the edge Deployment template to pass `--edge-service-name`).

## Tests

- New unit tests: a reconciled class-`aether` Gateway gets `status.addresses` = the resolved edge IP (mocked Service lookup); no address written when the LB IP is unset.
- `make gazelle`; `bazel build //...`; `bazel test //... --test_output=errors` (61/61 pass); `bazel run //:format`.

## Notes

Unblocks the ~20 GATEWAY-HTTP "no IP address in status" failures. Distinct per-Gateway addresses (per-Gateway LB Service + internal-port demux) are **Phase 2**.

## e2e idea

Apply a class-`aether` Gateway in any namespace, then:
```
kubectl get gateway <name> -n <ns> -o jsonpath='{.status.addresses}'
```
should show `[{"type":"IPAddress","value":"192.168.100.101"}]` (the edge LB IP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
