### PR TITLE
fix(edge): stamp observedGeneration on invalid-TLS Gateways + advertise implemented redirect/rewrite features

### DIFF
--- a/agent/internal/edge/gatewayapi/edge_cases_test.go
+++ b/agent/internal/edge/gatewayapi/edge_cases_test.go
@@ -154,6 +154,19 @@ func TestListenerInvalidTLS(t *testing.T) {
 	gwProg := meta.FindStatusCondition(got.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
 	require.NotNil(t, gwProg)
 	assert.Equal(t, metav1.ConditionFalse, gwProg.Status)
+
+	// observedGeneration must be stamped to the Gateway's current generation on BOTH
+	// the Accepted AND Programmed conditions even on the invalid-TLS path — the
+	// controller must not early-return before stamping it (rev13 regression: the
+	// cert-error Gateways reported observedGeneration 0 while generation was 1, so
+	// GatewayInvalidTLSConfiguration failed waiting for observedGeneration==1). The
+	// conformance suite waits for status.conditions[].observedGeneration ==
+	// metadata.generation before asserting the condition values.
+	gwAcc := meta.FindStatusCondition(got.Status.Conditions, string(gatewayv1.GatewayConditionAccepted))
+	require.NotNil(t, gwAcc)
+	assert.Equal(t, metav1.ConditionTrue, gwAcc.Status, "Accepted stays True even with an invalid-TLS listener")
+	assert.Equal(t, got.Generation, gwAcc.ObservedGeneration, "Accepted observedGeneration must track metadata.generation on the invalid-TLS path")
+	assert.Equal(t, got.Generation, gwProg.ObservedGeneration, "Programmed observedGeneration must track metadata.generation on the invalid-TLS path")
 }
 
 // TestRouteNotMatchingSectionName: a route whose parentRef names a sectionName

--- a/agent/internal/edge/gatewayapi/features.go
+++ b/agent/internal/edge/gatewayapi/features.go
@@ -11,13 +11,18 @@ import (
 // features the aether edge implements (docs/conformance/gateway-api-features.md).
 // The upstream conformance suite reads GatewayClass.status.supportedFeatures to
 // decide which suites to run vs skip, so advertising ONLY what we implement makes
-// unsupported tests (redirect/rewrite/mirror, ReferenceGrant) skip cleanly instead
-// of failing. The named feature constants come from the pinned gateway-api module
+// unsupported tests (mirror, query/header-match flags) skip cleanly instead of
+// failing. The named feature constants come from the pinned gateway-api module
 // (sigs.k8s.io/gateway-api/pkg/features).
 //
 //   - Gateway / GatewayPort8080 — north-south Gateways on the standard test port.
 //
-//   - HTTPRoute / GRPCRoute — both route types (edge HTTPRoute, GAMMA HTTPRoute+GRPCRoute).
+//   - HTTPRoute — the edge (parentRef=Gateway) and GAMMA (parentRef=Service) route
+//     type. NOTE: GRPCRoute is deliberately NOT advertised on the GatewayClass:
+//     aether serves GRPCRoute only east-west via GAMMA (parentRef=Service), which is
+//     a mesh feature with no GatewayClass, so the north-south Gateway does not serve
+//     GRPCRoute. Advertising SupportGRPCRoute here makes the GATEWAY-GRPC suite send
+//     gRPC traffic through a Gateway the edge cannot serve (run→fail/timeout).
 //
 //   - HTTPRouteMethodMatching — gRPC method match → path; HTTP method match.
 //
@@ -25,22 +30,37 @@ import (
 //
 //   - HTTPRouteRequestTimeout — HTTPRoute timeouts.request.
 //
+//   - HTTPRoutePortRedirect / HTTPRouteSchemeRedirect / HTTPRoutePathRedirect —
+//     the RequestRedirect filter (port/scheme/path redirects; 301/302 status codes),
+//     implemented on edge + GAMMA HTTPRoute (proxy.gammaRedirectAction). Host redirect
+//     carries no separate feature flag (host+status is core). The 303/307/308 redirect
+//     status-code features are NOT advertised — only 301 (MOVED_PERMANENTLY) and 302
+//     (FOUND) are implemented.
+//
+//   - HTTPRouteHostRewrite / HTTPRoutePathRewrite — the URLRewrite filter (host +
+//     path rewrite), implemented on edge + GAMMA HTTPRoute (proxy.applyURLRewrite).
+//
 //   - ReferenceGrant — cross-namespace backendRef admission + status enforcement
 //     (ungranted cross-ns refs report ResolvedRefs=False/RefNotPermitted and are
 //     dropped). Resolution stays namespace-blind today (proposal 020 Part 1).
 //
 // Path match (Exact/PathPrefix), header match (Exact), weighted backends, and the
 // RequestHeaderModifier filter are part of HTTPRoute *core* conformance and carry
-// no separate feature flag. Redirect/rewrite/mirror are deliberately omitted (not
-// implemented) so their suites skip.
+// no separate feature flag. Request mirroring is deliberately omitted (not
+// implemented) so its suite skips. Query-param / header-match feature flags are
+// intentionally not advertised here yet — that matching lands in a separate change.
 var aetherSupportedFeaturesList = []features.FeatureName{
 	features.SupportGateway,
 	features.SupportGatewayPort8080,
-	features.SupportGRPCRoute,
 	features.SupportHTTPRoute,
+	features.SupportHTTPRouteHostRewrite,
 	features.SupportHTTPRouteMethodMatching,
+	features.SupportHTTPRoutePathRedirect,
+	features.SupportHTTPRoutePathRewrite,
+	features.SupportHTTPRoutePortRedirect,
 	features.SupportHTTPRouteRequestTimeout,
 	features.SupportHTTPRouteResponseHeaderModification,
+	features.SupportHTTPRouteSchemeRedirect,
 	features.SupportReferenceGrant,
 }
 

--- a/agent/internal/edge/gatewayapi/status_test.go
+++ b/agent/internal/edge/gatewayapi/status_test.go
@@ -458,8 +458,9 @@ func TestReconcile_GatewayStatusAddresses_NoLBIP(t *testing.T) {
 }
 
 // TestReconcile_GatewayClassSupportedFeatures: the GatewayClass status carries the
-// advertised supportedFeatures, sorted ascending and including HTTPRoute/GRPCRoute,
-// and omitting features aether does not implement.
+// advertised supportedFeatures, sorted ascending and including HTTPRoute plus the
+// implemented redirect/rewrite filter features, and omitting features aether does
+// not implement (mirror) or does not serve on the north-south Gateway (GRPCRoute).
 func TestReconcile_GatewayClassSupportedFeatures(t *testing.T) {
 	gc := &gatewayv1.GatewayClass{
 		ObjectMeta: metav1.ObjectMeta{Name: "aether", Generation: 1},
@@ -484,11 +485,25 @@ func TestReconcile_GatewayClassSupportedFeatures(t *testing.T) {
 	}
 	assert.True(t, sort.StringsAreSorted(names), "supportedFeatures must be ascending by name")
 	assert.Contains(t, names, "HTTPRoute")
-	assert.Contains(t, names, "GRPCRoute")
 	assert.Contains(t, names, "HTTPRouteRequestTimeout")
 	// ReferenceGrant is now implemented (cross-namespace backendRef admission +
 	// status) and therefore advertised so the suite runs those tests.
 	assert.Contains(t, names, "ReferenceGrant")
-	// Unsupported features must NOT be advertised (so their suites skip).
+	// The RequestRedirect filter (port/scheme/path redirect) and URLRewrite filter
+	// (host/path rewrite) are implemented on edge + GAMMA HTTPRoute, so the suite
+	// should RUN (not skip) those tests.
+	assert.Contains(t, names, "HTTPRoutePortRedirect")
+	assert.Contains(t, names, "HTTPRouteSchemeRedirect")
+	assert.Contains(t, names, "HTTPRoutePathRedirect")
+	assert.Contains(t, names, "HTTPRouteHostRewrite")
+	assert.Contains(t, names, "HTTPRoutePathRewrite")
+	// GRPCRoute is served only east-west via GAMMA (parentRef=Service), not on the
+	// north-south Gateway, so it must NOT be advertised on the GatewayClass — else
+	// the GATEWAY-GRPC suite runs gRPC traffic the edge Gateway cannot serve.
+	assert.NotContains(t, names, "GRPCRoute")
+	// Unsupported features must NOT be advertised (so their suites skip): request
+	// mirroring is not implemented, and the 303/307/308 redirect status codes are not
+	// (only 301/302).
 	assert.NotContains(t, names, "HTTPRouteRequestMirror")
+	assert.NotContains(t, names, "HTTPRoute303RedirectStatusCode")
 }

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -73,14 +73,28 @@ address; distinct per-Gateway addresses are proposal 021 Phase 2.
 
 The GatewayClass also publishes a machine-readable `status.supportedFeatures` list so
 the suite skips (rather than fails) the features aether does not implement. The
-advertised set is: `Gateway`, `GatewayPort8080`, `HTTPRoute`, `GRPCRoute`,
-`HTTPRouteMethodMatching`, `HTTPRouteRequestTimeout`,
-`HTTPRouteResponseHeaderModification`, `ReferenceGrant`. Path/header/method match,
-weighted backends, and the `RequestHeaderModifier` filter are part of HTTPRoute *core*
-and carry no separate feature flag. Redirect/rewrite/mirror are deliberately omitted
-(not implemented). `ReferenceGrant` is advertised now that cross-namespace backendRef
-admission + status enforcement is implemented (resolution stays namespace-blind until
-proposal 020 Part 1).
+advertised set (sorted) is: `Gateway`, `GatewayPort8080`, `HTTPRoute`,
+`HTTPRouteHostRewrite`, `HTTPRouteMethodMatching`, `HTTPRoutePathRedirect`,
+`HTTPRoutePathRewrite`, `HTTPRoutePortRedirect`, `HTTPRouteRequestTimeout`,
+`HTTPRouteResponseHeaderModification`, `HTTPRouteSchemeRedirect`, `ReferenceGrant`.
+Path/header/method match, weighted backends, and the `RequestHeaderModifier` filter
+are part of HTTPRoute *core* and carry no separate feature flag. The `RequestRedirect`
+filter (`HTTPRoutePortRedirect`/`HTTPRouteSchemeRedirect`/`HTTPRoutePathRedirect`) and
+`URLRewrite` filter (`HTTPRouteHostRewrite`/`HTTPRoutePathRewrite`) are advertised now
+that both are implemented on edge + GAMMA HTTPRoute; host redirect carries no separate
+flag (host+status is core), and only the 301/302 redirect status codes are implemented
+(the `303`/`307`/`308` status-code features are not advertised). Request mirroring is
+deliberately omitted (not implemented). `ReferenceGrant` is advertised now that
+cross-namespace backendRef admission + status enforcement is implemented (resolution
+stays namespace-blind until proposal 020 Part 1).
+
+`GRPCRoute` is **not** advertised on the GatewayClass: aether serves `GRPCRoute` only
+east-west via GAMMA (`parentRef: Service`), which is a mesh feature with no
+GatewayClass, so the north-south Gateway does not serve `GRPCRoute`. Advertising
+`SupportGRPCRoute` on the GatewayClass makes the upstream `GATEWAY-GRPC` suite send
+gRPC traffic through a Gateway the edge cannot serve (the tests run and fail/timeout),
+so it is omitted here while GAMMA continues to implement `GRPCRoute` for the mesh
+profile (see "Route types" above).
 
 ### Data-plane / addressing gap
 


### PR DESCRIPTION
Two GATEWAY-HTTP conformance hygiene items in the edge controller (`agent/internal/edge/gatewayapi/`). No data-plane behavior change; only Gateway status-condition stamping, the advertised feature set, and the conformance doc.

## 1. observedGeneration on the invalid-TLS path

rev13 `GatewayInvalidTLSConfiguration` regression: cert-error Gateways reported `observedGeneration 0` while `metadata.generation` was 1, so the suite blocked waiting for `observedGeneration == 1` on the `Accepted`/`Programmed` conditions.

The Gateway status path (`writeGatewayStatuses` → `gatewaystatus.MergeConditions`) already stamps `gw.Generation` on **every** condition it writes — `Accepted` and `Programmed` — including the invalid-TLS branch, and the reconcile never early-returns before writing status (`resolveGateways` only returns an error on a `List` failure; `resolveListenerTLS` returns an unresolved result, not an error). `meta.SetStatusCondition` always updates `ObservedGeneration` when it differs.

This PR locks that in with a regression assertion in `TestListenerInvalidTLS` (`edge_cases_test.go`): a Gateway with a bad `certificateRef` gets `Accepted=True` + `Programmed=False/Invalid`, and **both** carry `observedGeneration == metadata.generation`.

## 2. Advertise implemented redirect/rewrite features; drop GRPCRoute from the GatewayClass

`features.go` advertised 8 features and claimed redirect/rewrite were "deliberately omitted", but `docs/conformance/gateway-api-features.md` lists `RequestRedirect` and `URLRewrite` as **Supported**, and they are genuinely wired on both edge (`buildVirtualHost` → `buildHTTPRedirect`/`buildHTTPURLRewrite`) and GAMMA HTTPRoute (`proxy.gammaRedirectAction` / `proxy.applyURLRewrite`).

**Added** (gateway-api v1.5.1 constants), all implemented + doc-evidenced:
- `HTTPRoutePortRedirect`, `HTTPRouteSchemeRedirect`, `HTTPRoutePathRedirect` — `RequestRedirect` (port/scheme/path; 301/302 only)
- `HTTPRouteHostRewrite`, `HTTPRoutePathRewrite` — `URLRewrite` (host/path)

Conservatively **not** added:
- `HTTPRoute303/307/308RedirectStatusCode` — only 301 (`MOVED_PERMANENTLY`) / 302 (`FOUND`) implemented.
- Host redirect — no separate feature flag (host+status is core).
- `HTTPRouteRequestMirror` — mirror is not implemented (`Planned`).
- Query-param / header-match flags — left to the concurrent matching change so we don't advertise before it lands.

The advertised list stays sorted ascending (`aetherSupportedFeatures()` sorts by name; the test asserts `sort.StringsAreSorted`).

### GRPCRoute-on-GatewayClass finding (action taken)

`SupportGRPCRoute` was advertised on the edge GatewayClass, but **GRPCRoute is east-west GAMMA only** (`parentRef: Service`): the edge `gatewayapi` reconciler handles HTTPRoute/TCPRoute/TLSRoute attached to Gateways and never processes GRPCRoute — only `agent/internal/gamma/reconciler.go` does, off a `Service` parent. GAMMA is a mesh feature with **no GatewayClass**, so its GRPCRoute support is not (and should not be) surfaced via GatewayClass `supportedFeatures`.

The upstream `GATEWAY-GRPC` suite gates on `SupportGRPCRoute` in `GatewayClass.status.supportedFeatures` and then creates a GRPCRoute with `parentRef: Gateway` and sends gRPC traffic through that Gateway's address — which the north-south edge cannot serve (rev13: `GRPCRoute*` tests ran and failed/timed out).

**Recommendation, taken:** remove `SupportGRPCRoute` from the GatewayClass feature list. This makes the `GATEWAY-GRPC` suite skip cleanly while GAMMA continues to implement GRPCRoute unchanged. Low-risk: no code path other than the advertised set changes, and GAMMA's GRPCRoute handling/tests are untouched.

## Build / test
- `make gazelle` — no BUILD changes (no new imports).
- `bazel build //...` — green.
- `bazel test //... --test_output=errors` — 62/62 pass (incl. `gatewayapi_test`, `gamma_test`).
- `bazel run //:format` — clean.

Rebased on latest `main` (948b5f0). Status edits are confined to the Gateway/observedGeneration path; `backendsResolveL4` is untouched (concurrent route-matching PR reads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)