### PR TITLE
fix(edge): assign per-Gateway vhosts by attachment, not by cert tag (the suite 404)

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -176,6 +176,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 				"route", hr.Namespace+"/"+hr.Name, "rules", len(hr.Spec.Rules))
 			continue
 		}
+		// Scope the vhost to the Gateways the route actually attaches to (Phase 2
+		// assigns by attachment, not by the vhost's cert tag).
+		vh.Gateways = attachedGatewayKeys(hr.Spec.ParentRefs, hr.Namespace, gateways)
 		vhosts = append(vhosts, vh)
 	}
 
@@ -587,6 +590,30 @@ func attachedToOurGateway(parentRefs []gatewayv1.ParentReference, routeNamespace
 		}
 	}
 	return false
+}
+
+// attachedGatewayKeys returns the "<ns>/<name>" keys of OUR Gateways a route's
+// parentRefs attach to. Used to scope a vhost to its actual Gateways' route tables
+// (Phase 2 assignment by attachment, not by cert).
+func attachedGatewayKeys(parentRefs []gatewayv1.ParentReference, routeNamespace string, gateways map[gatewayKey]struct{}) []string {
+	seen := map[string]struct{}{}
+	var keys []string
+	for _, p := range parentRefs {
+		if !parentRefIsGateway(p) {
+			continue
+		}
+		key := gatewayKey{Namespace: parentRefNamespace(p.Namespace, routeNamespace), Name: string(p.Name)}
+		if _, ok := gateways[key]; !ok {
+			continue
+		}
+		s := key.Namespace + "/" + key.Name
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		keys = append(keys, s)
+	}
+	return keys
 }
 
 // parentRefIsGateway reports whether a parentRef targets a Gateway (the default

--- a/agent/internal/edge/gatewayapi/service.go
+++ b/agent/internal/edge/gatewayapi/service.go
@@ -3,6 +3,7 @@ package gatewayapi
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 
 	"github.com/bpalermo/aether/agent/internal/edge/portalloc"
@@ -360,14 +361,6 @@ func buildEdgeGatewayEntries(
 		redirect := gatewayHTTPRedirect[gk]
 		lns := make([]cache.EdgeGatewayListenerEntry, 0, len(allocs))
 
-		// Determine which TLS certs are used by this Gateway's listeners.
-		tlsSecretSet := map[string]struct{}{}
-		for _, a := range allocs {
-			for _, s := range a.tlsSecretNames {
-				tlsSecretSet[s] = struct{}{}
-			}
-		}
-
 		for _, a := range allocs {
 			isHTTPRedirect := redirect && len(a.tlsSecretNames) == 0
 			lns = append(lns, cache.EdgeGatewayListenerEntry{
@@ -378,24 +371,17 @@ func buildEdgeGatewayEntries(
 			})
 		}
 
-		// Assign vhosts to this Gateway: those whose TLSSecret matches one of this
-		// Gateway's TLS certs (for HTTPS Gateways), or those with no TLSSecret (for
-		// HTTP Gateways, or HTTPS Gateways also serve plain-HTTP routes on their
-		// HTTP listener).
+		// Assign vhosts to this Gateway by ATTACHMENT: a vhost goes to this Gateway's
+		// route table iff the route attaches to it (vh.Gateways contains this Gateway).
+		// A vhost with no recorded Gateways (legacy/Phase 1 fallback) attaches to all.
+		// Assigning by the vhost's cert tag was wrong: a plain-HTTP route could pick up
+		// an unrelated Gateway's catch-all cert and then attach to ZERO Gateways
+		// (present-but-empty route table → 404).
+		gwKey := gw.Namespace + "/" + gw.Name
 		var gwVhosts []cache.VirtualHost
 		for _, vh := range allVhosts {
-			if vh.TLSSecret == "" {
-				// Plain HTTP vhost: attach to all Gateways (the listener serving HTTP
-				// for this Gateway will route it). In a multi-Gateway setup this means
-				// every Gateway's HTTP listener has access to all plain-HTTP vhosts.
-				// The per-Gateway route config + per-listener port demux ensures
-				// isolation at the network level.
+			if len(vh.Gateways) == 0 || slices.Contains(vh.Gateways, gwKey) {
 				gwVhosts = append(gwVhosts, vh)
-			} else {
-				// TLS vhost: attach only to the Gateway whose listener resolved this cert.
-				if _, ok := tlsSecretSet[vh.TLSSecret]; ok {
-					gwVhosts = append(gwVhosts, vh)
-				}
 			}
 		}
 

--- a/agent/internal/edge/gatewayapi/service_test.go
+++ b/agent/internal/edge/gatewayapi/service_test.go
@@ -147,10 +147,11 @@ func TestAllocateGatewayListenerPorts_MultiListenerSamePort(t *testing.T) {
 	assert.NotEqual(t, byPort[80].internalPort, byPort[443].internalPort, "distinct internal ports per external port")
 }
 
-// TestBuildEdgeGatewayEntries_HTTPVhostsAttachedToAllGateways verifies that
-// plain-HTTP vhosts (no TLSSecret) are assigned to ALL Gateways, while TLS vhosts
-// are only assigned to the Gateway whose listener cert matches.
-func TestBuildEdgeGatewayEntries_HTTPVhostsAttachedToAllGateways(t *testing.T) {
+// TestBuildEdgeGatewayEntries_AssignByAttachment verifies vhosts are assigned to a
+// Gateway's route table by ATTACHMENT (vh.Gateways = the route's parentRefs), not by
+// cert tag — a route lands on exactly the Gateways it attaches to; a vhost with no
+// recorded Gateways attaches to all (fallback).
+func TestBuildEdgeGatewayEntries_AssignByAttachment(t *testing.T) {
 	gws := []gatewayv1.Gateway{
 		{
 			ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "gw-http"},
@@ -170,8 +171,13 @@ func TestBuildEdgeGatewayEntries_HTTPVhostsAttachedToAllGateways(t *testing.T) {
 		},
 	}
 	allVhosts := []cache.VirtualHost{
-		{Hosts: []string{"plain.example.com"}, Routes: []cache.Route{{Prefix: "/", Service: "svc-1"}}},
-		{Hosts: []string{"secure.example.com"}, TLSSecret: "kubernetes/my-cert", Routes: []cache.Route{{Prefix: "/", Service: "svc-2"}}},
+		// Attached to the HTTP Gateway only.
+		{Hosts: []string{"plain.example.com"}, Gateways: []string{"ns-a/gw-http"}, Routes: []cache.Route{{Prefix: "/", Service: "svc-1"}}},
+		// Attached to the HTTPS Gateway only (and TLS-tagged — but assignment is by
+		// attachment, NOT the cert tag).
+		{Hosts: []string{"secure.example.com"}, Gateways: []string{"ns-b/gw-https"}, TLSSecret: "kubernetes/my-cert", Routes: []cache.Route{{Prefix: "/", Service: "svc-2"}}},
+		// No recorded Gateways → attaches to ALL (fallback).
+		{Hosts: []string{"shared.example.com"}, Routes: []cache.Route{{Prefix: "/", Service: "svc-3"}}},
 	}
 	allocs := map[gatewayKey][]gatewayListenerAllocation{
 		{Namespace: "ns-a", Name: "gw-http"}: {
@@ -189,25 +195,28 @@ func TestBuildEdgeGatewayEntries_HTTPVhostsAttachedToAllGateways(t *testing.T) {
 	for _, e := range entries {
 		byName[e.Namespace+"/"+e.Name] = e
 	}
-
-	httpGW := byName["ns-a/gw-http"]
-	httpsGW := byName["ns-b/gw-https"]
-
-	// HTTP Gateway gets the plain-HTTP vhost only.
-	require.Len(t, httpGW.VirtualHosts, 1)
-	assert.Equal(t, []string{"plain.example.com"}, httpGW.VirtualHosts[0].Hosts)
-
-	// HTTPS Gateway gets both: the TLS vhost (cert match) and the plain-HTTP vhost
-	// (HTTP vhosts attach to all Gateways for their HTTP listeners).
-	require.Len(t, httpsGW.VirtualHosts, 2)
-	vhostHosts := map[string]bool{}
-	for _, vh := range httpsGW.VirtualHosts {
-		for _, h := range vh.Hosts {
-			vhostHosts[h] = true
+	hostsOf := func(e cache.EdgeGatewayEntry) map[string]bool {
+		m := map[string]bool{}
+		for _, vh := range e.VirtualHosts {
+			for _, h := range vh.Hosts {
+				m[h] = true
+			}
 		}
+		return m
 	}
-	assert.True(t, vhostHosts["secure.example.com"])
-	assert.True(t, vhostHosts["plain.example.com"])
+
+	// HTTP Gateway: its own attached route + the unscoped (fallback) one; NOT the
+	// HTTPS-attached route (even though it is plain assignment-wise).
+	httpHosts := hostsOf(byName["ns-a/gw-http"])
+	assert.True(t, httpHosts["plain.example.com"], "attached route on its Gateway")
+	assert.True(t, httpHosts["shared.example.com"], "unscoped vhost attaches to all")
+	assert.False(t, httpHosts["secure.example.com"], "a route attached elsewhere must NOT land here")
+
+	// HTTPS Gateway: its own attached route + the unscoped one; NOT the HTTP route.
+	httpsHosts := hostsOf(byName["ns-b/gw-https"])
+	assert.True(t, httpsHosts["secure.example.com"])
+	assert.True(t, httpsHosts["shared.example.com"])
+	assert.False(t, httpsHosts["plain.example.com"])
 }
 
 // TestGatewayServiceShape verifies the shape of the per-Gateway LoadBalancer

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -54,6 +54,11 @@ type VirtualHost struct {
 	// virtual host's hosts (empty = no cert). Cert bytes are supplied separately
 	// via SetEdgeTLSSecrets.
 	TLSSecret string
+	// Gateways are the "<ns>/<name>" keys of the Gateways this route attaches to
+	// (its parentRefs). Under proposal 021 Phase 2 it scopes which per-Gateway route
+	// tables get this vhost — assignment is by ATTACHMENT, not by cert. Empty means
+	// unscoped (Phase 1 shared listener, or attach-to-all fallback).
+	Gateways []string
 }
 
 // Route is one path-match -> backend rule within a VirtualHost. Exactly one of


### PR DESCRIPTION
The DIAG run root-caused the GATEWAY-HTTP 404: conformance Gateways projected with valid allocs but **0 vhosts** (present-but-empty table). `buildEdgeGatewayEntries` assigned vhosts by cert tag — and `certForHosts` could TLS-tag a plain-HTTP route with an unrelated Gateway's catch-all cert (`hostCerts[""]` bleed), so it attached to **zero** Gateways. Fix: assign by **attachment** (`vh.Gateways` = the route's parentRefs ∩ our Gateways); cert no longer drives assignment. Tests updated. This is the load-bearing fix for the suite 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)