### PR TITLE
fix(edge): appendEdgeCatchAll404 must not mutate the input "*" vhost

### DIFF
--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -179,9 +179,16 @@ func appendEdgeCatchAll404(vhosts []*routev3.VirtualHost) []*routev3.VirtualHost
 		Action: &routev3.Route_DirectResponse{DirectResponse: &routev3.DirectResponseAction{Status: 404}},
 	}
 	all := append([]*routev3.VirtualHost{}, vhosts...)
-	for _, vh := range all {
+	for i, vh := range all {
 		if len(vh.GetDomains()) == 1 && vh.GetDomains()[0] == "*" {
-			vh.Routes = append(vh.Routes, notFound)
+			// Append the 404 to a COPY of the "*" vhost — never mutate the input vhost
+			// (it may be shared/reused across snapshot builds, which would accumulate
+			// duplicate 404 routes).
+			all[i] = &routev3.VirtualHost{
+				Name:    vh.GetName(),
+				Domains: vh.GetDomains(),
+				Routes:  append(append([]*routev3.Route{}, vh.GetRoutes()...), notFound),
+			}
 			return all
 		}
 	}


### PR DESCRIPTION
Follow-up to #343/#345. `appendEdgeCatchAll404` mutated the input `*` vhost's Routes slice; a reused vhost accumulates duplicate 404 routes (caught by the single-wildcard test passing the same `*` vhost to both builders → 3 routes). Append to a copy. 🤖 Generated with [Claude Code](https://claude.com/claude-code)