### PR TITLE
fix(edge): distinct HTTPS listener name (the :443-dropping collision from #330)

### DIFF
--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -33,7 +33,7 @@ func TestEdgeTLSModeListeners(t *testing.T) {
 		l := r.(*listenerv3.Listener)
 		names[l.GetName()] = l
 	}
-	tls := names[proxy.EdgeListenerName]
+	tls := names[proxy.EdgeHTTPSListenerName]
 	redirect := names[proxy.EdgeRedirectListenerName]
 	require.NotNil(t, tls)
 	require.NotNil(t, redirect)
@@ -215,9 +215,9 @@ func TestEdgeHTTPRedirectOptIn(t *testing.T) {
 			l := r.(*listenerv3.Listener)
 			names[l.GetName()] = l
 		}
-		// The HTTPS routing listener must be present.
-		require.NotNil(t, names[proxy.EdgeListenerName], "HTTPS routing listener must be present")
-		assert.Equal(t, uint32(443), names[proxy.EdgeListenerName].GetAddress().GetSocketAddress().GetPortValue())
+		// The HTTPS routing listener must be present (distinct name from the :80 listener).
+		require.NotNil(t, names[proxy.EdgeHTTPSListenerName], "HTTPS routing listener must be present")
+		assert.Equal(t, uint32(443), names[proxy.EdgeHTTPSListenerName].GetAddress().GetSocketAddress().GetPortValue())
 		// The redirect listener replaces the plain HTTP routing listener.
 		require.NotNil(t, names[proxy.EdgeRedirectListenerName], "redirect listener must be present when opt-in is set")
 		assert.Equal(t, uint32(80), names[proxy.EdgeRedirectListenerName].GetAddress().GetSocketAddress().GetPortValue())
@@ -233,19 +233,16 @@ func TestEdgeHTTPRedirectOptIn(t *testing.T) {
 
 		ls := c.Listeners()
 		require.Len(t, ls, 2, "HTTPS listener + HTTP routing listener")
-		// Both listeners are named edge_http (one TLS on 443, one plain on 80).
-		ports := []uint32{}
+		// The two listeners MUST have DISTINCT names (edge_https on 443, edge_http on
+		// 80) — a shared name collides in the snapshot/LDS and drops :443 (regression).
+		byName := map[string]uint32{}
 		for _, r := range ls {
 			l := r.(*listenerv3.Listener)
-			assert.Equal(t, proxy.EdgeListenerName, l.GetName(), "all HTTP-type listeners are named edge_http")
-			ports = append(ports, l.GetAddress().GetSocketAddress().GetPortValue())
-		}
-		assert.Contains(t, ports, uint32(443), "TLS listener on 443 must be present")
-		assert.Contains(t, ports, uint32(80), "plain HTTP routing listener on 80 must be present")
-		// No redirect listener.
-		for _, r := range ls {
-			l := r.(*listenerv3.Listener)
+			byName[l.GetName()] = l.GetAddress().GetSocketAddress().GetPortValue()
 			assert.NotEqual(t, proxy.EdgeRedirectListenerName, l.GetName(), "redirect listener must NOT be present without opt-in")
 		}
+		assert.Len(t, byName, 2, "the two listeners must have distinct names (no collision)")
+		assert.Equal(t, uint32(443), byName[proxy.EdgeHTTPSListenerName], "HTTPS listener named edge_https on 443")
+		assert.Equal(t, uint32(80), byName[proxy.EdgeListenerName], "plain HTTP routing listener named edge_http on 80")
 	})
 }

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -112,9 +112,10 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 
 		var resources []types.Resource
 		if c.edgeTLSEnabled {
-			// TLS listener on httpsPort; HTTP behaviour depends on per-Gateway opt-in.
+			// TLS listener on httpsPort, under a name DISTINCT from the :80 listener so
+			// the two never collide in the snapshot/LDS (a shared name dropped :443).
 			resources = append(resources,
-				proxy.BuildEdgeListener(c.edgeHTTPSPort, c.edgeTLSSecretNames()),
+				proxy.BuildEdgeListener(proxy.EdgeHTTPSListenerName, c.edgeHTTPSPort, c.edgeTLSSecretNames()),
 			)
 		}
 		if httpRedirect {
@@ -123,7 +124,7 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 			resources = append(resources, proxy.BuildEdgeRedirectListener(c.edgeHTTPPort))
 		} else {
 			// Default: the HTTP-port listener serves its attached HTTPRoutes directly.
-			resources = append(resources, proxy.BuildEdgeListener(c.edgeHTTPPort, nil))
+			resources = append(resources, proxy.BuildEdgeListener(proxy.EdgeListenerName, c.edgeHTTPPort, nil))
 		}
 		resources = append(resources, c.edgeTCPListeners()...)
 		return resources

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -23,9 +23,15 @@ const (
 	// under it.
 	EdgeHTTPRouteName = "edge_http"
 
-	// EdgeListenerName is the name of the edge proxy's public-facing listener
-	// (plain HTTP, or HTTPS-terminating when TLS is enabled).
+	// EdgeListenerName is the name of the edge proxy's plain-HTTP public listener.
 	EdgeListenerName = "edge_http"
+
+	// EdgeHTTPSListenerName is the name of the edge proxy's TLS-terminating public
+	// listener. It MUST differ from EdgeListenerName: when TLS is enabled and no
+	// Gateway opts into HTTP→HTTPS redirect, both the HTTPS (:443) and the plain-HTTP
+	// (:80) routing listeners are emitted; a shared name collides in the snapshot/LDS
+	// and one clobbers the other (regression that dropped the :443 listener).
+	EdgeHTTPSListenerName = "edge_https"
 
 	// EdgeRedirectListenerName is the :80 listener that 301-redirects to https
 	// when TLS is enabled.
@@ -165,25 +171,26 @@ func BuildEdgeTLSPassthroughListener(port uint32, rules []L4ServiceRoute) *liste
 // When tlsSecretNames is non-empty the filter chain terminates downstream TLS,
 // presenting one of those SDS-served certs selected by SNI; otherwise the edge
 // serves plain HTTP. Either way the upstream (edge -> pod) hop stays mTLS.
-func BuildEdgeListener(port uint32, tlsSecretNames []string) *listenerv3.Listener {
-	hcm := buildHTTPConnectionManager(EdgeListenerName, ReporterSource, "", "", nil)
+func BuildEdgeListener(name string, port uint32, tlsSecretNames []string) *listenerv3.Listener {
+	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
+			// Both the HTTP and HTTPS listeners serve the same edge route table.
 			RouteConfigName: EdgeHTTPRouteName,
 			ConfigSource:    config.XDSConfigSourceADS(),
 		},
 	}
 
 	filterChain := &listenerv3.FilterChain{
-		Name:    EdgeListenerName,
+		Name:    name,
 		Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
 	}
 	if len(tlsSecretNames) > 0 {
 		filterChain.TransportSocket = edgeDownstreamTLSFromSDS(tlsSecretNames)
 	}
 
-	return edgeListener(EdgeListenerName, port, filterChain)
+	return edgeListener(name, port, filterChain)
 }
 
 // BuildEdgeRedirectListener builds the :80 listener that 301-redirects every

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -54,7 +54,7 @@ func TestNewServiceCluster_EdgePoolingOff(t *testing.T) {
 // interfaces at the configured port, RDS-driven, with the readiness filter
 // ahead of the router.
 func TestBuildEdgeListener(t *testing.T) {
-	l := BuildEdgeListener(8080, nil)
+	l := BuildEdgeListener(EdgeListenerName, 8080, nil)
 
 	assert.Equal(t, EdgeListenerName, l.GetName())
 	assert.Equal(t, corev3.TrafficDirection_INBOUND, l.GetTrafficDirection())
@@ -80,7 +80,7 @@ func TestBuildEdgeListener(t *testing.T) {
 // gets a TLS transport socket serving the named SDS certs (SNI-selected), does
 // NOT require a client certificate, and sets the TLS floor + ALPN.
 func TestBuildEdgeListenerTLS(t *testing.T) {
-	l := BuildEdgeListener(8443, []string{"kubernetes/api-tls", "kubernetes/foo-tls"})
+	l := BuildEdgeListener(EdgeHTTPSListenerName, 8443, []string{"kubernetes/api-tls", "kubernetes/foo-tls"})
 
 	ts := l.GetFilterChains()[0].GetTransportSocket()
 	require.NotNil(t, ts, "TLS filter chain has a transport socket")
@@ -128,7 +128,7 @@ func TestBuildEdgeRedirectListener(t *testing.T) {
 // TestBuildEdgeListenerNoTLS verifies the plain-HTTP edge listener has no
 // transport socket.
 func TestBuildEdgeListenerNoTLS(t *testing.T) {
-	l := BuildEdgeListener(8080, nil)
+	l := BuildEdgeListener(EdgeListenerName, 8080, nil)
 	assert.Nil(t, l.GetFilterChains()[0].GetTransportSocket())
 }
 


### PR DESCRIPTION
#330 emits a default :80 HTTP routing listener alongside the :443 HTTPS listener, but `BuildEdgeListener` named both `edge_http` → snapshot/LDS collision → the :80 listener clobbered :443 → Envoy never bound :443 → edge readiness failed → api.palermo.dev down (caught on the rev-72→73 deploy, rolled back to 0.45.0). Fix: distinct `edge_https` name on :443. Added a regression guard (the prior test literally asserted 'all named edge_http' — it encoded the bug). 🤖 Generated with [Claude Code](https://claude.com/claude-code)