### PR TITLE
fix(edge): dial targetPort for headless-Service HTTPRoute backends

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -533,7 +533,7 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 
 		// Collect ALL admissible backends in this rule with their weights.
 		// backendRef.weight nil → default 1 (per Gateway API spec).
-		backends := buildHTTPRouteBackends(rule.BackendRefs, hr.Namespace, grants)
+		backends := r.buildHTTPRouteBackends(ctx, rule.BackendRefs, hr.Namespace, grants)
 
 		// A rule must have either at least one backend or a redirect to produce a route.
 		// Exception: a rule where all backends are UNRESOLVABLE (InvalidKind /
@@ -613,11 +613,12 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 		// For backward-compat we also populate the legacy Service/Port/BackendNamespace
 		// from the first backend so that code paths that read those fields still work.
 		var legacySvc, legacyNS string
-		var legacyPort uint32
+		var legacyPort, legacyDialPort uint32
 		if len(backends) > 0 {
 			legacySvc = backends[0].Service
 			legacyPort = backends[0].Port
 			legacyNS = backends[0].BackendNamespace
+			legacyDialPort = backends[0].DialPort
 		}
 
 		if len(rule.Matches) == 0 {
@@ -627,6 +628,7 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 				Service:          legacySvc,
 				Port:             legacyPort,
 				BackendNamespace: legacyNS,
+				DialPort:         legacyDialPort,
 				Backends:         backends,
 				HeaderMutation:   mutation,
 				Redirect:         redirect,
@@ -678,6 +680,7 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 				Service:          legacySvc,
 				Port:             legacyPort,
 				BackendNamespace: legacyNS,
+				DialPort:         legacyDialPort,
 				Backends:         backends,
 				HeaderMutation:   mutation,
 				Redirect:         redirect,
@@ -698,7 +701,13 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 // RouteBackend values, applying Gateway API admission rules: non-core group/kind
 // refs are skipped; ungranted cross-namespace refs are skipped (RefNotPermitted).
 // Weight nil → default 1 per spec. Returns an empty slice when no backend is admissible.
-func buildHTTPRouteBackends(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) []cache.RouteBackend {
+//
+// For each admitted backend it resolves the cleartext STRICT_DNS dial port via
+// resolveDialPort: a HEADLESS Service's FQDN resolves to pod IPs (no kube-proxy in
+// the path), so the edge must dial the Service's numeric targetPort rather than the
+// service port. A mesh-registered or ClusterIP backend leaves DialPort 0 (the cache
+// falls back to Port).
+func (r *Reconciler) buildHTTPRouteBackends(ctx context.Context, refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) []cache.RouteBackend {
 	out := make([]cache.RouteBackend, 0, len(refs))
 	for _, b := range refs {
 		if b.Group != nil && string(*b.Group) != "" {
@@ -731,9 +740,47 @@ func buildHTTPRouteBackends(refs []gatewayv1.HTTPBackendRef, routeNamespace stri
 			BackendNamespace: ns,
 			Port:             port,
 			Weight:           weight,
+			DialPort:         r.resolveDialPort(ctx, ns, name, port),
 		})
 	}
 	return out
+}
+
+// resolveDialPort returns the TCP port the edge's cleartext STRICT_DNS cluster must
+// connect to for a non-mesh backend Service. It only differs from servicePort for a
+// HEADLESS Service (clusterIP: None): its FQDN resolves straight to pod IPs, so the
+// edge must dial the numeric targetPort of the matching ServicePort instead of the
+// service port (there is no kube-proxy VIP to remap port→targetPort). For a ClusterIP
+// Service — or when the Service can't be read, the targetPort is named (we cannot
+// resolve a named targetPort to a number without the pod spec), or there is no match —
+// it returns 0, signalling the cache to fall back to servicePort (the existing,
+// already-correct ClusterIP behavior). It never returns an error: a missing/unreadable
+// Service degrades to the prior behavior rather than breaking the route.
+func (r *Reconciler) resolveDialPort(ctx context.Context, namespace, service string, servicePort uint32) uint32 {
+	if servicePort == 0 || r.Client == nil {
+		return 0
+	}
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: service}, svc); err != nil {
+		return 0 // unreadable/missing → fall back to servicePort (no change)
+	}
+	if svc.Spec.ClusterIP != corev1.ClusterIPNone {
+		return 0 // ClusterIP Service: kube-proxy remaps port→targetPort; dial servicePort.
+	}
+	// Headless Service: find the ServicePort matching servicePort and dial its
+	// numeric targetPort. A named (string) targetPort can't be resolved here without
+	// the pod spec, so fall back to servicePort for that (uncommon) case.
+	for _, sp := range svc.Spec.Ports {
+		if uint32(sp.Port) != servicePort {
+			continue
+		}
+		if tp := sp.TargetPort.IntValue(); tp > 0 {
+			return uint32(tp)
+		}
+		// targetPort unset → defaults to the service port; named → unresolved here.
+		return 0
+	}
+	return 0
 }
 
 // attachedToOurGateway reports whether the given parentRefs (belonging to a route

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -10,7 +10,11 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
@@ -178,7 +182,7 @@ func TestBuildHTTPRouteBackends_WeightedSplit(t *testing.T) {
 			weight int32
 		}{"svc-b", 9090, 1},
 	)
-	got := buildHTTPRouteBackends(refs, "my-ns", nil)
+	got := (&Reconciler{}).buildHTTPRouteBackends(context.Background(), refs, "my-ns", nil)
 	require.Len(t, got, 2, "both backends must be admitted")
 	assert.Equal(t, cache.RouteBackend{Service: "svc-a", BackendNamespace: "my-ns", Port: 8080, Weight: 3}, got[0])
 	assert.Equal(t, cache.RouteBackend{Service: "svc-b", BackendNamespace: "my-ns", Port: 9090, Weight: 1}, got[1])
@@ -188,7 +192,7 @@ func TestBuildHTTPRouteBackends_WeightedSplit(t *testing.T) {
 // explicit weight defaults to 1 (per Gateway API spec).
 func TestBuildHTTPRouteBackends_DefaultWeight(t *testing.T) {
 	refs := backend("svc-1", 8080) // uses the single-backend helper (no Weight field)
-	got := buildHTTPRouteBackends(refs, "ns", nil)
+	got := (&Reconciler{}).buildHTTPRouteBackends(context.Background(), refs, "ns", nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, uint32(1), got[0].Weight, "nil weight must default to 1")
 }
@@ -203,7 +207,7 @@ func TestBuildHTTPRouteBackends_ZeroWeight(t *testing.T) {
 	}{"svc-x", 80, 0})
 	// Note: our helper only sets Weight when > 0, so we need to set it explicitly.
 	refs[0].Weight = ptr(int32(0))
-	got := buildHTTPRouteBackends(refs, "ns", nil)
+	got := (&Reconciler{}).buildHTTPRouteBackends(context.Background(), refs, "ns", nil)
 	require.Len(t, got, 1)
 	assert.Equal(t, uint32(0), got[0].Weight, "explicit zero weight must be preserved")
 }
@@ -217,7 +221,7 @@ func TestBuildHTTPRouteBackends_UngrantedCrossNsSkipped(t *testing.T) {
 		{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "cross", Namespace: &otherNs}}},
 		{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "local"}}},
 	}
-	got := buildHTTPRouteBackends(refs, "ns", nil)
+	got := (&Reconciler{}).buildHTTPRouteBackends(context.Background(), refs, "ns", nil)
 	require.Len(t, got, 1, "ungranted cross-ns backend dropped, same-ns backend admitted")
 	assert.Equal(t, "local", got[0].Service)
 }
@@ -1089,4 +1093,68 @@ func TestBuildVirtualHost_InvalidBackend_PathMatchPreserved(t *testing.T) {
 	assert.Equal(t, uint32(500), rt.DirectResponseStatus)
 	require.Len(t, rt.Headers, 1)
 	assert.Equal(t, "x-test", rt.Headers[0].Name, "header match must be preserved on the 500 route")
+}
+
+// svcWith builds a core Service with one port (port -> targetPort) and the given
+// clusterIP (use corev1.ClusterIPNone for a headless Service).
+func svcWith(name, ns, clusterIP string, port int32, targetPort intstr.IntOrString) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: clusterIP,
+			Ports:     []corev1.ServicePort{{Port: port, TargetPort: targetPort}},
+		},
+	}
+}
+
+// TestResolveDialPort covers the headless-vs-ClusterIP Service-type distinction that
+// drives the edge's cleartext STRICT_DNS dial port (the HTTPRouteServiceTypes
+// conformance fix). A headless Service's FQDN resolves to pod IPs, so the edge must
+// dial the numeric targetPort; a ClusterIP Service keeps the service port (kube-proxy
+// remaps). Unresolvable cases fall back to 0 (= dial service port).
+func TestResolveDialPort(t *testing.T) {
+	objs := []client.Object{
+		svcWith("headless", "ns", corev1.ClusterIPNone, 8080, intstr.FromInt(3000)),
+		svcWith("clusterip", "ns", "10.0.0.1", 8080, intstr.FromInt(3000)),
+		svcWith("headless-named", "ns", corev1.ClusterIPNone, 8080, intstr.FromString("http")),
+		svcWith("headless-defaulttp", "ns", corev1.ClusterIPNone, 8080, intstr.IntOrString{}),
+	}
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).WithObjects(objs...).Build()
+	r := &Reconciler{Client: c}
+	ctx := context.Background()
+
+	// Headless: dial the numeric targetPort, not the service port.
+	assert.Equal(t, uint32(3000), r.resolveDialPort(ctx, "ns", "headless", 8080),
+		"headless Service must dial its numeric targetPort (pods, not VIP)")
+	// ClusterIP: kube-proxy remaps; keep the service port (0 = fall back to Port).
+	assert.Equal(t, uint32(0), r.resolveDialPort(ctx, "ns", "clusterip", 8080),
+		"ClusterIP Service keeps the service port")
+	// Headless with a NAMED targetPort: unresolvable here → fall back (0).
+	assert.Equal(t, uint32(0), r.resolveDialPort(ctx, "ns", "headless-named", 8080),
+		"headless Service with named targetPort falls back to service port")
+	// Headless with targetPort unset (defaults to service port) → fall back (0).
+	assert.Equal(t, uint32(0), r.resolveDialPort(ctx, "ns", "headless-defaulttp", 8080),
+		"headless Service with unset targetPort falls back to service port")
+	// Missing Service → fall back (0), no error.
+	assert.Equal(t, uint32(0), r.resolveDialPort(ctx, "ns", "absent", 8080),
+		"missing Service falls back to service port")
+	// servicePort 0 → fall back (0) without a Get.
+	assert.Equal(t, uint32(0), r.resolveDialPort(ctx, "ns", "headless", 0),
+		"zero service port falls back without lookup")
+	// Nil client → fall back (0), no panic.
+	assert.Equal(t, uint32(0), (&Reconciler{}).resolveDialPort(ctx, "ns", "headless", 8080),
+		"nil client degrades gracefully")
+}
+
+// TestBuildHTTPRouteBackends_HeadlessDialPort verifies the dial port is threaded onto
+// the RouteBackend for a headless backend so the cleartext cluster reaches targetPort.
+func TestBuildHTTPRouteBackends_HeadlessDialPort(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(svcWith("headless", "ns", corev1.ClusterIPNone, 8080, intstr.FromInt(3000))).
+		Build()
+	r := &Reconciler{Client: c}
+	got := r.buildHTTPRouteBackends(context.Background(), backend("headless", 8080), "ns", nil)
+	require.Len(t, got, 1)
+	assert.Equal(t, uint32(8080), got[0].Port, "cluster name stays keyed by service port")
+	assert.Equal(t, uint32(3000), got[0].DialPort, "headless backend dials the targetPort")
 }

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -142,6 +142,16 @@ type RouteBackend struct {
 	// The Envoy weighted_clusters total_weight is the sum of all backend weights
 	// within the rule. Weight 0 = backend receives no traffic.
 	Weight uint32
+	// DialPort is the TCP port a non-mesh (cleartext STRICT_DNS) cluster actually
+	// connects to. It differs from Port for a HEADLESS Service: the Service FQDN
+	// resolves directly to pod IPs (no kube-proxy in the path to remap the port), so
+	// the edge must dial the Service's numeric targetPort, not its service port.
+	// For a ClusterIP Service the FQDN resolves to the ClusterIP and kube-proxy
+	// DNATs port->targetPort, so DialPort == Port. Zero means "same as Port" (the
+	// reconciler leaves it 0 when no Service-type-specific remap is needed); the
+	// cluster builder falls back to Port. The cluster NAME stays keyed by Port so
+	// route->cluster names remain stable regardless of the resolved dial port.
+	DialPort uint32
 }
 
 // Route is one path-match -> backend rule within a VirtualHost. Exactly one of
@@ -177,6 +187,9 @@ type Route struct {
 	Service          string
 	Port             uint32
 	BackendNamespace string
+	// DialPort is the cleartext STRICT_DNS dial port for the legacy single-backend
+	// path (mirrors RouteBackend.DialPort). Zero = dial Port. See RouteBackend.DialPort.
+	DialPort uint32
 	// Backends is the weighted backend list for this rule. A single-element list
 	// is equivalent to the legacy Service/Port/BackendNamespace fields. An empty
 	// Backends with a non-empty Service falls back to the legacy single-backend
@@ -683,21 +696,28 @@ func (c *SnapshotCache) edgeK8sBackendClusters() []types.Resource {
 	gws := slices.Clone(c.edgeGateways)
 	c.edgeMu.RUnlock()
 
-	// key: "namespace/service:port"
+	// key: "namespace/service:port" — the cluster NAME is keyed by the service port,
+	// matching edgeClusterNameLocked. dialPort is the resolved STRICT_DNS connect
+	// port (differs from port for headless Services; see RouteBackend.DialPort).
 	type k8sBackend struct {
 		namespace string
 		service   string
 		port      uint32
+		dialPort  uint32
 	}
 	seen := make(map[k8sBackend]struct{})
 	var backends []k8sBackend
 
-	addBackend := func(service, namespace string, port uint32) {
+	addBackend := func(service, namespace string, port, dialPort uint32) {
 		p := port
 		if p == 0 {
 			p = 80
 		}
-		bk := k8sBackend{namespace: namespace, service: service, port: p}
+		dp := dialPort
+		if dp == 0 {
+			dp = p
+		}
+		bk := k8sBackend{namespace: namespace, service: service, port: p, dialPort: dp}
 		if _, dup := seen[bk]; dup {
 			return
 		}
@@ -712,13 +732,13 @@ func (c *SnapshotCache) edgeK8sBackendClusters() []types.Resource {
 				if b.Service == "" {
 					continue
 				}
-				addBackend(b.Service, b.BackendNamespace, b.Port)
+				addBackend(b.Service, b.BackendNamespace, b.Port, b.DialPort)
 			}
 			// Legacy single-backend field (also populated for single-backend routes).
 			if r.Service == "" {
 				continue
 			}
-			addBackend(r.Service, r.BackendNamespace, r.Port)
+			addBackend(r.Service, r.BackendNamespace, r.Port, r.DialPort)
 		}
 	}
 
@@ -754,7 +774,9 @@ func (c *SnapshotCache) edgeK8sBackendClusters() []types.Resource {
 		}
 		name := proxy.EdgeK8sClusterName(bk.namespace, bk.service, bk.port)
 		fqdn := bk.service + "." + bk.namespace + ".svc.cluster.local"
-		out = append(out, proxy.BuildEdgeK8sCluster(name, fqdn, bk.port))
+		// Dial bk.dialPort, not bk.port: for a headless Service the FQDN resolves to
+		// pod IPs and must reach the targetPort; for ClusterIP they are equal.
+		out = append(out, proxy.BuildEdgeK8sCluster(name, fqdn, bk.dialPort))
 	}
 	return out
 }
@@ -768,7 +790,7 @@ func equalRoutes(a, b []Route) bool {
 	}
 	for i := range a {
 		ra, rb := a[i], b[i]
-		if ra.Prefix != rb.Prefix || ra.Exact != rb.Exact || ra.Service != rb.Service || ra.Port != rb.Port || ra.BackendNamespace != rb.BackendNamespace {
+		if ra.Prefix != rb.Prefix || ra.Exact != rb.Exact || ra.Service != rb.Service || ra.Port != rb.Port || ra.BackendNamespace != rb.BackendNamespace || ra.DialPort != rb.DialPort {
 			return false
 		}
 		if ra.Method != rb.Method || ra.DirectResponseStatus != rb.DirectResponseStatus {

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -757,6 +757,37 @@ func TestEdgeK8sBackendClusters_NonMeshOnly(t *testing.T) {
 	assert.Equal(t, uint32(9000), ep.GetPortValue())
 }
 
+// TestEdgeK8sBackendClusters_HeadlessDialPort verifies that a non-mesh backend with a
+// DialPort (set for a headless Service, whose FQDN resolves to pod IPs) produces a
+// STRICT_DNS cluster that DIALS the DialPort while keeping the cluster name keyed by
+// the service Port. This is the HTTPRouteServiceTypes conformance fix: dialing the
+// service port (8080) against pod IPs is refused; the pods listen on targetPort 3000.
+func TestEdgeK8sBackendClusters_HeadlessDialPort(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+
+	c.SetVirtualHosts([]VirtualHost{
+		{
+			Hosts: []string{"api.example.com"},
+			Routes: []Route{
+				// Headless backend: service port 8080, but pods listen on 3000.
+				{Prefix: "/headless", Service: "headless-svc", Port: 8080, DialPort: 3000, BackendNamespace: "ns"},
+			},
+		},
+	})
+
+	clusters := c.edgeK8sBackendClusters()
+	require.Len(t, clusters, 1)
+	cl, ok := clusters[0].(*clusterv3.Cluster)
+	require.True(t, ok)
+	// Cluster name stays keyed by the SERVICE port so route→cluster names match.
+	assert.Equal(t, "edge_k8s_ns_headless-svc_8080", cl.GetName())
+	ep := cl.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "headless-svc.ns.svc.cluster.local", ep.GetAddress())
+	// The endpoint DIALS the targetPort (3000), not the service port (8080).
+	assert.Equal(t, uint32(3000), ep.GetPortValue(), "headless cluster must dial the targetPort")
+}
+
 // TestVirtualHostVhostsSameHostMerge verifies that two VirtualHosts sharing a
 // hostname have their routes MERGED into ONE Envoy vhost — not keep-first-drop.
 // This is the Gateway API HTTPRouteMatchingAcrossRoutes behavior: multiple


### PR DESCRIPTION
## Problem

The edge's non-mesh backend path (#353) builds a cleartext `STRICT_DNS` cluster to the k8s Service FQDN on the Gateway API `backendRef.port` (the **service** port). That works for a **ClusterIP** Service (the FQDN resolves to the ClusterIP and kube-proxy DNATs `port`→`targetPort`) but **breaks for a headless Service** (`clusterIP: None`): its FQDN resolves directly to **pod IPs** with no kube-proxy in the path, so dialing the service port against a pod that listens on its `targetPort` is **connection-refused → 503**.

This is the root cause of the Gateway API conformance failure **`HTTPRouteServiceTypes`** (bucket E). That test's backends are `port: 8080 → targetPort: 3000`:
- `manual-endpointslices` — ClusterIP Service → resolves to ClusterIP, kube-proxy remaps → **200**
- `headless` / `headless-manual-endpointslices` — headless Services → resolve to pod IPs, dial `:8080` against pods listening on `:3000` → **503**

### Reproduced on talos-main

A headless + ClusterIP Service over the same pods (`port 8080 → targetPort 3000`), one HTTPRoute path each, curl'd through the edge:

```
/clusterip  → HTTP 200  "hello-from-svctypes"
/headless   → HTTP 503  "...connection refused"
```

DNS confirmed the headless FQDN resolves to pod IPs (`10.244.3.36`, `10.244.3.38`), and the pods listen on `3000`, not `8080`. (Repro namespace cleaned up.)

## Fix

Resolve the **dial port** per backend in the reconciler — which already watches `corev1.Service` and has `services get/list/watch` RBAC, so no new mechanism is needed:

- **Headless** Service (`clusterIP: None`) → dial the matching ServicePort's **numeric `targetPort`**.
- **ClusterIP** / mesh / unreadable / missing / **named** `targetPort` → fall back to the service port (`DialPort` 0 in the cache; the existing, already-correct behavior).

The cluster **name stays keyed by the service port** so route→cluster names are unchanged; only the `STRICT_DNS` endpoint address dials the resolved port. **`STRICT_DNS` is sufficient** — this is not the design-significant EDS-over-EndpointSlices path.

### Scope note
Stays clear of the concurrent edge HCM / `effectiveHostnames` work — this change is entirely in the cluster/backend path (`BuildEdgeK8sCluster` / `edgeK8sBackendClusters` / `RouteBackend`) plus the reconciler's backend builder.

A **named** `targetPort` on a headless Service is not resolved here (would need the pod spec) and falls back to the service port — documented in `resolveDialPort`. The conformance test uses a numeric `targetPort`, so it is covered.

## Tests

- `resolveDialPort`: headless→targetPort, ClusterIP→0, named/unset targetPort→0, missing Service→0, `servicePort 0`→0, nil client→0 (no panic).
- `buildHTTPRouteBackends`: `DialPort` threaded onto the `RouteBackend` for a headless backend.
- `edgeK8sBackendClusters`: resulting `STRICT_DNS` cluster — name keyed by service port (`edge_k8s_ns_headless-svc_8080`), endpoint **dials `targetPort` (3000)**.

`bazel test //agent/...` (short mode) green; `bazel run //:format` clean. (Full `//...` build hit an unrelated `no space left on device` fetching integration-test `moby/moby` deps; the affected packages build + test cleanly.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)