### PR TITLE
feat(edge): cleartext clusters for non-mesh HTTPRoute backends (k8s Service ingress)

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -157,13 +157,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return strings.Compare(a.Name, b.Name)
 	})
 	vhosts := make([]cache.VirtualHost, 0, len(httpRoutes.Items))
-	var droppedUnattached, droppedNoRoutes int // DIAGNOSTIC (projection investigation)
 	for i := range httpRoutes.Items {
 		hr := &httpRoutes.Items[i]
 		if !attachedToOurGateway(hr.Spec.ParentRefs, hr.Namespace, gateways) {
-			droppedUnattached++
-			r.Log.DebugContext(ctx, "DIAG route dropped: not attached to our gateway",
-				"route", hr.Namespace+"/"+hr.Name, "parentRefs", len(hr.Spec.ParentRefs))
 			continue
 		}
 		vh := r.buildVirtualHost(hr, hostCerts, grants)
@@ -171,9 +167,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		// its listener, served via the cache's catch-all "*" vhost. Only an empty
 		// route set (no backend/redirect produced a route) makes it skippable.
 		if len(vh.Routes) == 0 {
-			droppedNoRoutes++
-			r.Log.DebugContext(ctx, "DIAG route dropped: built 0 routes (backend unresolved?)",
-				"route", hr.Namespace+"/"+hr.Name, "rules", len(hr.Spec.Rules))
 			continue
 		}
 		// Scope the vhost to the Gateways the route actually attaches to (Phase 2
@@ -286,28 +279,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			perGWAssignedIPs = ips
 			entries := buildEdgeGatewayEntries(ourGateways, vhosts, allocations, gatewayHTTPRedirect)
 			r.Sink.SetEdgeGateways(entries)
-			// DIAGNOSTIC (projection investigation): per-Gateway alloc/vhost/entry
-			// detail, and which of our Gateways did NOT make it into the snapshot.
-			entryByKey := make(map[gatewayKey]int, len(entries))
-			for ei := range entries {
-				entryByKey[gatewayKey{Namespace: entries[ei].Namespace, Name: entries[ei].Name}] = len(entries[ei].VirtualHosts)
-			}
-			for gi := range ourGateways {
-				gk := gatewayKey{Namespace: ourGateways[gi].Namespace, Name: ourGateways[gi].Name}
-				vhCount, projected := entryByKey[gk]
-				if !projected {
-					r.Log.DebugContext(ctx, "DIAG gateway NOT projected into snapshot",
-						"gateway", gk.Namespace+"/"+gk.Name,
-						"listeners", len(ourGateways[gi].Spec.Listeners),
-						"allocs", len(allocations[gk]))
-				} else if vhCount == 0 {
-					r.Log.DebugContext(ctx, "DIAG gateway projected but EMPTY (0 vhosts)",
-						"gateway", gk.Namespace+"/"+gk.Name, "allocs", len(allocations[gk]))
-				}
-			}
 			r.Log.DebugContext(ctx, "projected per-Gateway entries",
 				"gateways", len(entries), "ourGateways", len(ourGateways),
-				"totalVhosts", len(vhosts), "droppedUnattached", droppedUnattached, "droppedNoRoutes", droppedNoRoutes)
+				"totalVhosts", len(vhosts))
 			// In Phase 2 we still call SetVirtualHosts with the full vhosts so
 			// the Phase 1 fallback route table is up-to-date (no-op at snapshot
 			// time when per-Gateway mode is active, but keeps state consistent
@@ -433,11 +407,6 @@ func (r *Reconciler) resolveGateways(ctx context.Context, grants []gatewayv1beta
 			tlsResults[lk] = res
 		}
 	}
-	// DIAGNOSTIC (projection investigation): raw listed Gateways vs ours (our class).
-	// A gap between len(list.Items) and what exists in the cluster points at a partial
-	// informer cache; a small ourGateways under suite churn points there too.
-	r.Log.DebugContext(ctx, "DIAG resolved gateways",
-		"listed", len(list.Items), "ours", len(ourGateways))
 	return gateways, ourGateways, listenerKeys, hostCerts, certs, tlsResults, nil
 }
 
@@ -536,25 +505,32 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 		if p := firstBackendPort(rule.BackendRefs, hr.Namespace, grants); p != 0 {
 			port = p
 		}
+		// Resolve the namespace of the first admissible backendRef for the cleartext
+		// cluster FQDN. Same-namespace refs default to the route's own namespace;
+		// cross-namespace refs use their explicit namespace (already validated by
+		// backendPermitted / firstBackendService above).
+		backendNS := firstBackendNamespace(rule.BackendRefs, hr.Namespace, grants)
 		mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
 		if len(rule.Matches) == 0 {
 			vh.Routes = append(vh.Routes, cache.Route{
-				Prefix:         "/",
-				Service:        backend,
-				Port:           port,
-				HeaderMutation: mutation,
-				Redirect:       redirect,
-				URLRewrite:     urlRewrite,
+				Prefix:           "/",
+				Service:          backend,
+				Port:             port,
+				BackendNamespace: backendNS,
+				HeaderMutation:   mutation,
+				Redirect:         redirect,
+				URLRewrite:       urlRewrite,
 			})
 			continue
 		}
 		for _, m := range rule.Matches {
 			route := cache.Route{
-				Service:        backend,
-				Port:           port,
-				HeaderMutation: mutation,
-				Redirect:       redirect,
-				URLRewrite:     urlRewrite,
+				Service:          backend,
+				Port:             port,
+				BackendNamespace: backendNS,
+				HeaderMutation:   mutation,
+				Redirect:         redirect,
+				URLRewrite:       urlRewrite,
 			}
 			if m.Path != nil && m.Path.Value != nil {
 				switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
@@ -761,6 +737,30 @@ func firstBackendPort(refs []gatewayv1.HTTPBackendRef, routeNamespace string, gr
 		}
 	}
 	return 0
+}
+
+// firstBackendNamespace returns the resolved namespace of the first admissible
+// (same-namespace or granted cross-namespace) backendRef. Same-namespace refs
+// default to the route's own namespace when backendRef.Namespace is unset.
+// Matches the selection logic of firstBackendService so they return data for
+// the same ref.
+func firstBackendNamespace(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) string {
+	for _, b := range refs {
+		if b.Group != nil && string(*b.Group) != "" {
+			continue
+		}
+		if b.Kind != nil && string(*b.Kind) != "Service" {
+			continue
+		}
+		if !backendPermitted(b.Namespace, routeNamespace, "HTTPRoute", string(b.Name), grants) {
+			continue
+		}
+		if b.Namespace != nil && string(*b.Namespace) != "" {
+			return string(*b.Namespace)
+		}
+		return routeNamespace
+	}
+	return routeNamespace
 }
 
 // derefBackendNamespace returns the backendRef namespace ("" when unset).

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -67,14 +67,18 @@ type VirtualHost struct {
 // this rule (nil = no header mutations).
 // When Redirect is non-nil the route returns a redirect response (no backend).
 // When URLRewrite is non-nil the route rewrites the request URL before forwarding.
+// BackendNamespace is the namespace of the backendRef (defaults to the route's own
+// namespace when not set by the reconciler). Used to build the k8s-Service FQDN
+// for non-mesh (cleartext) backends: <service>.<BackendNamespace>.svc.cluster.local.
 type Route struct {
-	Prefix         string
-	Exact          string
-	Service        string
-	Port           uint32
-	HeaderMutation *proxy.GammaHeaderMutation
-	Redirect       *proxy.GammaRedirect
-	URLRewrite     *proxy.GammaURLRewrite
+	Prefix           string
+	Exact            string
+	Service          string
+	Port             uint32
+	BackendNamespace string
+	HeaderMutation   *proxy.GammaHeaderMutation
+	Redirect         *proxy.GammaRedirect
+	URLRewrite       *proxy.GammaURLRewrite
 }
 
 // EdgeTLSCert is raw certificate material for an edge downstream TLS secret,
@@ -204,7 +208,7 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 			}
 			cluster := ""
 			if r.Service != "" {
-				cluster = c.edgeClusterNameLocked(r.Service, r.Port)
+				cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
 			}
 			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
 		}
@@ -290,24 +294,64 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 	return c.buildEdgeVhostsLocked(vhosts)
 }
 
-// edgeClusterNameLocked resolves a (service, port) backend to the data-plane
-// cluster it targets. Port 0 -> the default cluster (ServiceClusterName). A
-// non-zero port -> its per-port cluster if one exists; otherwise, if the port is
-// the service's default port (no dedicated per-port cluster), the default
-// cluster serves it. Caller must hold clusterMu.
-func (c *SnapshotCache) edgeClusterNameLocked(service string, port uint32) string {
-	fqdn := proxy.ServiceClusterName(service, c.meshDomain)
-	if port == 0 {
-		return fqdn
-	}
-	portName := proxy.PortClusterName(service, c.meshDomain, port)
-	if _, ok := c.clusters[portName]; ok {
+// edgeClusterNameLocked resolves a (service, backendNamespace, port) backend to
+// the data-plane cluster it targets.
+//
+// Dual-mode decision: if the service IS in the registry (c.clusters), this is a
+// mesh-registered backend — use the existing mTLS mesh cluster path (unchanged).
+// If NOT in the registry, the backend is a plain k8s Service: return the cleartext
+// STRICT_DNS cluster name (EdgeK8sClusterName) so the edge dials the k8s Service
+// FQDN over cleartext instead of attempting a mesh mTLS connection to :15008.
+//
+// Mesh path: Port 0 -> the default cluster (ServiceClusterName). A non-zero port ->
+// its per-port cluster if one exists; otherwise, if the port is the service's
+// default port (no dedicated per-port cluster), the default cluster serves it.
+//
+// Caller must hold clusterMu.
+func (c *SnapshotCache) edgeClusterNameLocked(service, backendNamespace string, port uint32) string {
+	// Check whether the service is mesh-registered (in the registry cluster map).
+	// The registry keys services by bare name (and by per-port name), so check both
+	// the bare name and the per-port name.
+	meshFQDN := proxy.ServiceClusterName(service, c.meshDomain)
+	if _, ok := c.clusters[service]; ok {
+		// Mesh path: service is in the registry.
+		if port == 0 {
+			return meshFQDN
+		}
+		portName := proxy.PortClusterName(service, c.meshDomain, port)
+		if _, ok := c.clusters[portName]; ok {
+			return portName
+		}
+		if entry, ok := c.clusters[service]; ok && entry.sni == strconv.Itoa(int(port)) {
+			return meshFQDN
+		}
 		return portName
 	}
-	if entry, ok := c.clusters[service]; ok && entry.sni == strconv.Itoa(int(port)) {
-		return fqdn
+	// Also check by mesh FQDN and per-port mesh name (some callers may have added
+	// clusters under those keys directly).
+	if _, ok := c.clusters[meshFQDN]; ok {
+		if port == 0 {
+			return meshFQDN
+		}
+		portName := proxy.PortClusterName(service, c.meshDomain, port)
+		if _, ok := c.clusters[portName]; ok {
+			return portName
+		}
+		return portName
 	}
-	return portName
+	if port != 0 {
+		portName := proxy.PortClusterName(service, c.meshDomain, port)
+		if _, ok := c.clusters[portName]; ok {
+			return portName
+		}
+	}
+	// Non-mesh path: service is not in the registry. Route to the k8s Service FQDN
+	// over cleartext (STRICT_DNS, no transport socket). Port defaults to 80 if unset.
+	p := port
+	if p == 0 {
+		p = 80
+	}
+	return proxy.EdgeK8sClusterName(backendNamespace, service, p)
 }
 
 // SetEdgeTCPRoutes replaces the edge's TCP listener routes (one per Gateway TCP
@@ -436,6 +480,88 @@ func (c *SnapshotCache) edgeTCPListeners() []types.Resource {
 	return out
 }
 
+// edgeK8sBackendClusters returns cleartext STRICT_DNS clusters for every
+// non-mesh backend referenced by the edge's HTTP routes (Phase 1 virtual hosts
+// and Phase 2 per-Gateway virtual hosts). A backend is non-mesh when its service
+// name is NOT present in the registry cluster map (c.clusters). One cluster is
+// emitted per unique (BackendNamespace, service, port) triple, using the k8s
+// Service FQDN <service>.<namespace>.svc.cluster.local.
+//
+// These clusters have NO transport socket (cleartext). They are appended to the
+// CDS snapshot alongside the mTLS mesh clusters so Envoy can reach plain k8s
+// Service backends that are not registered in the mesh.
+//
+// Caller need not hold any lock — all maps are read under their own locks.
+func (c *SnapshotCache) edgeK8sBackendClusters() []types.Resource {
+	c.edgeMu.RLock()
+	vhosts := slices.Clone(c.virtualHosts)
+	gws := slices.Clone(c.edgeGateways)
+	c.edgeMu.RUnlock()
+
+	// key: "namespace/service:port"
+	type k8sBackend struct {
+		namespace string
+		service   string
+		port      uint32
+	}
+	seen := make(map[k8sBackend]struct{})
+	var backends []k8sBackend
+
+	collectRoutes := func(routes []Route) {
+		for _, r := range routes {
+			if r.Service == "" {
+				continue
+			}
+			p := r.Port
+			if p == 0 {
+				p = 80
+			}
+			bk := k8sBackend{namespace: r.BackendNamespace, service: r.Service, port: p}
+			if _, dup := seen[bk]; dup {
+				continue
+			}
+			seen[bk] = struct{}{}
+			backends = append(backends, bk)
+		}
+	}
+
+	for _, v := range vhosts {
+		collectRoutes(v.Routes)
+	}
+	for _, gw := range gws {
+		for _, v := range gw.VirtualHosts {
+			collectRoutes(v.Routes)
+		}
+	}
+	if len(backends) == 0 {
+		return nil
+	}
+
+	c.clusterMu.RLock()
+	defer c.clusterMu.RUnlock()
+
+	var out []types.Resource
+	for _, bk := range backends {
+		// Only emit a cleartext cluster if the service is NOT a registry cluster.
+		// If it IS in the registry, the mesh mTLS cluster covers it.
+		if _, ok := c.clusters[bk.service]; ok {
+			continue
+		}
+		meshFQDN := proxy.ServiceClusterName(bk.service, c.meshDomain)
+		if _, ok := c.clusters[meshFQDN]; ok {
+			continue
+		}
+		portName := proxy.PortClusterName(bk.service, c.meshDomain, bk.port)
+		if _, ok := c.clusters[portName]; ok {
+			continue
+		}
+		name := proxy.EdgeK8sClusterName(bk.namespace, bk.service, bk.port)
+		fqdn := bk.service + "." + bk.namespace + ".svc.cluster.local"
+		out = append(out, proxy.BuildEdgeK8sCluster(name, fqdn, bk.port))
+	}
+	return out
+}
+
 // equalRoutes reports whether two Route slices are content-equal. Route carries
 // pointer fields (*GammaHeaderMutation, *GammaRedirect, *GammaURLRewrite), so we
 // cannot rely on slices.Equal (pointer identity) — we need a deep comparison.
@@ -445,7 +571,7 @@ func equalRoutes(a, b []Route) bool {
 	}
 	for i := range a {
 		ra, rb := a[i], b[i]
-		if ra.Prefix != rb.Prefix || ra.Exact != rb.Exact || ra.Service != rb.Service || ra.Port != rb.Port {
+		if ra.Prefix != rb.Prefix || ra.Exact != rb.Exact || ra.Service != rb.Service || ra.Port != rb.Port || ra.BackendNamespace != rb.BackendNamespace {
 			return false
 		}
 		if !equalHeaderMutation(ra.HeaderMutation, rb.HeaderMutation) {

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -126,8 +127,12 @@ func TestSetVirtualHostsDependencySet(t *testing.T) {
 func TestVirtualHostVhosts(t *testing.T) {
 	c := newTestCache("edge-1")
 
-	// A per-port cluster must exist for the explicit-port backend to resolve to it.
+	// Register services as mesh-registered so edgeClusterNameLocked uses the mesh path.
+	// A per-port cluster must also exist for the explicit-port backend to resolve to it.
 	c.clusterMu.Lock()
+	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
+	c.clusters["svc-3"] = clusterEntry{service: "svc-3"}
+	c.clusters["svc-2"] = clusterEntry{service: "svc-2"}
 	c.clusters["svc-2.aether.internal:9090"] = clusterEntry{service: "svc-2", sni: "9090"}
 	c.clusterMu.Unlock()
 
@@ -191,6 +196,14 @@ func TestVirtualHostVhostsHostlessMerge(t *testing.T) {
 // different services, preserving CR order (first match wins) and prefix vs exact.
 func TestVirtualHostPathRoutes(t *testing.T) {
 	c := newTestCache("edge-1")
+
+	// Register services as mesh so edgeClusterNameLocked resolves to mesh names.
+	c.clusterMu.Lock()
+	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
+	c.clusters["svc-2"] = clusterEntry{service: "svc-2"}
+	c.clusters["svc-3"] = clusterEntry{service: "svc-3"}
+	c.clusterMu.Unlock()
+
 	c.SetVirtualHosts([]VirtualHost{
 		{Hosts: []string{"api.example.com"}, Routes: []Route{
 			{Prefix: "/users", Service: "svc-1"},
@@ -217,6 +230,13 @@ func TestVirtualHostPathRoutes(t *testing.T) {
 // backstop to the controller's duplicate-FQDN webhook, keep-first by input order.
 func TestVirtualHostVhostsDedupDomains(t *testing.T) {
 	c := newTestCache("edge-1")
+
+	// Register services as mesh so edgeClusterNameLocked resolves to mesh names.
+	c.clusterMu.Lock()
+	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
+	c.clusters["svc-2"] = clusterEntry{service: "svc-2"}
+	c.clusterMu.Unlock()
+
 	c.SetVirtualHosts([]VirtualHost{
 		{Hosts: []string{"a.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-1"}}},
 		{Hosts: []string{"a.example.com", "b.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-2"}}},
@@ -488,4 +508,90 @@ func TestPerGatewayCertWired(t *testing.T) {
 	assert.Equal(t, "edge_gw_ns-tls_secure-gw_18110", l.GetName())
 	// TLS transport socket must be wired (not nil).
 	require.NotNil(t, l.GetFilterChains()[0].GetTransportSocket(), "per-Gateway HTTPS listener must terminate TLS")
+}
+
+// TestEdgeClusterNameLocked_MeshVsNonMesh verifies that edgeClusterNameLocked
+// returns the mesh cluster name when the service IS in the registry, and the
+// edge_k8s_… cleartext name when it is NOT.
+func TestEdgeClusterNameLocked_MeshVsNonMesh(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+
+	// Register "mesh-svc" as a registry service.
+	c.clusterMu.Lock()
+	c.clusters["mesh-svc"] = clusterEntry{service: "mesh-svc"}
+	c.clusterMu.Unlock()
+
+	c.clusterMu.RLock()
+	defer c.clusterMu.RUnlock()
+
+	// Mesh path: service in registry → mesh FQDN.
+	name := c.edgeClusterNameLocked("mesh-svc", "default", 0)
+	assert.Equal(t, "mesh-svc.aether.internal", name, "registry service resolves to mesh cluster")
+
+	// Non-mesh path: service NOT in registry → edge_k8s_… cleartext name.
+	name2 := c.edgeClusterNameLocked("plain-svc", "conformance-ns", 8080)
+	assert.Equal(t, "edge_k8s_conformance-ns_plain-svc_8080", name2, "non-registry service resolves to cleartext k8s cluster")
+
+	// Non-mesh with port 0 defaults to :80.
+	name3 := c.edgeClusterNameLocked("plain-svc", "conformance-ns", 0)
+	assert.Equal(t, "edge_k8s_conformance-ns_plain-svc_80", name3, "non-registry service with port 0 defaults to :80")
+}
+
+// TestEdgeK8sBackendClusters_NonMeshOnly verifies that edgeK8sBackendClusters
+// emits one STRICT_DNS cleartext cluster per unique (namespace, service, port)
+// that is NOT in the registry, and skips any service that IS registry-registered.
+func TestEdgeK8sBackendClusters_NonMeshOnly(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+
+	// Register "mesh-svc" as a registry service; "plain-svc" is NOT registered.
+	c.clusterMu.Lock()
+	c.clusters["mesh-svc"] = clusterEntry{service: "mesh-svc"}
+	c.clusterMu.Unlock()
+
+	c.SetVirtualHosts([]VirtualHost{
+		{
+			Hosts: []string{"api.example.com"},
+			Routes: []Route{
+				{Prefix: "/mesh", Service: "mesh-svc", Port: 8080, BackendNamespace: "default"},
+				{Prefix: "/plain", Service: "plain-svc", Port: 9000, BackendNamespace: "conformance-ns"},
+			},
+		},
+		{
+			Hosts: []string{"other.example.com"},
+			Routes: []Route{
+				// Same (namespace, service, port) as above — must be deduped to one cluster.
+				{Prefix: "/", Service: "plain-svc", Port: 9000, BackendNamespace: "conformance-ns"},
+			},
+		},
+	})
+
+	clusters := c.edgeK8sBackendClusters()
+	// Only one cleartext cluster: plain-svc/9000 (mesh-svc is in registry → no cleartext cluster).
+	require.Len(t, clusters, 1, "exactly one non-mesh backend cluster (mesh-svc skipped; duplicate plain-svc/9000 deduped)")
+
+	cl, ok := clusters[0].(*clusterv3.Cluster)
+	require.True(t, ok)
+	assert.Equal(t, "edge_k8s_conformance-ns_plain-svc_9000", cl.GetName())
+	assert.Equal(t, clusterv3.Cluster_STRICT_DNS, cl.GetType())
+	assert.Nil(t, cl.GetTransportSocket(), "cleartext cluster must have NO transport socket")
+	ep := cl.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "plain-svc.conformance-ns.svc.cluster.local", ep.GetAddress())
+	assert.Equal(t, uint32(9000), ep.GetPortValue())
+}
+
+// TestBuildEdgeK8sCluster verifies the cluster builder produces a STRICT_DNS
+// cleartext cluster with the right FQDN and no transport socket.
+func TestBuildEdgeK8sCluster_Shape(t *testing.T) {
+	cl := proxy.BuildEdgeK8sCluster("edge_k8s_ns_svc_8080", "svc.ns.svc.cluster.local", 8080)
+
+	assert.Equal(t, "edge_k8s_ns_svc_8080", cl.GetName())
+	assert.Equal(t, clusterv3.Cluster_STRICT_DNS, cl.GetType())
+	assert.Nil(t, cl.GetTransportSocket(), "k8s cleartext cluster must have NO transport socket")
+	la := cl.GetLoadAssignment()
+	require.NotNil(t, la)
+	ep := la.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "svc.ns.svc.cluster.local", ep.GetAddress())
+	assert.Equal(t, uint32(8080), ep.GetPortValue())
 }

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -69,6 +69,10 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 	// the edge SPIRE identity and fetch SDS from spire_agent directly.
 	if c.edge {
 		clusters = append(clusters, c.edgeTCPClusters()...)
+		// Cleartext k8s-Service clusters: one per unique non-mesh HTTPRoute backend
+		// (BackendNamespace, service, port). STRICT_DNS, no transport socket — the
+		// backend is a plain k8s Service, not a mesh-registered endpoint.
+		clusters = append(clusters, c.edgeK8sBackendClusters()...)
 	}
 	// UDP floor clusters (proposal 018, Phase 3b): one per service with UDPRoute
 	// backends. These are plain EDS clusters with no transport socket — UDP datagrams

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -2,12 +2,16 @@ package proxy
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -493,5 +497,57 @@ func BuildEdgeRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteCo
 	return &routev3.RouteConfiguration{
 		Name:         EdgeHTTPRouteName,
 		VirtualHosts: appendEdgeCatchAll404(vhosts),
+	}
+}
+
+// EdgeK8sClusterName returns the data-plane name for a cleartext k8s-Service
+// cluster that reaches a non-mesh (non-registry) HTTPRoute backend. The name is
+// unique per (namespace, service, port) and DNS-safe.
+// Scheme: edge_k8s_<namespace>_<service>_<port>
+func EdgeK8sClusterName(namespace, service string, port uint32) string {
+	return fmt.Sprintf("edge_k8s_%s_%s_%d", namespace, service, port)
+}
+
+// BuildEdgeK8sCluster builds a STRICT_DNS cleartext cluster that reaches a
+// non-mesh HTTPRoute backend via the k8s Service FQDN. It has NO transport socket
+// (cleartext — the backend is a plain k8s Service, not a mesh endpoint). HTTP/1.1
+// upstream (no h2 options), STRICT_DNS so CoreDNS resolves the FQDN on demand.
+// fqdn must be the full cluster-local FQDN (e.g. "svc.ns.svc.cluster.local").
+func BuildEdgeK8sCluster(name, fqdn string, port uint32) *clusterv3.Cluster {
+	return &clusterv3.Cluster{
+		Name:                          name,
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		ConnectTimeout:                durationpb.New(2 * time.Second),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_STRICT_DNS,
+		},
+		LoadAssignment: &endpointv3.ClusterLoadAssignment{
+			ClusterName: name,
+			Endpoints: []*endpointv3.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*endpointv3.LbEndpoint{
+						{
+							HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+								Endpoint: &endpointv3.Endpoint{
+									Address: &corev3.Address{
+										Address: &corev3.Address_SocketAddress{
+											SocketAddress: &corev3.SocketAddress{
+												Protocol: corev3.SocketAddress_TCP,
+												Address:  fqdn,
+												PortSpecifier: &corev3.SocketAddress_PortValue{
+													PortValue: port,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		// No TransportSocket: cleartext connection to the k8s Service (non-mesh backend).
+		// No TypedExtensionProtocolOptions: plain HTTP/1.1 upstream.
 	}
 }

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"testing"
 
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -153,6 +154,39 @@ func TestBuildEdgeRouteConfiguration(t *testing.T) {
 func TestEdgeL4ListenerNames(t *testing.T) {
 	assert.Equal(t, "edge_tcp_5432", EdgeTCPListenerName(5432))
 	assert.Equal(t, "edge_tls_8443", EdgeTLSListenerName(8443))
+}
+
+// TestEdgeK8sClusterName verifies the naming scheme is stable and unique across
+// (namespace, service, port) tuples.
+func TestEdgeK8sClusterName(t *testing.T) {
+	assert.Equal(t, "edge_k8s_default_my-svc_8080", EdgeK8sClusterName("default", "my-svc", 8080))
+	assert.Equal(t, "edge_k8s_conformance-ns_infra-backend_80", EdgeK8sClusterName("conformance-ns", "infra-backend", 80))
+	// Different port → different name.
+	assert.NotEqual(t, EdgeK8sClusterName("ns", "svc", 80), EdgeK8sClusterName("ns", "svc", 8080))
+	// Different namespace → different name.
+	assert.NotEqual(t, EdgeK8sClusterName("ns-a", "svc", 80), EdgeK8sClusterName("ns-b", "svc", 80))
+}
+
+// TestBuildEdgeK8sCluster verifies STRICT_DNS discovery, inline load assignment,
+// and absence of a transport socket (cleartext).
+func TestBuildEdgeK8sCluster(t *testing.T) {
+	cl := BuildEdgeK8sCluster("edge_k8s_default_my-svc_8080", "my-svc.default.svc.cluster.local", 8080)
+
+	require.NotNil(t, cl)
+	assert.Equal(t, "edge_k8s_default_my-svc_8080", cl.GetName())
+
+	// Must be STRICT_DNS (not EDS or STATIC).
+	assert.Equal(t, clusterv3.Cluster_STRICT_DNS, cl.GetType())
+
+	// No transport socket → cleartext upstream.
+	assert.Nil(t, cl.GetTransportSocket(), "k8s cleartext cluster must have NO transport socket")
+
+	// Load assignment must be inline with the correct FQDN and port.
+	la := cl.GetLoadAssignment()
+	require.NotNil(t, la)
+	ep := la.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "my-svc.default.svc.cluster.local", ep.GetAddress())
+	assert.Equal(t, uint32(8080), ep.GetPortValue())
 }
 
 // TestEdgeGatewayListenerNaming verifies per-Gateway listener and route names are


### PR DESCRIPTION
## Summary

- **Dual-mode backend resolution:** registry lookup decides transport. A backendRef whose service IS in `c.clusters` (mesh-registered) keeps the existing mTLS path to `:15008`. A backendRef NOT in the registry gets a new STRICT_DNS cleartext cluster (`edge_k8s_<ns>_<svc>_<port>`) that dials `<svc>.<ns>.svc.cluster.local:<port>` over plain HTTP — unblocking the GATEWAY-HTTP conformance 503s where backends are plain non-mesh k8s pods.
- **New `BuildEdgeK8sCluster`** in `proxy/edge.go`: STRICT_DNS, inline load assignment to k8s Service FQDN, NO transport socket (cleartext). `EdgeK8sClusterName(ns, svc, port)` produces the unique `edge_k8s_<ns>_<svc>_<port>` name.
- **`Route.BackendNamespace`** added to `cache.Route`; the reconciler sets it via a new `firstBackendNamespace` helper that mirrors the selection logic of `firstBackendService`/`firstBackendPort` and respects ReferenceGrant for cross-namespace refs.
- **`edgeClusterNameLocked`** is now dual-mode: if `c.clusters[service]` (or its mesh FQDN / per-port name) exists, take the mesh path; otherwise return `EdgeK8sClusterName(backendNamespace, service, port)`.
- **`edgeK8sBackendClusters`** iterates all edge vhosts (Phase 1 and Phase 2 per-Gateway), deduplicates by `(BackendNamespace, service, port)`, skips registry services, and emits one `BuildEdgeK8sCluster` per unique non-mesh backend. Appended in `snapshot.go` alongside `edgeTCPClusters` when in edge mode.
- **DIAG logging reverted** in `reconciler.go`: removed the `DIAG`-prefixed `DebugContext` lines added in `27db932` (`resolveGateways`, route-drop loop, per-Gateway Phase 2 block) and the now-unused `droppedUnattached`/`droppedNoRoutes` counters. Real logic (attachment assignment, `attachedGatewayKeys`, `vh.Gateways`) untouched.

## Follow-up

`ResolvedRefs=False/BackendNotFound` status for non-existent k8s Service backends is not set in this PR — it would require a `Service` GET/informer check, and STRICT_DNS resolves at connection time without one. The data plane works today; the status condition is a conformance detail for a follow-up.

## Test plan

- `TestEdgeClusterNameLocked_MeshVsNonMesh`: registry service → mesh FQDN; non-registry → `edge_k8s_…`; port 0 defaults to `:80`
- `TestEdgeK8sBackendClusters_NonMeshOnly`: mesh backend skipped; non-mesh emitted once per unique `(ns,svc,port)`; STRICT_DNS + no transport socket + correct FQDN
- `TestBuildEdgeK8sCluster` (proxy + cache): STRICT_DNS, inline load assignment, nil transport socket
- `TestEdgeK8sClusterName`: naming scheme stable + unique across `(ns, svc, port)`
- All 59 existing Go test targets pass (`bazel test //... --test_arg=-test.short`)
- e2e idea: deploy a plain (non-mesh) k8s Deployment+Service in the conformance namespace; add an HTTPRoute backendRef pointing at it → expect `200`; a mesh-registered service on the same Gateway still gets mTLS; `api.palermo.dev` on the production edge unaffected (registry-registered → mesh path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S