### PR TITLE
fix(edge): registry-aware backend existence (mesh backends 500 regression)

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -50,6 +50,13 @@ type RouteSink interface {
 	// (one per Gateway, bound on allocated internal ports) instead of the shared
 	// Phase 1 listeners. When empty, falls back to Phase 1 behavior.
 	SetEdgeGateways(gateways []cache.EdgeGatewayEntry)
+	// HasRegistryService reports whether the named service is currently known to
+	// the mesh registry (namespace-blind, bare service name). Used by the
+	// backend-existence check to distinguish mesh/registry services (which need
+	// no k8s Service object in the route namespace) from k8s-only Services.
+	// Returns false when the registry does not implement ServiceCatalog or no
+	// registry has been configured (safe default = not a registry service).
+	HasRegistryService(name string) bool
 }
 
 // Reconciler watches Gateway API HTTPRoutes, TCPRoutes, and TLSRoutes (and the
@@ -703,6 +710,37 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 	return vh
 }
 
+// backendExists reports whether a named backend is admissible on the data plane:
+// it exists if it is a mesh/registry service (resolved namespace-blind via the
+// registry ServiceCatalog) OR if a k8s Service with the given name/namespace can
+// be read from the API server. The registry is checked first (cheap, in-memory).
+//
+// Only a hard k8s NotFound with no registry hit causes the backend to be treated
+// as non-existent. Transient API errors leave the backend admitted to avoid
+// false-positive 500s on a momentary API server hiccup.
+//
+// When r.Sink is nil or r.Client is nil, the check degrades gracefully (the
+// backend is admitted) to preserve prior behavior for callers that don't wire up
+// those dependencies (e.g. unit tests that focus on other behavior).
+func (r *Reconciler) backendExists(ctx context.Context, name, namespace string) bool {
+	// Registry check first: mesh services are namespace-blind (bare name).
+	if r.Sink != nil && r.Sink.HasRegistryService(name) {
+		return true
+	}
+	// Fall back to k8s Service existence check.
+	if r.Client == nil {
+		return true // no client → treat as admitted (safe degradation)
+	}
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false // neither a registry service nor a k8s Service → BackendNotFound
+		}
+		// Transient error: admit the backend to avoid false-positive 500s.
+	}
+	return true
+}
+
 // buildHTTPRouteBackends converts the HTTPRoute rule's backendRefs into a list of
 // RouteBackend values, applying Gateway API admission rules: non-core group/kind
 // refs are skipped; ungranted cross-namespace refs are skipped (RefNotPermitted).
@@ -733,22 +771,12 @@ func (r *Reconciler) buildHTTPRouteBackends(ctx context.Context, refs []gatewayv
 		if b.Namespace != nil && string(*b.Namespace) != "" {
 			ns = string(*b.Namespace)
 		}
-		// Existence check: drop backends whose Service does not exist. This mirrors the
-		// check backendsResolveL4 (status.go) already performs for status, and ensures
-		// that a rule whose only backends are missing (BackendNotFound) arrives at
-		// buildVirtualHost with len(backends)==0 so the 500 direct_response path fires
-		// (see Gateway API invalid-backend semantics). Mesh services have a generated
-		// Service object; real k8s Services are real. Only drop on hard NotFound — a
-		// transient API error leaves the backend admitted so we don't break the data
-		// plane on a momentary API server hiccup.
-		if r.Client != nil {
-			svc := &corev1.Service{}
-			if err := r.Get(ctx, types.NamespacedName{Namespace: ns, Name: name}, svc); err != nil {
-				if apierrors.IsNotFound(err) {
-					continue // BackendNotFound: drop from admitted set
-				}
-				// Transient error: admit the backend to avoid false-positive 500s.
-			}
+		// Registry-aware existence check: a backend is admissible if it is a
+		// mesh/registry service OR a real k8s Service. Only drop on confirmed
+		// non-existence in both (BackendNotFound). Transient API errors leave the
+		// backend admitted to avoid false-positive 500s on API server hiccups.
+		if !r.backendExists(ctx, name, ns) {
+			continue // BackendNotFound: drop from admitted set
 		}
 		var port uint32
 		if b.Port != nil {

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -627,8 +627,11 @@ func TestHTTPRouteGatewaySortOrder(t *testing.T) {
 }
 
 // fakeSink is a minimal RouteSink that records SetEdgeHTTPRedirect calls.
+// hasRegistryService, when non-nil, is consulted by HasRegistryService so tests
+// can inject mesh/registry service names without a real registry.
 type fakeSink struct {
-	httpRedirect bool
+	httpRedirect       bool
+	hasRegistryService func(name string) bool
 }
 
 func (f *fakeSink) SetVirtualHosts(_ []cache.VirtualHost) {}
@@ -639,6 +642,12 @@ func (f *fakeSink) SetEdgeTCPRoutes(_ []proxy.EdgeL4TCPRoute)  {}
 func (f *fakeSink) SetEdgeTLSRoutes(_ []proxy.EdgeL4TLSRoute)  {}
 func (f *fakeSink) SetEdgeHTTPRedirect(enabled bool)           { f.httpRedirect = enabled }
 func (f *fakeSink) SetEdgeGateways(_ []cache.EdgeGatewayEntry) {}
+func (f *fakeSink) HasRegistryService(name string) bool {
+	if f.hasRegistryService != nil {
+		return f.hasRegistryService(name)
+	}
+	return false
+}
 
 // TestHTTPRedirectAnnotation verifies that the reconciler reads the
 // gateway.aether.io/http-redirect annotation from Gateways and calls
@@ -1213,7 +1222,7 @@ func TestBuildHTTPRouteBackends_HeadlessDialPort(t *testing.T) {
 func TestBuildHTTPRouteBackends_NonExistentService_Dropped(t *testing.T) {
 	// Client has no Services registered — "ghost-svc" does not exist.
 	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
-	r := &Reconciler{Client: c}
+	r := &Reconciler{Client: c, Sink: &fakeSink{}}
 
 	got := r.buildHTTPRouteBackends(
 		context.Background(),
@@ -1222,6 +1231,92 @@ func TestBuildHTTPRouteBackends_NonExistentService_Dropped(t *testing.T) {
 		nil,
 	)
 	assert.Empty(t, got, "nonexistent Service must be dropped from the admitted backend set")
+}
+
+// --- Registry-aware backend existence (mesh/registry service regression) ---
+
+// TestBuildHTTPRouteBackends_RegistryService_Admitted is the regression guard for
+// #367: a backend that IS a registry/mesh service (HasRegistryService=true) but has
+// NO corresponding k8s Service in the route namespace must be ADMITTED (not dropped).
+// This is the api.palermo.dev 200→500 regression: mesh backends are namespace-blind
+// and only exist in the registry, not as k8s Services in the edge namespace.
+func TestBuildHTTPRouteBackends_RegistryService_Admitted(t *testing.T) {
+	// Client has no Services — "echo" does not exist as a k8s Service.
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	// Sink reports "echo" as a registry/mesh service.
+	sink := &fakeSink{hasRegistryService: func(name string) bool { return name == "echo" }}
+	r := &Reconciler{Client: c, Sink: sink}
+
+	got := r.buildHTTPRouteBackends(
+		context.Background(),
+		backend("echo", 8080),
+		"aether-ingress",
+		nil,
+	)
+	require.Len(t, got, 1, "registry/mesh backend must be admitted even without a k8s Service")
+	assert.Equal(t, "echo", got[0].Service)
+}
+
+// TestBuildVirtualHost_RegistryBackend_NoDirectResponse500 verifies the end-to-end
+// regression guard: a rule whose backend is a registry/mesh service must NOT produce
+// a DirectResponseStatus=500 route (it must produce a normal forwarding route).
+func TestBuildVirtualHost_RegistryBackend_NoDirectResponse500(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	sink := &fakeSink{hasRegistryService: func(name string) bool { return name == "echo" }}
+	r := &Reconciler{Client: c, Sink: sink}
+
+	hr := httpRoute([]string{"api.palermo.dev"}, []gatewayv1.HTTPRouteRule{
+		{
+			Matches:     pathMatch(gatewayv1.PathMatchPathPrefix, "/"),
+			BackendRefs: backend("echo", 8080),
+		},
+	})
+	vh := r.buildVirtualHost(context.Background(), hr, nil, nil)
+
+	require.Len(t, vh.Routes, 1, "registry backend must produce exactly one forwarding route")
+	rt := vh.Routes[0]
+	assert.Equal(t, uint32(0), rt.DirectResponseStatus,
+		"registry/mesh backend must NOT produce DirectResponseStatus=500")
+	assert.Equal(t, "echo", rt.Service, "forwarding route must carry the backend service name")
+}
+
+// TestBuildHTTPRouteBackends_K8sService_RegistryMiss_Admitted verifies that a
+// backend that IS a k8s Service (exists in the API server) but is NOT a registry
+// service (e.g. a cleartext edge backend to a real k8s service outside the mesh)
+// is admitted normally.
+func TestBuildHTTPRouteBackends_K8sService_RegistryMiss_Admitted(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(svcWith("real-svc", "ns", "10.0.0.1", 8080, intstr.FromInt(8080))).
+		Build()
+	// Sink reports NO registry services (real-svc is a pure k8s service).
+	r := &Reconciler{Client: c, Sink: &fakeSink{}}
+
+	got := r.buildHTTPRouteBackends(
+		context.Background(),
+		backend("real-svc", 8080),
+		"ns",
+		nil,
+	)
+	require.Len(t, got, 1, "k8s Service (non-registry) must be admitted")
+	assert.Equal(t, "real-svc", got[0].Service)
+}
+
+// TestBuildHTTPRouteBackends_NeitherRegistryNorK8s_Dropped verifies that a backend
+// that is NEITHER a registry service nor a real k8s Service is dropped (BackendNotFound
+// → 500 direct_response). This is the conformance HTTPRouteInvalidNonExistentBackendRef
+// case that #367 was intended to handle.
+func TestBuildHTTPRouteBackends_NeitherRegistryNorK8s_Dropped(t *testing.T) {
+	// Client has no Services; sink has no registry services.
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	r := &Reconciler{Client: c, Sink: &fakeSink{}}
+
+	got := r.buildHTTPRouteBackends(
+		context.Background(),
+		backend("nonexistent", 8080),
+		"ns",
+		nil,
+	)
+	assert.Empty(t, got, "backend that is neither registry nor k8s Service must be dropped → 500")
 }
 
 // TestBuildVirtualHost_NonExistentBackend_DirectResponse500 verifies the end-to-end

--- a/agent/internal/edge/gatewayapi/status.go
+++ b/agent/internal/edge/gatewayapi/status.go
@@ -625,15 +625,16 @@ func l4BackendObjectRefs(rules []gatewayv1alpha2.TCPRouteRule) []gatewayv1.Backe
 //   - its group/kind is the core ("") Service kind — otherwise InvalidKind;
 //   - it has a non-empty name — otherwise BackendNotFound (empty name);
 //   - if cross-namespace, a ReferenceGrant permits it — otherwise RefNotPermitted;
-//   - the referenced Service actually EXISTS — otherwise BackendNotFound.
+//   - the referenced backend EXISTS — either as a mesh/registry service (checked
+//     first, namespace-blind) or as a real k8s Service — otherwise BackendNotFound.
 //
-// Existence is a cached r.Get on the Service {namespace: backendRef.namespace ||
-// routeNamespace, name}. The edge reads Services cluster-wide (services get/list/
-// watch RBAC + a Service watch), so a Service create/delete re-triggers reconciliation
-// and flips the condition. A mesh/registry backend has a generated Service object and
-// conformance backends are real Services, so a Service Get covers both cases. Across
-// the refs in a rule the first/most-specific failure wins, with InvalidKind taking
-// precedence over BackendNotFound (it short-circuits before the existence check).
+// Existence uses the registry-aware backendExists helper: a backend is resolved
+// when the registry's ServiceCatalog knows the bare service name (mesh backend,
+// no k8s Service required in the route namespace), or when a k8s Service Get
+// succeeds. This prevents mesh-backed edge routes from being incorrectly marked
+// BackendNotFound when the route namespace differs from the service's k8s namespace.
+// Across the refs in a rule the first/most-specific failure wins, with InvalidKind
+// taking precedence over BackendNotFound (it short-circuits before the existence check).
 func (r *Reconciler) backendsResolveL4(ctx context.Context, routeNamespace, routeKind string, refs []gatewayv1.BackendObjectReference, grants []gatewayv1beta1.ReferenceGrant) (bool, string, string) {
 	for _, ref := range refs {
 		if (ref.Group != nil && string(*ref.Group) != "") || (ref.Kind != nil && string(*ref.Kind) != "Service") {
@@ -648,25 +649,16 @@ func (r *Reconciler) backendsResolveL4(ctx context.Context, routeNamespace, rout
 			return false, string(gatewayv1.RouteReasonRefNotPermitted),
 				fmt.Sprintf("cross-namespace backendRef to Service %q in namespace %q is not permitted by any ReferenceGrant", ref.Name, backendNS)
 		}
-		// Existence: the backend must resolve to a real k8s Service (mesh services
-		// have a generated Service; conformance backends are real Services). The
-		// namespace defaults to the route's namespace when the ref omits it.
+		// Registry-aware existence check: a mesh/registry backend resolves even when
+		// there is no k8s Service in the route namespace (registry is namespace-blind).
+		// Falls back to k8s Service Get for cleartext edge backends.
 		svcNS := backendNS
 		if svcNS == "" {
 			svcNS = routeNamespace
 		}
-		svc := &corev1.Service{}
-		if err := r.Get(ctx, types.NamespacedName{Namespace: svcNS, Name: string(ref.Name)}, svc); err != nil {
-			if apierrors.IsNotFound(err) {
-				return false, string(gatewayv1.RouteReasonBackendNotFound),
-					fmt.Sprintf("backendRef Service %q in namespace %q does not exist", ref.Name, svcNS)
-			}
-			// Transient API error: don't assert BackendNotFound on an unknown state;
-			// surface it as unresolved so the next reconcile re-evaluates.
-			r.Log.WarnContext(ctx, "failed to get backendRef Service for ResolvedRefs",
-				"service", ref.Name, "namespace", svcNS, "error", err.Error())
+		if !r.backendExists(ctx, string(ref.Name), svcNS) {
 			return false, string(gatewayv1.RouteReasonBackendNotFound),
-				fmt.Sprintf("backendRef Service %q in namespace %q could not be resolved: %v", ref.Name, svcNS, err)
+				fmt.Sprintf("backendRef Service %q in namespace %q does not exist", ref.Name, svcNS)
 		}
 	}
 	return true, string(gatewayv1.RouteReasonResolvedRefs), "All backend references resolved"

--- a/agent/internal/edge/gatewayapi/status_test.go
+++ b/agent/internal/edge/gatewayapi/status_test.go
@@ -35,6 +35,7 @@ func (statusFakeSink) SetEdgeTCPRoutes([]proxy.EdgeL4TCPRoute)  {}
 func (statusFakeSink) SetEdgeTLSRoutes([]proxy.EdgeL4TLSRoute)  {}
 func (statusFakeSink) SetEdgeHTTPRedirect(bool)                 {}
 func (statusFakeSink) SetEdgeGateways([]cache.EdgeGatewayEntry) {}
+func (statusFakeSink) HasRegistryService(string) bool           { return false }
 
 func statusScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -162,6 +163,24 @@ func routeResolvedRefs(t *testing.T, c client.Client) *metav1.Condition {
 	return meta.FindStatusCondition(gotHR.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionResolvedRefs))
 }
 
+// statusFakeSinkWithRegistry is a RouteSink that reports specific service names as
+// registry/mesh services. Used to test registry-aware backend-existence behavior.
+type statusFakeSinkWithRegistry struct {
+	registryServices map[string]bool
+}
+
+func (s statusFakeSinkWithRegistry) SetVirtualHosts([]cache.VirtualHost) {}
+func (s statusFakeSinkWithRegistry) SetEdgeTLSSecrets(context.Context, map[string]cache.EdgeTLSCert) error {
+	return nil
+}
+func (s statusFakeSinkWithRegistry) SetEdgeTCPRoutes([]proxy.EdgeL4TCPRoute)  {}
+func (s statusFakeSinkWithRegistry) SetEdgeTLSRoutes([]proxy.EdgeL4TLSRoute)  {}
+func (s statusFakeSinkWithRegistry) SetEdgeHTTPRedirect(bool)                 {}
+func (s statusFakeSinkWithRegistry) SetEdgeGateways([]cache.EdgeGatewayEntry) {}
+func (s statusFakeSinkWithRegistry) HasRegistryService(name string) bool {
+	return s.registryServices[name]
+}
+
 // TestReconcile_BackendNotFound: an HTTPRoute whose core-Service backendRef names a
 // Service that does not exist gets ResolvedRefs=False/BackendNotFound.
 func TestReconcile_BackendNotFound(t *testing.T) {
@@ -200,6 +219,33 @@ func TestReconcile_BackendExists(t *testing.T) {
 	rres := routeResolvedRefs(t, c)
 	require.NotNil(t, rres)
 	assert.Equal(t, metav1.ConditionTrue, rres.Status, "existing Service backend → ResolvedRefs True")
+	assert.Equal(t, string(gatewayv1.RouteReasonResolvedRefs), rres.Reason)
+}
+
+// TestReconcile_RegistryOnlyBackend_ResolvedRefs: an HTTPRoute whose backendRef is a
+// mesh/registry service (HasRegistryService=true) but has no k8s Service in the route
+// namespace gets ResolvedRefs=True. This is the regression guard for #367: before the
+// fix, such a backend returned BackendNotFound because the namespaced Service.Get
+// failed. The registry-aware check must report it as resolved.
+func TestReconcile_RegistryOnlyBackend_ResolvedRefs(t *testing.T) {
+	gc, gw, hr := resolvedRefsFixture(gatewayv1.BackendObjectReference{Name: "echo", Port: ptr(gatewayv1.PortNumber(8080))})
+
+	// Client has NO Services — "echo" is registry-only (no k8s Service in "ns").
+	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).
+		WithObjects(gc, gw, hr).
+		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
+		Build()
+	// Sink reports "echo" as a mesh/registry service.
+	sink := statusFakeSinkWithRegistry{registryServices: map[string]bool{"echo": true}}
+	r := &Reconciler{Client: c, APIReader: c, Sink: sink, Namespace: "ns", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	rres := routeResolvedRefs(t, c)
+	require.NotNil(t, rres)
+	assert.Equal(t, metav1.ConditionTrue, rres.Status,
+		"registry-only backend must report ResolvedRefs=True (not BackendNotFound)")
 	assert.Equal(t, string(gatewayv1.RouteReasonResolvedRefs), rres.Reason)
 }
 

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	"github.com/bpalermo/aether/common/constants"
+	"github.com/bpalermo/aether/registry"
 
 	commonlog "github.com/bpalermo/aether/common/log"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -226,6 +227,11 @@ type SnapshotCache struct {
 	meshDNS *meshdns.Server
 
 	version *atomic.Uint64
+
+	// regMu guards reg, the service registry used to resolve mesh service
+	// existence for the edge backend-existence check (HasRegistryService).
+	regMu sync.RWMutex
+	reg   registry.Registry
 }
 
 // listenerEntry holds the inbound and outbound Envoy listeners for a single pod,
@@ -428,6 +434,35 @@ func (c *SnapshotCache) SetEdgeIdentity(spiffeID, trustDomain string) {
 	c.nodeSpiffeID = spiffeID
 	c.trustDomain = trustDomain
 	c.localMu.Unlock()
+}
+
+// SetRegistry stores the service registry for use in HasRegistryService.
+// Called once from NewAgentXdsServer before the manager starts; safe for
+// concurrent use after that point (registry is only read, never replaced).
+func (c *SnapshotCache) SetRegistry(reg registry.Registry) {
+	c.regMu.Lock()
+	c.reg = reg
+	c.regMu.Unlock()
+}
+
+// HasRegistryService reports whether the named service is currently known to
+// the mesh registry. It delegates to the registry's ServiceCatalog.HasService
+// when available; returns false if the registry does not implement ServiceCatalog
+// or no registry has been set (safe default = treat as not a registry service).
+// Used by the edge reconciler's backend-existence check to distinguish mesh
+// services (namespace-blind, registry-resolved) from k8s Services.
+func (c *SnapshotCache) HasRegistryService(name string) bool {
+	c.regMu.RLock()
+	reg := c.reg
+	c.regMu.RUnlock()
+	if reg == nil {
+		return false
+	}
+	cat, ok := reg.(registry.ServiceCatalog)
+	if !ok {
+		return false
+	}
+	return cat.HasService(name)
 }
 
 // perDownstreamConnectionPool reports whether service clusters should key

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -58,6 +58,10 @@ func NewAgentXdsServer(ctx context.Context, clusterName string, nodeName string,
 		combined = append(combined, callbacks)
 	}
 
+	// Store the registry in the cache so the edge reconciler can query mesh
+	// service existence via HasRegistryService (registry-aware backend check).
+	snapshotCache.SetRegistry(registry)
+
 	aXdsServer := &AgentXdsServer{
 		XdsServer:   xds.NewXdsServer(ctx, cfg, snapshotCache, combined, log),
 		log:         commonlog.Named(log, "agent-xds"),


### PR DESCRIPTION
## Regression

`api.palermo.dev` went 200 → 500 after #367. Every mesh-backed edge route started returning HTTP 500.

## Root Cause

#367 added a `Service.Get(namespace, name)` existence check to `buildHTTPRouteBackends` to implement the Gateway API `BackendNotFound → 500 direct_response` behavior. The lookup uses the **route's namespace** (`aether-ingress`).

Aether's mesh services are resolved **namespace-blind, by bare name** via the registry (e.g. the production `api` HTTPRoute in `aether-ingress` references `echo`/`svc-1`/`svc-2`, which are registry services — not k8s `Service` objects in `aether-ingress`). The namespaced `Service.Get` returns `NotFound` → backend dropped → rule has zero admissible backends → `buildVirtualHost` emits HTTP 500 `direct_response`. Every mesh-backed edge route 500s.

The same latent flaw existed in `backendsResolveL4` (status.go), causing `ResolvedRefs=False/BackendNotFound` on the route status for mesh backends (unnoticed because nobody was asserting production route status).

## Fix

### Oracle wiring (`SnapshotCache` + `RouteSink`)

- `cache.SnapshotCache` gains a `reg registry.Registry` field + `SetRegistry(registry.Registry)` method.
- `NewAgentXdsServer` calls `snapshotCache.SetRegistry(registry)` immediately, so the edge cache has the registry before the reconciler runs.
- `SnapshotCache.HasRegistryService(name string) bool` delegates to `registry.ServiceCatalog.HasService` (type asserted; returns `false` if the registry does not implement `ServiceCatalog` — safe default).
- `HasRegistryService(name string) bool` is added to the edge `RouteSink` interface.

### Shared helper (`reconciler.go`)

`func (r *Reconciler) backendExists(ctx, name, namespace string) bool`:
- Checks `r.Sink.HasRegistryService(name)` **first** (cheap, in-memory, namespace-blind).
- Falls back to `r.Client.Get(Service{namespace, name})`.
- Returns `true` on transient API errors (avoids false-positive 500s on API hiccups).
- Returns `false` only when NEITHER check passes — the true `BackendNotFound` case.

### Applied in two code paths

- `buildHTTPRouteBackends` (reconciler.go): replaces the bare `Service.Get` with `backendExists`.
- `backendsResolveL4` (status.go): replaces the bare `Service.Get` (+ warn log) with `backendExists`.

## Preserved Behaviors

| Case | Before fix | After fix |
|------|-----------|-----------|
| Backend is a mesh/registry service (no k8s Service in route ns) | DROPPED → 500 (**regression**) | ADMITTED → forwarding route |
| Backend is a real k8s Service (not in registry) | Admitted | Admitted |
| Backend exists in neither registry nor k8s | Dropped → 500 | Dropped → 500 (conformance `HTTPRouteInvalidNonExistentBackendRef`) |
| Route status: registry-only backend | `ResolvedRefs=False/BackendNotFound` | `ResolvedRefs=True` |

## Tests

Added to `reconciler_test.go`:
- `TestBuildHTTPRouteBackends_RegistryService_Admitted` — regression guard: mesh backend (HasRegistryService=true, no k8s Service) → admitted, not dropped.
- `TestBuildVirtualHost_RegistryBackend_NoDirectResponse500` — end-to-end: api.palermo.dev-shaped route → forwarding route, not 500.
- `TestBuildHTTPRouteBackends_K8sService_RegistryMiss_Admitted` — cleartext k8s backend (not in registry) → admitted.
- `TestBuildHTTPRouteBackends_NeitherRegistryNorK8s_Dropped` — truly non-existent backend → dropped → 500 (conformance case preserved).

Added to `status_test.go`:
- `TestReconcile_RegistryOnlyBackend_ResolvedRefs` — registry-only backend → `ResolvedRefs=True` on route status.

Updated mock sinks: `fakeSink` (reconciler_test) gains `hasRegistryService func(name string) bool` (injectable); `statusFakeSink` (status_test) gains `HasRegistryService(string) bool { return false }`.

All existing tests pass. `bazel test //agent/internal/edge/gatewayapi:gatewayapi_test //agent/internal/xds/cache:cache_test //agent/internal/xds/server:server_test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S