### PR TITLE
feat(edge): detect invalid/missing listener TLS certs (ResolvedRefs=False/InvalidCertificateRef)

### DIFF
--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
     embed = [":gatewayapi"],
     deps = [
         "//agent/internal/edge/portalloc",
+        "//agent/internal/edge/secret",
         "//agent/internal/gatewaystatus",
         "//agent/internal/xds/cache",
         "//agent/internal/xds/proxy",

--- a/agent/internal/edge/gatewayapi/edge_cases_test.go
+++ b/agent/internal/edge/gatewayapi/edge_cases_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/bpalermo/aether/agent/internal/edge/secret"
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,10 +13,70 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+// A real self-signed ECDSA keypair (CN=test) for the listener-TLS tests: the
+// kubernetes secret provider validates the keypair with tls.X509KeyPair, so a
+// "valid cert" fixture must hold parseable material.
+const (
+	validListenerTLSCert = `-----BEGIN CERTIFICATE-----
+MIIBHzCBxqADAgECAgEBMAoGCCqGSM49BAMCMA8xDTALBgNVBAMTBHRlc3QwHhcN
+MjYwNjI2MTU1MzUwWhcNMjcwNjI2MTY1MzUwWjAPMQ0wCwYDVQQDEwR0ZXN0MFkw
+EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEn4alJ26H8ozmsdz28/d8BUxOcmTuHYiT
+IdRPGfJR6P6CHstygFvJD1N7mvblUBSGyaJq8jI9p0eIFI+km0F5k6MTMBEwDwYD
+VR0RBAgwBoIEdGVzdDAKBggqhkjOPQQDAgNIADBFAiEA8t876pZRDOkFPAoZV0gg
+36yLul1OYTpOylOe9NsAyHwCIE7SBys13i6g5re4YmKgv1GBo6wW3VhxZWO6qm/Y
+KTqF
+-----END CERTIFICATE-----
+`
+	validListenerTLSKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIsvYanqaRRY782l1DBVdbGmnaBSmptup19WIFXx2vdjoAoGCCqGSM49
+AwEHoUQDQgAEn4alJ26H8ozmsdz28/d8BUxOcmTuHYiTIdRPGfJR6P6CHstygFvJ
+D1N7mvblUBSGyaJq8jI9p0eIFI+km0F5kw==
+-----END EC PRIVATE KEY-----
+`
+)
+
+// listenerTLSGateway builds an HTTPS Gateway of our class whose single listener
+// references the named Secret as its certificateRef.
+func listenerTLSGateway(name, secretName string) *gatewayv1.Gateway {
+	secretKind := gatewayv1.Kind("Secret")
+	emptyGroup := gatewayv1.Group("")
+	return &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns", Generation: 1},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "aether",
+			Listeners: []gatewayv1.Listener{{
+				Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType,
+				TLS: &gatewayv1.ListenerTLSConfig{
+					CertificateRefs: []gatewayv1.SecretObjectReference{{
+						Group: &emptyGroup, Kind: &secretKind, Name: gatewayv1.ObjectName(secretName),
+					}},
+				},
+			}},
+		},
+	}
+}
+
+// tlsTypeSecret builds a kubernetes.io/tls Secret with the given cert/key bytes
+// (used to construct missing-key, malformed, and valid fixtures).
+func tlsTypeSecret(name, cert, key string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{corev1.TLSCertKey: []byte(cert), corev1.TLSPrivateKeyKey: []byte(key)},
+	}
+}
+
+// secretsRegistryFor builds a real Secrets Registry backed by the given fake
+// client so the reconciler resolves (and validates) certificateRefs end-to-end.
+func secretsRegistryFor(c client.Client) *secret.Registry {
+	return secret.NewRegistry(secret.NewKubernetesProvider(c, "ns"))
+}
 
 func ourClass() *gatewayv1.GatewayClass {
 	return &gatewayv1.GatewayClass{
@@ -167,6 +228,98 @@ func TestListenerInvalidTLS(t *testing.T) {
 	assert.Equal(t, metav1.ConditionTrue, gwAcc.Status, "Accepted stays True even with an invalid-TLS listener")
 	assert.Equal(t, got.Generation, gwAcc.ObservedGeneration, "Accepted observedGeneration must track metadata.generation on the invalid-TLS path")
 	assert.Equal(t, got.Generation, gwProg.ObservedGeneration, "Programmed observedGeneration must track metadata.generation on the invalid-TLS path")
+}
+
+// TestListenerInvalidTLSWithProvider exercises the real Secrets provider on the
+// listener-TLS resolution path (the GatewayInvalidTLSConfiguration conformance
+// cases): a certificateRef to a missing Secret, a Secret missing tls.key, and a
+// Secret of the right type whose cert/key bytes don't parse as a keypair all yield
+// ResolvedRefs=False/InvalidCertificateRef + Programmed=False (observedGeneration
+// stamped). A VALID keypair stays ResolvedRefs=True/Programmed=True (regression
+// guard — api.palermo.dev must stay green).
+func TestListenerInvalidTLSWithProvider(t *testing.T) {
+	cases := []struct {
+		name        string
+		gwName      string
+		secretName  string
+		secret      *corev1.Secret // nil → no Secret created (nonexistent ref)
+		wantInvalid bool
+	}{
+		{
+			name:        "nonexistent secret",
+			gwName:      "gw-tls-missing",
+			secretName:  "nonexistent-certificate",
+			secret:      nil,
+			wantInvalid: true,
+		},
+		{
+			name:        "secret missing tls.key",
+			gwName:      "gw-tls-no-key",
+			secretName:  "no-key",
+			secret:      tlsTypeSecret("no-key", validListenerTLSCert, ""),
+			wantInvalid: true,
+		},
+		{
+			name:        "malformed cert/key bytes",
+			gwName:      "gw-tls-malformed",
+			secretName:  "malformed-certificate",
+			secret:      tlsTypeSecret("malformed-certificate", "Hello world\n", "Hello world\n"),
+			wantInvalid: true,
+		},
+		{
+			name:        "valid keypair (regression)",
+			gwName:      "gw-tls-valid",
+			secretName:  "valid-certificate",
+			secret:      tlsTypeSecret("valid-certificate", validListenerTLSCert, validListenerTLSKey),
+			wantInvalid: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gw := listenerTLSGateway(tc.gwName, tc.secretName)
+			b := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+				WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{})
+			objs := []client.Object{ourClass(), gw}
+			if tc.secret != nil {
+				objs = append(objs, tc.secret)
+			}
+			c := b.WithObjects(objs...).Build()
+			r := &Reconciler{
+				Client: c, APIReader: c, Sink: statusFakeSink{}, Namespace: "ns",
+				GatewayClassName: "aether", MeshDomain: "mesh",
+				Secrets: secretsRegistryFor(c), Log: slog.Default(),
+			}
+
+			_, err := r.Reconcile(context.Background(), reconcile.Request{})
+			require.NoError(t, err)
+
+			got := &gatewayv1.Gateway{}
+			require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: "ns", Name: tc.gwName}, got))
+			require.Len(t, got.Status.Listeners, 1)
+			rr := meta.FindStatusCondition(got.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionResolvedRefs))
+			require.NotNil(t, rr)
+			prog := meta.FindStatusCondition(got.Status.Listeners[0].Conditions, string(gatewayv1.ListenerConditionProgrammed))
+			require.NotNil(t, prog)
+			gwProg := meta.FindStatusCondition(got.Status.Conditions, string(gatewayv1.GatewayConditionProgrammed))
+			require.NotNil(t, gwProg)
+
+			if tc.wantInvalid {
+				assert.Equal(t, metav1.ConditionFalse, rr.Status, "invalid cert → ResolvedRefs=False")
+				assert.Equal(t, string(gatewayv1.ListenerReasonInvalidCertificateRef), rr.Reason)
+				assert.Equal(t, metav1.ConditionFalse, prog.Status, "invalid cert → listener not Programmed")
+				assert.Equal(t, string(gatewayv1.ListenerReasonInvalid), prog.Reason)
+				assert.Equal(t, metav1.ConditionFalse, gwProg.Status, "invalid cert → Gateway not Programmed")
+				// observedGeneration must still be stamped on the invalid path (#361 guard).
+				assert.Equal(t, got.Generation, rr.ObservedGeneration)
+				assert.Equal(t, got.Generation, prog.ObservedGeneration)
+			} else {
+				assert.Equal(t, metav1.ConditionTrue, rr.Status, "valid cert → ResolvedRefs=True (regression)")
+				assert.Equal(t, string(gatewayv1.ListenerReasonResolvedRefs), rr.Reason)
+				assert.Equal(t, metav1.ConditionTrue, prog.Status, "valid cert → listener Programmed (regression)")
+				assert.Equal(t, metav1.ConditionTrue, gwProg.Status, "valid cert → Gateway Programmed (regression)")
+			}
+		})
+	}
 }
 
 // TestRouteNotMatchingSectionName: a route whose parentRef names a sectionName

--- a/agent/internal/edge/secret/kubernetes.go
+++ b/agent/internal/edge/secret/kubernetes.go
@@ -2,6 +2,7 @@ package secret
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"strings"
 
@@ -56,6 +57,14 @@ func (k *kubernetesProvider) Resolve(ctx context.Context, ref string) (TLSCert, 
 	key := sec.Data[corev1.TLSPrivateKeyKey]
 	if len(cert) == 0 || len(key) == 0 {
 		return TLSCert{}, fmt.Errorf("secret %s/%s missing %s/%s", ns, name, corev1.TLSCertKey, corev1.TLSPrivateKeyKey)
+	}
+	// The Secret may be the right type with both keys present yet hold material
+	// that is not a usable TLS keypair (malformed PEM, a cert/key mismatch, or
+	// the conformance "Hello world" bytes). Reject it here so the listener path
+	// reports ResolvedRefs=False/InvalidCertificateRef instead of pushing
+	// unservable cert bytes to Envoy over SDS.
+	if _, err := tls.X509KeyPair(cert, key); err != nil {
+		return TLSCert{}, fmt.Errorf("secret %s/%s is not a valid TLS keypair: %w", ns, name, err)
 	}
 	return TLSCert{Cert: cert, Key: key, Version: sec.ResourceVersion}, nil
 }

--- a/agent/internal/edge/secret/provider_test.go
+++ b/agent/internal/edge/secret/provider_test.go
@@ -13,6 +13,28 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+// validTLSCert / validTLSKey are a real, self-signed ECDSA keypair (CN=test). The
+// provider validates the keypair with tls.X509KeyPair, so fixtures must hold
+// parseable material, not placeholder bytes.
+const (
+	validTLSCert = `-----BEGIN CERTIFICATE-----
+MIIBHzCBxqADAgECAgEBMAoGCCqGSM49BAMCMA8xDTALBgNVBAMTBHRlc3QwHhcN
+MjYwNjI2MTU1MzUwWhcNMjcwNjI2MTY1MzUwWjAPMQ0wCwYDVQQDEwR0ZXN0MFkw
+EwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEn4alJ26H8ozmsdz28/d8BUxOcmTuHYiT
+IdRPGfJR6P6CHstygFvJD1N7mvblUBSGyaJq8jI9p0eIFI+km0F5k6MTMBEwDwYD
+VR0RBAgwBoIEdGVzdDAKBggqhkjOPQQDAgNIADBFAiEA8t876pZRDOkFPAoZV0gg
+36yLul1OYTpOylOe9NsAyHwCIE7SBys13i6g5re4YmKgv1GBo6wW3VhxZWO6qm/Y
+KTqF
+-----END CERTIFICATE-----
+`
+	validTLSKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIIsvYanqaRRY782l1DBVdbGmnaBSmptup19WIFXx2vdjoAoGCCqGSM49
+AwEHoUQDQgAEn4alJ26H8ozmsdz28/d8BUxOcmTuHYiTIdRPGfJR6P6CHstygFvJ
+D1N7mvblUBSGyaJq8jI9p0eIFI+km0F5kw==
+-----END EC PRIVATE KEY-----
+`
+)
+
 func tlsSecret(ns, name, cert, key string) *corev1.Secret {
 	s := &corev1.Secret{
 		Type: corev1.SecretTypeTLS,
@@ -35,7 +57,7 @@ func newFakeClient(objs ...*corev1.Secret) client.WithWatch {
 }
 
 func TestKubernetesProviderResolve(t *testing.T) {
-	cl := newFakeClient(tlsSecret("edge", "api-tls", "CERT", "KEY"))
+	cl := newFakeClient(tlsSecret("edge", "api-tls", validTLSCert, validTLSKey))
 	p := NewKubernetesProvider(cl, "edge")
 
 	assert.Equal(t, configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, p.Provider())
@@ -43,8 +65,8 @@ func TestKubernetesProviderResolve(t *testing.T) {
 
 	got, err := p.Resolve(context.Background(), "api-tls")
 	require.NoError(t, err)
-	assert.Equal(t, []byte("CERT"), got.Cert)
-	assert.Equal(t, []byte("KEY"), got.Key)
+	assert.Equal(t, []byte(validTLSCert), got.Cert)
+	assert.Equal(t, []byte(validTLSKey), got.Key)
 	assert.Equal(t, "7", got.Version)
 }
 
@@ -52,12 +74,12 @@ func TestKubernetesProviderResolveNamespacedRef(t *testing.T) {
 	// A "<ns>/<name>" ref reads from that namespace, NOT the provider's default —
 	// so a Gateway certificateRef resolves from the Gateway's own namespace, not
 	// the edge's. (Regression: the edge read all certs from its own namespace.)
-	cl := newFakeClient(tlsSecret("other-ns", "their-tls", "OTHERCERT", "OTHERKEY"))
+	cl := newFakeClient(tlsSecret("other-ns", "their-tls", validTLSCert, validTLSKey))
 	p := NewKubernetesProvider(cl, "edge") // default namespace is "edge"
 
 	got, err := p.Resolve(context.Background(), "other-ns/their-tls")
 	require.NoError(t, err)
-	assert.Equal(t, []byte("OTHERCERT"), got.Cert)
+	assert.Equal(t, []byte(validTLSCert), got.Cert)
 
 	// A bare name still resolves in the default namespace (no Secret there → error).
 	_, err = p.Resolve(context.Background(), "their-tls")
@@ -67,7 +89,21 @@ func TestKubernetesProviderResolveNamespacedRef(t *testing.T) {
 func TestKubernetesProviderResolveErrors(t *testing.T) {
 	opaque := &corev1.Secret{Type: corev1.SecretTypeOpaque, Data: map[string][]byte{"x": []byte("y")}}
 	opaque.Name, opaque.Namespace = "opaque", "edge"
-	cl := newFakeClient(opaque)
+
+	// Right type, both keys present, but no tls.key (empty) — missing material.
+	noKey := tlsSecret("edge", "no-key", validTLSCert, "")
+
+	// Right type, both keys non-empty, but the bytes are NOT a valid keypair —
+	// this is the Gateway API conformance "malformed-certificate" case
+	// (base64("Hello world") in both tls.crt and tls.key). The provider must
+	// reject it via tls.X509KeyPair so the listener reports InvalidCertificateRef.
+	malformed := tlsSecret("edge", "malformed", "Hello world\n", "Hello world\n")
+
+	// Right type, non-empty bytes, but tls.crt is a valid cert while tls.key is
+	// junk PEM — the keypair can't be assembled (a cert/key mismatch case).
+	badKey := tlsSecret("edge", "bad-key", validTLSCert, "-----BEGIN EC PRIVATE KEY-----\nbm90LWEta2V5\n-----END EC PRIVATE KEY-----\n")
+
+	cl := newFakeClient(opaque, noKey, malformed, badKey)
 	p := NewKubernetesProvider(cl, "edge")
 
 	_, err := p.Resolve(context.Background(), "absent")
@@ -75,10 +111,19 @@ func TestKubernetesProviderResolveErrors(t *testing.T) {
 
 	_, err = p.Resolve(context.Background(), "opaque")
 	require.Error(t, err, "non-tls secret type")
+
+	_, err = p.Resolve(context.Background(), "no-key")
+	require.Error(t, err, "secret missing tls.key")
+
+	_, err = p.Resolve(context.Background(), "malformed")
+	require.Error(t, err, "malformed cert/key bytes are not a valid keypair")
+
+	_, err = p.Resolve(context.Background(), "bad-key")
+	require.Error(t, err, "unparseable private key is not a valid keypair")
 }
 
 func TestRegistryDispatchAndSDSName(t *testing.T) {
-	cl := newFakeClient(tlsSecret("edge", "api-tls", "C", "K"))
+	cl := newFakeClient(tlsSecret("edge", "api-tls", validTLSCert, validTLSKey))
 	r := NewRegistry(NewKubernetesProvider(cl, "edge"))
 
 	// UNSPECIFIED defaults to kubernetes.
@@ -88,7 +133,7 @@ func TestRegistryDispatchAndSDSName(t *testing.T) {
 
 	got, err := r.Resolve(context.Background(), configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, "api-tls")
 	require.NoError(t, err)
-	assert.Equal(t, []byte("C"), got.Cert)
+	assert.Equal(t, []byte(validTLSCert), got.Cert)
 
 	// An enum value with no registered impl errors (not panics).
 	_, err = r.Resolve(context.Background(), configv1.SecretProvider_SECRET_PROVIDER_AWS_SECRETS_MANAGER, "x")


### PR DESCRIPTION
## What

The edge resolved a Gateway HTTPS listener's `certificateRef` but never validated that the referenced Secret held a **usable TLS keypair**. A listener whose `certificateRef` pointed at a Secret of the right type (`kubernetes.io/tls`) with non-empty `tls.crt`/`tls.key` but **malformed bytes** was reported `ResolvedRefs=True` / `Programmed=True`.

rev15 confirmed `GatewayInvalidTLSConfiguration` (conformance bucket F) is a real gap, not a flake: its `malformed-certificate` Secret — base64 of `"Hello world"` in both `tls.crt` and `tls.key`, type `kubernetes.io/tls` — passed the existing type + non-empty checks. #361 stamped `observedGeneration` on the invalid-TLS Gateway but did not add malformed-cert detection.

## Validation approach

Validate the keypair in the kubernetes secret provider's `Resolve` via `tls.X509KeyPair`: a Secret that is the right type with both keys present but does **not** parse as a valid keypair is now rejected. The listener-TLS resolution path (`resolveListenerTLS`) already maps a `Resolve` error to a non-resolved listener result, so the malformed and nonexistent-Secret cases now drive the correct conditions, and the bad cert is never added to the served SDS set.

## Conditions

For each HTTPS listener `certificateRef` (resolved from `certificateRef.namespace` defaulting to the Gateway's namespace, gated by ReferenceGrant for cross-ns refs):

- certificateRef Secret missing / wrong type / missing `tls.crt`|`tls.key` / **unparseable keypair** → listener `ResolvedRefs=False` / `InvalidCertificateRef`.
- ungranted cross-namespace certificateRef → `ResolvedRefs=False` / `RefNotPermitted`.
- listener can't be programmed → `Programmed=False` / `Invalid`; top-level Gateway `Programmed=False`.
- `observedGeneration` stamped on all of the above (keeps #361's behavior).
- **Regression guard:** a VALID keypair stays `ResolvedRefs=True` / `Programmed=True` (so the `api.palermo.dev` wildcard cert stays green).

## Watch / RBAC

No chart change needed. The edge already `Watches` Secrets (when a Secrets provider is configured) and already has `secrets get/list/watch` RBAC for SDS, so a Secret create/delete re-triggers reconcile and flips the condition.

## Tests

- `TestListenerInvalidTLSWithProvider` (table, real Secrets provider): missing Secret, Secret missing `tls.key`, and malformed cert/key bytes each → `ResolvedRefs=False`/`InvalidCertificateRef` + `Programmed=False`/`Invalid` (`observedGeneration` stamped); a valid keypair → `ResolvedRefs=True`/`Programmed=True`.
- `provider_test.go`: keypair-parse rejection covered directly (missing key, malformed bytes, unparseable key); existing fixtures updated to a real self-signed ECDSA keypair.

`bazel build //...`, `bazel test //...` (62 tests pass), and `bazel run //:format` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)