### PR TITLE
feat(edge): wildcard hostname intersection promotion + strip host port

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -1055,6 +1055,51 @@ func TestBuildVirtualHost_ValidBackend_NormalRoute(t *testing.T) {
 	require.NotNil(t, rt.Redirect)
 }
 
+// --- Wildcard hostname intersection (HTTPRouteListenerHostnameMatching /
+// HTTPRouteHostnameIntersection conformance regression guards) ---
+
+// TestEffectiveHostnames_WildcardIntersectSpecific is the primary conformance
+// regression guard for HTTPRouteListenerHostnameMatching: a route with hostname
+// "baz.bar.com" on a Gateway listener "*.bar.com" must yield effective host
+// "baz.bar.com" (specific wins over wildcard), never the catch-all "".
+func TestEffectiveHostnames_WildcardIntersectSpecific(t *testing.T) {
+	gws := []gatewayv1.Gateway{makeGateway("ns", "gw", "*.bar.com")}
+	m := buildGatewayListenerHostnames(gws)
+	gwKeys := []string{"ns/gw"}
+
+	got := effectiveHostnames([]string{"baz.bar.com"}, gwKeys, m)
+	require.Len(t, got, 1)
+	assert.Equal(t, "baz.bar.com", got[0],
+		"wildcard listener ∩ specific route → specific host (never catch-all)")
+}
+
+// TestEffectiveHostnames_WildcardIntersectWildcard verifies that
+// "*.bar.com" listener ∩ "*.bar.com" route = "*.bar.com" (wildcard vhost,
+// NOT the catch-all "").
+func TestEffectiveHostnames_WildcardIntersectWildcard(t *testing.T) {
+	gws := []gatewayv1.Gateway{makeGateway("ns", "gw", "*.bar.com")}
+	m := buildGatewayListenerHostnames(gws)
+	gwKeys := []string{"ns/gw"}
+
+	got := effectiveHostnames([]string{"*.bar.com"}, gwKeys, m)
+	require.Len(t, got, 1)
+	assert.Equal(t, "*.bar.com", got[0],
+		"wildcard listener ∩ wildcard route (same suffix) → wildcard named vhost (not catch-all)")
+}
+
+// TestEffectiveHostnames_NoIntersection_DifferentSuffix verifies that
+// "*.a.com" ∩ "*.b.com" = no match (empty → route discarded). This is the
+// negative case that must return 404 for an unmatched hostname.
+func TestEffectiveHostnames_NoIntersection_DifferentSuffix(t *testing.T) {
+	gws := []gatewayv1.Gateway{makeGateway("ns", "gw", "*.a.com")}
+	m := buildGatewayListenerHostnames(gws)
+	gwKeys := []string{"ns/gw"}
+
+	got := effectiveHostnames([]string{"foo.b.com"}, gwKeys, m)
+	assert.Empty(t, got,
+		"different-suffix wildcard ∩ specific → no match (route discarded, request gets 404)")
+}
+
 // TestBuildVirtualHost_InvalidBackend_PathMatchPreserved verifies that the 500
 // direct_response route carries the path match predicates from the match block,
 // including exact path and header matches, so the route only fires for the right

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -1086,3 +1086,116 @@ func TestDirectResponseRoute_AdmittedByBuildEdgeVhosts(t *testing.T) {
 	assert.NotNil(t, routes[0].GetDirectResponse(), "direct_response action must be present")
 	assert.Equal(t, uint32(500), routes[0].GetDirectResponse().GetStatus())
 }
+
+// --- Wildcard hostname vhost routing (HTTPRouteListenerHostnameMatching /
+// HTTPRouteHostnameIntersection conformance regression guards) ---
+
+// TestBuildEdgeVhostsLocked_SpecificHostUnderWildcard is the conformance
+// regression guard for HTTPRouteListenerHostnameMatching: when effectiveHostnames
+// computes "baz.bar.com" for a *.bar.com listener ∩ baz.bar.com route,
+// buildEdgeVhostsLocked must emit a vhost with domain "baz.bar.com" (not the
+// catch-all "*"). This ensures requests to baz.bar.com route to the correct
+// backend instead of the catch-all.
+func TestBuildEdgeVhostsLocked_SpecificHostUnderWildcard(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.clusterMu.Lock()
+	c.clusters["svc-v3"] = clusterEntry{service: "svc-v3"}
+	c.clusters["svc-v1"] = clusterEntry{service: "svc-v1"}
+	c.clusterMu.Unlock()
+
+	// effectiveHostnames("baz.bar.com", listener "*.bar.com") = "baz.bar.com".
+	// The vhost is given the intersection result as its Hosts.
+	c.SetVirtualHosts([]VirtualHost{
+		// v3 backend: specific intersection host baz.bar.com (from *.bar.com ∩ baz.bar.com).
+		{Hosts: []string{"baz.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-v3"}}},
+		// v1 catch-all: hostname-less route → "*" catch-all.
+		{Routes: []Route{{Prefix: "/", Service: "svc-v1"}}},
+	})
+
+	vhosts := c.virtualHostVhosts()
+	// Expected: one named vhost "baz.bar.com" + one catch-all "*".
+	require.Len(t, vhosts, 2)
+
+	byDomain := map[string]*routev3.VirtualHost{}
+	for _, vh := range vhosts {
+		byDomain[vh.GetName()] = vh
+	}
+
+	// baz.bar.com must be a named vhost, NOT the catch-all.
+	bazVH := byDomain["baz.bar.com"]
+	require.NotNil(t, bazVH, "baz.bar.com must get its own named vhost (intersection result)")
+	assert.Equal(t, []string{"baz.bar.com"}, bazVH.GetDomains())
+	assert.Equal(t, "svc-v3.aether.internal", bazVH.GetRoutes()[0].GetRoute().GetCluster())
+
+	// The catch-all "*" holds the v1 backend.
+	starVH := byDomain["*"]
+	require.NotNil(t, starVH)
+	assert.Equal(t, "svc-v1.aether.internal", starVH.GetRoutes()[0].GetRoute().GetCluster())
+}
+
+// TestBuildEdgeVhostsLocked_WildcardDomain verifies that when the effective
+// hostname is a wildcard "*.bar.com" (from *.bar.com listener ∩ *.bar.com route),
+// buildEdgeVhostsLocked emits a vhost with domain "*.bar.com" — NOT the catch-all
+// "*". Envoy matches "*.bar.com" to any request whose Host has bar.com as suffix,
+// so this is a real named vhost, not the catch-all.
+func TestBuildEdgeVhostsLocked_WildcardDomain(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.clusterMu.Lock()
+	c.clusters["svc-backend"] = clusterEntry{service: "svc-backend"}
+	c.clusterMu.Unlock()
+
+	// effectiveHostnames("*.bar.com", listener "*.bar.com") = "*.bar.com".
+	c.SetVirtualHosts([]VirtualHost{
+		{Hosts: []string{"*.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-backend"}}},
+	})
+
+	vhosts := c.virtualHostVhosts()
+	// Only one vhost: "*.bar.com". No catch-all "*" (there are no hostname-less routes).
+	require.Len(t, vhosts, 1)
+	vh := vhosts[0]
+	assert.Equal(t, "*.bar.com", vh.GetName(), "wildcard hostname must produce named vhost, NOT catch-all *")
+	assert.Equal(t, []string{"*.bar.com"}, vh.GetDomains())
+	assert.Equal(t, "svc-backend.aether.internal", vh.GetRoutes()[0].GetRoute().GetCluster())
+}
+
+// TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated verifies the full
+// HTTPRouteHostnameIntersection conformance shape: a *.bar.com listener has two
+// routes — one with hostname baz.bar.com (intersection = baz.bar.com) and one
+// with hostname *.bar.com (intersection = *.bar.com). Each must get its own
+// named vhost; neither must land in the catch-all "*".
+// This mirrors the data-plane state after effectiveHostnames runs correctly.
+func TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.clusterMu.Lock()
+	c.clusters["svc-specific"] = clusterEntry{service: "svc-specific"}
+	c.clusters["svc-wildcard"] = clusterEntry{service: "svc-wildcard"}
+	c.clusterMu.Unlock()
+
+	c.SetVirtualHosts([]VirtualHost{
+		// baz.bar.com route: intersection of *.bar.com listener ∩ baz.bar.com route.
+		{Hosts: []string{"baz.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-specific"}}},
+		// *.bar.com route: intersection of *.bar.com listener ∩ *.bar.com route.
+		{Hosts: []string{"*.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-wildcard"}}},
+	})
+
+	vhosts := c.virtualHostVhosts()
+	// Two named vhosts; no catch-all "*".
+	require.Len(t, vhosts, 2)
+
+	byName := map[string]*routev3.VirtualHost{}
+	for _, vh := range vhosts {
+		byName[vh.GetName()] = vh
+	}
+
+	bazVH := byName["baz.bar.com"]
+	require.NotNil(t, bazVH, "baz.bar.com must be a named vhost")
+	assert.Equal(t, "svc-specific.aether.internal", bazVH.GetRoutes()[0].GetRoute().GetCluster())
+
+	wildVH := byName["*.bar.com"]
+	require.NotNil(t, wildVH, "*.bar.com must be a named vhost (not catch-all *)")
+	assert.Equal(t, []string{"*.bar.com"}, wildVH.GetDomains())
+	assert.Equal(t, "svc-wildcard.aether.internal", wildVH.GetRoutes()[0].GetRoute().GetCluster())
+
+	// Confirm no catch-all "*" was emitted.
+	assert.Nil(t, byName["*"], "no hostname-less routes → no catch-all * vhost")
+}

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -112,9 +112,12 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 	if httpRedirect {
 		// Redirect listener: inline route config (no RDS), no separate route config
 		// resource needed. Re-uses the redirect route logic but names the HCM and
-		// vhost after the Gateway to keep stats distinct.
+		// vhost after the Gateway to keep stats distinct. The redirect route table
+		// uses a catch-all "*" domain so strip_any_host_port is irrelevant here, but
+		// set it for consistency with the routing listeners.
 		hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", buildEdgeRedirectRouteConfig())
 		hcm.GetRouteConfig().Name = name // unique inline config name avoids any residual collision
+		hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
 		filterChain := &listenerv3.FilterChain{
 			Name:    name,
 			Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
@@ -122,9 +125,19 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 		return edgeListener(name, internalPort, filterChain)
 	}
 	// Plain HTTP routing listener: RDS-driven, per-Gateway route config.
+	// strip_any_host_port: strip the port from the :authority pseudo-header before
+	// vhost domain matching. Gateway API hostname matching is port-agnostic: a
+	// route hostname "baz.bar.com" must match a request with Host: baz.bar.com:80
+	// or Host: baz.bar.com:1234. Without stripping, Go HTTP clients (including the
+	// conformance suite) send the port in the Host header even for standard ports,
+	// causing the authority "baz.bar.com:80" to miss the "baz.bar.com" vhost domain
+	// and fall through to the catch-all "*". This ONLY applies to edge (external)
+	// listeners — the node/east-west outbound HCM must NOT strip ports because the
+	// port is a first-class FQDN:port routing selector (proposal 005).
 	routeName := EdgeGatewayRouteName(namespace, gatewayName)
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
+	hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			RouteConfigName: routeName,
@@ -146,6 +159,11 @@ func BuildEdgeGatewayHTTPSListener(namespace, gatewayName string, internalPort u
 	routeName := EdgeGatewayRouteName(namespace, gatewayName)
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
+	// strip_any_host_port: see BuildEdgeGatewayHTTPListener for the rationale.
+	// HTTPS clients connecting on a non-standard port (e.g. :8443 or the
+	// conformance port :1234) include the port in the Host header, causing the
+	// same catch-all fall-through without stripping.
+	hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			RouteConfigName: routeName,
@@ -327,6 +345,9 @@ func BuildEdgeTLSPassthroughListener(port uint32, rules []L4ServiceRoute) *liste
 func BuildEdgeListener(name string, port uint32, tlsSecretNames []string) *listenerv3.Listener {
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
+	// strip_any_host_port: see BuildEdgeGatewayHTTPListener for the rationale.
+	// The Phase 1 shared listener faces the same port-in-Host-header issue.
+	hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			// Both the HTTP and HTTPS listeners serve the same edge route table.

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -53,7 +53,8 @@ func TestNewServiceCluster_EdgePoolingOff(t *testing.T) {
 
 // TestBuildEdgeListener verifies the public-facing edge listener: bound on all
 // interfaces at the configured port, RDS-driven, with the readiness filter
-// ahead of the router.
+// ahead of the router, and strip_any_host_port enabled for Gateway API hostname
+// matching (port-agnostic per the spec).
 func TestBuildEdgeListener(t *testing.T) {
 	l := BuildEdgeListener(EdgeListenerName, 8080, nil)
 
@@ -75,6 +76,17 @@ func TestBuildEdgeListener(t *testing.T) {
 	require.GreaterOrEqual(t, len(hcm.GetHttpFilters()), 2)
 	assert.Equal(t, httpHealthCheckFilterName, hcm.GetHttpFilters()[0].GetName())
 	assert.Equal(t, httpRouterFilterName, hcm.GetHttpFilters()[len(hcm.GetHttpFilters())-1].GetName())
+
+	// strip_any_host_port must be set on edge listeners: Gateway API hostname
+	// matching is port-agnostic, but Go HTTP clients (including the Gateway API
+	// conformance suite) include the port in the Host header even for the standard
+	// port (e.g. "baz.bar.com:80"). Without stripping, the ":authority" header
+	// "baz.bar.com:80" misses the vhost domain "baz.bar.com" and falls to the
+	// catch-all "*", causing HTTPRouteListenerHostnameMatching and
+	// HTTPRouteHostnameIntersection to fail. The node/east-west outbound HCM must
+	// NOT strip ports (FQDN:port is a routing selector there — proposal 005).
+	assert.True(t, hcm.GetStripAnyHostPort(),
+		"edge listener must strip :port from Host header for Gateway API hostname matching")
 }
 
 // TestBuildEdgeListenerTLS verifies downstream TLS termination: the filter chain
@@ -248,7 +260,8 @@ func TestEdgeGatewayRouteNameUnique(t *testing.T) {
 }
 
 // TestBuildEdgeGatewayHTTPListener verifies the per-Gateway plain-HTTP listener:
-// unique name, bound on the internal port, RDS to the per-Gateway route config.
+// unique name, bound on the internal port, RDS to the per-Gateway route config,
+// and strip_any_host_port enabled.
 func TestBuildEdgeGatewayHTTPListener(t *testing.T) {
 	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18150, false)
 	assert.Equal(t, "edge_gw_ns-a_my-gw_18150", l.GetName())
@@ -262,10 +275,14 @@ func TestBuildEdgeGatewayHTTPListener(t *testing.T) {
 	assert.Equal(t, "edge_rt_ns-a_my-gw", hcm.GetRds().GetRouteConfigName())
 	// Plain HTTP: no transport socket.
 	assert.Nil(t, l.GetFilterChains()[0].GetTransportSocket())
+	// strip_any_host_port must be set (Gateway API hostname matching is port-agnostic).
+	assert.True(t, hcm.GetStripAnyHostPort(),
+		"per-Gateway HTTP listener must strip :port from Host header for hostname matching")
 }
 
 // TestBuildEdgeGatewayHTTPListener_Redirect verifies the per-Gateway HTTP→HTTPS
-// redirect listener uses an inline route config (no RDS) with the per-Gateway name.
+// redirect listener uses an inline route config (no RDS) with the per-Gateway name
+// and carries strip_any_host_port.
 func TestBuildEdgeGatewayHTTPListener_Redirect(t *testing.T) {
 	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18151, true)
 	assert.Equal(t, "edge_gw_ns-a_my-gw_18151", l.GetName())
@@ -279,10 +296,14 @@ func TestBuildEdgeGatewayHTTPListener_Redirect(t *testing.T) {
 	red := rc.GetVirtualHosts()[0].GetRoutes()[0].GetRedirect()
 	require.NotNil(t, red)
 	assert.True(t, red.GetHttpsRedirect())
+	// strip_any_host_port: set for consistency with routing listeners.
+	assert.True(t, hcm.GetStripAnyHostPort(),
+		"redirect listener carries strip_any_host_port for consistency")
 }
 
 // TestBuildEdgeGatewayHTTPSListener verifies the per-Gateway HTTPS listener
-// terminates TLS, uses the per-Gateway route config, and has the unique name.
+// terminates TLS, uses the per-Gateway route config, has the unique name, and
+// carries strip_any_host_port.
 func TestBuildEdgeGatewayHTTPSListener(t *testing.T) {
 	l := BuildEdgeGatewayHTTPSListener("ns-b", "secure-gw", 18160, []string{"kubernetes/my-cert"})
 	assert.Equal(t, "edge_gw_ns-b_secure-gw_18160", l.GetName())
@@ -297,6 +318,9 @@ func TestBuildEdgeGatewayHTTPSListener(t *testing.T) {
 	require.NoError(t, fc.GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
 	// Routes via per-Gateway RDS route config.
 	assert.Equal(t, "edge_rt_ns-b_secure-gw", hcm.GetRds().GetRouteConfigName())
+	// strip_any_host_port must be set (HTTPS clients include the port in Host).
+	assert.True(t, hcm.GetStripAnyHostPort(),
+		"per-Gateway HTTPS listener must strip :port from Host header for hostname matching")
 }
 
 // TestBuildEdgeGatewayRouteConfiguration verifies per-Gateway route config:


### PR DESCRIPTION
## Summary

- **Root cause diagnosed**: Two conformance buckets (`HTTPRouteListenerHostnameMatching`, `HTTPRouteHostnameIntersection`) failed because Envoy matches the raw `:authority` pseudo-header (including port) against vhost domains. Go HTTP clients — including the conformance suite — include the port even for the standard port (e.g. `Host: baz.bar.com:80`), so `baz.bar.com:80` missed the `baz.bar.com` vhost domain and fell through to the catch-all `*`.
- **Fix**: Set `strip_any_host_port: true` on all three edge HCMs (`BuildEdgeListener`, `BuildEdgeGatewayHTTPListener` routing + redirect, `BuildEdgeGatewayHTTPSListener`). Gateway API hostname matching is port-agnostic per the spec; Envoy must strip the port before vhost domain matching.
- **Scope**: Edge (external-facing) listeners only. The node/east-west outbound HCM retains `strip_any_host_port: false` — the port is a first-class FQDN:port routing selector there (proposal 005).

## Intersection logic confirmed correct

`hostnameIntersect` and `effectiveHostnames` were audited and confirmed correct:
- `*.bar.com` ∩ `baz.bar.com` = `baz.bar.com` (specific wins)
- `*.bar.com` ∩ `*.bar.com` = `*.bar.com` (same wildcard)
- `*.a.com` ∩ `*.b.com` = empty (no match → 404)

The intersection code was not the bug; the issue was purely Envoy's port-in-authority matching.

## Regressions guarded

- `filterchain_test.go` (existing): asserts outbound HCM has `GetStripAnyHostPort() == false` — still passes, unchanged
- `api.palermo.dev` routing: listener hostname `*.palermo.dev` ∩ route hostname `api.palermo.dev` = `api.palermo.dev` vhost; unaffected by this change

## Tests

New tests added:

**`agent/internal/xds/proxy/edge_test.go`**
- `TestBuildEdgeListener`: added `StripAnyHostPort == true` assertion
- `TestBuildEdgeGatewayHTTPListener`: added `StripAnyHostPort == true` assertion
- `TestBuildEdgeGatewayHTTPListener_Redirect`: added `StripAnyHostPort == true` assertion
- `TestBuildEdgeGatewayHTTPSListener`: added `StripAnyHostPort == true` assertion

**`agent/internal/xds/cache/edge_test.go`**
- `TestBuildEdgeVhostsLocked_SpecificHostUnderWildcard`: `baz.bar.com` vhost produced (not catch-all `*`)
- `TestBuildEdgeVhostsLocked_WildcardDomain`: `*.bar.com` named vhost produced (not catch-all `*`)
- `TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated`: both coexist, no spurious `*` catch-all

**`agent/internal/edge/gatewayapi/reconciler_test.go`**
- `TestEffectiveHostnames_WildcardIntersectSpecific`: `*.bar.com` listener ∩ `baz.bar.com` route = `baz.bar.com`
- `TestEffectiveHostnames_WildcardIntersectWildcard`: `*.bar.com` listener ∩ `*.bar.com` route = `*.bar.com`
- `TestEffectiveHostnames_NoIntersection_DifferentSuffix`: `*.a.com` ∩ `foo.b.com` = empty

## Test plan

- [x] `bazel test //agent/internal/xds/proxy:proxy_test //agent/internal/xds/cache:cache_test //agent/internal/edge/gatewayapi:gatewayapi_test` — all pass
- [x] `bazel build //...` — clean
- [x] `bazel run //:format` — no drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S