### PR TITLE
feat(edge): weighted backendRefs (HTTPRoute traffic splitting)

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -504,12 +504,17 @@ func (r *Reconciler) resolveListenerTLS(
 }
 
 // buildVirtualHost maps one HTTPRoute to an edge VirtualHost: its hostnames become
-// the vhost domains, each rule's path match + first backendRef becomes a Route, and
-// the matching Gateway listener cert (by hostname, falling back to a catch-all
-// listener) sets the downstream TLS.
+// the vhost domains, each rule's path match + backendRefs becomes a Route (with
+// weighted backends when there are multiple), and the matching Gateway listener
+// cert (by hostname, falling back to a catch-all listener) sets the downstream TLS.
 //
 // Rules with a RequestRedirect filter emit a redirect route (no backend required).
 // Rules with a URLRewrite filter apply host/path rewriting on the forwarding route.
+//
+// Gateway API weight semantics: backendRef.weight defaults to 1 when nil. A rule
+// where ALL backends are invalid/ungranted is skipped (no route). A rule where all
+// valid backends have weight 0 is a valid route that produces no traffic (spec
+// allows it; Envoy returns 500 for that case — acceptable).
 func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[string]string, grants []gatewayv1beta1.ReferenceGrant) cache.VirtualHost {
 	vh := cache.VirtualHost{}
 	for _, h := range hr.Spec.Hostnames {
@@ -519,59 +524,105 @@ func (r *Reconciler) buildVirtualHost(hr *gatewayv1.HTTPRoute, hostCerts map[str
 		redirect := buildHTTPRedirect(rule.Filters)
 		urlRewrite := buildHTTPURLRewrite(rule.Filters)
 
-		backend := firstBackendService(rule.BackendRefs, hr.Namespace, grants)
-		// A rule must have either a backend or a redirect to produce a route.
-		if backend == "" && redirect == nil {
+		// Collect ALL admissible backends in this rule with their weights.
+		// backendRef.weight nil → default 1 (per Gateway API spec).
+		backends := buildHTTPRouteBackends(rule.BackendRefs, hr.Namespace, grants)
+
+		// A rule must have either at least one backend or a redirect to produce a route.
+		if len(backends) == 0 && redirect == nil {
 			continue
 		}
-		var port uint32
-		if p := firstBackendPort(rule.BackendRefs, hr.Namespace, grants); p != 0 {
-			port = p
-		}
-		// Resolve the namespace of the first admissible backendRef for the cleartext
-		// cluster FQDN. Same-namespace refs default to the route's own namespace;
-		// cross-namespace refs use their explicit namespace (already validated by
-		// backendPermitted / firstBackendService above).
-		backendNS := firstBackendNamespace(rule.BackendRefs, hr.Namespace, grants)
+
 		mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
-		if len(rule.Matches) == 0 {
+
+		// For backward-compat we also populate the legacy Service/Port/BackendNamespace
+		// from the first backend so that code paths that read those fields still work.
+		var legacySvc, legacyNS string
+		var legacyPort uint32
+		if len(backends) > 0 {
+			legacySvc = backends[0].Service
+			legacyPort = backends[0].Port
+			legacyNS = backends[0].BackendNamespace
+		}
+
+		appendRoute := func(prefix, exact string) {
 			vh.Routes = append(vh.Routes, cache.Route{
-				Prefix:           "/",
-				Service:          backend,
-				Port:             port,
-				BackendNamespace: backendNS,
+				Prefix:           prefix,
+				Exact:            exact,
+				Service:          legacySvc,
+				Port:             legacyPort,
+				BackendNamespace: legacyNS,
+				Backends:         backends,
 				HeaderMutation:   mutation,
 				Redirect:         redirect,
 				URLRewrite:       urlRewrite,
 			})
+		}
+
+		if len(rule.Matches) == 0 {
+			appendRoute("/", "")
 			continue
 		}
 		for _, m := range rule.Matches {
-			route := cache.Route{
-				Service:          backend,
-				Port:             port,
-				BackendNamespace: backendNS,
-				HeaderMutation:   mutation,
-				Redirect:         redirect,
-				URLRewrite:       urlRewrite,
-			}
+			prefix, exact := "/", ""
 			if m.Path != nil && m.Path.Value != nil {
 				switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
 				case gatewayv1.PathMatchExact:
-					route.Exact = *m.Path.Value
+					exact = *m.Path.Value
+					prefix = ""
 				default: // PathPrefix (and unimplemented types) → prefix
-					route.Prefix = *m.Path.Value
+					prefix = *m.Path.Value
 				}
-			} else {
-				route.Prefix = "/"
 			}
-			vh.Routes = append(vh.Routes, route)
+			appendRoute(prefix, exact)
 		}
 	}
 	if cert := certForHosts(vh.Hosts, hostCerts); cert != "" {
 		vh.TLSSecret = cert
 	}
 	return vh
+}
+
+// buildHTTPRouteBackends converts the HTTPRoute rule's backendRefs into a list of
+// RouteBackend values, applying Gateway API admission rules: non-core group/kind
+// refs are skipped; ungranted cross-namespace refs are skipped (RefNotPermitted).
+// Weight nil → default 1 per spec. Returns an empty slice when no backend is admissible.
+func buildHTTPRouteBackends(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) []cache.RouteBackend {
+	out := make([]cache.RouteBackend, 0, len(refs))
+	for _, b := range refs {
+		if b.Group != nil && string(*b.Group) != "" {
+			continue // only core Services
+		}
+		if b.Kind != nil && string(*b.Kind) != "Service" {
+			continue
+		}
+		name := string(b.Name)
+		if name == "" {
+			continue
+		}
+		if !backendPermitted(b.Namespace, routeNamespace, "HTTPRoute", name, grants) {
+			continue
+		}
+		ns := routeNamespace
+		if b.Namespace != nil && string(*b.Namespace) != "" {
+			ns = string(*b.Namespace)
+		}
+		var port uint32
+		if b.Port != nil {
+			port = uint32(*b.Port)
+		}
+		weight := uint32(1) // default per Gateway API spec
+		if b.Weight != nil {
+			weight = uint32(*b.Weight)
+		}
+		out = append(out, cache.RouteBackend{
+			Service:          name,
+			BackendNamespace: ns,
+			Port:             port,
+			Weight:           weight,
+		})
+	}
+	return out
 }
 
 // attachedToOurGateway reports whether the given parentRefs (belonging to a route

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -41,7 +41,8 @@ func pathMatch(t gatewayv1.PathMatchType, v string) []gatewayv1.HTTPRouteMatch {
 }
 
 // TestBuildVirtualHost: hostnames → domains, path matches → routes (prefix/exact),
-// first backendRef → service, default "/" when no match.
+// backends → Backends list + legacy Service/Port/BackendNamespace from first backend,
+// default "/" when no match.
 func TestBuildVirtualHost(t *testing.T) {
 	r := &Reconciler{}
 	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
@@ -52,11 +53,30 @@ func TestBuildVirtualHost(t *testing.T) {
 	vh := r.buildVirtualHost(hr, nil, nil)
 
 	assert.Equal(t, []string{"api.example.com"}, vh.Hosts)
-	assert.Equal(t, []cache.Route{
-		{Prefix: "/echo", Service: "echo"},
-		{Exact: "/exact", Service: "svc-2", Port: 8080},
-		{Prefix: "/", Service: "svc-1"},
-	}, vh.Routes)
+	require.Len(t, vh.Routes, 3)
+
+	// Route 0: /echo → echo (weight=1, default). Namespace defaults to route's own (empty).
+	r0 := vh.Routes[0]
+	assert.Equal(t, "/echo", r0.Prefix)
+	assert.Equal(t, "echo", r0.Service)
+	require.Len(t, r0.Backends, 1)
+	assert.Equal(t, cache.RouteBackend{Service: "echo", BackendNamespace: "", Port: 0, Weight: 1}, r0.Backends[0])
+
+	// Route 1: /exact → svc-2:8080 (weight=1, default).
+	r1 := vh.Routes[1]
+	assert.Equal(t, "/exact", r1.Exact)
+	assert.Equal(t, "svc-2", r1.Service)
+	assert.Equal(t, uint32(8080), r1.Port)
+	require.Len(t, r1.Backends, 1)
+	assert.Equal(t, cache.RouteBackend{Service: "svc-2", BackendNamespace: "", Port: 8080, Weight: 1}, r1.Backends[0])
+
+	// Route 2: default "/" → svc-1 (weight=1, default).
+	r2 := vh.Routes[2]
+	assert.Equal(t, "/", r2.Prefix)
+	assert.Equal(t, "svc-1", r2.Service)
+	require.Len(t, r2.Backends, 1)
+	assert.Equal(t, cache.RouteBackend{Service: "svc-1", BackendNamespace: "", Port: 0, Weight: 1}, r2.Backends[0])
+
 	assert.Empty(t, vh.TLSSecret)
 }
 
@@ -113,6 +133,129 @@ func TestFirstBackendService(t *testing.T) {
 		},
 	}}
 	assert.Equal(t, "echo", firstBackendService(crossRefs, "ns", grants), "granted cross-ns backend kept")
+}
+
+// --- Weighted backendRefs ---
+
+// weightedBackend constructs a multi-backend HTTPBackendRef slice for testing
+// weighted splits (each entry has an explicit weight).
+func weightedBackend(entries ...struct {
+	svc    string
+	port   int32
+	weight int32
+},
+) []gatewayv1.HTTPBackendRef {
+	refs := make([]gatewayv1.HTTPBackendRef, 0, len(entries))
+	for _, e := range entries {
+		ref := gatewayv1.HTTPBackendRef{BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{Name: gatewayv1.ObjectName(e.svc)},
+		}}
+		if e.port != 0 {
+			ref.Port = ptr(gatewayv1.PortNumber(e.port))
+		}
+		if e.weight != 0 {
+			w := e.weight
+			ref.Weight = &w
+		}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// TestBuildHTTPRouteBackends_WeightedSplit verifies that buildHTTPRouteBackends
+// collects all admissible backends with their weights. The primary test for the
+// core weighted backendRefs logic.
+func TestBuildHTTPRouteBackends_WeightedSplit(t *testing.T) {
+	refs := weightedBackend(
+		struct {
+			svc    string
+			port   int32
+			weight int32
+		}{"svc-a", 8080, 3},
+		struct {
+			svc    string
+			port   int32
+			weight int32
+		}{"svc-b", 9090, 1},
+	)
+	got := buildHTTPRouteBackends(refs, "my-ns", nil)
+	require.Len(t, got, 2, "both backends must be admitted")
+	assert.Equal(t, cache.RouteBackend{Service: "svc-a", BackendNamespace: "my-ns", Port: 8080, Weight: 3}, got[0])
+	assert.Equal(t, cache.RouteBackend{Service: "svc-b", BackendNamespace: "my-ns", Port: 9090, Weight: 1}, got[1])
+}
+
+// TestBuildHTTPRouteBackends_DefaultWeight verifies that a backendRef without an
+// explicit weight defaults to 1 (per Gateway API spec).
+func TestBuildHTTPRouteBackends_DefaultWeight(t *testing.T) {
+	refs := backend("svc-1", 8080) // uses the single-backend helper (no Weight field)
+	got := buildHTTPRouteBackends(refs, "ns", nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, uint32(1), got[0].Weight, "nil weight must default to 1")
+}
+
+// TestBuildHTTPRouteBackends_ZeroWeight verifies that an explicit weight=0 is
+// preserved (per spec: zero-weight backend receives no traffic but is valid).
+func TestBuildHTTPRouteBackends_ZeroWeight(t *testing.T) {
+	refs := weightedBackend(struct {
+		svc    string
+		port   int32
+		weight int32
+	}{"svc-x", 80, 0})
+	// Note: our helper only sets Weight when > 0, so we need to set it explicitly.
+	refs[0].Weight = ptr(int32(0))
+	got := buildHTTPRouteBackends(refs, "ns", nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, uint32(0), got[0].Weight, "explicit zero weight must be preserved")
+}
+
+// TestBuildHTTPRouteBackends_UngrantedCrossNsSkipped verifies that a cross-namespace
+// backendRef without a ReferenceGrant is dropped (RefNotPermitted). A same-namespace
+// backend in the same rule is still admitted.
+func TestBuildHTTPRouteBackends_UngrantedCrossNsSkipped(t *testing.T) {
+	otherNs := gatewayv1.Namespace("other")
+	refs := []gatewayv1.HTTPBackendRef{
+		{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "cross", Namespace: &otherNs}}},
+		{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "local"}}},
+	}
+	got := buildHTTPRouteBackends(refs, "ns", nil)
+	require.Len(t, got, 1, "ungranted cross-ns backend dropped, same-ns backend admitted")
+	assert.Equal(t, "local", got[0].Service)
+}
+
+// TestBuildVirtualHost_WeightedBackends verifies that buildVirtualHost projects
+// multiple backendRefs as a Backends list, with per-backend weights and namespaces.
+// The legacy Service/Port/BackendNamespace fields are set from the FIRST backend.
+func TestBuildVirtualHost_WeightedBackends(t *testing.T) {
+	r := &Reconciler{}
+	refs := weightedBackend(
+		struct {
+			svc    string
+			port   int32
+			weight int32
+		}{"svc-a", 8080, 3},
+		struct {
+			svc    string
+			port   int32
+			weight int32
+		}{"svc-b", 9090, 1},
+	)
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{Matches: pathMatch(gatewayv1.PathMatchPathPrefix, "/split"), BackendRefs: refs},
+	})
+	vh := r.buildVirtualHost(hr, nil, nil)
+
+	require.Len(t, vh.Routes, 1)
+	rt := vh.Routes[0]
+	assert.Equal(t, "/split", rt.Prefix)
+
+	// Backends list must contain both entries.
+	require.Len(t, rt.Backends, 2)
+	assert.Equal(t, cache.RouteBackend{Service: "svc-a", BackendNamespace: "", Port: 8080, Weight: 3}, rt.Backends[0])
+	assert.Equal(t, cache.RouteBackend{Service: "svc-b", BackendNamespace: "", Port: 9090, Weight: 1}, rt.Backends[1])
+
+	// Legacy fields must be populated from the first backend.
+	assert.Equal(t, "svc-a", rt.Service, "legacy Service = first backend")
+	assert.Equal(t, uint32(8080), rt.Port, "legacy Port = first backend's port")
 }
 
 // --- L4 edge helpers ---

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -96,24 +96,51 @@ type VirtualHost struct {
 	Gateways []string
 }
 
+// RouteBackend is one weighted backend within an HTTPRoute rule. It corresponds
+// to one element of backendRefs with its resolved service name, namespace, port,
+// and weight. Weight 0 means the backend receives no traffic but is still a
+// valid entry (per Gateway API — a zero-weight backend is not an error).
+type RouteBackend struct {
+	Service          string
+	BackendNamespace string
+	Port             uint32
+	// Weight is the Gateway API backendRef weight. Defaults to 1 when unset.
+	// The Envoy weighted_clusters total_weight is the sum of all backend weights
+	// within the rule. Weight 0 = backend receives no traffic.
+	Weight uint32
+}
+
 // Route is one path-match -> backend rule within a VirtualHost. Exactly one of
-// Prefix/Exact is set; Port 0 means the service's default port.
+// Prefix/Exact is set.
 // HeaderMutation carries the merged request/response header modifier filters for
 // this rule (nil = no header mutations).
 // When Redirect is non-nil the route returns a redirect response (no backend).
 // When URLRewrite is non-nil the route rewrites the request URL before forwarding.
-// BackendNamespace is the namespace of the backendRef (defaults to the route's own
-// namespace when not set by the reconciler). Used to build the k8s-Service FQDN
-// for non-mesh (cleartext) backends: <service>.<BackendNamespace>.svc.cluster.local.
+//
+// Backends holds the weighted backend list for this rule. When populated,
+// BuildEdgeRoute emits a weighted_clusters action (multiple backends) or a
+// plain single-cluster action (one backend). Backends supersedes the legacy
+// Service/Port/BackendNamespace fields; all three are populated for backward
+// compatibility when there is exactly one backend so existing single-backend
+// code paths continue to work.
+//
+// BackendNamespace is the namespace of the (first) backendRef (defaults to the
+// route's own namespace when not set by the reconciler). Used to build the k8s-
+// Service FQDN for non-mesh (cleartext) backends when Backends is not set.
 type Route struct {
 	Prefix           string
 	Exact            string
 	Service          string
 	Port             uint32
 	BackendNamespace string
-	HeaderMutation   *proxy.GammaHeaderMutation
-	Redirect         *proxy.GammaRedirect
-	URLRewrite       *proxy.GammaURLRewrite
+	// Backends is the weighted backend list for this rule. A single-element list
+	// is equivalent to the legacy Service/Port/BackendNamespace fields. An empty
+	// Backends with a non-empty Service falls back to the legacy single-backend
+	// path so old callers remain compatible.
+	Backends       []RouteBackend
+	HeaderMutation *proxy.GammaHeaderMutation
+	Redirect       *proxy.GammaRedirect
+	URLRewrite     *proxy.GammaURLRewrite
 }
 
 // EdgeTLSCert is raw certificate material for an edge downstream TLS secret,
@@ -279,6 +306,27 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 		}
 	}
 
+	// buildEnvoyRoute converts a cache Route to an Envoy route, resolving each
+	// backend's cluster name via edgeClusterNameLocked (mesh vs k8s cleartext).
+	// Caller must hold clusterMu.
+	buildEnvoyRoute := func(r Route) *routev3.Route {
+		// Weighted multi-backend path: when Backends is populated use it.
+		if len(r.Backends) > 0 {
+			weighted := make([]proxy.WeightedRouteBackend, 0, len(r.Backends))
+			for _, b := range r.Backends {
+				cn := c.edgeClusterNameLocked(b.Service, b.BackendNamespace, b.Port)
+				weighted = append(weighted, proxy.WeightedRouteBackend{Cluster: cn, Weight: b.Weight})
+			}
+			return proxy.BuildEdgeRouteWeighted(r.Prefix, r.Exact, weighted, r.HeaderMutation, r.Redirect, r.URLRewrite)
+		}
+		// Legacy single-backend path (backward compat).
+		cluster := ""
+		if r.Service != "" {
+			cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
+		}
+		return proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite)
+	}
+
 	// Emit one Envoy virtual host per domain group, sorted by path specificity.
 	out := make([]*routev3.VirtualHost, 0, len(domainOrder))
 	for _, domain := range domainOrder {
@@ -286,11 +334,7 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 		sortRoutesBySpecificity(merged)
 		routes := make([]*routev3.Route, 0, len(merged))
 		for _, r := range merged {
-			cluster := ""
-			if r.Service != "" {
-				cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
-			}
-			routes = append(routes, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
+			routes = append(routes, buildEnvoyRoute(r))
 		}
 		out = append(out, proxy.BuildEdgeVirtualHost(domain, []string{domain}, routes))
 	}
@@ -301,11 +345,7 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 		sortRoutesBySpecificity(catchAllRoutes)
 		catchAll := make([]*routev3.Route, 0, len(catchAllRoutes))
 		for _, r := range catchAllRoutes {
-			cluster := ""
-			if r.Service != "" {
-				cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
-			}
-			catchAll = append(catchAll, proxy.BuildEdgeRoute(r.Prefix, r.Exact, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite))
+			catchAll = append(catchAll, buildEnvoyRoute(r))
 		}
 		out = append(out, proxy.BuildEdgeVirtualHost("*", []string{"*"}, catchAll))
 	}
@@ -481,6 +521,17 @@ func (c *SnapshotCache) rebuildEdgeDependencies() {
 		// on its listener (the edge serves it via the catch-all "*" vhost), so its
 		// backend services must be scoped in (their clusters loaded) too.
 		for _, r := range v.Routes {
+			// Collect from Backends (weighted multi-backend).
+			for _, b := range r.Backends {
+				if b.Service == "" {
+					continue
+				}
+				if _, ok := seen[b.Service]; !ok {
+					seen[b.Service] = struct{}{}
+					services = append(services, b.Service)
+				}
+			}
+			// Legacy single-backend field (also populated for single-backend routes).
 			if r.Service == "" {
 				continue
 			}
@@ -577,21 +628,33 @@ func (c *SnapshotCache) edgeK8sBackendClusters() []types.Resource {
 	seen := make(map[k8sBackend]struct{})
 	var backends []k8sBackend
 
+	addBackend := func(service, namespace string, port uint32) {
+		p := port
+		if p == 0 {
+			p = 80
+		}
+		bk := k8sBackend{namespace: namespace, service: service, port: p}
+		if _, dup := seen[bk]; dup {
+			return
+		}
+		seen[bk] = struct{}{}
+		backends = append(backends, bk)
+	}
+
 	collectRoutes := func(routes []Route) {
 		for _, r := range routes {
+			// Weighted multi-backend: iterate each backend in the list.
+			for _, b := range r.Backends {
+				if b.Service == "" {
+					continue
+				}
+				addBackend(b.Service, b.BackendNamespace, b.Port)
+			}
+			// Legacy single-backend field (also populated for single-backend routes).
 			if r.Service == "" {
 				continue
 			}
-			p := r.Port
-			if p == 0 {
-				p = 80
-			}
-			bk := k8sBackend{namespace: r.BackendNamespace, service: r.Service, port: p}
-			if _, dup := seen[bk]; dup {
-				continue
-			}
-			seen[bk] = struct{}{}
-			backends = append(backends, bk)
+			addBackend(r.Service, r.BackendNamespace, r.Port)
 		}
 	}
 
@@ -644,6 +707,9 @@ func equalRoutes(a, b []Route) bool {
 		if ra.Prefix != rb.Prefix || ra.Exact != rb.Exact || ra.Service != rb.Service || ra.Port != rb.Port || ra.BackendNamespace != rb.BackendNamespace {
 			return false
 		}
+		if !equalRouteBackends(ra.Backends, rb.Backends) {
+			return false
+		}
 		if !equalHeaderMutation(ra.HeaderMutation, rb.HeaderMutation) {
 			return false
 		}
@@ -651,6 +717,19 @@ func equalRoutes(a, b []Route) bool {
 			return false
 		}
 		if !equalRouteURLRewrite(ra.URLRewrite, rb.URLRewrite) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalRouteBackends reports whether two RouteBackend slices are identical.
+func equalRouteBackends(a, b []RouteBackend) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
 			return false
 		}
 	}

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -556,6 +556,136 @@ func TestPerGatewayCertWired(t *testing.T) {
 	require.NotNil(t, l.GetFilterChains()[0].GetTransportSocket(), "per-Gateway HTTPS listener must terminate TLS")
 }
 
+// TestVirtualHostVhosts_WeightedSplit verifies end-to-end that a route with
+// multiple weighted Backends produces a weighted_clusters Envoy route action.
+// Each backend independently resolves via edgeClusterNameLocked (mesh vs cleartext).
+func TestVirtualHostVhosts_WeightedSplit(t *testing.T) {
+	c := newTestCache("edge-1")
+
+	// Register svc-a in the mesh registry; svc-b is a plain k8s Service (non-mesh).
+	c.clusterMu.Lock()
+	c.clusters["svc-a"] = clusterEntry{service: "svc-a"}
+	c.clusterMu.Unlock()
+
+	c.SetVirtualHosts([]VirtualHost{
+		{
+			Hosts: []string{"split.example.com"},
+			Routes: []Route{{
+				Prefix: "/split",
+				// Weighted backends: svc-a (mesh, port 0 = default cluster) weight=3,
+				// svc-b (k8s cleartext, port 9090) weight=1.
+				Backends: []RouteBackend{
+					{Service: "svc-a", BackendNamespace: "default", Port: 0, Weight: 3},
+					{Service: "svc-b", BackendNamespace: "conformance-ns", Port: 9090, Weight: 1},
+				},
+				Service:          "svc-a", // legacy field: first backend
+				Port:             0,
+				BackendNamespace: "default",
+			}},
+		},
+	})
+
+	vhosts := c.virtualHostVhosts()
+	require.Len(t, vhosts, 1)
+	routes := vhosts[0].GetRoutes()
+	require.Len(t, routes, 1)
+
+	ra := routes[0].GetRoute()
+	require.NotNil(t, ra, "must have a RouteAction (not a redirect)")
+
+	wc := ra.GetWeightedClusters()
+	require.NotNil(t, wc, "multiple backends must produce weighted_clusters")
+	assert.Equal(t, uint32(4), wc.GetTotalWeight().GetValue(), "total_weight = 3+1 = 4")
+
+	require.Len(t, wc.GetClusters(), 2)
+	// First backend: svc-a is in the registry → mesh default cluster.
+	assert.Equal(t, "svc-a.aether.internal", wc.GetClusters()[0].GetName())
+	assert.Equal(t, uint32(3), wc.GetClusters()[0].GetWeight().GetValue())
+	// Second backend: svc-b is NOT in the registry → edge_k8s cleartext cluster.
+	assert.Equal(t, "edge_k8s_conformance-ns_svc-b_9090", wc.GetClusters()[1].GetName())
+	assert.Equal(t, uint32(1), wc.GetClusters()[1].GetWeight().GetValue())
+}
+
+// TestVirtualHostVhosts_SingleBackendNoWeightedClusters verifies that a route with
+// a single Backends entry uses the plain single-cluster RouteAction (not weighted_clusters).
+func TestVirtualHostVhosts_SingleBackendNoWeightedClusters(t *testing.T) {
+	c := newTestCache("edge-1")
+	// Register svc-1 in mesh (default port path — no explicit per-port cluster needed).
+	c.clusterMu.Lock()
+	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
+	c.clusterMu.Unlock()
+
+	c.SetVirtualHosts([]VirtualHost{
+		{
+			Hosts: []string{"api.example.com"},
+			Routes: []Route{{
+				Prefix: "/",
+				Backends: []RouteBackend{
+					// Port 0 → default mesh cluster (svc-1.aether.internal).
+					{Service: "svc-1", BackendNamespace: "default", Port: 0, Weight: 1},
+				},
+				Service:          "svc-1",
+				Port:             0,
+				BackendNamespace: "default",
+			}},
+		},
+	})
+
+	vhosts := c.virtualHostVhosts()
+	require.Len(t, vhosts, 1)
+	routes := vhosts[0].GetRoutes()
+	require.Len(t, routes, 1)
+
+	ra := routes[0].GetRoute()
+	require.NotNil(t, ra)
+	assert.Equal(t, "svc-1.aether.internal", ra.GetCluster(), "single backend must use plain cluster")
+	assert.Nil(t, ra.GetWeightedClusters(), "single backend must NOT use weighted_clusters")
+}
+
+// TestEdgeK8sBackendClusters_WeightedBackends verifies that edgeK8sBackendClusters
+// emits a cleartext cluster for every non-mesh weighted backend (iterating Backends),
+// deduplicating by (namespace, service, port) as with single-backend routes.
+func TestEdgeK8sBackendClusters_WeightedBackends(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+
+	// mesh-svc in registry; plain-svc-a and plain-svc-b are non-mesh.
+	c.clusterMu.Lock()
+	c.clusters["mesh-svc"] = clusterEntry{service: "mesh-svc"}
+	c.clusterMu.Unlock()
+
+	c.SetVirtualHosts([]VirtualHost{
+		{
+			Hosts: []string{"split.example.com"},
+			Routes: []Route{{
+				Prefix: "/",
+				Backends: []RouteBackend{
+					{Service: "mesh-svc", BackendNamespace: "default", Port: 8080, Weight: 1}, // mesh → skipped
+					{Service: "plain-svc-a", BackendNamespace: "ns-a", Port: 9000, Weight: 2}, // non-mesh → cluster
+					{Service: "plain-svc-b", BackendNamespace: "ns-b", Port: 8080, Weight: 1}, // non-mesh → cluster
+					// Duplicate of plain-svc-a/9000 — must be deduped.
+					{Service: "plain-svc-a", BackendNamespace: "ns-a", Port: 9000, Weight: 1},
+				},
+				Service:          "mesh-svc",
+				BackendNamespace: "default",
+			}},
+		},
+	})
+
+	clusters := c.edgeK8sBackendClusters()
+	// mesh-svc → skipped; plain-svc-a deduplicated to 1; plain-svc-b → 1. Total = 2.
+	require.Len(t, clusters, 2, "mesh cluster skipped; duplicates deduped; 2 cleartext clusters")
+
+	names := make(map[string]bool)
+	for _, r := range clusters {
+		cl, ok := r.(*clusterv3.Cluster)
+		require.True(t, ok)
+		names[cl.GetName()] = true
+	}
+	assert.True(t, names["edge_k8s_ns-a_plain-svc-a_9000"], "non-mesh svc-a cluster must be emitted")
+	assert.True(t, names["edge_k8s_ns-b_plain-svc-b_8080"], "non-mesh svc-b cluster must be emitted")
+}
+
 // TestEdgeClusterNameLocked_MeshVsNonMesh verifies that edgeClusterNameLocked
 // returns the mesh cluster name when the service IS in the registry, and the
 // edge_k8s_… cleartext name when it is NOT.

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -444,6 +444,75 @@ func buildEdgeRedirectRouteConfig() *routev3.RouteConfiguration {
 	}
 }
 
+// WeightedRouteBackend is one entry in a weighted_clusters route action. Cluster
+// is the resolved Envoy cluster name; Weight is the Gateway API backendRef weight
+// (default 1; 0 = receives no traffic but is a valid backend per spec).
+type WeightedRouteBackend struct {
+	Cluster string
+	Weight  uint32
+}
+
+// BuildEdgeRouteWeighted builds one Envoy route for the edge with a
+// weighted_clusters action when there are multiple backends, or a plain
+// single-cluster action when there is exactly one (keeping the common path clean).
+//
+// Gateway API weight semantics:
+//   - total_weight = sum of all entry weights; each entry's share = weight/total.
+//   - Weight 0 = the backend receives no traffic (remains valid per spec).
+//   - If all backends have weight 0 (total_weight = 0), Envoy treats this as
+//     "no healthy backend" and returns 500 — this is the expected behavior per
+//     the Gateway API spec for that edge case; we do not special-case it.
+//
+// redirect is applied ahead of backend resolution (no backends needed for a
+// redirect). urlRewrite is applied on forwarding routes only.
+func BuildEdgeRouteWeighted(prefix, exact string, backends []WeightedRouteBackend, mutation *GammaHeaderMutation, redirect *GammaRedirect, urlRewrite *GammaURLRewrite) *routev3.Route {
+	if redirect != nil || len(backends) <= 1 {
+		// Redirect path or single backend: delegate to the plain builder.
+		cluster := ""
+		if len(backends) == 1 {
+			cluster = backends[0].Cluster
+		}
+		return BuildEdgeRoute(prefix, exact, cluster, mutation, redirect, urlRewrite)
+	}
+	// Multiple backends: weighted_clusters action.
+	match := &routev3.RouteMatch{}
+	if exact != "" {
+		match.PathSpecifier = &routev3.RouteMatch_Path{Path: exact}
+	} else {
+		match.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: prefix}
+	}
+	reqAdd, respAdd, reqRemove, respRemove := headerMutationFields(mutation)
+
+	var totalWeight uint32
+	clusters := make([]*routev3.WeightedCluster_ClusterWeight, 0, len(backends))
+	for _, b := range backends {
+		totalWeight += b.Weight
+		clusters = append(clusters, &routev3.WeightedCluster_ClusterWeight{
+			Name:   b.Cluster,
+			Weight: wrapperspb.UInt32(b.Weight),
+		})
+	}
+	wc := &routev3.WeightedCluster{
+		Clusters:    clusters,
+		TotalWeight: wrapperspb.UInt32(totalWeight),
+	}
+
+	ra := &routev3.RouteAction{
+		ClusterSpecifier: &routev3.RouteAction_WeightedClusters{WeightedClusters: wc},
+		RetryPolicy:      outboundRetryPolicy(),
+	}
+	applyURLRewrite(ra, urlRewrite)
+
+	return &routev3.Route{
+		Match:                   match,
+		RequestHeadersToAdd:     reqAdd,
+		RequestHeadersToRemove:  reqRemove,
+		ResponseHeadersToAdd:    respAdd,
+		ResponseHeadersToRemove: respRemove,
+		Action:                  &routev3.Route_Route{Route: ra},
+	}
+}
+
 // BuildEdgeRoute builds one Envoy route for the edge. Exactly one of prefix/exact
 // is non-empty (exact takes precedence if both are set). Prefix "/" matches all.
 // mutation applies RequestHeaderModifier / ResponseHeaderModifier at the route level.

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -446,6 +446,107 @@ func TestBuildEdgeTLSPassthroughListener_EmptyRules(t *testing.T) {
 	}))
 }
 
+// TestBuildEdgeRouteWeighted_MultipleBackends verifies that BuildEdgeRouteWeighted
+// emits a weighted_clusters RouteAction when multiple backends are present.
+// The total_weight must equal the sum of individual weights; each entry maps to its
+// cluster name. This is the primary test for the Gateway API HTTPRouteWeight split.
+func TestBuildEdgeRouteWeighted_MultipleBackends(t *testing.T) {
+	backends := []WeightedRouteBackend{
+		{Cluster: "svc-a.aether.internal", Weight: 3},
+		{Cluster: "svc-b.aether.internal", Weight: 1},
+	}
+	r := BuildEdgeRouteWeighted("/split", "", backends, nil, nil, nil)
+
+	require.NotNil(t, r)
+	assert.Equal(t, "/split", r.GetMatch().GetPrefix())
+
+	ra := r.GetRoute()
+	require.NotNil(t, ra, "must have a RouteAction")
+	assert.Nil(t, r.GetRedirect(), "no redirect for a weighted forwarding route")
+
+	wc := ra.GetWeightedClusters()
+	require.NotNil(t, wc, "must use weighted_clusters for multiple backends")
+	assert.Equal(t, uint32(4), wc.GetTotalWeight().GetValue(), "total_weight = 3+1 = 4")
+	require.Len(t, wc.GetClusters(), 2)
+	assert.Equal(t, "svc-a.aether.internal", wc.GetClusters()[0].GetName())
+	assert.Equal(t, uint32(3), wc.GetClusters()[0].GetWeight().GetValue())
+	assert.Equal(t, "svc-b.aether.internal", wc.GetClusters()[1].GetName())
+	assert.Equal(t, uint32(1), wc.GetClusters()[1].GetWeight().GetValue())
+}
+
+// TestBuildEdgeRouteWeighted_SingleBackend verifies that a single-entry backends
+// list produces a plain single-cluster RouteAction (no weighted_clusters overhead).
+func TestBuildEdgeRouteWeighted_SingleBackend(t *testing.T) {
+	backends := []WeightedRouteBackend{{Cluster: "svc-1.aether.internal", Weight: 1}}
+	r := BuildEdgeRouteWeighted("/api", "", backends, nil, nil, nil)
+
+	require.NotNil(t, r)
+	ra := r.GetRoute()
+	require.NotNil(t, ra)
+	// Single backend: plain cluster specifier, NOT weighted_clusters.
+	assert.Equal(t, "svc-1.aether.internal", ra.GetCluster(), "single-backend route uses plain cluster")
+	assert.Nil(t, ra.GetWeightedClusters(), "single backend must NOT use weighted_clusters")
+}
+
+// TestBuildEdgeRouteWeighted_ExactMatch verifies the exact path match is preserved
+// correctly when using weighted_clusters.
+func TestBuildEdgeRouteWeighted_ExactMatch(t *testing.T) {
+	backends := []WeightedRouteBackend{
+		{Cluster: "svc-v1.aether.internal", Weight: 90},
+		{Cluster: "svc-v2.aether.internal", Weight: 10},
+	}
+	r := BuildEdgeRouteWeighted("", "/healthz", backends, nil, nil, nil)
+
+	require.NotNil(t, r)
+	assert.Equal(t, "/healthz", r.GetMatch().GetPath(), "exact match must be preserved")
+	assert.Empty(t, r.GetMatch().GetPrefix())
+
+	wc := r.GetRoute().GetWeightedClusters()
+	require.NotNil(t, wc)
+	assert.Equal(t, uint32(100), wc.GetTotalWeight().GetValue(), "total_weight = 90+10")
+}
+
+// TestBuildEdgeRouteWeighted_ZeroWeightBackends verifies that all-zero-weight
+// backends produce a weighted_clusters route with total_weight=0. Per the Gateway
+// API spec this is valid; Envoy returns 500 for such a route (no healthy backend).
+func TestBuildEdgeRouteWeighted_ZeroWeightBackends(t *testing.T) {
+	backends := []WeightedRouteBackend{
+		{Cluster: "svc-a.aether.internal", Weight: 0},
+		{Cluster: "svc-b.aether.internal", Weight: 0},
+	}
+	r := BuildEdgeRouteWeighted("/drain", "", backends, nil, nil, nil)
+
+	require.NotNil(t, r)
+	wc := r.GetRoute().GetWeightedClusters()
+	require.NotNil(t, wc, "must still produce weighted_clusters (not a redirect/error)")
+	assert.Equal(t, uint32(0), wc.GetTotalWeight().GetValue(), "total_weight=0 is valid per spec")
+}
+
+// TestBuildEdgeRouteWeighted_RetryPolicy verifies the retry policy is wired on the
+// weighted_clusters RouteAction (same as the single-cluster path).
+func TestBuildEdgeRouteWeighted_RetryPolicy(t *testing.T) {
+	backends := []WeightedRouteBackend{
+		{Cluster: "svc-a.aether.internal", Weight: 1},
+		{Cluster: "svc-b.aether.internal", Weight: 1},
+	}
+	r := BuildEdgeRouteWeighted("/", "", backends, nil, nil, nil)
+	ra := r.GetRoute()
+	require.NotNil(t, ra)
+	require.NotNil(t, ra.GetRetryPolicy(), "retry policy must be set on weighted route")
+}
+
+// TestBuildEdgeRouteWeighted_Redirect verifies that a redirect (non-nil GammaRedirect)
+// takes precedence over backends and produces a Route_Redirect action.
+func TestBuildEdgeRouteWeighted_Redirect(t *testing.T) {
+	backends := []WeightedRouteBackend{{Cluster: "svc-a.aether.internal", Weight: 1}}
+	rd := &GammaRedirect{Scheme: "https", StatusCode: 301}
+	r := BuildEdgeRouteWeighted("/old", "", backends, nil, rd, nil)
+
+	require.NotNil(t, r)
+	assert.NotNil(t, r.GetRedirect(), "redirect must produce Route_Redirect")
+	assert.Nil(t, r.GetRoute(), "redirect must not have a RouteAction")
+}
+
 // TestBuildEdgeRoute_Redirect: BuildEdgeRoute with a non-nil GammaRedirect emits a
 // Route_Redirect action (no cluster) with the correct fields.
 func TestBuildEdgeRoute_Redirect(t *testing.T) {


### PR DESCRIPTION
## Summary

- **`cache.Route` shape change**: adds `RouteBackend{Service, BackendNamespace, Port, Weight}` and `Route.Backends []RouteBackend` replacing the single-backend `firstBackendService`/`firstBackendPort`/`firstBackendNamespace` path. Legacy `Service`/`Port`/`BackendNamespace` fields are still populated from the first backend for backward compatibility.
- **`weighted_clusters` route action**: `proxy.BuildEdgeRouteWeighted` emits a `weighted_clusters` Envoy route action for >1 backend (each entry's `total_weight` = sum of weights), delegates to the existing single-cluster `BuildEdgeRoute` for exactly 1 backend. `buildEdgeVhostsLocked` uses the new path when `route.Backends` is populated.
- **Per-backend dual-mode cluster resolution**: each weighted entry independently resolves via `edgeClusterNameLocked` — mesh-registered services go to the mTLS mesh cluster, non-registered services go to the cleartext STRICT_DNS `edge_k8s_<ns>_<svc>_<port>` cluster (PR #353 dual-mode intact). `edgeK8sBackendClusters` iterates all `Backends` entries (not just the first) so every non-mesh weighted backend gets a cluster in CDS.
- **Weight semantics**: `backendRef.weight` nil → default 1 (Gateway API spec). Weight 0 = valid backend receiving no traffic (per spec). All-zero-weight rule produces `total_weight=0`; Envoy returns 500 in that case — acceptable per spec, no special-casing.
- **Preserved**: `sortRoutesBySpecificity`, `vh.Gateways` attachment model, `effectiveHostnames`, `equalEdgeGateways`/`equalVirtualHosts`, and the full dual-mode resolver.

## Test plan

- [ ] `TestBuildEdgeRouteWeighted_MultipleBackends` — weighted_clusters shape, total_weight, cluster names, weights
- [ ] `TestBuildEdgeRouteWeighted_SingleBackend` — single backend → plain cluster, no weighted_clusters
- [ ] `TestBuildEdgeRouteWeighted_ExactMatch` — exact path match preserved in weighted route
- [ ] `TestBuildEdgeRouteWeighted_ZeroWeightBackends` — all-zero weights → total_weight=0, valid route
- [ ] `TestBuildEdgeRouteWeighted_RetryPolicy` — retry policy wired on weighted route
- [ ] `TestBuildEdgeRouteWeighted_Redirect` — redirect takes precedence over backends
- [ ] `TestBuildHTTPRouteBackends_WeightedSplit` — reconciler collects all backends with weights
- [ ] `TestBuildHTTPRouteBackends_DefaultWeight` — nil weight defaults to 1
- [ ] `TestBuildHTTPRouteBackends_ZeroWeight` — explicit zero preserved
- [ ] `TestBuildHTTPRouteBackends_UngrantedCrossNsSkipped` — RefNotPermitted still drops
- [ ] `TestBuildVirtualHost_WeightedBackends` — Backends list populated, legacy fields from first
- [ ] `TestVirtualHostVhosts_WeightedSplit` — end-to-end: mesh + cleartext backends, weighted_clusters, dual-mode resolution
- [ ] `TestVirtualHostVhosts_SingleBackendNoWeightedClusters` — single-backend Backends → plain cluster
- [ ] `TestEdgeK8sBackendClusters_WeightedBackends` — all non-mesh Backends entries emit clusters; mesh skipped; dedup
- [ ] All existing edge proxy/cache/reconciler tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S