### PR TITLE
fix(edge): Gateway API status edge-cases (supportedKinds, InvalidTLS, attachment, observedGeneration, attachedRoutes)

### DIFF
--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "gatewayapi",
     srcs = [
+        "attachment.go",
         "features.go",
         "reconciler.go",
         "status.go",
@@ -21,6 +22,7 @@ go_library(
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_apimachinery//pkg/labels",
         "@io_k8s_apimachinery//pkg/types",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",
@@ -36,6 +38,7 @@ go_library(
 go_test(
     name = "gatewayapi_test",
     srcs = [
+        "edge_cases_test.go",
         "reconciler_test.go",
         "status_test.go",
     ],

--- a/agent/internal/edge/gatewayapi/attachment.go
+++ b/agent/internal/edge/gatewayapi/attachment.go
@@ -1,0 +1,267 @@
+package gatewayapi
+
+import (
+	"context"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// routeAttachReason enumerates why a route does (Accepted) or does not attach to
+// any listener of a Gateway. The zero value (attachAccepted) means it attaches.
+type routeAttachReason int
+
+const (
+	// attachAccepted: the route attaches to at least one listener.
+	attachAccepted routeAttachReason = iota
+	// attachNoMatchingParent: the parentRef names a sectionName/port that no
+	// listener on the Gateway has.
+	attachNoMatchingParent
+	// attachNotAllowedByListeners: a candidate listener exists, but its
+	// allowedRoutes.namespaces excludes the route's namespace (or no candidate
+	// listener allowed the route's namespace).
+	attachNotAllowedByListeners
+	// attachNoMatchingListenerHostname: a candidate listener exists and allows the
+	// namespace, but the route's hostnames don't intersect the listener hostname.
+	attachNoMatchingListenerHostname
+)
+
+// listenerAcceptsKind reports whether a listener (by protocol + allowedRoutes.kinds)
+// accepts the given route kind. allowedRoutes.kinds, when set, restricts the
+// otherwise protocol-default supported kinds; a kind not in the protocol default
+// is never accepted.
+func listenerAcceptsKind(ln gatewayv1.Listener, routeKind string) bool {
+	for _, s := range listenerSupportedKinds(ln) {
+		if string(s.Kind) == routeKind {
+			return true
+		}
+	}
+	return false
+}
+
+// listenerSupportedKinds returns the supportedKinds to publish on a listener's
+// status: the protocol-default kinds, intersected with allowedRoutes.kinds when
+// the listener sets one. A listener whose allowedRoutes.kinds names only
+// unsupported kinds yields an empty (non-nil) slice, matching the upstream
+// conformance expectation (supportedKinds: []).
+func listenerSupportedKinds(ln gatewayv1.Listener) []gatewayv1.RouteGroupKind {
+	defaults := supportedKindsFor(ln.Protocol)
+	if ln.AllowedRoutes == nil || len(ln.AllowedRoutes.Kinds) == 0 {
+		return defaults
+	}
+	out := make([]gatewayv1.RouteGroupKind, 0, len(defaults))
+	for _, want := range ln.AllowedRoutes.Kinds {
+		for _, d := range defaults {
+			if d.Kind == want.Kind && groupEqual(d.Group, want.Group) {
+				out = append(out, d)
+			}
+		}
+	}
+	return out
+}
+
+// listenerHasInvalidRouteKinds reports whether a listener's allowedRoutes.kinds
+// names any kind the listener's protocol does not support (drives the
+// ResolvedRefs=False / InvalidRouteKinds listener condition).
+func listenerHasInvalidRouteKinds(ln gatewayv1.Listener) bool {
+	if ln.AllowedRoutes == nil || len(ln.AllowedRoutes.Kinds) == 0 {
+		return false
+	}
+	defaults := supportedKindsFor(ln.Protocol)
+	for _, want := range ln.AllowedRoutes.Kinds {
+		ok := false
+		for _, d := range defaults {
+			if d.Kind == want.Kind && groupEqual(d.Group, want.Group) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return true
+		}
+	}
+	return false
+}
+
+func groupEqual(a, b *gatewayv1.Group) bool {
+	ag, bg := gatewayv1.Group(""), gatewayv1.Group("")
+	if a != nil {
+		ag = *a
+	}
+	if b != nil {
+		bg = *b
+	}
+	// An empty group on a RouteGroupKind defaults to the Gateway API group.
+	if ag == "" {
+		ag = gatewayv1.Group(gatewayv1.GroupName)
+	}
+	if bg == "" {
+		bg = gatewayv1.Group(gatewayv1.GroupName)
+	}
+	return ag == bg
+}
+
+// parentRefSelectsListener reports whether a parentRef (already known to target
+// this Gateway) selects the given listener by sectionName and/or port. An unset
+// sectionName/port selects every listener; a set one must match.
+func parentRefSelectsListener(p gatewayv1.ParentReference, ln gatewayv1.Listener) bool {
+	if p.SectionName != nil && *p.SectionName != ln.Name {
+		return false
+	}
+	if p.Port != nil && uint32(*p.Port) != uint32(ln.Port) {
+		return false
+	}
+	return true
+}
+
+// parentRefNamesAnyListener reports whether the parentRef's sectionName/port (if
+// set) matches at least one listener on the Gateway. A parentRef naming a
+// sectionName/port that no listener has yields NoMatchingParent.
+func parentRefNamesAnyListener(p gatewayv1.ParentReference, listeners []gatewayv1.Listener) bool {
+	for _, ln := range listeners {
+		if parentRefSelectsListener(p, ln) {
+			return true
+		}
+	}
+	return false
+}
+
+// namespaceAllowed reports whether a listener's allowedRoutes.namespaces admits a
+// route in routeNamespace. The Gateway lives in gwNamespace. Selector matching
+// fetches the route namespace's labels via the client; a fetch failure is treated
+// as "not allowed" (fail-closed) rather than panicking.
+func (r *Reconciler) namespaceAllowed(ctx context.Context, gwNamespace, routeNamespace string, ln gatewayv1.Listener) bool {
+	from := gatewayv1.NamespacesFromSame
+	var selector *metav1.LabelSelector
+	if ln.AllowedRoutes != nil && ln.AllowedRoutes.Namespaces != nil {
+		ns := ln.AllowedRoutes.Namespaces
+		if ns.From != nil {
+			from = *ns.From
+		}
+		selector = ns.Selector
+	}
+	switch from {
+	case gatewayv1.NamespacesFromAll:
+		return true
+	case gatewayv1.NamespacesFromNone:
+		return false
+	case gatewayv1.NamespacesFromSelector:
+		if selector == nil {
+			return false
+		}
+		sel, err := metav1.LabelSelectorAsSelector(selector)
+		if err != nil {
+			return false
+		}
+		nsObj := &corev1.Namespace{}
+		if err := r.Get(ctx, types.NamespacedName{Name: routeNamespace}, nsObj); err != nil {
+			if !apierrors.IsNotFound(err) {
+				r.Log.WarnContext(ctx, "failed to get namespace for allowedRoutes selector",
+					"namespace", routeNamespace, "error", err.Error())
+			}
+			return false
+		}
+		return sel.Matches(labels.Set(nsObj.Labels))
+	default: // Same
+		return routeNamespace == gwNamespace
+	}
+}
+
+// hostnamesIntersect reports whether a route's hostnames intersect a listener's
+// hostname. An empty listener hostname matches any route hostname; an empty route
+// hostname set matches any listener hostname. Wildcard (*.suffix) listener
+// hostnames match by suffix. This mirrors the Gateway API hostname-intersection
+// rule used to drive NoMatchingListenerHostname.
+func hostnamesIntersect(listenerHostname *gatewayv1.Hostname, routeHostnames []gatewayv1.Hostname) bool {
+	if listenerHostname == nil || *listenerHostname == "" {
+		return true
+	}
+	if len(routeHostnames) == 0 {
+		return true
+	}
+	lh := string(*listenerHostname)
+	for _, rh := range routeHostnames {
+		if hostnameMatch(lh, string(rh)) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostnameMatch reports whether a listener hostname and a route hostname overlap,
+// honoring wildcard prefixes on either side.
+func hostnameMatch(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if strings.HasPrefix(a, "*.") {
+		if strings.HasSuffix(b, a[1:]) && b != a[1:] {
+			return true
+		}
+		if strings.HasPrefix(b, "*.") {
+			return strings.HasSuffix(a, b[1:]) || strings.HasSuffix(b, a[1:])
+		}
+	}
+	if strings.HasPrefix(b, "*.") {
+		return strings.HasSuffix(a, b[1:]) && a != b[1:]
+	}
+	return false
+}
+
+// httpRouteAttachment computes whether an HTTPRoute attaches to the named Gateway
+// and, if not, why. It honors: parentRef sectionName/port (NoMatchingParent),
+// allowedRoutes.namespaces (NotAllowedByListeners), allowedRoutes.kinds, and
+// listener-hostname intersection (NoMatchingListenerHostname). A route attaches
+// when at least one listener of the Gateway accepts it on all axes.
+func (r *Reconciler) httpRouteAttachment(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	parentRefs []gatewayv1.ParentReference,
+	routeNamespace string,
+	routeHostnames []gatewayv1.Hostname,
+) routeAttachReason {
+	reason := attachNoMatchingParent
+	for _, p := range parentRefs {
+		if !parentRefIsGateway(p) {
+			continue
+		}
+		if string(p.Name) != gw.Name || parentRefNamespace(p.Namespace, routeNamespace) != gw.Namespace {
+			continue
+		}
+		// The parentRef targets this Gateway. Does its sectionName/port name a
+		// real listener?
+		if !parentRefNamesAnyListener(p, gw.Spec.Listeners) {
+			// NoMatchingParent unless a better (already-found) reason exists.
+			continue
+		}
+		// Walk the listeners this parentRef selects, narrowing the failure reason
+		// from namespace → hostname as we get closer to a match.
+		for _, ln := range gw.Spec.Listeners {
+			if !parentRefSelectsListener(p, ln) {
+				continue
+			}
+			if !listenerAcceptsKind(ln, "HTTPRoute") {
+				continue
+			}
+			if !r.namespaceAllowed(ctx, gw.Namespace, routeNamespace, ln) {
+				if reason == attachNoMatchingParent {
+					reason = attachNotAllowedByListeners
+				}
+				continue
+			}
+			if !hostnamesIntersect(ln.Hostname, routeHostnames) {
+				reason = attachNoMatchingListenerHostname
+				continue
+			}
+			return attachAccepted
+		}
+		// This parentRef named a real listener but none accepted; keep the most
+		// specific reason found so far (namespace/hostname over NoMatchingParent).
+	}
+	return reason
+}

--- a/agent/internal/edge/gatewayapi/edge_cases_test.go
+++ b/agent/internal/edge/gatewayapi/edge_cases_test.go
@@ -1,0 +1,332 @@
+package gatewayapi
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func ourClass() *gatewayv1.GatewayClass {
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+}
+
+// TestGatewayClassObservedGeneration: the Accepted condition on the GatewayClass
+// carries the class's own metadata.generation as observedGeneration (not 0), and a
+// GatewayClass that bears our controllerName but a DIFFERENT name than the
+// configured one is still reconciled — covering GatewayClassObservedGenerationBump.
+func TestGatewayClassObservedGeneration(t *testing.T) {
+	// Configured class name is "aether", but the conformance bump test creates a
+	// differently-named class that still carries our controllerName.
+	other := &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: "gatewayclass-observed-generation-bump", Generation: 7},
+		Spec:       gatewayv1.GatewayClassSpec{ControllerName: gatewaystatus.EdgeControllerName},
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(ourClass(), other).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "aether-ingress", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	got := &gatewayv1.GatewayClass{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "gatewayclass-observed-generation-bump"}, got))
+	acc := meta.FindStatusCondition(got.Status.Conditions, string(gatewayv1.GatewayClassConditionStatusAccepted))
+	require.NotNil(t, acc, "differently-named class with our controllerName must be reconciled")
+	assert.Equal(t, metav1.ConditionTrue, acc.Status)
+	assert.Equal(t, int64(7), acc.ObservedGeneration, "observedGeneration must equal the class generation, not 0")
+}
+
+// TestListenerInvalidRouteKinds: a listener whose allowedRoutes.kinds names an
+// unsupported kind must publish ResolvedRefs=False/InvalidRouteKinds and an
+// appropriate supportedKinds list (empty when ALL named kinds are unsupported;
+// the supported subset otherwise) — covers GatewayInvalidRouteKind.
+func TestListenerInvalidRouteKinds(t *testing.T) {
+	gwOnlyInvalid := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-only-invalid", Namespace: "ns", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{Kinds: []gatewayv1.RouteGroupKind{{Kind: "InvalidRoute"}}},
+			}},
+		},
+	}
+	gwSupportedAndInvalid := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-supported-and-invalid", Namespace: "ns", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{Kinds: []gatewayv1.RouteGroupKind{{Kind: "InvalidRoute"}, {Kind: "HTTPRoute"}}},
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(ourClass(), gwOnlyInvalid, gwSupportedAndInvalid).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "ns", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	// Only-invalid: ResolvedRefs=False/InvalidRouteKinds, supportedKinds empty.
+	got := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "gw-only-invalid"}, got))
+	require.Len(t, got.Status.Listeners, 1)
+	rr := meta.FindStatusCondition(got.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+	require.NotNil(t, rr)
+	assert.Equal(t, metav1.ConditionFalse, rr.Status)
+	assert.Equal(t, string(gatewayv1.ListenerReasonInvalidRouteKinds), rr.Reason)
+	assert.Empty(t, got.Status.Listeners[0].SupportedKinds, "all-invalid kinds → empty supportedKinds")
+
+	// Supported-and-invalid: ResolvedRefs=False/InvalidRouteKinds, supportedKinds=[HTTPRoute].
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "gw-supported-and-invalid"}, got))
+	require.Len(t, got.Status.Listeners, 1)
+	rr = meta.FindStatusCondition(got.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+	require.NotNil(t, rr)
+	assert.Equal(t, metav1.ConditionFalse, rr.Status)
+	assert.Equal(t, string(gatewayv1.ListenerReasonInvalidRouteKinds), rr.Reason)
+	require.Len(t, got.Status.Listeners[0].SupportedKinds, 1)
+	assert.Equal(t, gatewayv1.Kind("HTTPRoute"), got.Status.Listeners[0].SupportedKinds[0].Kind)
+}
+
+// TestListenerInvalidTLS: an HTTPS listener whose certificateRef doesn't resolve
+// (no Secrets provider configured) gets ResolvedRefs=False/InvalidCertificateRef
+// and a NON-Programmed listener + Gateway — covers GatewayInvalidTLSConfiguration.
+func TestListenerInvalidTLS(t *testing.T) {
+	secretKind := gatewayv1.Kind("Secret")
+	emptyGroup := gatewayv1.Group("")
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-bad-tls", Namespace: "ns", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{{
+						Group: &emptyGroup, Kind: &secretKind, Name: "nonexistent-certificate",
+					}},
+				},
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(ourClass(), gw).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}).
+		Build()
+	// Secrets nil → TLS cannot resolve → InvalidCertificateRef.
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "ns", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	got := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "gw-bad-tls"}, got))
+	require.Len(t, got.Status.Listeners, 1)
+	rr := meta.FindStatusCondition(got.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+	require.NotNil(t, rr)
+	assert.Equal(t, metav1.ConditionFalse, rr.Status)
+	assert.Equal(t, string(gatewayv1.ListenerReasonInvalidCertificateRef), rr.Reason)
+	prog := meta.FindStatusCondition(got.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionProgrammed))
+	require.NotNil(t, prog)
+	assert.Equal(t, metav1.ConditionFalse, prog.Status, "listener with invalid TLS must not be Programmed")
+	// supportedKinds still HTTPRoute (the kind is fine; the cert is not).
+	require.Len(t, got.Status.Listeners[0].SupportedKinds, 1)
+	assert.Equal(t, gatewayv1.Kind("HTTPRoute"), got.Status.Listeners[0].SupportedKinds[0].Kind)
+	// Top-level Gateway Programmed must be False while a listener is broken.
+	gwProg := meta.FindStatusCondition(got.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+	require.NotNil(t, gwProg)
+	assert.Equal(t, metav1.ConditionFalse, gwProg.Status)
+}
+
+// TestRouteNotMatchingSectionName: a route whose parentRef names a sectionName
+// that no listener has gets Accepted=False/NoMatchingParent and is NOT counted in
+// the listener attachedRoutes — covers HTTPRouteInvalidParentRefNotMatchingSectionName.
+func TestRouteNotMatchingSectionName(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-namespace", Namespace: "ns", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners:        []gatewayv1.Listener{{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType}},
+		},
+	}
+	badSection := gatewayv1.SectionName("http1") // no such listener
+	port := gatewayv1.PortNumber(80)
+	hr := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "ns", Generation: 1},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{
+				Kind: ptr(gatewayv1.Kind("Gateway")), Name: "same-namespace",
+				SectionName: &badSection, Port: &port,
+			}}},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc", Port: ptr(gatewayv1.PortNumber(8080))},
+				}}},
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(ourClass(), gw, hr).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "ns", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotHR := &gatewayv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "r1"}, gotHR))
+	require.Len(t, gotHR.Status.Parents, 1)
+	acc := meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionFalse, acc.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonNoMatchingParent), acc.Reason)
+
+	gotGW := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: "same-namespace"}, gotGW))
+	require.Len(t, gotGW.Status.Listeners, 1)
+	assert.Equal(t, int32(0), gotGW.Status.Listeners[0].AttachedRoutes, "non-matching sectionName must not attach")
+}
+
+// TestRouteNotAllowedByListeners: a cross-namespace route attaching to a Gateway
+// whose listener allowedRoutes.namespaces is "Same" gets
+// Accepted=False/NotAllowedByListeners and is not attached — covers
+// HTTPRouteInvalidCrossNamespaceParentRef.
+func TestRouteNotAllowedByListeners(t *testing.T) {
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "same-namespace", Namespace: "infra", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+				AllowedRoutes: &gatewayv1.AllowedRoutes{Namespaces: &gatewayv1.RouteNamespaces{
+					From: ptr(gatewayv1.NamespacesFromSame),
+				}},
+			}},
+		},
+	}
+	infraNs := gatewayv1.Namespace("infra")
+	hr := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "cross", Namespace: "web-backend", Generation: 1},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{
+				Kind: ptr(gatewayv1.Kind("Gateway")), Name: "same-namespace", Namespace: &infraNs,
+			}}},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "web-backend", Port: ptr(gatewayv1.PortNumber(8080))},
+				}}},
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(ourClass(), gw, hr).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "infra", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotHR := &gatewayv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "web-backend", Name: "cross"}, gotHR))
+	require.Len(t, gotHR.Status.Parents, 1)
+	acc := meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionFalse, acc.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonNotAllowedByListeners), acc.Reason)
+
+	gotGW := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "infra", Name: "same-namespace"}, gotGW))
+	require.Len(t, gotGW.Status.Listeners, 1)
+	assert.Equal(t, int32(0), gotGW.Status.Listeners[0].AttachedRoutes)
+}
+
+// TestAttachedRoutesNon8080AndHostname: a non-8080 (port 80) listener with a
+// hostname counts only the routes whose hostnames intersect the listener hostname
+// (allowedRoutes.namespaces=Selector honored), and a mismatched-hostname route is
+// Accepted=False/NoMatchingListenerHostname — covers the non-port-8080
+// GatewayWithAttachedRoutes variant.
+func TestAttachedRoutesNon8080AndHostname(t *testing.T) {
+	infraNsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   "infra",
+		Labels: map[string]string{"kubernetes.io/metadata.name": "infra"},
+	}}
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw2", Namespace: "infra", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType,
+				Hostname: ptr(gatewayv1.Hostname("foo.example.com")),
+				AllowedRoutes: &gatewayv1.AllowedRoutes{
+					Kinds: []gatewayv1.RouteGroupKind{{Kind: "HTTPRoute"}},
+					Namespaces: &gatewayv1.RouteNamespaces{
+						From:     ptr(gatewayv1.NamespacesFromSelector),
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"kubernetes.io/metadata.name": "infra"}},
+					},
+				},
+			}},
+		},
+	}
+	mkRoute := func(name string, hostnames ...gatewayv1.Hostname) *gatewayv1.HTTPRoute {
+		return &gatewayv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "infra", Generation: 1},
+			Spec: gatewayv1.HTTPRouteSpec{
+				CommonRouteSpec: gatewayv1.CommonRouteSpec{ParentRefs: []gatewayv1.ParentReference{{
+					Kind: ptr(gatewayv1.Kind("Gateway")), Name: "gw2",
+				}}},
+				Hostnames: hostnames,
+				Rules: []gatewayv1.HTTPRouteRule{{
+					BackendRefs: []gatewayv1.HTTPBackendRef{{BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: "infra-backend-v1", Port: ptr(gatewayv1.PortNumber(8080))},
+					}}},
+				}},
+			},
+		}
+	}
+	r2 := mkRoute("http-route-2") // no hostname → intersects
+	r3 := mkRoute("http-route-3") // no hostname → intersects
+	rNA := mkRoute("http-route-not-accepted", "not-accepted.test.com")
+
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(ourClass(), infraNsObj, gw, r2, r3, rNA).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
+		Build()
+	r := &Reconciler{Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "infra", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	gotGW := &gatewayv1.Gateway{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "infra", Name: "gw2"}, gotGW))
+	require.Len(t, gotGW.Status.Listeners, 1)
+	assert.Equal(t, int32(2), gotGW.Status.Listeners[0].AttachedRoutes,
+		"port-80 listener with hostname must count only the 2 intersecting routes")
+
+	gotNA := &gatewayv1.HTTPRoute{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "infra", Name: "http-route-not-accepted"}, gotNA))
+	require.Len(t, gotNA.Status.Parents, 1)
+	acc := meta.FindStatusCondition(gotNA.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
+	require.NotNil(t, acc)
+	assert.Equal(t, metav1.ConditionFalse, acc.Status)
+	assert.Equal(t, string(gatewayv1.RouteReasonNoMatchingListenerHostname), acc.Reason)
+}

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -7,6 +7,7 @@ package gatewayapi
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
@@ -91,6 +92,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	})
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1.HTTPRoute{}).
+		// GatewayClass: a spec change must re-publish status (observedGeneration
+		// bump). We reconcile any GatewayClass bearing our controllerName.
+		Watches(&gatewayv1.GatewayClass{}, resync).
 		Watches(&gatewayv1.Gateway{}, resync).
 		Watches(&gatewayv1alpha2.TCPRoute{}, resync).
 		Watches(&gatewayv1.TLSRoute{}, resync).
@@ -110,7 +114,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	// Our Gateways (those of our GatewayClass) and, per listener hostname, the SDS
 	// cert name to present. listenerCerts also accumulates the cert bytes to push.
-	gateways, ourGateways, gatewayListeners, hostCerts, certs, err := r.resolveGateways(ctx)
+	gateways, ourGateways, gatewayListeners, hostCerts, certs, tlsResults, err := r.resolveGateways(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -250,8 +254,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// not fatal — the data plane is already projected and the next reconcile
 	// retries. The GatewayClass, Gateways, and routes we own all get conditions.
 	r.writeGatewayClassStatus(ctx)
-	r.writeGatewayStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners)
-	r.writeRouteStatuses(ctx, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, grants)
+	r.writeGatewayStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, tlsResults)
+	r.writeRouteStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, grants)
 	return reconcile.Result{}, nil
 }
 
@@ -273,6 +277,25 @@ type gatewayListenerKey struct {
 	Protocol gatewayv1.ProtocolType
 }
 
+// listenerStatusKey identifies a listener within a Gateway by namespaced Gateway
+// name + listener (section) name. Used to carry per-listener TLS-resolution
+// results from resolveGateways into status writing (the InvalidCertificateRef
+// gate).
+type listenerStatusKey struct {
+	Gateway gatewayKey
+	Name    gatewayv1.SectionName
+}
+
+// listenerTLSResult records whether a TLS listener's certificateRefs resolved.
+// hasTLS is true for any HTTPS/TLS listener that declares a tls block; resolved
+// is true only when every (supported) certificateRef resolved to usable material.
+// message carries the first failure for the listener condition.
+type listenerTLSResult struct {
+	hasTLS   bool
+	resolved bool
+	message  string
+}
+
 // resolveGateways lists the Gateways of our GatewayClass CLUSTER-WIDE and resolves
 // each TLS listener's cert. It returns the set of our Gateways (by namespaced
 // name), the Gateway objects themselves (for status), a set of listener keys (for
@@ -281,16 +304,17 @@ type gatewayListenerKey struct {
 // GatewayClassName: every Gateway whose gatewayClassName is the class this edge
 // serves (whose controllerName is gateway.aether.io/edge) is ours, regardless of
 // namespace.
-func (r *Reconciler) resolveGateways(ctx context.Context) (map[gatewayKey]struct{}, []gatewayv1.Gateway, map[gatewayListenerKey]struct{}, map[string]string, map[string]cache.EdgeTLSCert, error) {
+func (r *Reconciler) resolveGateways(ctx context.Context) (map[gatewayKey]struct{}, []gatewayv1.Gateway, map[gatewayListenerKey]struct{}, map[string]string, map[string]cache.EdgeTLSCert, map[listenerStatusKey]listenerTLSResult, error) {
 	list := &gatewayv1.GatewayList{}
 	if err := r.List(ctx, list); err != nil {
-		return nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, err
 	}
 	gateways := map[gatewayKey]struct{}{}
 	var ourGateways []gatewayv1.Gateway
 	listenerKeys := map[gatewayListenerKey]struct{}{}
 	hostCerts := map[string]string{} // listener hostname ("" = catch-all) -> SDS name
 	certs := map[string]cache.EdgeTLSCert{}
+	tlsResults := map[listenerStatusKey]listenerTLSResult{}
 	for i := range list.Items {
 		gw := &list.Items[i]
 		if string(gw.Spec.GatewayClassName) != r.GatewayClassName {
@@ -306,39 +330,72 @@ func (r *Reconciler) resolveGateways(ctx context.Context) (map[gatewayKey]struct
 				Protocol: ln.Protocol,
 			}] = struct{}{}
 		}
-		if r.Secrets == nil {
-			continue
-		}
 		for _, ln := range gw.Spec.Listeners {
 			if ln.TLS == nil {
 				continue
 			}
-			host := ""
-			if ln.Hostname != nil {
-				host = string(*ln.Hostname)
-			}
-			for _, ref := range ln.TLS.CertificateRefs {
-				if ref.Kind != nil && string(*ref.Kind) != "Secret" {
-					continue
-				}
-				name := string(ref.Name)
-				sdsName, sErr := r.Secrets.SDSName(configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, name)
-				if sErr != nil {
-					r.Log.WarnContext(ctx, "gateway listener TLS provider unavailable", "gateway", gw.Name, "secret", name, "error", sErr.Error())
-					continue
-				}
-				cert, cErr := r.Secrets.Resolve(ctx, configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, name)
-				if cErr != nil {
-					r.Log.WarnContext(ctx, "gateway listener TLS cert unresolved", "gateway", gw.Name, "secret", name, "error", cErr.Error())
-					continue
-				}
-				certs[sdsName] = cache.EdgeTLSCert{Cert: cert.Cert, Key: cert.Key}
-				hostCerts[host] = sdsName
-				break // one cert per listener
-			}
+			lk := listenerStatusKey{Gateway: gk, Name: ln.Name}
+			res := r.resolveListenerTLS(ctx, gw, ln, hostCerts, certs)
+			tlsResults[lk] = res
 		}
 	}
-	return gateways, ourGateways, listenerKeys, hostCerts, certs, nil
+	return gateways, ourGateways, listenerKeys, hostCerts, certs, tlsResults, nil
+}
+
+// resolveListenerTLS resolves a single TLS listener's certificateRefs, recording
+// each resolved cert into certs/hostCerts and returning whether the listener's TLS
+// configuration is valid. A listener is INVALID (resolved=false) when any
+// certificateRef has an unsupported group/kind, names a missing Secret, or holds
+// malformed cert material — driving the ResolvedRefs=False/InvalidCertificateRef
+// listener condition. With no Secrets provider configured, TLS cannot be resolved,
+// so a TLS listener is reported invalid.
+func (r *Reconciler) resolveListenerTLS(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	ln gatewayv1.Listener,
+	hostCerts map[string]string,
+	certs map[string]cache.EdgeTLSCert,
+) listenerTLSResult {
+	if len(ln.TLS.CertificateRefs) == 0 {
+		return listenerTLSResult{hasTLS: true, resolved: false, message: "TLS listener has no certificateRefs"}
+	}
+	if r.Secrets == nil {
+		return listenerTLSResult{hasTLS: true, resolved: false, message: "no TLS secret provider configured"}
+	}
+	host := ""
+	if ln.Hostname != nil {
+		host = string(*ln.Hostname)
+	}
+	var firstResolved string
+	for _, ref := range ln.TLS.CertificateRefs {
+		// Only core ("") group Secret kind is supported; any other group/kind is an
+		// invalid certificateRef.
+		if ref.Group != nil && string(*ref.Group) != "" {
+			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q has unsupported group %q", ref.Name, *ref.Group)}
+		}
+		if ref.Kind != nil && string(*ref.Kind) != "Secret" {
+			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q has unsupported kind %q", ref.Name, *ref.Kind)}
+		}
+		name := string(ref.Name)
+		sdsName, sErr := r.Secrets.SDSName(configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, name)
+		if sErr != nil {
+			r.Log.WarnContext(ctx, "gateway listener TLS provider unavailable", "gateway", gw.Name, "secret", name, "error", sErr.Error())
+			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q provider unavailable", name)}
+		}
+		cert, cErr := r.Secrets.Resolve(ctx, configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, name)
+		if cErr != nil {
+			r.Log.WarnContext(ctx, "gateway listener TLS cert unresolved", "gateway", gw.Name, "secret", name, "error", cErr.Error())
+			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q did not resolve: %v", name, cErr)}
+		}
+		certs[sdsName] = cache.EdgeTLSCert{Cert: cert.Cert, Key: cert.Key}
+		if firstResolved == "" {
+			firstResolved = sdsName
+		}
+	}
+	if firstResolved != "" {
+		hostCerts[host] = firstResolved
+	}
+	return listenerTLSResult{hasTLS: true, resolved: true}
 }
 
 // buildVirtualHost maps one HTTPRoute to an edge VirtualHost: its hostnames become

--- a/agent/internal/edge/gatewayapi/status.go
+++ b/agent/internal/edge/gatewayapi/status.go
@@ -16,41 +16,46 @@ import (
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
-// writeGatewayClassStatus sets Accepted=True and the supportedFeatures list on the
-// GatewayClass whose controllerName is the edge controller and whose name is the
-// one we serve. It is a no-op for any other class (we MUST only touch classes we
-// control). supportedFeatures is what the upstream conformance suite reads to
-// decide which test suites to run vs skip.
+// writeGatewayClassStatus sets Accepted=True and the supportedFeatures list on
+// EVERY GatewayClass whose controllerName is the edge controller (not only the
+// configured GatewayClassName). The Accepted condition carries the class's own
+// metadata.generation as observedGeneration, so a spec change that bumps the
+// generation re-publishes an in-sync observedGeneration (the
+// GatewayClassObservedGenerationBump conformance test). It is a no-op for any
+// class owned by another controller (we MUST only touch classes we control).
+// supportedFeatures is what the upstream conformance suite reads to decide which
+// test suites to run vs skip.
 func (r *Reconciler) writeGatewayClassStatus(ctx context.Context) {
-	gc := &gatewayv1.GatewayClass{}
-	// Uncached read: GatewayClass is cluster-scoped and a cached Get can race the
-	// informer sync and return NotFound on the first reconcile.
-	if err := r.APIReader.Get(ctx, types.NamespacedName{Name: r.GatewayClassName}, gc); err != nil {
-		if !apierrors.IsNotFound(err) {
-			r.Log.WarnContext(ctx, "failed to get GatewayClass for status", "gatewayClass", r.GatewayClassName, "error", err.Error())
+	list := &gatewayv1.GatewayClassList{}
+	// Uncached read: GatewayClass is cluster-scoped and a cached List can race the
+	// informer sync on the first reconcile.
+	if err := r.APIReader.List(ctx, list); err != nil {
+		r.Log.WarnContext(ctx, "failed to list GatewayClasses for status", "error", err.Error())
+		return
+	}
+	for i := range list.Items {
+		gc := &list.Items[i]
+		if gc.Spec.ControllerName != gatewaystatus.EdgeControllerName {
+			continue
 		}
-		return
-	}
-	if gc.Spec.ControllerName != gatewaystatus.EdgeControllerName {
-		return
-	}
-	conds, condChanged := gatewaystatus.MergeConditions(gc.Status.Conditions, gc.Generation, gatewaystatus.Condition{
-		Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
-		Status:  metav1.ConditionTrue,
-		Reason:  string(gatewayv1.GatewayClassReasonAccepted),
-		Message: "GatewayClass accepted by the aether edge controller",
-	})
+		conds, condChanged := gatewaystatus.MergeConditions(gc.Status.Conditions, gc.Generation, gatewaystatus.Condition{
+			Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayv1.GatewayClassReasonAccepted),
+			Message: "GatewayClass accepted by the aether edge controller",
+		})
 
-	features := aetherSupportedFeatures()
-	featChanged := !supportedFeaturesEqual(gc.Status.SupportedFeatures, features)
+		features := aetherSupportedFeatures()
+		featChanged := !supportedFeaturesEqual(gc.Status.SupportedFeatures, features)
 
-	if !condChanged && !featChanged {
-		return
-	}
-	gc.Status.Conditions = conds
-	gc.Status.SupportedFeatures = features
-	if err := r.Status().Update(ctx, gc); err != nil {
-		r.Log.WarnContext(ctx, "failed to write GatewayClass status", "gatewayClass", gc.Name, "error", err.Error())
+		if !condChanged && !featChanged {
+			continue
+		}
+		gc.Status.Conditions = conds
+		gc.Status.SupportedFeatures = features
+		if err := r.Status().Update(ctx, gc); err != nil {
+			r.Log.WarnContext(ctx, "failed to write GatewayClass status", "gatewayClass", gc.Name, "error", err.Error())
+		}
 	}
 }
 
@@ -67,6 +72,7 @@ func (r *Reconciler) writeGatewayStatuses(
 	tlsRoutes []gatewayv1.TLSRoute,
 	gateways map[gatewayKey]struct{},
 	listenerKeys map[gatewayListenerKey]struct{},
+	tlsResults map[listenerStatusKey]listenerTLSResult,
 ) {
 	// Proposal 021 Phase 1: resolve the shared edge LoadBalancer address once and
 	// publish it on every class-aether Gateway. Resolved at runtime (robust to
@@ -78,6 +84,90 @@ func (r *Reconciler) writeGatewayStatuses(
 		gw := &ourGateways[i]
 		desired := *gw.DeepCopy()
 
+		gk := gatewayKey{Namespace: gw.Namespace, Name: gw.Name}
+		listeners := make([]gatewayv1.ListenerStatus, 0, len(gw.Spec.Listeners))
+		allListenersProgrammed := true
+		for _, ln := range gw.Spec.Listeners {
+			attached := r.attachedRoutesForListener(ctx, gw, ln, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys)
+
+			// ResolvedRefs: InvalidRouteKinds (allowedRoutes.kinds names an
+			// unsupported kind) takes precedence; then InvalidCertificateRef
+			// (a TLS listener whose certificateRefs don't resolve).
+			resolvedStatus := metav1.ConditionTrue
+			resolvedReason := string(gatewayv1.ListenerReasonResolvedRefs)
+			resolvedMsg := "All listener references resolved"
+			programmed := true
+			switch {
+			case listenerHasInvalidRouteKinds(ln):
+				resolvedStatus = metav1.ConditionFalse
+				resolvedReason = string(gatewayv1.ListenerReasonInvalidRouteKinds)
+				resolvedMsg = "allowedRoutes.kinds names a Route kind this listener does not support"
+				programmed = false
+			default:
+				if res, ok := tlsResults[listenerStatusKey{Gateway: gk, Name: ln.Name}]; ok && res.hasTLS && !res.resolved {
+					resolvedStatus = metav1.ConditionFalse
+					resolvedReason = string(gatewayv1.ListenerReasonInvalidCertificateRef)
+					resolvedMsg = res.message
+					programmed = false
+				}
+			}
+
+			acceptedStatus := metav1.ConditionTrue
+			acceptedReason := string(gatewayv1.ListenerReasonAccepted)
+			acceptedMsg := "Listener accepted"
+
+			programmedStatus := metav1.ConditionTrue
+			programmedReason := string(gatewayv1.ListenerReasonProgrammed)
+			programmedMsg := "Listener programmed"
+			if !programmed {
+				programmedStatus = metav1.ConditionFalse
+				programmedReason = string(gatewayv1.ListenerReasonInvalid)
+				programmedMsg = "Listener not programmed: " + resolvedMsg
+				allListenersProgrammed = false
+			}
+
+			lc, _ := gatewaystatus.MergeConditions(existingListenerConditions(gw.Status.Listeners, ln.Name), gw.Generation,
+				gatewaystatus.Condition{
+					Type:    string(gatewayv1.ListenerConditionAccepted),
+					Status:  acceptedStatus,
+					Reason:  acceptedReason,
+					Message: acceptedMsg,
+				},
+				gatewaystatus.Condition{
+					Type:    string(gatewayv1.ListenerConditionProgrammed),
+					Status:  programmedStatus,
+					Reason:  programmedReason,
+					Message: programmedMsg,
+				},
+				gatewaystatus.Condition{
+					Type:    string(gatewayv1.ListenerConditionResolvedRefs),
+					Status:  resolvedStatus,
+					Reason:  resolvedReason,
+					Message: resolvedMsg,
+				},
+			)
+			listeners = append(listeners, gatewayv1.ListenerStatus{
+				Name:           ln.Name,
+				SupportedKinds: listenerSupportedKinds(ln),
+				AttachedRoutes: attached,
+				Conditions:     lc,
+			})
+		}
+
+		// Top-level Programmed is False when any listener failed to program (e.g.
+		// invalid TLS or invalid route kinds), so the Gateway is not advertised as
+		// fully programmed while a listener is broken.
+		programmedCond := gatewaystatus.Condition{
+			Type:    string(gatewayv1.GatewayConditionProgrammed),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayv1.GatewayReasonProgrammed),
+			Message: "Gateway programmed into the aether edge data plane",
+		}
+		if !allListenersProgrammed {
+			programmedCond.Status = metav1.ConditionFalse
+			programmedCond.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
+			programmedCond.Message = "One or more listeners are not programmed (invalid TLS or route kinds)"
+		}
 		conds, topChanged := gatewaystatus.MergeConditions(desired.Status.Conditions, gw.Generation,
 			gatewaystatus.Condition{
 				Type:    string(gatewayv1.GatewayConditionAccepted),
@@ -85,45 +175,9 @@ func (r *Reconciler) writeGatewayStatuses(
 				Reason:  string(gatewayv1.GatewayReasonAccepted),
 				Message: "Gateway accepted by the aether edge controller",
 			},
-			gatewaystatus.Condition{
-				Type:    string(gatewayv1.GatewayConditionProgrammed),
-				Status:  metav1.ConditionTrue,
-				Reason:  string(gatewayv1.GatewayReasonProgrammed),
-				Message: "Gateway programmed into the aether edge data plane",
-			},
+			programmedCond,
 		)
 		desired.Status.Conditions = conds
-
-		listeners := make([]gatewayv1.ListenerStatus, 0, len(gw.Spec.Listeners))
-		for _, ln := range gw.Spec.Listeners {
-			attached := r.attachedRoutesForListener(gw.Namespace, gw.Name, ln, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys)
-			lc, _ := gatewaystatus.MergeConditions(existingListenerConditions(gw.Status.Listeners, ln.Name), gw.Generation,
-				gatewaystatus.Condition{
-					Type:    string(gatewayv1.ListenerConditionAccepted),
-					Status:  metav1.ConditionTrue,
-					Reason:  string(gatewayv1.ListenerReasonAccepted),
-					Message: "Listener accepted",
-				},
-				gatewaystatus.Condition{
-					Type:    string(gatewayv1.ListenerConditionProgrammed),
-					Status:  metav1.ConditionTrue,
-					Reason:  string(gatewayv1.ListenerReasonProgrammed),
-					Message: "Listener programmed",
-				},
-				gatewaystatus.Condition{
-					Type:    string(gatewayv1.ListenerConditionResolvedRefs),
-					Status:  metav1.ConditionTrue,
-					Reason:  string(gatewayv1.ListenerReasonResolvedRefs),
-					Message: "All listener references resolved",
-				},
-			)
-			listeners = append(listeners, gatewayv1.ListenerStatus{
-				Name:           ln.Name,
-				SupportedKinds: supportedKindsFor(ln.Protocol),
-				AttachedRoutes: attached,
-				Conditions:     lc,
-			})
-		}
 
 		listenersChanged := !listenerStatusesEqual(gw.Status.Listeners, listeners)
 		desired.Status.Listeners = listeners
@@ -213,7 +267,8 @@ func gatewayAddressesEqual(a, b []gatewayv1.GatewayStatusAddress) bool {
 // gateway; TCP/TLS listeners accept TCP/TLSRoutes whose parentRef resolves to
 // that listener's port (via gatewayParentPorts).
 func (r *Reconciler) attachedRoutesForListener(
-	gwNamespace, gwName string,
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
 	ln gatewayv1.Listener,
 	httpRoutes []gatewayv1.HTTPRoute,
 	tcpRoutes []gatewayv1alpha2.TCPRoute,
@@ -226,7 +281,7 @@ func (r *Reconciler) attachedRoutesForListener(
 	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
 		for i := range httpRoutes {
 			hr := &httpRoutes[i]
-			if httpRouteAttachesToListener(hr.Spec.ParentRefs, hr.Namespace, gwNamespace, gwName, ln) {
+			if r.httpRouteAttachesToListener(ctx, gw, hr.Spec.ParentRefs, hr.Namespace, hr.Spec.Hostnames, ln) {
 				count++
 			}
 		}
@@ -250,25 +305,38 @@ func (r *Reconciler) attachedRoutesForListener(
 	return count
 }
 
-// httpRouteAttachesToListener reports whether an HTTPRoute (in routeNamespace)
-// attaches to the given gateway listener. A parentRef with no sectionName/port
-// attaches to every HTTP/HTTPS listener; a sectionName or port narrows it to that
-// listener. The parentRef namespace defaults to the route's namespace.
-func httpRouteAttachesToListener(parentRefs []gatewayv1.ParentReference, routeNamespace, gwNamespace, gwName string, ln gatewayv1.Listener) bool {
+// httpRouteAttachesToListener reports whether an HTTPRoute (in routeNamespace, with
+// routeHostnames) attaches to the given gateway listener. A parentRef with no
+// sectionName/port may attach to every HTTP/HTTPS listener; a sectionName or port
+// narrows it. Attachment additionally requires the listener to admit the route's
+// namespace (allowedRoutes.namespaces), accept HTTPRoute (allowedRoutes.kinds),
+// and the route's hostnames to intersect the listener hostname. The parentRef
+// namespace defaults to the route's namespace.
+func (r *Reconciler) httpRouteAttachesToListener(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	parentRefs []gatewayv1.ParentReference,
+	routeNamespace string,
+	routeHostnames []gatewayv1.Hostname,
+	ln gatewayv1.Listener,
+) bool {
 	for _, p := range parentRefs {
-		if p.Group != nil && string(*p.Group) != gatewayv1.GroupName {
+		if !parentRefIsGateway(p) {
 			continue
 		}
-		if p.Kind != nil && string(*p.Kind) != "Gateway" {
+		if string(p.Name) != gw.Name || parentRefNamespace(p.Namespace, routeNamespace) != gw.Namespace {
 			continue
 		}
-		if string(p.Name) != gwName || parentRefNamespace(p.Namespace, routeNamespace) != gwNamespace {
+		if !parentRefSelectsListener(p, ln) {
 			continue
 		}
-		if p.SectionName != nil && *p.SectionName != ln.Name {
+		if !listenerAcceptsKind(ln, "HTTPRoute") {
 			continue
 		}
-		if p.Port != nil && uint32(*p.Port) != uint32(ln.Port) {
+		if !r.namespaceAllowed(ctx, gw.Namespace, routeNamespace, ln) {
+			continue
+		}
+		if !hostnamesIntersect(ln.Hostname, routeHostnames) {
 			continue
 		}
 		return true
@@ -346,6 +414,7 @@ func listenerStatusesEqual(a, b []gatewayv1.ListenerStatus) bool {
 // ResolvedRefs (per backend resolution).
 func (r *Reconciler) writeRouteStatuses(
 	ctx context.Context,
+	ourGateways []gatewayv1.Gateway,
 	httpRoutes []gatewayv1.HTTPRoute,
 	tcpRoutes []gatewayv1alpha2.TCPRoute,
 	tlsRoutes []gatewayv1.TLSRoute,
@@ -353,24 +422,79 @@ func (r *Reconciler) writeRouteStatuses(
 	listenerKeys map[gatewayListenerKey]struct{},
 	grants []gatewayv1beta1.ReferenceGrant,
 ) {
+	gwByKey := map[gatewayKey]*gatewayv1.Gateway{}
+	for i := range ourGateways {
+		gwByKey[gatewayKey{Namespace: ourGateways[i].Namespace, Name: ourGateways[i].Name}] = &ourGateways[i]
+	}
 	for i := range httpRoutes {
 		hr := &httpRoutes[i]
-		accepted := attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways)
+		// Acceptance is per parentRef: a route may attach to one Gateway and be
+		// rejected by another. We resolve the most specific reason against each of
+		// our Gateways via httpRouteAttachment.
+		accepted, acceptedReason, acceptedMsg := r.httpRouteAcceptance(ctx, hr, gwByKey)
 		resolved, reason, msg := r.backendsResolveHTTP(ctx, hr.Namespace, hr.Spec.Rules, grants)
-		r.writeRouteParentStatus(ctx, hr, hr.Generation, &hr.Status.RouteStatus, ourGatewayParentRefs(hr.Spec.ParentRefs, hr.Namespace, gateways), accepted, resolved, reason, msg, "HTTPRoute")
+		r.writeRouteParentStatus(ctx, hr, hr.Generation, &hr.Status.RouteStatus, ourGatewayParentRefs(hr.Spec.ParentRefs, hr.Namespace, gateways), accepted, acceptedReason, acceptedMsg, resolved, reason, msg, "HTTPRoute")
 	}
 	for i := range tcpRoutes {
 		tr := &tcpRoutes[i]
 		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, listenerKeys)) > 0
+		ar, am := acceptedReasonMsg(accepted)
 		resolved, reason, msg := r.backendsResolveL4(ctx, tr.Namespace, "TCPRoute", l4BackendObjectRefs(tr.Spec.Rules), grants)
-		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, resolved, reason, msg, "TCPRoute")
+		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, ar, am, resolved, reason, msg, "TCPRoute")
 	}
 	for i := range tlsRoutes {
 		tr := &tlsRoutes[i]
 		accepted := len(gatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, listenerKeys)) > 0
+		ar, am := acceptedReasonMsg(accepted)
 		resolved, reason, msg := r.backendsResolveTLS(ctx, tr.Namespace, tr.Spec.Rules, grants)
-		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, resolved, reason, msg, "TLSRoute")
+		r.writeRouteParentStatus(ctx, tr, tr.Generation, &tr.Status.RouteStatus, ourGatewayParentRefs(tr.Spec.ParentRefs, tr.Namespace, gateways), accepted, ar, am, resolved, reason, msg, "TLSRoute")
 	}
+}
+
+// httpRouteAcceptance computes the route-level Accepted condition for an HTTPRoute
+// across all of our Gateways it references. The route is Accepted when it attaches
+// to at least one listener of at least one of our Gateways; otherwise the most
+// specific failure reason wins (NoMatchingListenerHostname > NotAllowedByListeners
+// > NoMatchingParent).
+func (r *Reconciler) httpRouteAcceptance(ctx context.Context, hr *gatewayv1.HTTPRoute, gwByKey map[gatewayKey]*gatewayv1.Gateway) (bool, string, string) {
+	best := attachNoMatchingParent
+	for _, p := range hr.Spec.ParentRefs {
+		if !parentRefIsGateway(p) {
+			continue
+		}
+		key := gatewayKey{Namespace: parentRefNamespace(p.Namespace, hr.Namespace), Name: string(p.Name)}
+		gw, ok := gwByKey[key]
+		if !ok {
+			continue
+		}
+		switch r.httpRouteAttachment(ctx, gw, []gatewayv1.ParentReference{p}, hr.Namespace, hr.Spec.Hostnames) {
+		case attachAccepted:
+			return true, string(gatewayv1.RouteReasonAccepted), "Route accepted by the aether edge controller"
+		case attachNoMatchingListenerHostname:
+			best = attachNoMatchingListenerHostname
+		case attachNotAllowedByListeners:
+			if best != attachNoMatchingListenerHostname {
+				best = attachNotAllowedByListeners
+			}
+		}
+	}
+	switch best {
+	case attachNoMatchingListenerHostname:
+		return false, string(gatewayv1.RouteReasonNoMatchingListenerHostname), "No listener hostname intersects the route hostnames"
+	case attachNotAllowedByListeners:
+		return false, string(gatewayv1.RouteReasonNotAllowedByListeners), "Route namespace is not allowed by the listener allowedRoutes.namespaces"
+	default:
+		return false, string(gatewayv1.RouteReasonNoMatchingParent), "Route does not attach to a matching listener on this Gateway"
+	}
+}
+
+// acceptedReasonMsg returns the Accepted reason/message for a simple
+// (TCP/TLS) attach boolean.
+func acceptedReasonMsg(accepted bool) (string, string) {
+	if accepted {
+		return string(gatewayv1.RouteReasonAccepted), "Route accepted by the aether edge controller"
+	}
+	return string(gatewayv1.RouteReasonNoMatchingParent), "Route does not attach to a matching listener on this Gateway"
 }
 
 // ourGatewayParentRefs returns the parentRefs of a route (in routeNamespace) that
@@ -403,7 +527,9 @@ func (r *Reconciler) writeRouteParentStatus(
 	generation int64,
 	status *gatewayv1.RouteStatus,
 	parentRefs []gatewayv1.ParentReference,
-	accepted, backendsResolved bool,
+	accepted bool,
+	acceptedReason, acceptedMsg string,
+	backendsResolved bool,
 	resolvedReason, resolvedMsg, kind string,
 ) {
 	if len(parentRefs) == 0 {
@@ -412,12 +538,8 @@ func (r *Reconciler) writeRouteParentStatus(
 	parents := status.Parents
 	changed := false
 	acceptedStatus := metav1.ConditionTrue
-	acceptedReason := string(gatewayv1.RouteReasonAccepted)
-	acceptedMsg := "Route accepted by the aether edge controller"
 	if !accepted {
 		acceptedStatus = metav1.ConditionFalse
-		acceptedReason = string(gatewayv1.RouteReasonNoMatchingParent)
-		acceptedMsg = "Route does not attach to a matching listener on this Gateway"
 	}
 	resolvedStatus := metav1.ConditionTrue
 	if !backendsResolved {


### PR DESCRIPTION
Fixes the **genuinely-other** GATEWAY-HTTP conformance status edge-cases from the rev3 baseline (`docs/conformance/baseline-2026-06-25-rev3.md`, "Status edge-cases — not traffic-related"). These are independent of the shared-address / bare-IP-TLS-SAN traffic bucket (021 Phase 2) and the dup-FQDN webhook design conflict — both untouched here.

Attachment correctness (kinds / namespaces / sectionName / port / hostname) is centralized in a new `attachment.go` and shared by both the listener `attachedRoutes` count and the route `Accepted` condition.

## Conformance tests addressed

| Conformance test | Change |
|---|---|
| `GatewayClassObservedGenerationBump` | `writeGatewayClassStatus` now reconciles **every** GatewayClass bearing our controllerName (not just the configured `aether`), publishing `Accepted` with `observedGeneration = metadata.generation`. Added a `GatewayClass` watch so a spec bump re-publishes. |
| `GatewayInvalidRouteKind` | Per-listener `supportedKinds` = protocol-default ∩ `allowedRoutes.kinds` (empty `[]` when all named kinds are unsupported); listener `ResolvedRefs=False` / `InvalidRouteKinds` when an unsupported kind is named. |
| `GatewayInvalidTLSConfiguration` | Per-listener TLS resolution result drives status: an unresolvable / unsupported-group / unsupported-kind / missing / malformed `certificateRef` sets listener `ResolvedRefs=False` / `InvalidCertificateRef`, and the listener (and the Gateway top-level `Programmed`) is no longer `Programmed=True`. |
| `HTTPRouteInvalidParentRefNotMatchingSectionName` | A `parentRef` naming a `sectionName`/`port` that no listener has → route `Accepted=False` / `NoMatchingParent` and the listener counts 0 attached routes. |
| `HTTPRouteInvalidCrossNamespaceParentRef` | `allowedRoutes.namespaces` (`Same`/`All`/`Selector`/`None`) is honored → a cross-namespace route on a `from: Same` listener gets `Accepted=False` / `NotAllowedByListeners`. |
| `GatewayWithAttachedRoutes` (non-port-8080 variant) | `attachedRoutes` now honors `allowedRoutes.namespaces` + listener-hostname intersection, so a mismatched-hostname route is excluded from the count and reported `Accepted=False` / `NoMatchingListenerHostname` (the port-8080 variant already passed). |

The dup-FQDN admission webhook semantics are **not** changed (separate item).

## Tests

New `edge_cases_test.go` adds one unit test per fix (observedGeneration, InvalidRouteKinds incl. supportedKinds shape, InvalidTLS incl. non-Programmed, non-matching sectionName, NotAllowedByListeners, non-8080 + hostname attachedRoutes). Existing tests unchanged and green.

- `make gazelle` ✓
- `bazel build //...` ✓
- `bazel test //... --test_output=errors` ✓ (the 3 chart-lint "fails" seen under `-test.short` are flag-incompat noise; charts pass on their own run)
- `bazel run //:format` ✓

## Chart

Status-only / code-only — no template or RBAC change → **no chart version bump**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)