### PR TITLE
fix(edge): stop dropping hostname-less HTTPRoutes in the reconciler

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -163,7 +163,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			continue
 		}
 		vh := r.buildVirtualHost(hr, hostCerts, grants)
-		if len(vh.Hosts) == 0 || len(vh.Routes) == 0 {
+		// A hostname-less route is NOT inert: per Gateway API it matches every host on
+		// its listener, served via the cache's catch-all "*" vhost. Only an empty
+		// route set (no backend/redirect produced a route) makes it skippable.
+		if len(vh.Routes) == 0 {
 			continue
 		}
 		vhosts = append(vhosts, vh)


### PR DESCRIPTION
Follow-up to #341. The catch-all `*` vhost fix handled the cache, but the reconciler dropped hostname-less vhosts one layer earlier (`if len(vh.Hosts) == 0 …`), so the route never reached the cache (verified live: `virtualHosts:1` = only the hosted api route; a hostname-less route still 404'd via the per-Gw IP). Drop the `Hosts==0` condition — a hostname-less route matches every host on its listener (served via `*`); only an empty route set is skippable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)