### PR TITLE
fix(edge): Phase 2 readiness wedge + per-Gateway Service GC on downgrade

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -127,6 +127,11 @@ type AgentConfig struct {
 	// EdgeHTTPSPort is the port the edge TLS listener binds when EdgeTLS is set.
 	EdgeHTTPSPort uint32
 
+	// EdgeReadinessPort is the port the dedicated always-bound readiness listener
+	// binds; the kubelet readiness probe targets it over plain HTTP. Independent of
+	// the public listeners so the probe survives proposal 021 Phase 2 (edge only).
+	EdgeReadinessPort uint32
+
 	// EdgePerGatewayAddressing enables proposal 021 Phase 2: a per-Gateway
 	// LoadBalancer Service + internal-port demux so each class-aether Gateway
 	// gets its own external IP. When false, falls back to Phase 1 (single shared
@@ -146,6 +151,7 @@ func NewAgentConfig() *AgentConfig {
 		ProxyServiceNodeID:       constants.DefaultProxyID,
 		EdgeHTTPPort:             proxy.DefaultEdgeHTTPPort,
 		EdgeHTTPSPort:            proxy.DefaultEdgeHTTPSPort,
+		EdgeReadinessPort:        proxy.DefaultEdgeReadinessPort,
 		EdgePerGatewayAddressing: true,
 		GatewayClassName:         "aether",
 		CNIServerConfig:          cniServer.NewCNIServerConfig(),

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -54,6 +54,7 @@ func init() {
 	edgeCmd.Flags().StringVar(&cfg.RouteNamespace, "route-namespace", "", "Namespace to watch Gateways/HTTPRoutes in (empty = the edge pod's own namespace)")
 	edgeCmd.Flags().BoolVar(&cfg.EdgeTLS, "edge-tls", false, "Terminate downstream TLS: serve an HTTPS listener (certs per Gateway listener via SDS) + an HTTP->HTTPS redirect")
 	edgeCmd.Flags().Uint32Var(&cfg.EdgeHTTPSPort, "edge-https-port", cfg.EdgeHTTPSPort, "Port the edge TLS listener binds when --edge-tls is set")
+	edgeCmd.Flags().Uint32Var(&cfg.EdgeReadinessPort, "edge-readiness-port", cfg.EdgeReadinessPort, "Port the dedicated always-bound readiness listener binds; the readiness probe targets it (independent of the public listeners)")
 	edgeCmd.Flags().StringVar(&cfg.GatewayClassName, "gateway-class", cfg.GatewayClassName, "GatewayClass name whose Gateways this edge serves")
 	edgeCmd.Flags().StringVar(&cfg.EdgeServiceName, "edge-service-name", "", "Name of the edge's own LoadBalancer Service (in the edge namespace); its assigned LB address is published as every class-aether Gateway's status.addresses. Empty disables address publication")
 	edgeCmd.Flags().BoolVar(&cfg.EdgePerGatewayAddressing, "edge-per-gateway-addressing", true, "Enable proposal 021 Phase 2: create a per-Gateway LoadBalancer Service + internal-port demux so each Gateway gets its own external IP (default: true). Set false to fall back to Phase 1 (shared IP)")
@@ -185,6 +186,7 @@ func runEdge(ctx context.Context) (retErr error) {
 	snapshotCache.SetMeshDomain(cfg.MeshDomain)
 	snapshotCache.SetEmitStatsPod(cfg.EmitStatsPod)
 	snapshotCache.SetEdgeMode(cfg.EdgeHTTPPort)
+	snapshotCache.SetEdgeReadinessPort(cfg.EdgeReadinessPort)
 	if cfg.EdgeTLS {
 		snapshotCache.SetEdgeTLSMode(cfg.EdgeHTTPSPort)
 	}

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -280,8 +280,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			// for edge cases like a reconcile that loses the Phase 2 allocations).
 		}
 	} else {
-		// Phase 1 / disabled: clear any stale Phase 2 state.
+		// Phase 1 / disabled: clear any stale Phase 2 state, and garbage-collect any
+		// per-Gateway Services left over from a previous Phase 2 run. The Phase 2
+		// reconcile path is skipped here, so without this the Services orphan and
+		// keep holding their LoadBalancer IP (e.g. the pinned edge address), which
+		// blocks the shared Service from reclaiming it on a downgrade.
 		r.Sink.SetEdgeGateways(nil)
+		if r.EdgeServiceName != "" {
+			if err := r.gcStaleGatewayServices(ctx, map[string]struct{}{}); err != nil {
+				r.Log.WarnContext(ctx, "GC of stale per-Gateway Services failed", "error", err.Error())
+			}
+		}
 	}
 	r.Sink.SetVirtualHosts(vhosts)
 	r.Sink.SetEdgeTCPRoutes(tcpRoutes)

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -98,6 +98,10 @@ type SnapshotCache struct {
 	edge bool
 	// edgeHTTPPort is the port the edge plain-HTTP / redirect listener binds.
 	edgeHTTPPort uint32
+	// edgeReadinessPort is the port the dedicated always-bound readiness listener
+	// binds (the kubelet probe target). Defaults to proxy.DefaultEdgeReadinessPort
+	// when unset, so the readiness listener is always emitted regardless of phase.
+	edgeReadinessPort uint32
 	// edgeTLSEnabled serves a TLS-terminating listener on edgeHTTPSPort (certs
 	// per VirtualHost via SDS). Set once before the manager starts via SetEdgeTLSMode.
 	edgeTLSEnabled bool
@@ -381,6 +385,13 @@ func (c *SnapshotCache) SetEmitStatsPod(enabled bool) {
 func (c *SnapshotCache) SetEdgeMode(httpPort uint32) {
 	c.edge = true
 	c.edgeHTTPPort = httpPort
+}
+
+// SetEdgeReadinessPort sets the port the dedicated always-bound readiness listener
+// binds (the kubelet probe target). Must be called before the manager starts. A
+// zero value leaves the default (proxy.DefaultEdgeReadinessPort) in effect.
+func (c *SnapshotCache) SetEdgeReadinessPort(port uint32) {
+	c.edgeReadinessPort = port
 }
 
 // SetEdgeTLSMode enables downstream TLS termination: the edge serves a TLS

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -7,9 +7,30 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// stripReadiness asserts the dedicated always-bound readiness listener is present
+// (on the default readiness port) and returns the remaining PUBLIC edge listeners,
+// so the public-listener assertions below are unaffected by it.
+func stripReadiness(t *testing.T, ls []types.Resource) []*listenerv3.Listener {
+	t.Helper()
+	var public []*listenerv3.Listener
+	foundReadiness := false
+	for _, r := range ls {
+		l := r.(*listenerv3.Listener)
+		if l.GetName() == proxy.EdgeReadinessListenerName {
+			foundReadiness = true
+			assert.Equal(t, uint32(proxy.DefaultEdgeReadinessPort), l.GetAddress().GetSocketAddress().GetPortValue())
+			continue
+		}
+		public = append(public, l)
+	}
+	require.True(t, foundReadiness, "the dedicated readiness listener must always be present")
+	return public
+}
 
 // TestEdgeTLSModeListeners verifies that with TLS enabled AND the per-Gateway
 // HTTP redirect opt-in set, the cache serves a TLS listener on the https port
@@ -27,11 +48,10 @@ func TestEdgeTLSModeListeners(t *testing.T) {
 		"kubernetes/api-tls": {Cert: []byte("CERT"), Key: []byte("KEY")},
 	}))
 
-	ls := c.Listeners()
+	ls := stripReadiness(t, c.Listeners())
 	require.Len(t, ls, 2)
 	names := map[string]*listenerv3.Listener{}
-	for _, r := range ls {
-		l := r.(*listenerv3.Listener)
+	for _, l := range ls {
 		names[l.GetName()] = l
 	}
 	tls := names[proxy.EdgeHTTPSListenerName]
@@ -72,10 +92,9 @@ func TestEdgeModeListeners(t *testing.T) {
 	c := newTestCache("edge-1")
 	c.SetEdgeMode(8080)
 
-	listeners := c.Listeners()
+	listeners := stripReadiness(t, c.Listeners())
 	require.Len(t, listeners, 1)
-	l, ok := listeners[0].(*listenerv3.Listener)
-	require.True(t, ok)
+	l := listeners[0]
 	assert.Equal(t, proxy.EdgeListenerName, l.GetName())
 	assert.Equal(t, uint32(8080), l.GetAddress().GetSocketAddress().GetPortValue())
 }
@@ -197,9 +216,9 @@ func TestEdgeHTTPRedirectOptIn(t *testing.T) {
 		c.SetEdgeMode(80)
 		// No SetEdgeHTTPRedirect call → default off.
 
-		ls := c.Listeners()
+		ls := stripReadiness(t, c.Listeners())
 		require.Len(t, ls, 1)
-		l := ls[0].(*listenerv3.Listener)
+		l := ls[0]
 		assert.Equal(t, proxy.EdgeListenerName, l.GetName(), "HTTP listener serves routes, not a redirect")
 		assert.Equal(t, uint32(80), l.GetAddress().GetSocketAddress().GetPortValue())
 	})
@@ -210,10 +229,9 @@ func TestEdgeHTTPRedirectOptIn(t *testing.T) {
 		c.SetEdgeTLSMode(443)
 		c.SetEdgeHTTPRedirect(true)
 
-		ls := c.Listeners()
+		ls := stripReadiness(t, c.Listeners())
 		names := map[string]*listenerv3.Listener{}
-		for _, r := range ls {
-			l := r.(*listenerv3.Listener)
+		for _, l := range ls {
 			names[l.GetName()] = l
 		}
 		// The HTTPS routing listener must be present (distinct name from the :80 listener).
@@ -232,13 +250,12 @@ func TestEdgeHTTPRedirectOptIn(t *testing.T) {
 		c.SetEdgeTLSMode(443)
 		// TLS enabled but redirect annotation not set → HTTP listener still serves routes.
 
-		ls := c.Listeners()
+		ls := stripReadiness(t, c.Listeners())
 		require.Len(t, ls, 2, "HTTPS listener + HTTP routing listener")
 		// The two listeners MUST have DISTINCT names (edge_https on 443, edge_http on
 		// 80) — a shared name collides in the snapshot/LDS and drops :443 (regression).
 		byName := map[string]uint32{}
-		for _, r := range ls {
-			l := r.(*listenerv3.Listener)
+		for _, l := range ls {
 			byName[l.GetName()] = l.GetAddress().GetSocketAddress().GetPortValue()
 			assert.NotEqual(t, proxy.EdgeRedirectListenerName, l.GetName(), "redirect listener must NOT be present without opt-in")
 		}
@@ -291,10 +308,9 @@ func TestPerGatewayListenerNamesAllDistinct(t *testing.T) {
 	}
 	c.SetEdgeGateways(gateways)
 
-	ls := c.Listeners()
+	ls := stripReadiness(t, c.Listeners())
 	names := map[string]bool{}
-	for _, r := range ls {
-		l := r.(*listenerv3.Listener)
+	for _, l := range ls {
 		name := l.GetName()
 		assert.False(t, names[name], "listener name %q must be unique (duplicate = LDS drop, regression for #332)", name)
 		names[name] = true
@@ -322,11 +338,44 @@ func TestPerGatewayListenerFallbackToPhase1(t *testing.T) {
 	})
 	c.SetEdgeGateways(nil) // reset to Phase 1
 
-	ls := c.Listeners()
+	ls := stripReadiness(t, c.Listeners())
 	require.Len(t, ls, 1)
-	l := ls[0].(*listenerv3.Listener)
+	l := ls[0]
 	assert.Equal(t, proxy.EdgeListenerName, l.GetName(), "Phase 1 fallback: listener must be the shared edge_http")
 	assert.Equal(t, uint32(80), l.GetAddress().GetSocketAddress().GetPortValue())
+}
+
+// TestEdgeReadinessListenerAlwaysPresent is the regression guard for the Phase 2
+// readiness wedge: the dedicated readiness listener (edge_readiness on the
+// readiness port) MUST be emitted in BOTH Phase 1 (shared listeners) and Phase 2
+// (per-Gateway listeners on internal ports, where nothing binds :443), so the
+// kubelet readiness probe always has a stable target.
+func TestEdgeReadinessListenerAlwaysPresent(t *testing.T) {
+	readiness := func(ls []types.Resource) *listenerv3.Listener {
+		for _, r := range ls {
+			if l := r.(*listenerv3.Listener); l.GetName() == proxy.EdgeReadinessListenerName {
+				return l
+			}
+		}
+		return nil
+	}
+
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+	c.SetEdgeTLSMode(443)
+
+	// Phase 1 (shared listeners).
+	rl := readiness(c.Listeners())
+	require.NotNil(t, rl, "readiness listener must be present in Phase 1")
+	assert.Equal(t, uint32(proxy.DefaultEdgeReadinessPort), rl.GetAddress().GetSocketAddress().GetPortValue())
+
+	// Phase 2 (per-Gateway listeners on internal ports — nothing binds :443).
+	c.SetEdgeGateways([]EdgeGatewayEntry{
+		{Namespace: "aether-ingress", Name: "edge", Listeners: []EdgeGatewayListenerEntry{{ExternalPort: 443, InternalPort: 18100}}},
+	})
+	rl2 := readiness(c.Listeners())
+	require.NotNil(t, rl2, "readiness listener must ALSO be present in Phase 2 (the probe target when :443 is unbound)")
+	assert.Equal(t, uint32(proxy.DefaultEdgeReadinessPort), rl2.GetAddress().GetSocketAddress().GetPortValue())
 }
 
 // TestPerGatewayRouteConfigIsolation verifies that each Gateway gets its own route
@@ -401,9 +450,9 @@ func TestPerGatewayCertWired(t *testing.T) {
 		},
 	})
 
-	ls := c.Listeners()
+	ls := stripReadiness(t, c.Listeners())
 	require.Len(t, ls, 1)
-	l := ls[0].(*listenerv3.Listener)
+	l := ls[0]
 	assert.Equal(t, "edge_gw_ns-tls_secure-gw_18110", l.GetName())
 	// TLS transport socket must be wired (not nil).
 	require.NotNil(t, l.GetFilterChains()[0].GetTransportSocket(), "per-Gateway HTTPS listener must terminate TLS")

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -108,6 +108,16 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 	if c.edge {
 		var resources []types.Resource
 
+		// Always emit the dedicated readiness listener so the kubelet probe has a
+		// stable target independent of which public listeners are bound. Under
+		// Phase 2 the public listeners move to per-Gateway internal ports and
+		// nothing binds the HTTPS port — probing it there fails and wedges the roll.
+		readinessPort := c.edgeReadinessPort
+		if readinessPort == 0 {
+			readinessPort = proxy.DefaultEdgeReadinessPort
+		}
+		resources = append(resources, proxy.BuildEdgeReadinessListener(readinessPort))
+
 		if c.hasPerGatewayAddressing() {
 			// Proposal 021 Phase 2: per-Gateway listeners, each with a unique name
 			// (edge_gw_<ns>_<gwname>_<internalPort>). No shared edge_http/edge_https

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -37,6 +37,13 @@ const (
 	// when TLS is enabled.
 	EdgeRedirectListenerName = "edge_redirect"
 
+	// EdgeReadinessListenerName is a dedicated, always-bound plain-HTTP listener
+	// serving only the drain-aware /aether/readyz endpoint. It is independent of
+	// any Gateway listener so the edge readiness probe has a stable target even
+	// under proposal 021 Phase 2 (where the public listeners move to per-Gateway
+	// internal ports and nothing binds the HTTPS port).
+	EdgeReadinessListenerName = "edge_readiness"
+
 	// DefaultEdgeHTTPPort is the port the edge plain-HTTP / redirect listener
 	// binds for external (north-south) traffic. Privileged (the edge is an ingress
 	// gateway); the pod is granted NET_BIND_SERVICE, so it binds unprivileged.
@@ -45,6 +52,11 @@ const (
 	// DefaultEdgeHTTPSPort is the port the edge TLS-terminating listener binds
 	// when downstream TLS is enabled.
 	DefaultEdgeHTTPSPort = 443
+
+	// DefaultEdgeReadinessPort is the (unprivileged, internal) port the dedicated
+	// readiness listener binds. The kubelet readiness probe targets it over plain
+	// HTTP; it is never exposed via a Service.
+	DefaultEdgeReadinessPort = 15021
 
 	// defaultEdgeAddress binds the edge listener on all interfaces (it fronts
 	// external traffic, unlike the node proxy's loopback-only outbound listener).
@@ -318,6 +330,47 @@ func BuildEdgeRedirectListener(port uint32) *listenerv3.Listener {
 		Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
 	}
 	return edgeListener(EdgeRedirectListenerName, port, filterChain)
+}
+
+// BuildEdgeReadinessListener builds the dedicated, always-bound plain-HTTP
+// readiness listener. It carries the drain-aware readiness health_check filter
+// (answers /aether/readyz with 200/503 from the server's drain state) ahead of a
+// catch-all that 404s every other path — this listener exists ONLY to give the
+// kubelet readiness probe a stable target that does not depend on which public
+// listeners are bound (the public listeners move to per-Gateway internal ports
+// under proposal 021 Phase 2, so probing :443 there fails).
+func BuildEdgeReadinessListener(port uint32) *listenerv3.Listener {
+	hcm := buildHTTPConnectionManager(EdgeReadinessListenerName, ReporterSource, "", "", buildEdgeReadinessRouteConfig())
+	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
+	filterChain := &listenerv3.FilterChain{
+		Name:    EdgeReadinessListenerName,
+		Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
+	}
+	return edgeListener(EdgeReadinessListenerName, port, filterChain)
+}
+
+// buildEdgeReadinessRouteConfig is the inline route table for the readiness
+// listener: a single catch-all that direct-responds 404. The readiness
+// health_check filter intercepts /aether/readyz before the router, so this only
+// covers stray non-readyz requests.
+func buildEdgeReadinessRouteConfig() *routev3.RouteConfiguration {
+	return &routev3.RouteConfiguration{
+		Name: EdgeReadinessListenerName,
+		VirtualHosts: []*routev3.VirtualHost{
+			{
+				Name:    EdgeReadinessListenerName,
+				Domains: []string{"*"},
+				Routes: []*routev3.Route{
+					{
+						Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
+						Action: &routev3.Route_DirectResponse{
+							DirectResponse: &routev3.DirectResponseAction{Status: 404},
+						},
+					},
+				},
+			},
+		},
+	}
 }
 
 // edgeListener wraps a filter chain in a 0.0.0.0:<port> INBOUND listener.

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.48.0-{GIT_COMMIT}"
+version: "0.49.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -81,6 +81,9 @@ spec:
             {{- if not .Values.edge.perGatewayAddressing }}
             - "--edge-per-gateway-addressing=false"
             {{- end }}
+            {{- if ne (int .Values.edge.readinessPort) 15021 }}
+            - "--edge-readiness-port={{ .Values.edge.readinessPort }}"
+            {{- end }}
             {{- if .Values.edge.tls.enabled }}
             - "--edge-tls"
             {{- if ne (int .Values.edge.httpsPort) 443 }}
@@ -197,18 +200,18 @@ spec:
               containerPort: {{ .Values.edge.httpsPort }}
               protocol: TCP
             {{- end }}
+            - name: readiness
+              containerPort: {{ .Values.edge.readinessPort }}
+              protocol: TCP
           readinessProbe:
-            # Envoy's /aether/readyz health_check filter rides the main route
-            # listener: 200 while serving, 503 while draining. With TLS that is the
-            # HTTPS listener (the :80 listener only redirects); else plain HTTP.
+            # /aether/readyz (drain-aware: 200 serving, 503 draining) is served by a
+            # DEDICATED always-bound plain-HTTP readiness listener, independent of the
+            # public listeners — so the probe survives proposal 021 Phase 2, where the
+            # public listeners move to per-Gateway internal ports and nothing binds
+            # the HTTPS port (probing it there fails and wedges the rollout).
             httpGet:
               path: /aether/readyz
-              {{- if .Values.edge.tls.enabled }}
-              port: https
-              scheme: HTTPS
-              {{- else }}
-              port: http
-              {{- end }}
+              port: readiness
             initialDelaySeconds: 2
             periodSeconds: 2
             failureThreshold: 3

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -213,6 +213,12 @@ edge:
   # plain HTTP on httpPort.
   httpPort: 80
   httpsPort: 443
+  # Port the dedicated, always-bound readiness listener binds (the kubelet
+  # readiness probe target, plain HTTP). It is independent of the public HTTP/HTTPS
+  # listeners so the probe survives proposal 021 Phase 2, where those listeners move
+  # to per-Gateway internal ports and nothing binds the HTTPS port. Internal only —
+  # never exposed via a Service.
+  readinessPort: 15021
   # Namespace the edge watches its Gateways/HTTPRoutes in. Empty = the edge's own
   # namespace.
   routeNamespace: ""


### PR DESCRIPTION
Two bugs found enabling 021 Phase 2 on the live edge (both reverted there):

1. **Readiness wedge** — the envoy readiness probe was on :443, but Phase 2 binds per-Gateway internal ports (nothing binds :443) → connection-refused → pods 1/2 → rollout timeout → api.palermo.dev down. #333 decoupled only the *agent* readiness (:8082), not the envoy one. Fix: a dedicated always-bound plain-HTTP readiness listener (`edge_readiness` on `edge.readinessPort`=15021) carrying the drain-aware /aether/readyz filter, emitted in BOTH phases; the probe targets that fixed port.
2. **Per-Gateway Service GC** — `reconcileGatewayServices` only ran when Phase 2 was on, so a downgrade orphaned the per-Gateway LB Services holding their IP (e.g. the pinned .101). Fix: GC them on the disabled path.

Tests: readiness listener present in both phases (regression guard). Chart 0.48→0.49. Unblocks enabling Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)