### PR TITLE
feat(edge): Gateway API route-matching precedence (path specificity + tie-break)

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -148,9 +148,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err := r.List(ctx, httpRoutes); err != nil {
 		return reconcile.Result{}, err
 	}
-	// Deterministic order so keep-first host-dedup in the cache is stable. Sort by
-	// namespace+name now that routes may span namespaces.
+	// Deterministic order so (a) keep-first host-dedup in the cache is stable and
+	// (b) the Gateway API tie-break for routes of equal path specificity is correct:
+	// oldest creationTimestamp first, then namespace, then name. The cache's stable
+	// path-specificity sort preserves this order for equal-specificity routes.
 	slices.SortFunc(httpRoutes.Items, func(a, b gatewayv1.HTTPRoute) int {
+		ta := a.CreationTimestamp.Time
+		tb := b.CreationTimestamp.Time
+		if ta.Before(tb) {
+			return -1
+		}
+		if tb.Before(ta) {
+			return 1
+		}
 		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
 			return c
 		}

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -2,6 +2,8 @@ package gatewayapi
 
 import (
 	"context"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
@@ -432,6 +434,49 @@ func TestBuildVirtualHost_NoMutationWhenNoFilters(t *testing.T) {
 	vh := r.buildVirtualHost(hr, nil, nil)
 	require.Len(t, vh.Routes, 1)
 	assert.Nil(t, vh.Routes[0].HeaderMutation)
+}
+
+// TestHTTPRouteGatewaySortOrder verifies that the HTTPRoute sort key used in
+// Reconcile produces the Gateway API tie-break order: creationTimestamp (oldest
+// first) is the primary key, namespace is secondary, name is tertiary. This
+// ensures the path-specificity stable sort in the cache preserves the correct
+// precedence for routes with equal specificity (older route wins).
+func TestHTTPRouteGatewaySortOrder(t *testing.T) {
+	t0 := metav1.Unix(1000, 0)
+	t1 := metav1.Unix(2000, 0)
+
+	routes := []gatewayv1.HTTPRoute{
+		{ObjectMeta: metav1.ObjectMeta{Name: "z-route", Namespace: "ns-a", CreationTimestamp: t1}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "a-route", Namespace: "ns-b", CreationTimestamp: t0}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "b-route", Namespace: "ns-a", CreationTimestamp: t1}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "a-route", Namespace: "ns-a", CreationTimestamp: t0}},
+	}
+	// Apply the same sort the Reconcile function uses.
+	slices.SortFunc(routes, func(a, b gatewayv1.HTTPRoute) int {
+		ta := a.CreationTimestamp.Time
+		tb := b.CreationTimestamp.Time
+		if ta.Before(tb) {
+			return -1
+		}
+		if tb.Before(ta) {
+			return 1
+		}
+		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	// Oldest (t0) first; within t0, ns-a before ns-b; within same ts+ns, name-order.
+	require.Len(t, routes, 4)
+	assert.Equal(t, "a-route", routes[0].Name)
+	assert.Equal(t, "ns-a", routes[0].Namespace, "t0/ns-a/a-route comes first")
+	assert.Equal(t, "a-route", routes[1].Name)
+	assert.Equal(t, "ns-b", routes[1].Namespace, "t0/ns-b/a-route comes second")
+	assert.Equal(t, "b-route", routes[2].Name)
+	assert.Equal(t, "ns-a", routes[2].Namespace, "t1/ns-a/b-route comes third")
+	assert.Equal(t, "z-route", routes[3].Name)
+	assert.Equal(t, "ns-a", routes[3].Namespace, "t1/ns-a/z-route comes last")
 }
 
 // fakeSink is a minimal RouteSink that records SetEdgeHTTPRedirect calls.

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -11,6 +11,41 @@ import (
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 )
 
+// routeSpecificity returns the sort key for a Route per Gateway API precedence:
+// Exact matches are most specific (2), PathPrefix matches rank by descending prefix
+// length (so a longer prefix wins over a shorter one). No-path routes default to
+// prefix "/" (length 1). A higher return value means higher precedence.
+func routeSpecificity(r Route) int {
+	if r.Exact != "" {
+		// Exact matches outrank any prefix; use a large constant above the max path len.
+		return 1<<30 + 1
+	}
+	p := r.Prefix
+	if p == "" {
+		p = "/"
+	}
+	return len(p)
+}
+
+// sortRoutesBySpecificity stable-sorts a Route slice in-place by Gateway API path
+// precedence (most-specific first): Exact > longer PathPrefix > shorter PathPrefix.
+// It is stable so the caller's tie-break order (creationTimestamp / namespace / name
+// / rule index, established by the reconciler's sort of HTTPRoute objects) is
+// preserved for routes with equal specificity.
+func sortRoutesBySpecificity(routes []Route) {
+	slices.SortStableFunc(routes, func(a, b Route) int {
+		sa, sb := routeSpecificity(a), routeSpecificity(b)
+		if sa != sb {
+			// Descending: higher specificity comes first.
+			if sa > sb {
+				return -1
+			}
+			return 1
+		}
+		return 0
+	})
+}
+
 // EdgeGatewayListenerEntry describes one listener port within a per-Gateway entry.
 // ExternalPort is the Gateway listener's declared port (e.g. 80 or 443).
 // InternalPort is the container port allocated by the port allocator that the
@@ -194,25 +229,28 @@ func (c *SnapshotCache) gatewayVhostsLocked(vhosts []VirtualHost) []*routev3.Vir
 // listener (Gateway API semantics — a hostname-less HTTPRoute is not host-scoped);
 // such routes are merged into a single catch-all "*" vhost. There can be only one
 // "*" per route table (duplicate domains NACK), so all hostname-less routes share
-// it, in input order (the reconciler sorts by namespace/name for determinism).
+// it.
+//
+// Gateway API route-matching precedence (applied per output vhost):
+// Exact > PathPrefix by descending prefix length. Within ties the input order is
+// preserved — the reconciler sorts HTTPRoutes by creationTimestamp/namespace/name
+// before building vhosts, so that tie-break carries through the stable sort here.
+//
 // Caller must hold clusterMu.
 func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.VirtualHost {
 	used := make(map[string]struct{})
 	out := make([]*routev3.VirtualHost, 0, len(vhosts))
-	var catchAll []*routev3.Route
+	var catchAllRoutes []Route
 	for _, v := range vhosts {
-		routes := make([]*routev3.Route, 0, len(v.Routes))
+		// Collect admissible routes (has a service or redirect).
+		admitted := make([]Route, 0, len(v.Routes))
 		for _, r := range v.Routes {
 			if r.Redirect == nil && r.Service == "" {
 				continue
 			}
-			cluster := ""
-			if r.Service != "" {
-				cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
-			}
-			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
+			admitted = append(admitted, r)
 		}
-		if len(routes) == 0 {
+		if len(admitted) == 0 {
 			continue
 		}
 		domains := make([]string, 0, len(v.Hosts))
@@ -228,14 +266,36 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 		}
 		if len(domains) == 0 {
 			// Hostname-less route: matches all hosts on its listener. Accumulate into
-			// the single "*" catch-all vhost emitted after the loop.
-			catchAll = append(catchAll, routes...)
+			// the single "*" catch-all vhost emitted after the loop. Preserve input
+			// order here; the catchAllRoutes slice is sorted as a whole below.
+			catchAllRoutes = append(catchAllRoutes, admitted...)
 			continue
+		}
+		// Apply Gateway API path-specificity sort (stable — preserves tie-break order).
+		sortRoutesBySpecificity(admitted)
+		routes := make([]*routev3.Route, 0, len(admitted))
+		for _, r := range admitted {
+			cluster := ""
+			if r.Service != "" {
+				cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
+			}
+			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
 		}
 		out = append(out, proxy.BuildEdgeVirtualHost(domains[0], domains, routes))
 	}
-	if len(catchAll) > 0 {
+	if len(catchAllRoutes) > 0 {
 		if _, ok := used["*"]; !ok {
+			// Sort the merged catch-all routes by path specificity. Ties preserve the
+			// input order (creationTimestamp/namespace/name tie-break from the reconciler).
+			sortRoutesBySpecificity(catchAllRoutes)
+			catchAll := make([]*routev3.Route, 0, len(catchAllRoutes))
+			for _, r := range catchAllRoutes {
+				cluster := ""
+				if r.Service != "" {
+					cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
+				}
+				catchAll = append(catchAll, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
+			}
 			out = append(out, proxy.BuildEdgeVirtualHost("*", []string{"*"}, catchAll))
 		}
 	}

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -193,7 +193,9 @@ func TestVirtualHostVhostsHostlessMerge(t *testing.T) {
 }
 
 // TestVirtualHostPathRoutes verifies one virtual host fans different paths to
-// different services, preserving CR order (first match wins) and prefix vs exact.
+// different services, ordered by Gateway API path specificity: Exact >
+// longer PathPrefix > shorter PathPrefix (most-specific first so Envoy's
+// first-match-wins logic applies correctly).
 func TestVirtualHostPathRoutes(t *testing.T) {
 	c := newTestCache("edge-1")
 
@@ -204,6 +206,8 @@ func TestVirtualHostPathRoutes(t *testing.T) {
 	c.clusters["svc-3"] = clusterEntry{service: "svc-3"}
 	c.clusterMu.Unlock()
 
+	// Input order: /users (prefix, len 6), /healthz (exact), / (prefix, len 1).
+	// Expected output order: /healthz (exact) → /users (prefix len 6) → / (prefix len 1).
 	c.SetVirtualHosts([]VirtualHost{
 		{Hosts: []string{"api.example.com"}, Routes: []Route{
 			{Prefix: "/users", Service: "svc-1"},
@@ -217,10 +221,13 @@ func TestVirtualHostPathRoutes(t *testing.T) {
 	routes := vhosts[0].GetRoutes()
 	require.Len(t, routes, 3)
 
-	assert.Equal(t, "/users", routes[0].GetMatch().GetPrefix())
-	assert.Equal(t, "svc-1.aether.internal", routes[0].GetRoute().GetCluster())
-	assert.Equal(t, "/healthz", routes[1].GetMatch().GetPath())
-	assert.Equal(t, "svc-2.aether.internal", routes[1].GetRoute().GetCluster())
+	// Exact match first (highest Gateway API precedence).
+	assert.Equal(t, "/healthz", routes[0].GetMatch().GetPath())
+	assert.Equal(t, "svc-2.aether.internal", routes[0].GetRoute().GetCluster())
+	// Longer prefix second.
+	assert.Equal(t, "/users", routes[1].GetMatch().GetPrefix())
+	assert.Equal(t, "svc-1.aether.internal", routes[1].GetRoute().GetCluster())
+	// Catch-all prefix last.
 	assert.Equal(t, "/", routes[2].GetMatch().GetPrefix())
 	assert.Equal(t, "svc-3.aether.internal", routes[2].GetRoute().GetCluster())
 }
@@ -594,4 +601,133 @@ func TestBuildEdgeK8sCluster_Shape(t *testing.T) {
 	ep := la.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
 	assert.Equal(t, "svc.ns.svc.cluster.local", ep.GetAddress())
 	assert.Equal(t, uint32(8080), ep.GetPortValue())
+}
+
+// TestSortRoutesBySpecificity verifies Gateway API path-precedence ordering:
+// Exact beats any prefix; longer prefix beats shorter prefix; ties preserve
+// input order (stable sort).
+func TestSortRoutesBySpecificity(t *testing.T) {
+	// Input order: / (shortest prefix), /v2 (prefix), /v2/exact (exact).
+	// Expected after sort: /v2/exact (exact), /v2 (longer prefix), / (shorter prefix).
+	routes := []Route{
+		{Prefix: "/", Service: "svc-root"},
+		{Prefix: "/v2", Service: "svc-v2"},
+		{Exact: "/v2/exact", Service: "svc-exact"},
+	}
+	sortRoutesBySpecificity(routes)
+
+	require.Len(t, routes, 3)
+	assert.Equal(t, "/v2/exact", routes[0].Exact, "exact match must come first")
+	assert.Equal(t, "svc-exact", routes[0].Service)
+	assert.Equal(t, "/v2", routes[1].Prefix, "longer prefix before shorter")
+	assert.Equal(t, "svc-v2", routes[1].Service)
+	assert.Equal(t, "/", routes[2].Prefix, "catch-all prefix last")
+	assert.Equal(t, "svc-root", routes[2].Service)
+}
+
+// TestSortRoutesBySpecificity_StableOnTie verifies that routes with the same
+// path specificity preserve their input order (stable sort = tie-break order).
+func TestSortRoutesBySpecificity_StableOnTie(t *testing.T) {
+	// Three routes all with prefix "/api" — same length, same type, different services.
+	// Input order must be preserved.
+	routes := []Route{
+		{Prefix: "/api", Service: "svc-a"},
+		{Prefix: "/api", Service: "svc-b"},
+		{Prefix: "/api", Service: "svc-c"},
+	}
+	sortRoutesBySpecificity(routes)
+
+	require.Len(t, routes, 3)
+	assert.Equal(t, "svc-a", routes[0].Service, "first equal-specificity route stays first")
+	assert.Equal(t, "svc-b", routes[1].Service)
+	assert.Equal(t, "svc-c", routes[2].Service)
+}
+
+// TestVirtualHostPathRoutes_SpecificitySort verifies that routes on a named vhost
+// are re-ordered by path specificity regardless of their input order:
+// Exact > longer prefix > shorter prefix; the 404 stays last.
+func TestVirtualHostPathRoutes_SpecificitySort(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.clusterMu.Lock()
+	c.clusters["svc-root"] = clusterEntry{service: "svc-root"}
+	c.clusters["svc-v2"] = clusterEntry{service: "svc-v2"}
+	c.clusters["svc-exact"] = clusterEntry{service: "svc-exact"}
+	c.clusterMu.Unlock()
+
+	// Input order: / (shortest) → /v2 (prefix) → /v2/exact (exact).
+	// Envoy must see them as: exact → /v2 → / (most-specific first).
+	c.SetVirtualHosts([]VirtualHost{
+		{Hosts: []string{"api.example.com"}, Routes: []Route{
+			{Prefix: "/", Service: "svc-root"},
+			{Prefix: "/v2", Service: "svc-v2"},
+			{Exact: "/v2/exact", Service: "svc-exact"},
+		}},
+	})
+
+	vhosts := c.virtualHostVhosts()
+	require.Len(t, vhosts, 1)
+	routes := vhosts[0].GetRoutes()
+	require.Len(t, routes, 3, "three application routes (no 404 on named vhosts — 404 is on the catch-all only)")
+	assert.NotEmpty(t, routes[0].GetMatch().GetPath(), "first route must be exact")
+	assert.Equal(t, "/v2/exact", routes[0].GetMatch().GetPath())
+	assert.Equal(t, "/v2", routes[1].GetMatch().GetPrefix(), "longer prefix second")
+	assert.Equal(t, "/", routes[2].GetMatch().GetPrefix(), "catch-all prefix last")
+}
+
+// TestCatchAllVhostSpecificitySort verifies that routes merged into the "*" catch-all
+// vhost (from multiple hostname-less HTTPRoutes) are ordered by path specificity.
+// The 404 fallback is appended by appendEdgeCatchAll404 (called inside
+// BuildEdgeRouteConfiguration), so this test uses the full route config to verify
+// the 404 stays last.
+func TestCatchAllVhostSpecificitySort(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.clusterMu.Lock()
+	c.clusters["svc-root"] = clusterEntry{service: "svc-root"}
+	c.clusters["svc-v2"] = clusterEntry{service: "svc-v2"}
+	c.clusters["svc-exact"] = clusterEntry{service: "svc-exact"}
+	c.clusterMu.Unlock()
+
+	// Three hostname-less vhosts (different HTTPRoutes) in order: /, /v2, /v2/exact.
+	// They merge into the single "*" vhost and must be sorted most-specific-first.
+	c.SetVirtualHosts([]VirtualHost{
+		{Routes: []Route{{Prefix: "/", Service: "svc-root"}}},
+		{Routes: []Route{{Prefix: "/v2", Service: "svc-v2"}}},
+		{Routes: []Route{{Exact: "/v2/exact", Service: "svc-exact"}}},
+	})
+
+	// virtualHostVhosts returns vhosts without the 404 (that is added by
+	// appendEdgeCatchAll404 inside BuildEdgeRouteConfiguration).
+	vhosts := c.virtualHostVhosts()
+	var starVH *routev3.VirtualHost
+	for _, vh := range vhosts {
+		if vh.GetName() == "*" {
+			starVH = vh
+			break
+		}
+	}
+	require.NotNil(t, starVH, "catch-all * vhost must be present")
+
+	// Verify path-specificity order (no 404 at this stage).
+	routes := starVH.GetRoutes()
+	require.Len(t, routes, 3, "three application routes before 404 is appended")
+	assert.NotEmpty(t, routes[0].GetMatch().GetPath(), "first route must be exact match")
+	assert.Equal(t, "/v2/exact", routes[0].GetMatch().GetPath())
+	assert.Equal(t, "/v2", routes[1].GetMatch().GetPrefix(), "longer prefix second")
+	assert.Equal(t, "/", routes[2].GetMatch().GetPrefix(), "catch-all prefix third")
+
+	// Build the full route config to verify the 404 is appended last.
+	rc := proxy.BuildEdgeRouteConfiguration(vhosts)
+	var starFull *routev3.VirtualHost
+	for _, vh := range rc.GetVirtualHosts() {
+		if vh.GetName() == "*" {
+			starFull = vh
+			break
+		}
+	}
+	require.NotNil(t, starFull, "* vhost must exist in full route config")
+	allRoutes := starFull.GetRoutes()
+	require.Len(t, allRoutes, 4, "3 application routes + 1 catch-all 404")
+	last := allRoutes[len(allRoutes)-1]
+	require.NotNil(t, last.GetDirectResponse(), "last route must be the 404 fallback")
+	assert.Equal(t, uint32(404), last.GetDirectResponse().GetStatus())
 }


### PR DESCRIPTION
## Summary

- **Path-specificity sort in the cache** (`buildEdgeVhostsLocked`): `sortRoutesBySpecificity` stable-sorts each output vhost's route list — both per-hostname vhosts and the merged `*` catch-all — by Gateway API precedence: `Exact` > `PathPrefix` by descending prefix length. The sort is stable so the secondary tie-break order (established by the reconciler) is preserved.
- **CreationTimestamp tie-break in the reconciler** (`Reconcile`): the HTTPRoute list sort key is changed from `(namespace, name)` to `(creationTimestamp, namespace, name)` — oldest HTTPRoute first — matching the Gateway API spec's older-wins tie-break. The cache's stable sort carries this through for equal-specificity routes.
- **404 stays last**: `sortRoutesBySpecificity` operates on `cache.Route` slices before proto conversion; `appendEdgeCatchAll404` appends after `buildEdgeVhostsLocked` returns, so the 404 is always the final route.

## Precedence rules implemented

1. **Path**: `Exact` first, then `PathPrefix` by descending length (`/v2/exact` > `/v2` > `/`)
2. **Tie-break**: oldest `creationTimestamp` → namespace → name → rule index (via stable sort + reconciler input order)
3. Method/header/query-param secondary criteria noted as follow-up; path is the dominant conformance signal

## Targets

Fixes `HTTPRoutePathMatchOrder` and `HTTPRouteMatchingAcrossRoutes` Gateway API conformance tests. The reconciler change is minimal and localized (one sort comparator change) for clean rebase against concurrent status-reporting work.

## Test plan

- `TestSortRoutesBySpecificity`: unit test for the sort function — `[/, /v2, /v2/exact]` → `[/v2/exact, /v2, /]`
- `TestSortRoutesBySpecificity_StableOnTie`: equal-specificity routes preserve input order
- `TestVirtualHostPathRoutes_SpecificitySort`: end-to-end through `virtualHostVhosts()` on a named vhost
- `TestCatchAllVhostSpecificitySort`: merged `*` catch-all vhost sorted correctly; 404 appended last via `BuildEdgeRouteConfiguration`
- `TestHTTPRouteGatewaySortOrder`: reconciler sort key uses `creationTimestamp` as primary
- Updated `TestVirtualHostPathRoutes` to match new correct Gateway API precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S