### PR TITLE
diag(edge): temporary projection logging for the conformance partial-projection bug

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -157,9 +157,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return strings.Compare(a.Name, b.Name)
 	})
 	vhosts := make([]cache.VirtualHost, 0, len(httpRoutes.Items))
+	var droppedUnattached, droppedNoRoutes int // DIAGNOSTIC (projection investigation)
 	for i := range httpRoutes.Items {
 		hr := &httpRoutes.Items[i]
 		if !attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways) {
+			droppedUnattached++
+			r.Log.DebugContext(ctx, "DIAG route dropped: not attached to our gateway",
+				"route", hr.Namespace+"/"+hr.Name, "parentRefs", len(hr.Spec.ParentRefs))
 			continue
 		}
 		vh := r.buildVirtualHost(hr, hostCerts, grants)
@@ -167,6 +171,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		// its listener, served via the cache's catch-all "*" vhost. Only an empty
 		// route set (no backend/redirect produced a route) makes it skippable.
 		if len(vh.Routes) == 0 {
+			droppedNoRoutes++
+			r.Log.DebugContext(ctx, "DIAG route dropped: built 0 routes (backend unresolved?)",
+				"route", hr.Namespace+"/"+hr.Name, "rules", len(hr.Spec.Rules))
 			continue
 		}
 		vhosts = append(vhosts, vh)
@@ -276,8 +283,28 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			perGWAssignedIPs = ips
 			entries := buildEdgeGatewayEntries(ourGateways, vhosts, allocations, gatewayHTTPRedirect)
 			r.Sink.SetEdgeGateways(entries)
+			// DIAGNOSTIC (projection investigation): per-Gateway alloc/vhost/entry
+			// detail, and which of our Gateways did NOT make it into the snapshot.
+			entryByKey := make(map[gatewayKey]int, len(entries))
+			for ei := range entries {
+				entryByKey[gatewayKey{Namespace: entries[ei].Namespace, Name: entries[ei].Name}] = len(entries[ei].VirtualHosts)
+			}
+			for gi := range ourGateways {
+				gk := gatewayKey{Namespace: ourGateways[gi].Namespace, Name: ourGateways[gi].Name}
+				vhCount, projected := entryByKey[gk]
+				if !projected {
+					r.Log.DebugContext(ctx, "DIAG gateway NOT projected into snapshot",
+						"gateway", gk.Namespace+"/"+gk.Name,
+						"listeners", len(ourGateways[gi].Spec.Listeners),
+						"allocs", len(allocations[gk]))
+				} else if vhCount == 0 {
+					r.Log.DebugContext(ctx, "DIAG gateway projected but EMPTY (0 vhosts)",
+						"gateway", gk.Namespace+"/"+gk.Name, "allocs", len(allocations[gk]))
+				}
+			}
 			r.Log.DebugContext(ctx, "projected per-Gateway entries",
-				"gateways", len(entries))
+				"gateways", len(entries), "ourGateways", len(ourGateways),
+				"totalVhosts", len(vhosts), "droppedUnattached", droppedUnattached, "droppedNoRoutes", droppedNoRoutes)
 			// In Phase 2 we still call SetVirtualHosts with the full vhosts so
 			// the Phase 1 fallback route table is up-to-date (no-op at snapshot
 			// time when per-Gateway mode is active, but keeps state consistent
@@ -403,6 +430,11 @@ func (r *Reconciler) resolveGateways(ctx context.Context, grants []gatewayv1beta
 			tlsResults[lk] = res
 		}
 	}
+	// DIAGNOSTIC (projection investigation): raw listed Gateways vs ours (our class).
+	// A gap between len(list.Items) and what exists in the cluster points at a partial
+	// informer cache; a small ourGateways under suite churn points there too.
+	r.Log.DebugContext(ctx, "DIAG resolved gateways",
+		"listed", len(list.Items), "ours", len(ourGateways))
 	return gateways, ourGateways, listenerKeys, hostCerts, certs, tlsResults, nil
 }
 


### PR DESCRIPTION
Temporary DEBUG `DIAG` logs to localize why conformance Gateway route tables are present-but-empty in the full suite (resolveGateways listed-vs-ours, dropped-route reasons, per-Gateway not-projected/empty with alloc counts). Reverted once root-caused. 🤖 Generated with [Claude Code](https://claude.com/claude-code)