### PR TITLE
fix(edge): hostname-less routes match all hosts via a catch-all "*" vhost

### DIFF
--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -41,11 +41,12 @@ type EdgeGatewayEntry struct {
 	VirtualHosts []VirtualHost
 }
 
-// VirtualHost is the cache's projection of a VirtualHost CR (without the
-// Kubernetes types): a set of external hosts carrying an ordered list of
-// path-matched routes to mesh services, optionally served under a downstream
-// cert. Empty Hosts or empty Routes makes it inert (it exposes nothing — the
-// internal mesh FQDN is never routable from the edge).
+// VirtualHost is the cache's projection of an HTTPRoute (and the legacy
+// VirtualHost CR): a set of external hosts carrying an ordered list of
+// path-matched routes to backend services, optionally served under a downstream
+// cert. Empty Routes makes it inert. Empty Hosts is NOT inert — per Gateway API a
+// hostname-less route matches every host on its listener, so it is served via the
+// edge's catch-all "*" vhost (see buildEdgeVhostsLocked).
 type VirtualHost struct {
 	Hosts  []string
 	Routes []Route
@@ -174,23 +175,23 @@ func (c *SnapshotCache) edgeGatewayRouteConfigs() []types.Resource {
 // slice. It is identical to virtualHostVhosts but scoped to one Gateway's vhosts.
 // Caller must hold clusterMu.
 func (c *SnapshotCache) gatewayVhostsLocked(vhosts []VirtualHost) []*routev3.VirtualHost {
+	return c.buildEdgeVhostsLocked(vhosts)
+}
+
+// buildEdgeVhostsLocked converts cache VirtualHosts into Envoy virtual hosts.
+// A route with explicit hostnames becomes a vhost whose domains are those hosts
+// (a host already claimed by an earlier vhost is dropped — keep-first, since Envoy
+// NACKs duplicate domains). A route with NO hostnames matches EVERY host on its
+// listener (Gateway API semantics — a hostname-less HTTPRoute is not host-scoped);
+// such routes are merged into a single catch-all "*" vhost. There can be only one
+// "*" per route table (duplicate domains NACK), so all hostname-less routes share
+// it, in input order (the reconciler sorts by namespace/name for determinism).
+// Caller must hold clusterMu.
+func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.VirtualHost {
 	used := make(map[string]struct{})
 	out := make([]*routev3.VirtualHost, 0, len(vhosts))
+	var catchAll []*routev3.Route
 	for _, v := range vhosts {
-		domains := make([]string, 0, len(v.Hosts))
-		for _, h := range v.Hosts {
-			if h == "" {
-				continue
-			}
-			if _, ok := used[h]; ok {
-				continue
-			}
-			used[h] = struct{}{}
-			domains = append(domains, h)
-		}
-		if len(domains) == 0 {
-			continue
-		}
 		routes := make([]*routev3.Route, 0, len(v.Routes))
 		for _, r := range v.Routes {
 			if r.Redirect == nil && r.Service == "" {
@@ -205,7 +206,29 @@ func (c *SnapshotCache) gatewayVhostsLocked(vhosts []VirtualHost) []*routev3.Vir
 		if len(routes) == 0 {
 			continue
 		}
+		domains := make([]string, 0, len(v.Hosts))
+		for _, h := range v.Hosts {
+			if h == "" {
+				continue
+			}
+			if _, ok := used[h]; ok {
+				continue
+			}
+			used[h] = struct{}{}
+			domains = append(domains, h)
+		}
+		if len(domains) == 0 {
+			// Hostname-less route: matches all hosts on its listener. Accumulate into
+			// the single "*" catch-all vhost emitted after the loop.
+			catchAll = append(catchAll, routes...)
+			continue
+		}
 		out = append(out, proxy.BuildEdgeVirtualHost(domains[0], domains, routes))
+	}
+	if len(catchAll) > 0 {
+		if _, ok := used["*"]; !ok {
+			out = append(out, proxy.BuildEdgeVirtualHost("*", []string{"*"}, catchAll))
+		}
 	}
 	return out
 }
@@ -247,12 +270,10 @@ func (c *SnapshotCache) SetVirtualHosts(vhosts []VirtualHost) {
 }
 
 // virtualHostVhosts builds the edge listener's Envoy virtual hosts from the
-// configured VirtualHosts: one Envoy vhost per CR — its hosts as domains, its
-// routes emitted IN ORDER (first match wins). A host already claimed by an
-// earlier vhost is dropped from later ones (Envoy NACKs duplicate domains): the
-// runtime backstop to the controller webhook's duplicate-FQDN rejection, with
-// keep-first determinism (the reconciler sorts the input by namespace/name). A
-// vhost left with no domains, or with no routable routes, is skipped.
+// configured VirtualHosts (see buildEdgeVhostsLocked): a host already claimed by an
+// earlier vhost is dropped (keep-first; Envoy NACKs duplicate domains) — the
+// runtime backstop to the controller webhook's duplicate-FQDN rejection — and
+// hostname-less routes are merged into a single catch-all "*" vhost.
 func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 	c.edgeMu.RLock()
 	vhosts := slices.Clone(c.virtualHosts)
@@ -261,40 +282,7 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 	c.clusterMu.RLock()
 	defer c.clusterMu.RUnlock()
 
-	used := make(map[string]struct{})
-	out := make([]*routev3.VirtualHost, 0, len(vhosts))
-	for _, v := range vhosts {
-		domains := make([]string, 0, len(v.Hosts))
-		for _, h := range v.Hosts {
-			if h == "" {
-				continue
-			}
-			if _, ok := used[h]; ok {
-				continue
-			}
-			used[h] = struct{}{}
-			domains = append(domains, h)
-		}
-		if len(domains) == 0 {
-			continue
-		}
-		routes := make([]*routev3.Route, 0, len(v.Routes))
-		for _, r := range v.Routes {
-			if r.Redirect == nil && r.Service == "" {
-				continue
-			}
-			cluster := ""
-			if r.Service != "" {
-				cluster = c.edgeClusterNameLocked(r.Service, r.Port)
-			}
-			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
-		}
-		if len(routes) == 0 {
-			continue
-		}
-		out = append(out, proxy.BuildEdgeVirtualHost(domains[0], domains, routes))
-	}
-	return out
+	return c.buildEdgeVhostsLocked(vhosts)
 }
 
 // edgeClusterNameLocked resolves a (service, port) backend to the data-plane
@@ -370,9 +358,9 @@ func (c *SnapshotCache) rebuildEdgeDependencies() {
 	var services []string
 
 	addVhost := func(v VirtualHost) {
-		if len(v.Hosts) == 0 {
-			return
-		}
+		// A hostname-less route is NOT inert: per Gateway API it matches every host
+		// on its listener (the edge serves it via the catch-all "*" vhost), so its
+		// backend services must be scoped in (their clusters loaded) too.
 		for _, r := range v.Routes {
 			if r.Service == "" {
 				continue

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -109,19 +109,20 @@ func TestSetVirtualHostsDependencySet(t *testing.T) {
 			{Prefix: "/a", Service: "svc-1"},
 			{Prefix: "/b", Service: "svc-2", Port: 9090},
 		}},
-		{Routes: []Route{{Prefix: "/", Service: "svc-3"}}}, // no hosts -> inert, never scoped
+		{Routes: []Route{{Prefix: "/", Service: "svc-3"}}}, // no hosts -> catch-all "*", IS routable + scoped
 	})
 
 	deps := c.DependencySet()
-	assert.Len(t, deps, 2)
+	assert.Len(t, deps, 3)
 	assert.Contains(t, deps, "svc-1")
 	assert.Contains(t, deps, "svc-2")
-	assert.NotContains(t, deps, "svc-3", "a hostless virtual host exposes nothing and must not scope its service")
+	assert.Contains(t, deps, "svc-3", "a hostname-less route matches all hosts (catch-all) and must scope its service")
 }
 
 // TestVirtualHostVhosts checks host->cluster resolution: external hosts become
-// the vhost domains and a non-default port targets the per-port cluster. A vhost
-// without hosts is NOT routable — the mesh FQDN is never an edge entrypoint.
+// the vhost domains, a non-default port targets the per-port cluster, and a route
+// WITHOUT hosts becomes the catch-all "*" vhost (Gateway API: a hostname-less route
+// matches all hosts on its listener).
 func TestVirtualHostVhosts(t *testing.T) {
 	c := newTestCache("edge-1")
 
@@ -132,27 +133,58 @@ func TestVirtualHostVhosts(t *testing.T) {
 
 	c.SetVirtualHosts([]VirtualHost{
 		{Hosts: []string{"api.example.com", "api2.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-1"}}},
-		{Routes: []Route{{Prefix: "/", Service: "svc-3"}}}, // no hosts -> NOT routable (no vhost)
+		{Routes: []Route{{Prefix: "/", Service: "svc-3"}}}, // no hosts -> catch-all "*"
 		{Hosts: []string{"grpc.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-2", Port: 9090}}},
 	})
 
 	vhosts := c.virtualHostVhosts()
-	require.Len(t, vhosts, 2)
+	require.Len(t, vhosts, 3)
 
-	assert.Equal(t, "api.example.com", vhosts[0].GetName())
-	assert.Equal(t, []string{"api.example.com", "api2.example.com"}, vhosts[0].GetDomains())
-	assert.Equal(t, "svc-1.aether.internal", vhosts[0].GetRoutes()[0].GetRoute().GetCluster())
-
-	assert.Equal(t, "grpc.example.com", vhosts[1].GetName())
-	assert.Equal(t, []string{"grpc.example.com"}, vhosts[1].GetDomains())
-	assert.Equal(t, "svc-2.aether.internal:9090", vhosts[1].GetRoutes()[0].GetRoute().GetCluster())
-
-	// No vhost exposes a mesh FQDN as a routable domain.
+	byName := map[string]*routev3.VirtualHost{}
 	for _, vh := range vhosts {
-		for _, d := range vh.GetDomains() {
-			assert.NotContains(t, d, ".aether.internal", "the mesh FQDN must not be routable from the edge")
+		byName[vh.GetName()] = vh
+	}
+
+	require.NotNil(t, byName["api.example.com"])
+	assert.Equal(t, []string{"api.example.com", "api2.example.com"}, byName["api.example.com"].GetDomains())
+	assert.Equal(t, "svc-1.aether.internal", byName["api.example.com"].GetRoutes()[0].GetRoute().GetCluster())
+
+	require.NotNil(t, byName["grpc.example.com"])
+	assert.Equal(t, []string{"grpc.example.com"}, byName["grpc.example.com"].GetDomains())
+	assert.Equal(t, "svc-2.aether.internal:9090", byName["grpc.example.com"].GetRoutes()[0].GetRoute().GetCluster())
+
+	// The hostname-less route is served by the catch-all "*" vhost.
+	require.NotNil(t, byName["*"], "a hostname-less route must produce the catch-all * vhost")
+	assert.Equal(t, []string{"*"}, byName["*"].GetDomains())
+	assert.Equal(t, "svc-3.aether.internal", byName["*"].GetRoutes()[0].GetRoute().GetCluster())
+}
+
+// TestVirtualHostVhostsHostlessMerge verifies that MULTIPLE hostname-less routes
+// merge into a SINGLE catch-all "*" vhost (Envoy NACKs duplicate domains, so there
+// can be only one "*"), preserving their routes in order.
+func TestVirtualHostVhostsHostlessMerge(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetVirtualHosts([]VirtualHost{
+		{Routes: []Route{{Prefix: "/a", Service: "svc-a"}}},                              // no hosts
+		{Hosts: []string{"x.example.com"}, Routes: []Route{{Prefix: "/", Service: "x"}}}, // hosted
+		{Routes: []Route{{Prefix: "/b", Service: "svc-b"}}},                              // no hosts
+	})
+
+	vhosts := c.virtualHostVhosts()
+	star := 0
+	var starVH *routev3.VirtualHost
+	for _, vh := range vhosts {
+		if vh.GetName() == "*" {
+			star++
+			starVH = vh
 		}
 	}
+	require.Equal(t, 1, star, "all hostname-less routes share ONE catch-all * vhost")
+	require.NotNil(t, starVH)
+	assert.Equal(t, []string{"*"}, starVH.GetDomains())
+	require.Len(t, starVH.GetRoutes(), 2, "both hostname-less routes land in the * vhost")
+	assert.Equal(t, "/a", starVH.GetRoutes()[0].GetMatch().GetPrefix())
+	assert.Equal(t, "/b", starVH.GetRoutes()[1].GetMatch().GetPrefix())
 }
 
 // TestVirtualHostPathRoutes verifies one virtual host fans different paths to


### PR DESCRIPTION
rev6's uniform 404 on every traffic test (zero 503s = no-route-matched, not missing-upstream): the edge built vhost domains from the HTTPRoute hostnames and **skipped vhosts with no domains**. But per Gateway API a hostname-less route matches **all** hosts on its listener, and conformance routes are mostly hostname-less, hit via the Gateway IP → no vhost → 404. Verified: a registry backend that works on api.palermo.dev 404s when the route is hostname-less + hit via the per-Gw IP.

Fix: hostname-less routes → catch-all `*` vhost (Phase 1 + Phase 2 share `buildEdgeVhostsLocked`, merging all hostname-less routes into one `*` since Envoy NACKs duplicate domains); their services are now scoped into the demand set so clusters load. Hosted routes (api.palermo.dev) unchanged.

To the design question: the edge traffic targets the Gateway **IP**, which only `*` matches — a synthesized registry FQDN wouldn't, so `*` is correct for the north-south path. Should unblock the ~20 GATEWAY traffic 404s. Tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)