### PR TITLE
feat(edge): chart-manage the edge Gateway + HTTPRoutes (deprecate hand-applied manifests)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.47.0-{GIT_COMMIT}"
+version: "0.48.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/NOTES.txt
+++ b/charts/aether/templates/NOTES.txt
@@ -7,6 +7,13 @@ System config:
 
 Components: agent (+ Envoy proxy), registrar, controller.
 CRD: install //charts/crds first (the MeshConfig CRD).
+{{- if .Values.edge.enabled }}
+
+Edge (ingress): the chart manages the edge Gateway{{ if .Values.edge.gateway.create }} (created){{ end }} and
+its HTTPRoutes declaratively. Declare routes under edge.gateway.httpRoutes and pin
+the address via edge.gateway.address — hand-applying edge Gateway/HTTPRoute
+manifests is DEPRECATED; let the chart own them so upgrades stay consistent.
+{{- end }}
 
 The proxy data plane inherits the system config above; override its access-log /
 tracing / metrics policy at runtime by editing the MeshConfig CR:

--- a/charts/aether/templates/edge-gateway.yaml
+++ b/charts/aether/templates/edge-gateway.yaml
@@ -26,14 +26,27 @@ metadata:
   {{- end }}
 spec:
   gatewayClassName: {{ .Values.edge.gatewayClassName }}
+  {{- with .Values.edge.gateway.address }}
+  # Pin the Gateway's address. Under perGatewayAddressing the edge controller
+  # requests this IP from MetalLB for the Gateway's own LoadBalancer Service.
+  addresses:
+    - type: IPAddress
+      value: {{ . | quote }}
+  {{- end }}
   listeners:
     - name: http
       port: {{ .Values.edge.httpPort }}
       protocol: HTTP
+      {{- with .Values.edge.gateway.hostname }}
+      hostname: {{ . | quote }}
+      {{- end }}
     {{- if .Values.edge.tls.enabled }}
     - name: https
       port: {{ .Values.edge.httpsPort }}
       protocol: HTTPS
+      {{- with .Values.edge.gateway.hostname }}
+      hostname: {{ . | quote }}
+      {{- end }}
       tls:
         mode: Terminate
         certificateRefs:

--- a/charts/aether/templates/edge-httproute.yaml
+++ b/charts/aether/templates/edge-httproute.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.edge.enabled .Values.edge.gateway.create }}
+{{- /*
+Chart-managed HTTPRoutes for the edge, each parented to the chart-managed edge
+Gateway. This is the supported, declarative replacement for hand-applying
+HTTPRoute manifests against the edge (DEPRECATED). Declare routes under
+edge.gateway.httpRoutes; the parentRef is wired to the edge Gateway automatically.
+*/ -}}
+{{- range .Values.edge.gateway.httpRoutes }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ required "edge.gateway.httpRoutes[].name is required" .name }}
+  namespace: {{ include "aether.edge.namespace" $ }}
+  labels:
+    {{- include "aether.edge.labels" $ | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ include "aether.edge.fullname" $ }}
+  {{- with .hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- toYaml (required "edge.gateway.httpRoutes[].rules is required" .rules) | nindent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/aether/templates/edge-service.yaml
+++ b/charts/aether/templates/edge-service.yaml
@@ -6,12 +6,18 @@ metadata:
   namespace: {{ include "aether.edge.namespace" . }}
   labels:
     {{- include "aether.edge.labels" . | nindent 4 }}
+  {{- if not .Values.edge.perGatewayAddressing }}
   {{- with .Values.edge.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- end }}
 spec:
-  type: {{ .Values.edge.service.type }}
+  # Under proposal 021 Phase 2 (perGatewayAddressing) each Gateway gets its own
+  # LoadBalancer Service (owning the external IP, e.g. edge.gateway.address); this
+  # shared Service must NOT also claim a LoadBalancer IP or it collides with the
+  # per-Gateway one, so it stays ClusterIP. In Phase 1 it is the single shared LB.
+  type: {{ if .Values.edge.perGatewayAddressing }}ClusterIP{{ else }}{{ .Values.edge.service.type }}{{ end }}
   selector:
     {{- include "aether.edge.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -234,6 +234,27 @@ edge:
     # The Secret must be in the edge namespace (or tlsSecretNamespace if set).
     tlsSecretName: ""
     tlsSecretNamespace: ""
+    # address pins the Gateway's spec.addresses. Under proposal 021 Phase 2
+    # (perGatewayAddressing) the edge controller requests this IP from MetalLB for
+    # the Gateway's own LoadBalancer Service, so the edge keeps a stable address
+    # (e.g. the IP api.palermo.dev resolves to). Empty = MetalLB auto-assigns from
+    # the pool.
+    address: ""
+    # hostname constrains the chart-managed Gateway's listeners (e.g.
+    # "*.palermo.dev"). Empty = listeners accept any host.
+    hostname: ""
+    # httpRoutes declares HTTPRoutes managed by this chart, each parented to the
+    # chart-managed edge Gateway above. This is the supported, declarative
+    # replacement for hand-applying HTTPRoute manifests (DEPRECATED). Each entry:
+    #   - name: api
+    #     hostnames: ["api.palermo.dev"]
+    #     rules:
+    #       - backendRefs:
+    #           - name: my-backend
+    #             port: 8080
+    # `rules` is a standard Gateway API HTTPRoute rules list (matches, backendRefs,
+    # filters), passed through verbatim.
+    httpRoutes: []
   # Per-Gateway addressing (proposal 021 Phase 2): when enabled (the default),
   # the edge controller creates one LoadBalancer Service per class-aether Gateway,
   # MetalLB assigns each its own IP from the pool, and the edge proxy binds a


### PR DESCRIPTION
The existing edge use case (api.palermo.dev) is already Gateway API, but the Gateway + HTTPRoute were hand-applied and the chart couldn't express `spec.addresses`/listener hostname — the reason 021 Phase 2 couldn't pin the edge IP.

Adds chart support for the edge Gateway API resources and deprecates hand-applying them:
- `edge.gateway.address` → Gateway `spec.addresses` (Phase 2 pins it via MetalLB on the per-Gateway LB Service)
- `edge.gateway.hostname` → listener hostname (`*.palermo.dev`)
- `edge.gateway.httpRoutes` → declarative HTTPRoutes parented to the edge Gateway (new `edge-httproute.yaml`)
- shared edge Service → ClusterIP under `perGatewayAddressing` (no `.101` collision with the per-Gateway Service); LoadBalancer in Phase 1
- NOTES.txt deprecation guidance

helm template + lint validated. Chart 0.47.0→0.48.0. Unblocks enabling Phase 2 for the production edge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)