### PR TITLE
fix(edge): merge hostname-less catch-all into the single "*" 404 vhost

### DIFF
--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -161,21 +161,35 @@ func BuildEdgeGatewayHTTPSListener(namespace, gatewayName string, internalPort u
 // given virtual hosts. It has a catch-all 404 (no ODCDS — the edge serves only
 // explicitly routed services). The route config name is unique per Gateway.
 func BuildEdgeGatewayRouteConfiguration(namespace, gatewayName string, vhosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
-	all := append([]*routev3.VirtualHost{}, vhosts...)
-	all = append(all, &routev3.VirtualHost{
-		Name:    "edge_not_found",
-		Domains: []string{"*"},
-		Routes: []*routev3.Route{
-			{
-				Match:  &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
-				Action: &routev3.Route_DirectResponse{DirectResponse: &routev3.DirectResponseAction{Status: 404}},
-			},
-		},
-	})
 	return &routev3.RouteConfiguration{
 		Name:         EdgeGatewayRouteName(namespace, gatewayName),
-		VirtualHosts: all,
+		VirtualHosts: appendEdgeCatchAll404(vhosts),
 	}
+}
+
+// appendEdgeCatchAll404 ensures the route table has exactly ONE wildcard "*" vhost
+// ending in a 404 for unmatched paths (Envoy permits only a single "*" domain per
+// route config). If a "*" vhost already exists — the catch-all built from
+// hostname-less HTTPRoutes (see buildEdgeVhostsLocked) — the 404 is appended to it
+// as the last (lowest-priority) route; otherwise a dedicated edge_not_found "*"
+// vhost is added. An unmatched authority thus gets an immediate 404.
+func appendEdgeCatchAll404(vhosts []*routev3.VirtualHost) []*routev3.VirtualHost {
+	notFound := &routev3.Route{
+		Match:  &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
+		Action: &routev3.Route_DirectResponse{DirectResponse: &routev3.DirectResponseAction{Status: 404}},
+	}
+	all := append([]*routev3.VirtualHost{}, vhosts...)
+	for _, vh := range all {
+		if len(vh.GetDomains()) == 1 && vh.GetDomains()[0] == "*" {
+			vh.Routes = append(vh.Routes, notFound)
+			return all
+		}
+	}
+	return append(all, &routev3.VirtualHost{
+		Name:    "edge_not_found",
+		Domains: []string{"*"},
+		Routes:  []*routev3.Route{notFound},
+	})
 }
 
 // EdgeTCPListenerName returns the name of an edge TCP listener for a given port.
@@ -469,21 +483,8 @@ func BuildEdgeVirtualHost(name string, domains []string, routes []*routev3.Route
 // it has NO on-demand catch-all (the edge serves only its explicit exposed set);
 // an unmatched authority gets an immediate 404 from the catch-all default vhost.
 func BuildEdgeRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteConfiguration {
-	all := append([]*routev3.VirtualHost{}, vhosts...)
-	all = append(all, &routev3.VirtualHost{
-		Name:    "edge_not_found",
-		Domains: []string{"*"},
-		Routes: []*routev3.Route{
-			{
-				Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
-				Action: &routev3.Route_DirectResponse{
-					DirectResponse: &routev3.DirectResponseAction{Status: 404},
-				},
-			},
-		},
-	})
 	return &routev3.RouteConfiguration{
 		Name:         EdgeHTTPRouteName,
-		VirtualHosts: all,
+		VirtualHosts: appendEdgeCatchAll404(vhosts),
 	}
 }

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -279,6 +279,37 @@ func TestBuildEdgeGatewayRouteConfiguration(t *testing.T) {
 	assert.Equal(t, uint32(404), last.GetRoutes()[0].GetDirectResponse().GetStatus())
 }
 
+// TestBuildEdgeRouteConfigurationSingleWildcard is the regression guard for the
+// NACK "Only a single wildcard domain is permitted": when the input already has a
+// "*" vhost (the hostname-less-route catch-all), the route config must NOT add a
+// SECOND "*" — it appends the 404 to the existing one as the last route.
+func TestBuildEdgeRouteConfigurationSingleWildcard(t *testing.T) {
+	starRoute := BuildEdgeRoute("/echo", "", "echo.aether.internal", nil, nil, nil)
+	star := BuildEdgeVirtualHost("*", []string{"*"}, []*routev3.Route{starRoute})
+	hosted := BuildEdgeVirtualHost("api.example.com", []string{"api.example.com"}, []*routev3.Route{starRoute})
+
+	for _, rc := range []*routev3.RouteConfiguration{
+		BuildEdgeGatewayRouteConfiguration("ns-a", "gw1", []*routev3.VirtualHost{hosted, star}),
+		BuildEdgeRouteConfiguration([]*routev3.VirtualHost{hosted, star}),
+	} {
+		wildcards := 0
+		var starVH *routev3.VirtualHost
+		for _, vh := range rc.GetVirtualHosts() {
+			for _, d := range vh.GetDomains() {
+				if d == "*" {
+					wildcards++
+					starVH = vh
+				}
+			}
+		}
+		require.Equal(t, 1, wildcards, "exactly one * vhost (Envoy NACKs duplicates) in %s", rc.GetName())
+		// The 404 fallback is appended to the existing "*" vhost as the last route.
+		require.NotNil(t, starVH)
+		require.Len(t, starVH.GetRoutes(), 2)
+		assert.Equal(t, uint32(404), starVH.GetRoutes()[1].GetDirectResponse().GetStatus())
+	}
+}
+
 // TestBuildEdgeTCPListener_SingleBackend verifies the TCP listener: INBOUND on 0.0.0.0,
 // one filter chain with a tcp_proxy (single-cluster form), no TLS transport socket.
 func TestBuildEdgeTCPListener_SingleBackend(t *testing.T) {


### PR DESCRIPTION
The hostname-less catch-all `*` vhost (#341/#342) collided with the route config's existing `edge_not_found` `*` vhost → two `*` domains → Envoy NACKs the whole route table (`Only a single wildcard domain is permitted`) → the Gateway stopped routing entirely, **including api.palermo.dev (404)**. Fix: `appendEdgeCatchAll404` appends the 404 fallback to an existing `*` vhost (as its last route) instead of adding a second; only adds `edge_not_found` when no `*` exists. Exactly one `*` per route table. Regression test added (both builders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)