### PR TITLE
fix(edge): unresolved-backend 500 + path-rewrite slash + port/scheme redirect + request timeout

### DIFF
--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@io_k8s_sigs_gateway_api//pkg/features",
+        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
 

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/bpalermo/aether/agent/internal/edge/secret"
 	"github.com/bpalermo/aether/agent/internal/referencegrant"
@@ -19,7 +20,9 @@ import (
 	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	constants "github.com/bpalermo/aether/common/constants"
 	commonlog "github.com/bpalermo/aether/common/log"
+	"google.golang.org/protobuf/types/known/durationpb"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -530,6 +533,7 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 	for _, rule := range hr.Spec.Rules {
 		redirect := buildHTTPRedirect(rule.Filters)
 		urlRewrite := buildHTTPURLRewrite(rule.Filters)
+		timeout := buildRouteTimeout(rule.Timeouts)
 
 		// Collect ALL admissible backends in this rule with their weights.
 		// backendRef.weight nil → default 1 (per Gateway API spec).
@@ -633,6 +637,7 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 				HeaderMutation:   mutation,
 				Redirect:         redirect,
 				URLRewrite:       urlRewrite,
+				Timeout:          timeout,
 			})
 			continue
 		}
@@ -688,6 +693,7 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 				Headers:          hdrs,
 				Method:           method,
 				QueryParams:      qps,
+				Timeout:          timeout,
 			})
 		}
 	}
@@ -726,6 +732,23 @@ func (r *Reconciler) buildHTTPRouteBackends(ctx context.Context, refs []gatewayv
 		ns := routeNamespace
 		if b.Namespace != nil && string(*b.Namespace) != "" {
 			ns = string(*b.Namespace)
+		}
+		// Existence check: drop backends whose Service does not exist. This mirrors the
+		// check backendsResolveL4 (status.go) already performs for status, and ensures
+		// that a rule whose only backends are missing (BackendNotFound) arrives at
+		// buildVirtualHost with len(backends)==0 so the 500 direct_response path fires
+		// (see Gateway API invalid-backend semantics). Mesh services have a generated
+		// Service object; real k8s Services are real. Only drop on hard NotFound — a
+		// transient API error leaves the backend admitted so we don't break the data
+		// plane on a momentary API server hiccup.
+		if r.Client != nil {
+			svc := &corev1.Service{}
+			if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, svc); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue // BackendNotFound: drop from admitted set
+				}
+				// Transient error: admit the backend to avoid false-positive 500s.
+			}
 		}
 		var port uint32
 		if b.Port != nil {
@@ -1041,6 +1064,21 @@ func ptrType(p *gatewayv1.PathMatchType, def gatewayv1.PathMatchType) gatewayv1.
 		return def
 	}
 	return *p
+}
+
+// buildRouteTimeout parses the HTTPRoute rule's timeouts.request field into a
+// protobuf Duration for the edge route action. Returns nil when no timeout is set
+// or the duration is zero/unparseable (GEP-2257: a zero-value timeout means "no
+// timeout", and an invalid string is treated as unset rather than an error).
+func buildRouteTimeout(timeouts *gatewayv1.HTTPRouteTimeouts) *durationpb.Duration {
+	if timeouts == nil || timeouts.Request == nil {
+		return nil
+	}
+	d, err := time.ParseDuration(string(*timeouts.Request))
+	if err != nil || d <= 0 {
+		return nil
+	}
+	return durationpb.New(d)
 }
 
 // buildHTTPRedirect extracts the first RequestRedirect filter and converts it to a

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -1203,3 +1203,143 @@ func TestBuildHTTPRouteBackends_HeadlessDialPort(t *testing.T) {
 	assert.Equal(t, uint32(8080), got[0].Port, "cluster name stays keyed by service port")
 	assert.Equal(t, uint32(3000), got[0].DialPort, "headless backend dials the targetPort")
 }
+
+// --- FIX 1: Nonexistent backend Service → HTTP 500 direct_response ---
+
+// TestBuildHTTPRouteBackends_NonExistentService_Dropped verifies that a backendRef
+// pointing to a Service that does not exist in the cluster is dropped from the
+// admitted set. This causes buildVirtualHost to see len(backends)==0 with
+// len(rule.BackendRefs)>0, which triggers the HTTP 500 direct_response route.
+func TestBuildHTTPRouteBackends_NonExistentService_Dropped(t *testing.T) {
+	// Client has no Services registered — "ghost-svc" does not exist.
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	r := &Reconciler{Client: c}
+
+	got := r.buildHTTPRouteBackends(
+		context.Background(),
+		backend("ghost-svc", 8080),
+		"ns",
+		nil,
+	)
+	assert.Empty(t, got, "nonexistent Service must be dropped from the admitted backend set")
+}
+
+// TestBuildVirtualHost_NonExistentBackend_DirectResponse500 verifies the end-to-end
+// contract: a rule with a valid-shaped but nonexistent Service backendRef must
+// produce a DirectResponseStatus=500 route (not a forwarding route to a ghost cluster).
+func TestBuildVirtualHost_NonExistentBackend_DirectResponse500(t *testing.T) {
+	// Fake client: Service "ghost-svc" in "ns" is NOT in the store.
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	r := &Reconciler{Client: c}
+
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/app"),
+			BackendRefs: backend("ghost-svc", 8080),
+		},
+	})
+	vh := r.buildVirtualHost(context.Background(), hr, nil, nil)
+
+	require.Len(t, vh.Routes, 1, "nonexistent backend must produce exactly one 500 route")
+	rt := vh.Routes[0]
+	assert.Equal(t, "/app", rt.Prefix, "path match must be preserved on the 500 route")
+	assert.Equal(t, uint32(500), rt.DirectResponseStatus,
+		"nonexistent Service backendRef must produce DirectResponseStatus=500")
+	assert.Empty(t, rt.Service, "500 route must carry no backend Service")
+}
+
+// TestBuildHTTPRouteBackends_ExistingService_Admitted verifies that a backendRef
+// whose Service DOES exist is admitted normally (not dropped by the existence check).
+func TestBuildHTTPRouteBackends_ExistingService_Admitted(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(svcWith("real-svc", "ns", "10.0.0.1", 8080, intstr.FromInt(8080))).
+		Build()
+	r := &Reconciler{Client: c}
+
+	got := r.buildHTTPRouteBackends(
+		context.Background(),
+		backend("real-svc", 8080),
+		"ns",
+		nil,
+	)
+	require.Len(t, got, 1, "existing Service must be admitted into the backend set")
+	assert.Equal(t, "real-svc", got[0].Service)
+}
+
+// --- FIX 4: HTTPRouteTimeoutRequest threading into cache.Route ---
+
+// TestBuildVirtualHost_TimeoutRequest verifies that a rule with timeouts.request
+// set propagates the parsed duration onto every cache.Route.Timeout produced from
+// that rule.
+func TestBuildVirtualHost_TimeoutRequest(t *testing.T) {
+	req := gatewayv1.Duration("5s")
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches: pathMatch(gatewayv1.PathMatchPathPrefix, "/slow"),
+			Timeouts: &gatewayv1.HTTPRouteTimeouts{
+				Request: &req,
+			},
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Scheme: ptr("https"),
+				},
+			}},
+		},
+	})
+	vh := r.buildVirtualHost(context.Background(), hr, nil, nil)
+
+	require.Len(t, vh.Routes, 1)
+	rt := vh.Routes[0]
+	require.NotNil(t, rt.Timeout, "Timeout must be set from timeouts.request")
+	assert.Equal(t, int64(5), rt.Timeout.GetSeconds(), "timeout must be 5s")
+}
+
+// TestBuildVirtualHost_NoTimeout verifies that a rule without timeouts.request
+// leaves cache.Route.Timeout nil (no timeout applied at the route level).
+func TestBuildVirtualHost_NoTimeout(t *testing.T) {
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches: pathMatch(gatewayv1.PathMatchPathPrefix, "/fast"),
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type: gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+					Scheme: ptr("https"),
+				},
+			}},
+		},
+	})
+	vh := r.buildVirtualHost(context.Background(), hr, nil, nil)
+
+	require.Len(t, vh.Routes, 1)
+	assert.Nil(t, vh.Routes[0].Timeout, "absent timeouts.request must leave Timeout nil")
+}
+
+// TestBuildVirtualHost_TimeoutRequest_MultiMatch verifies that when a rule produces
+// multiple routes (one per HTTPRouteMatch), all routes carry the same timeout.
+func TestBuildVirtualHost_TimeoutRequest_MultiMatch(t *testing.T) {
+	req := gatewayv1.Duration("2s")
+	r := &Reconciler{}
+	hr := httpRoute([]string{"api.example.com"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches: []gatewayv1.HTTPRouteMatch{
+				{Path: &gatewayv1.HTTPPathMatch{Type: ptr(gatewayv1.PathMatchExact), Value: ptr("/a")}},
+				{Path: &gatewayv1.HTTPPathMatch{Type: ptr(gatewayv1.PathMatchExact), Value: ptr("/b")}},
+			},
+			Timeouts: &gatewayv1.HTTPRouteTimeouts{Request: &req},
+			Filters: []gatewayv1.HTTPRouteFilter{{
+				Type:            gatewayv1.HTTPRouteFilterRequestRedirect,
+				RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{Scheme: ptr("https")},
+			}},
+		},
+	})
+	vh := r.buildVirtualHost(context.Background(), hr, nil, nil)
+
+	require.Len(t, vh.Routes, 2, "two matches must produce two routes")
+	for i, rt := range vh.Routes {
+		require.NotNil(t, rt.Timeout, "route %d must have Timeout set", i)
+		assert.Equal(t, int64(2), rt.Timeout.GetSeconds(), "route %d timeout must be 2s", i)
+	}
+}

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "@io_opentelemetry_go_otel_metric//:metric",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/durationpb",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -9,6 +9,7 @@ import (
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // routeSpecificity returns a composite sort key for a Route per Gateway API
@@ -212,6 +213,12 @@ type Route struct {
 	// for rules whose backendRef(s) cannot be resolved (BackendNotFound /
 	// InvalidKind / RefNotPermitted per Gateway API).
 	DirectResponseStatus uint32
+
+	// Timeout is the per-route request timeout from the HTTPRoute rule's
+	// timeouts.request field (GEP-2257 duration). Nil means no timeout is applied
+	// on this route (Envoy inherits the listener/cluster default). When set it is
+	// applied as RouteAction.timeout on the forwarding route.
+	Timeout *durationpb.Duration
 }
 
 // EdgeTLSCert is raw certificate material for an edge downstream TLS secret,
@@ -394,14 +401,14 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 				cn := c.edgeClusterNameLocked(b.Service, b.BackendNamespace, b.Port)
 				weighted = append(weighted, proxy.WeightedRouteBackend{Cluster: cn, Weight: b.Weight})
 			}
-			return proxy.BuildEdgeRouteWeighted(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, weighted, r.HeaderMutation, r.Redirect, r.URLRewrite)
+			return proxy.BuildEdgeRouteWeighted(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, weighted, r.HeaderMutation, r.Redirect, r.URLRewrite, r.Timeout)
 		}
 		// Legacy single-backend path (backward compat).
 		cluster := ""
 		if r.Service != "" {
 			cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
 		}
-		return proxy.BuildEdgeRoute(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite)
+		return proxy.BuildEdgeRoute(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite, r.Timeout)
 	}
 
 	// Emit one Envoy virtual host per domain group, sorted by path specificity.
@@ -796,6 +803,9 @@ func equalRoutes(a, b []Route) bool {
 		if ra.Method != rb.Method || ra.DirectResponseStatus != rb.DirectResponseStatus {
 			return false
 		}
+		if !equalRouteDuration(ra.Timeout, rb.Timeout) {
+			return false
+		}
 		if !equalRouteBackends(ra.Backends, rb.Backends) {
 			return false
 		}
@@ -855,6 +865,17 @@ func equalRouteBackends(a, b []RouteBackend) bool {
 		}
 	}
 	return true
+}
+
+// equalRouteDuration reports content equality for two *durationpb.Duration values.
+func equalRouteDuration(a, b *durationpb.Duration) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return a.Seconds == b.Seconds && a.Nanos == b.Nanos
 }
 
 // equalRouteRedirect reports content equality for two *proxy.GammaRedirect values.

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -123,6 +123,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/structpb",
     ],
 )

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -579,15 +579,16 @@ type WeightedRouteBackend struct {
 //
 // headers/method/queryParams add per-match predicates (ANDed with the path).
 // redirect is applied ahead of backend resolution (no backends needed for a
-// redirect). urlRewrite is applied on forwarding routes only.
-func BuildEdgeRouteWeighted(prefix, exact string, headers []RouteHeaderMatch, method string, queryParams []RouteQueryParamMatch, backends []WeightedRouteBackend, mutation *GammaHeaderMutation, redirect *GammaRedirect, urlRewrite *GammaURLRewrite) *routev3.Route {
+// redirect). urlRewrite is applied on forwarding routes only. timeout sets the
+// per-route request timeout (nil = no timeout / inherit cluster default).
+func BuildEdgeRouteWeighted(prefix, exact string, headers []RouteHeaderMatch, method string, queryParams []RouteQueryParamMatch, backends []WeightedRouteBackend, mutation *GammaHeaderMutation, redirect *GammaRedirect, urlRewrite *GammaURLRewrite, timeout *durationpb.Duration) *routev3.Route {
 	if redirect != nil || len(backends) <= 1 {
 		// Redirect path or single backend: delegate to the plain builder.
 		cluster := ""
 		if len(backends) == 1 {
 			cluster = backends[0].Cluster
 		}
-		return BuildEdgeRoute(prefix, exact, headers, method, queryParams, cluster, mutation, redirect, urlRewrite)
+		return BuildEdgeRoute(prefix, exact, headers, method, queryParams, cluster, mutation, redirect, urlRewrite, timeout)
 	}
 	// Multiple backends: weighted_clusters action.
 	match := &routev3.RouteMatch{}
@@ -617,6 +618,9 @@ func BuildEdgeRouteWeighted(prefix, exact string, headers []RouteHeaderMatch, me
 		ClusterSpecifier: &routev3.RouteAction_WeightedClusters{WeightedClusters: wc},
 		RetryPolicy:      outboundRetryPolicy(),
 	}
+	if timeout != nil {
+		ra.Timeout = timeout
+	}
 	applyURLRewrite(ra, urlRewrite)
 
 	return &routev3.Route{
@@ -633,11 +637,12 @@ func BuildEdgeRouteWeighted(prefix, exact string, headers []RouteHeaderMatch, me
 // is non-empty (exact takes precedence if both are set). Prefix "/" matches all.
 // headers/method/queryParams add per-match predicates (ANDed with the path match).
 // mutation applies RequestHeaderModifier / ResponseHeaderModifier at the route level.
+// timeout sets the per-route request timeout (nil = no timeout / inherit default).
 //
 // When redirect is non-nil the route emits a Route_Redirect (no cluster). When
 // urlRewrite is non-nil the route rewrite fields are applied before forwarding to
 // cluster. Both nil → plain forwarding route.
-func BuildEdgeRoute(prefix, exact string, headers []RouteHeaderMatch, method string, queryParams []RouteQueryParamMatch, cluster string, mutation *GammaHeaderMutation, redirect *GammaRedirect, urlRewrite *GammaURLRewrite) *routev3.Route {
+func BuildEdgeRoute(prefix, exact string, headers []RouteHeaderMatch, method string, queryParams []RouteQueryParamMatch, cluster string, mutation *GammaHeaderMutation, redirect *GammaRedirect, urlRewrite *GammaURLRewrite, timeout *durationpb.Duration) *routev3.Route {
 	match := &routev3.RouteMatch{}
 	if exact != "" {
 		match.PathSpecifier = &routev3.RouteMatch_Path{Path: exact}
@@ -659,6 +664,9 @@ func BuildEdgeRoute(prefix, exact string, headers []RouteHeaderMatch, method str
 		ra := &routev3.RouteAction{
 			ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: cluster},
 			RetryPolicy:      outboundRetryPolicy(),
+		}
+		if timeout != nil {
+			ra.Timeout = timeout
 		}
 		applyURLRewrite(ra, urlRewrite)
 		r.Action = &routev3.Route_Route{Route: ra}

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -11,6 +11,7 @@ import (
 	transport_sockets_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // TestEdgeUpstreamTransportSocket verifies the edge fetches its SVID and trust
@@ -342,7 +343,7 @@ func TestBuildEdgeGatewayRouteConfiguration(t *testing.T) {
 // "*" vhost (the hostname-less-route catch-all), the route config must NOT add a
 // SECOND "*" — it appends the 404 to the existing one as the last route.
 func TestBuildEdgeRouteConfigurationSingleWildcard(t *testing.T) {
-	starRoute := BuildEdgeRoute("/echo", "", nil, "", nil, "echo.aether.internal", nil, nil, nil)
+	starRoute := BuildEdgeRoute("/echo", "", nil, "", nil, "echo.aether.internal", nil, nil, nil, nil)
 	star := BuildEdgeVirtualHost("*", []string{"*"}, []*routev3.Route{starRoute})
 	hosted := BuildEdgeVirtualHost("api.example.com", []string{"api.example.com"}, []*routev3.Route{starRoute})
 
@@ -479,7 +480,7 @@ func TestBuildEdgeRouteWeighted_MultipleBackends(t *testing.T) {
 		{Cluster: "svc-a.aether.internal", Weight: 3},
 		{Cluster: "svc-b.aether.internal", Weight: 1},
 	}
-	r := BuildEdgeRouteWeighted("/split", "", nil, "", nil, backends, nil, nil, nil)
+	r := BuildEdgeRouteWeighted("/split", "", nil, "", nil, backends, nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	assert.Equal(t, "/split", r.GetMatch().GetPrefix())
@@ -502,7 +503,7 @@ func TestBuildEdgeRouteWeighted_MultipleBackends(t *testing.T) {
 // list produces a plain single-cluster RouteAction (no weighted_clusters overhead).
 func TestBuildEdgeRouteWeighted_SingleBackend(t *testing.T) {
 	backends := []WeightedRouteBackend{{Cluster: "svc-1.aether.internal", Weight: 1}}
-	r := BuildEdgeRouteWeighted("/api", "", nil, "", nil, backends, nil, nil, nil)
+	r := BuildEdgeRouteWeighted("/api", "", nil, "", nil, backends, nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	ra := r.GetRoute()
@@ -519,7 +520,7 @@ func TestBuildEdgeRouteWeighted_ExactMatch(t *testing.T) {
 		{Cluster: "svc-v1.aether.internal", Weight: 90},
 		{Cluster: "svc-v2.aether.internal", Weight: 10},
 	}
-	r := BuildEdgeRouteWeighted("", "/healthz", nil, "", nil, backends, nil, nil, nil)
+	r := BuildEdgeRouteWeighted("", "/healthz", nil, "", nil, backends, nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	assert.Equal(t, "/healthz", r.GetMatch().GetPath(), "exact match must be preserved")
@@ -538,7 +539,7 @@ func TestBuildEdgeRouteWeighted_ZeroWeightBackends(t *testing.T) {
 		{Cluster: "svc-a.aether.internal", Weight: 0},
 		{Cluster: "svc-b.aether.internal", Weight: 0},
 	}
-	r := BuildEdgeRouteWeighted("/drain", "", nil, "", nil, backends, nil, nil, nil)
+	r := BuildEdgeRouteWeighted("/drain", "", nil, "", nil, backends, nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	wc := r.GetRoute().GetWeightedClusters()
@@ -553,7 +554,7 @@ func TestBuildEdgeRouteWeighted_RetryPolicy(t *testing.T) {
 		{Cluster: "svc-a.aether.internal", Weight: 1},
 		{Cluster: "svc-b.aether.internal", Weight: 1},
 	}
-	r := BuildEdgeRouteWeighted("/", "", nil, "", nil, backends, nil, nil, nil)
+	r := BuildEdgeRouteWeighted("/", "", nil, "", nil, backends, nil, nil, nil, nil)
 	ra := r.GetRoute()
 	require.NotNil(t, ra)
 	require.NotNil(t, ra.GetRetryPolicy(), "retry policy must be set on weighted route")
@@ -564,7 +565,7 @@ func TestBuildEdgeRouteWeighted_RetryPolicy(t *testing.T) {
 func TestBuildEdgeRouteWeighted_Redirect(t *testing.T) {
 	backends := []WeightedRouteBackend{{Cluster: "svc-a.aether.internal", Weight: 1}}
 	rd := &GammaRedirect{Scheme: "https", StatusCode: 301}
-	r := BuildEdgeRouteWeighted("/old", "", nil, "", nil, backends, nil, rd, nil)
+	r := BuildEdgeRouteWeighted("/old", "", nil, "", nil, backends, nil, rd, nil, nil)
 
 	require.NotNil(t, r)
 	assert.NotNil(t, r.GetRedirect(), "redirect must produce Route_Redirect")
@@ -582,7 +583,7 @@ func TestBuildEdgeRoute_Redirect(t *testing.T) {
 		PathType:   "ReplaceFullPath",
 		PathValue:  "/new-path",
 	}
-	r := BuildEdgeRoute("/old", "", nil, "", nil, "", nil, rd, nil)
+	r := BuildEdgeRoute("/old", "", nil, "", nil, "", nil, rd, nil, nil)
 
 	require.NotNil(t, r, "BuildEdgeRoute must return a route")
 	assert.Nil(t, r.GetRoute(), "redirect route must not have a RouteAction")
@@ -603,7 +604,7 @@ func TestBuildEdgeRoute_URLRewrite(t *testing.T) {
 		PathType:  "ReplacePrefixMatch",
 		PathValue: "/v2",
 	}
-	r := BuildEdgeRoute("/api", "", nil, "", nil, "svc-1.aether.internal", nil, nil, rw)
+	r := BuildEdgeRoute("/api", "", nil, "", nil, "svc-1.aether.internal", nil, nil, rw, nil)
 
 	require.NotNil(t, r)
 	ra := r.GetRoute()
@@ -617,7 +618,7 @@ func TestBuildEdgeRoute_URLRewrite(t *testing.T) {
 // TestBuildEdgeRoute_URLRewrite_FullPath: ReplaceFullPath URLRewrite uses RegexRewrite.
 func TestBuildEdgeRoute_URLRewrite_FullPath(t *testing.T) {
 	rw := &GammaURLRewrite{PathType: "ReplaceFullPath", PathValue: "/fixed"}
-	r := BuildEdgeRoute("/", "", nil, "", nil, "svc-1.aether.internal", nil, nil, rw)
+	r := BuildEdgeRoute("/", "", nil, "", nil, "svc-1.aether.internal", nil, nil, rw, nil)
 
 	ra := r.GetRoute()
 	require.NotNil(t, ra)
@@ -658,7 +659,7 @@ func TestBuildEdgeRoute_HeaderMatch(t *testing.T) {
 		{Name: "x-env", Value: "prod", Regex: false},
 		{Name: "x-role", Value: "admin|editor", Regex: true},
 	}
-	r := BuildEdgeRoute("/api", "", hdrs, "", nil, "svc.aether.internal", nil, nil, nil)
+	r := BuildEdgeRoute("/api", "", hdrs, "", nil, "svc.aether.internal", nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	match := r.GetMatch()
@@ -680,7 +681,7 @@ func TestBuildEdgeRoute_HeaderMatch(t *testing.T) {
 // TestBuildEdgeRoute_MethodMatch verifies that a non-empty Method string is emitted
 // as an Envoy ":method" HeaderMatcher with an exact string match.
 func TestBuildEdgeRoute_MethodMatch(t *testing.T) {
-	r := BuildEdgeRoute("/write", "", nil, "POST", nil, "svc.aether.internal", nil, nil, nil)
+	r := BuildEdgeRoute("/write", "", nil, "POST", nil, "svc.aether.internal", nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	headers := r.GetMatch().GetHeaders()
@@ -697,7 +698,7 @@ func TestBuildEdgeRoute_QueryParamMatch(t *testing.T) {
 		{Name: "format", Value: "json", Regex: false},
 		{Name: "version", Value: "v[12]", Regex: true},
 	}
-	r := BuildEdgeRoute("/search", "", nil, "", qps, "svc.aether.internal", nil, nil, nil)
+	r := BuildEdgeRoute("/search", "", nil, "", qps, "svc.aether.internal", nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	params := r.GetMatch().GetQueryParameters()
@@ -720,7 +721,7 @@ func TestBuildEdgeRoute_QueryParamMatch(t *testing.T) {
 func TestBuildEdgeRoute_CombinedPredicates(t *testing.T) {
 	hdrs := []RouteHeaderMatch{{Name: "x-req", Value: "true", Regex: false}}
 	qps := []RouteQueryParamMatch{{Name: "env", Value: "staging", Regex: false}}
-	r := BuildEdgeRoute("/combined", "", hdrs, "DELETE", qps, "svc.aether.internal", nil, nil, nil)
+	r := BuildEdgeRoute("/combined", "", hdrs, "DELETE", qps, "svc.aether.internal", nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	match := r.GetMatch()
@@ -780,8 +781,8 @@ func TestBuildEdgeDirectResponseRoute_PredicatesPreserved(t *testing.T) {
 // share the same path the one with more headers sorts before the one with fewer.
 func TestSortRoutesBySpecificity_HeaderCountRanksHigher(t *testing.T) {
 	// Build two routes that differ only in header count.
-	fewer := BuildEdgeRoute("/api", "", []RouteHeaderMatch{{Name: "h1", Value: "v1"}}, "", nil, "svc", nil, nil, nil)
-	more := BuildEdgeRoute("/api", "", []RouteHeaderMatch{{Name: "h1", Value: "v1"}, {Name: "h2", Value: "v2"}}, "", nil, "svc", nil, nil, nil)
+	fewer := BuildEdgeRoute("/api", "", []RouteHeaderMatch{{Name: "h1", Value: "v1"}}, "", nil, "svc", nil, nil, nil, nil)
+	more := BuildEdgeRoute("/api", "", []RouteHeaderMatch{{Name: "h1", Value: "v1"}, {Name: "h2", Value: "v2"}}, "", nil, "svc", nil, nil, nil, nil)
 
 	require.NotNil(t, fewer)
 	require.NotNil(t, more)
@@ -796,10 +797,134 @@ func TestSortRoutesBySpecificity_HeaderCountRanksHigher(t *testing.T) {
 // both contribute distinct entries to GetHeaders().
 func TestBuildEdgeRoute_MethodAndHeadersCombined(t *testing.T) {
 	hdrs := []RouteHeaderMatch{{Name: "x-custom", Value: "yes", Regex: false}}
-	r := BuildEdgeRoute("/path", "", hdrs, "PATCH", nil, "svc", nil, nil, nil)
+	r := BuildEdgeRoute("/path", "", hdrs, "PATCH", nil, "svc", nil, nil, nil, nil)
 
 	require.NotNil(t, r)
 	headers := r.GetMatch().GetHeaders()
 	// x-custom + :method = 2 entries.
 	require.Len(t, headers, 2)
+}
+
+// --- FIX 2: HTTPRouteRewritePath prefix slash normalization ---
+
+// TestBuildEdgeRoute_URLRewrite_PrefixSlashNormalization verifies that
+// ReplacePrefixMatch with PathValue "/" does NOT produce a double-slash path
+// (Envoy concatenates match prefix + rewrite value; a trailing "/" on the rewrite
+// produces "//suffix"). The fix strips the trailing slash from PathValue before
+// setting PrefixRewrite, so "/prefix/three" → "/" not "//three".
+func TestBuildEdgeRoute_URLRewrite_PrefixSlashNormalization(t *testing.T) {
+	tests := []struct {
+		name        string
+		matchPrefix string
+		pathValue   string
+		wantRewrite string
+	}{
+		{
+			name:        "trailing slash stripped to empty → avoids double-slash",
+			matchPrefix: "/prefix",
+			pathValue:   "/",
+			wantRewrite: "",
+		},
+		{
+			name:        "no trailing slash → value unchanged",
+			matchPrefix: "/api",
+			pathValue:   "/v2",
+			wantRewrite: "/v2",
+		},
+		{
+			name:        "trailing slash on multi-segment → stripped",
+			matchPrefix: "/foo",
+			pathValue:   "/bar/",
+			wantRewrite: "/bar",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rw := &GammaURLRewrite{PathType: "ReplacePrefixMatch", PathValue: tc.pathValue}
+			r := BuildEdgeRoute(tc.matchPrefix, "", nil, "", nil, "svc.aether.internal", nil, nil, rw, nil)
+			require.NotNil(t, r)
+			ra := r.GetRoute()
+			require.NotNil(t, ra, "ReplacePrefixMatch must produce a RouteAction")
+			assert.Equal(t, tc.wantRewrite, ra.GetPrefixRewrite(),
+				"PrefixRewrite must have trailing slash stripped to prevent double-slash")
+		})
+	}
+}
+
+// --- FIX 3: HTTPRouteRedirectPortAndScheme — scheme-default port ---
+
+// TestBuildEdgeRoute_Redirect_SchemeOnly verifies that a redirect with scheme set
+// but no explicit port sets PortRedirect to the scheme's default (443 for https,
+// 80 for http). Without this fix, Envoy's proto3 zero-value for port_redirect
+// causes it to copy the original request port (e.g. https://host:80/path).
+func TestBuildEdgeRoute_Redirect_SchemeOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		scheme   string
+		wantPort uint32
+	}{
+		{name: "https no port → 443", scheme: "https", wantPort: 443},
+		{name: "http no port → 80", scheme: "http", wantPort: 80},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rd := &GammaRedirect{Scheme: tc.scheme, StatusCode: 301}
+			r := BuildEdgeRoute("/path", "", nil, "", nil, "", nil, rd, nil, nil)
+			require.NotNil(t, r)
+			rdr := r.GetRedirect()
+			require.NotNil(t, rdr)
+			assert.Equal(t, tc.wantPort, rdr.GetPortRedirect(),
+				"scheme-only redirect must use scheme-default port to avoid https://host:80")
+		})
+	}
+}
+
+// TestBuildEdgeRoute_Redirect_ExplicitPortOverridesSchemeDefault verifies that
+// when Port is explicitly set, it takes precedence over the scheme default.
+func TestBuildEdgeRoute_Redirect_ExplicitPortOverridesSchemeDefault(t *testing.T) {
+	rd := &GammaRedirect{Scheme: "https", Port: 8443, StatusCode: 301}
+	r := BuildEdgeRoute("/path", "", nil, "", nil, "", nil, rd, nil, nil)
+	require.NotNil(t, r)
+	rdr := r.GetRedirect()
+	require.NotNil(t, rdr)
+	assert.Equal(t, uint32(8443), rdr.GetPortRedirect(),
+		"explicit port must override scheme default")
+}
+
+// --- FIX 4: HTTPRouteTimeoutRequest enforcement in BuildEdgeRoute ---
+
+// TestBuildEdgeRoute_Timeout verifies that a non-nil timeout is wired onto
+// the RouteAction.Timeout field of the forwarding route.
+func TestBuildEdgeRoute_Timeout(t *testing.T) {
+	timeout := &durationpb.Duration{Seconds: 5}
+	r := BuildEdgeRoute("/slow", "", nil, "", nil, "backend.aether.internal", nil, nil, nil, timeout)
+	require.NotNil(t, r)
+	ra := r.GetRoute()
+	require.NotNil(t, ra)
+	require.NotNil(t, ra.GetTimeout(), "timeout must be wired onto RouteAction.Timeout")
+	assert.Equal(t, int64(5), ra.GetTimeout().GetSeconds())
+}
+
+// TestBuildEdgeRoute_NilTimeout verifies that a nil timeout leaves RouteAction.Timeout
+// unset (Envoy inherits the HCM-level default).
+func TestBuildEdgeRoute_NilTimeout(t *testing.T) {
+	r := BuildEdgeRoute("/fast", "", nil, "", nil, "backend.aether.internal", nil, nil, nil, nil)
+	require.NotNil(t, r)
+	ra := r.GetRoute()
+	require.NotNil(t, ra)
+	assert.Nil(t, ra.GetTimeout(), "nil timeout must leave RouteAction.Timeout unset")
+}
+
+// TestBuildEdgeRouteWeighted_Timeout verifies that a non-nil timeout is threaded
+// onto the WeightedCluster RouteAction.Timeout.
+func TestBuildEdgeRouteWeighted_Timeout(t *testing.T) {
+	backends := []WeightedRouteBackend{{Cluster: "svc-a.aether.internal", Weight: 1}}
+	timeout := &durationpb.Duration{Seconds: 2}
+	r := BuildEdgeRouteWeighted("/slow", "", nil, "", nil, backends, nil, nil, nil, timeout)
+	require.NotNil(t, r)
+	ra := r.GetRoute()
+	require.NotNil(t, ra)
+	require.NotNil(t, ra.GetTimeout(), "timeout must be set on weighted route's RouteAction")
+	assert.Equal(t, int64(2), ra.GetTimeout().GetSeconds())
 }

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
@@ -405,6 +406,13 @@ func gammaRouteAction(serviceCluster string, rule GammaRoute) *routev3.Route_Rou
 
 // gammaRedirectAction converts a GammaRedirect into an Envoy Route_Redirect action.
 // The returned action replaces the RouteAction entirely — no backend cluster is used.
+//
+// Port semantics (Gateway API compliance): when an explicit Port is set, it is used
+// directly. When Port is 0 (not set in the filter) but Scheme is set, we must NOT
+// preserve the original request port — Envoy's default (port_redirect = 0) copies the
+// original request port, which violates Gateway API semantics where a scheme change
+// implies the scheme's default port. We emit the scheme-default port explicitly so
+// the redirect URL uses the correct port for the new scheme.
 func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
 	a := &routev3.RedirectAction{}
 	if rd.Scheme != "" {
@@ -413,8 +421,17 @@ func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
 	if rd.Hostname != "" {
 		a.HostRedirect = rd.Hostname
 	}
-	if rd.Port != 0 {
+	switch {
+	case rd.Port != 0:
+		// Explicit port: use as specified.
 		a.PortRedirect = rd.Port
+	case rd.Scheme == "https":
+		// Scheme changed to https, no explicit port: use the https default (443) so
+		// the original request port is not preserved in the redirect URL.
+		a.PortRedirect = 443
+	case rd.Scheme == "http":
+		// Scheme changed to http, no explicit port: use the http default (80).
+		a.PortRedirect = 80
 	}
 	switch rd.StatusCode {
 	case 302:
@@ -433,8 +450,17 @@ func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
 }
 
 // applyURLRewrite writes URLRewrite fields onto an existing RouteAction.
-// hostname → HostRewriteLiteral; ReplacePrefixMatch → PrefixRewrite;
+// hostname → HostRewriteLiteral; ReplacePrefixMatch → PrefixRewrite (normalized);
 // ReplaceFullPath → RegexRewrite matching .* → the new path.
+//
+// Gateway API ReplacePrefixMatch semantics: the matched prefix is replaced by
+// PathValue. Envoy's prefix_rewrite literally substitutes the matched prefix bytes,
+// so a trailing slash in the replacement causes a double slash when the unmatched
+// suffix starts with "/" (e.g. match "/prefix", replacement "/", path "/prefix/three"
+// → "/" + "/three" = "//three"). To comply with Gateway API, we strip the trailing
+// slash from the replacement: the remaining suffix already carries its own leading
+// slash, so trimming produces the correct join. Trimming "/" to "" is also correct —
+// Envoy leaves path without a prefix and the suffix provides the leading slash.
 func applyURLRewrite(ra *routev3.RouteAction, rw *GammaURLRewrite) {
 	if rw == nil {
 		return
@@ -444,7 +470,9 @@ func applyURLRewrite(ra *routev3.RouteAction, rw *GammaURLRewrite) {
 	}
 	switch rw.PathType {
 	case "ReplacePrefixMatch":
-		ra.PrefixRewrite = rw.PathValue
+		// Strip trailing slash to avoid double-slash when the suffix starts with "/".
+		// strings.TrimRight is used (not TrimSuffix) so "/foo/" → "/foo", "/" → "".
+		ra.PrefixRewrite = strings.TrimRight(rw.PathValue, "/")
 	case "ReplaceFullPath":
 		ra.RegexRewrite = &matcherv3.RegexMatchAndSubstitute{
 			Pattern:      &matcherv3.RegexMatcher{Regex: ".*"},


### PR DESCRIPTION
## Summary

Four contained conformance bug fixes in the edge route/filter path (`buildVirtualHost`, `proxy.BuildEdgeRoute`, filter helpers). All share the same PR to avoid conflicts on the overlapping functions.

---

### FIX 1 — Unresolved backendRef does not fire HTTP 500

**Root cause:** `buildHTTPRouteBackends` filtered by kind/group/ReferenceGrant but did NOT check whether the referenced Service actually exists. A shape-valid-but-missing Service was admitted as a backend → `len(backends) == 1` → Envoy received a forwarding route to a ghost cluster → **Envoy 503**, not the Gateway API-required **HTTP 500 direct_response**.

The 500 path only fires when `len(backends) == 0 && len(rule.BackendRefs) > 0`. `backendsResolveHTTP` (status reporting) already did the `r.Get` existence check and set `BackendNotFound`; the data plane was missing the same guard.

**Fix:** Add `r.Get` in `buildHTTPRouteBackends`: `apierrors.IsNotFound` → drop backend; transient errors → admit (avoids false-positive 500s during API hiccups). Mirrors `status.go::backendsResolveL4`.

**Tests:** `TestBuildHTTPRouteBackends_NonExistentService_Dropped`, `TestBuildVirtualHost_NonExistentBackend_DirectResponse500`, `TestBuildHTTPRouteBackends_ExistingService_Admitted`.

---

### FIX 2 — HTTPRouteRewritePath emits double slash (`//three`)

**Root cause:** Envoy's `prefix_rewrite` is a literal string concatenation: match `/prefix`, rewrite `/`, path `/prefix/three` → Envoy replaces the matched prefix with the rewrite value → `/` + `/three` = `//three`.

**Fix:** `strings.TrimRight(PathValue, "/")` in `applyURLRewrite` for `ReplacePrefixMatch`. When `PathValue = "/"`, it becomes `""` — Envoy strips the matched prefix and the remaining path suffix (`/three`) already carries its leading slash. When `PathValue = "/v2"`, no trailing slash, value is unchanged.

**Tests:** `TestBuildEdgeRoute_URLRewrite_PrefixSlashNormalization` (table: `/` → `""`, `/v2` unchanged, `/bar/` → `/bar`).

---

### FIX 3 — HTTPRouteRedirectPortAndScheme: scheme-only redirect keeps original port

**Root cause:** `gammaRedirectAction` only set `PortRedirect` when `Port != 0`. Envoy's proto3 `port_redirect uint32` zero-value means *copy the original request port*. A scheme-only redirect (`https`, no explicit port) produced `https://host:80/path` instead of `https://host/path`.

**Fix:** When `Port == 0` and `Scheme` is set, default `PortRedirect` to the scheme's canonical port (443 for `https`, 80 for `http`). This is the correct Gateway API interpretation: scheme change with no explicit port means "use the scheme default".

**Tests:** `TestBuildEdgeRoute_Redirect_SchemeOnly` (https→443, http→80), `TestBuildEdgeRoute_Redirect_ExplicitPortOverridesSchemeDefault`.

---

### FIX 4 — HTTPRouteTimeoutRequest advertised but not enforced

**Root cause:** `buildVirtualHost` never read `rule.Timeouts.Request`. `cache.Route` had no `Timeout` field. A 1s backend delay returned 200 instead of 504.

**Fix:**
- Add `Timeout *durationpb.Duration` to `cache.Route` (with `equalRouteDuration` helper for snapshot diffing)
- Add `buildRouteTimeout` helper in `reconciler.go` (mirrors gamma reconciler pattern: `time.ParseDuration` → `durationpb.New`)
- Thread `timeout` through `buildVirtualHost` → all produced `cache.Route` entries → `BuildEdgeRoute`/`BuildEdgeRouteWeighted` (new `timeout` parameter) → `RouteAction.Timeout`

**Tests:** `TestBuildVirtualHost_TimeoutRequest`, `TestBuildVirtualHost_NoTimeout`, `TestBuildVirtualHost_TimeoutRequest_MultiMatch`, `TestBuildEdgeRoute_Timeout`, `TestBuildEdgeRoute_NilTimeout`, `TestBuildEdgeRouteWeighted_Timeout`.

---

## Test plan

- [x] `bazel build //...` — 230 targets, all pass
- [x] `bazel test //... --test_output=errors` — 59/62 pass; 3 chart lint failures are pre-existing (Helm lint tests reject `-test.short` flag) and unrelated to this change
- [x] `bazel run //:format` — all formatters clean
- [x] `make gazelle` — `durationpb` dep added to cache/gatewayapi BUILD.bazel automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S