### PR TITLE
fix(edge): one ServicePort per external port for multi-listener Gateways

### DIFF
--- a/agent/internal/edge/gatewayapi/service.go
+++ b/agent/internal/edge/gatewayapi/service.go
@@ -182,9 +182,21 @@ func (r *Reconciler) reconcileGatewayServices(
 			}
 		}
 
-		// Build the desired port list from the allocation.
+		// Build the desired port list from the allocation. Dedup by external port:
+		// a Service may have at most ONE ServicePort per (name, port) tuple — k8s
+		// rejects duplicates ("Duplicate value: port-80"), which drops the whole
+		// Service and leaves the Gateway without a status address. allocs is already
+		// one-per-external-port (allocateGatewayListenerPorts groups by external port),
+		// but we dedup here as a defensive backstop so any caller — present or future —
+		// that passes multiple allocations for the same external port still yields a
+		// single ServicePort rather than a Service the API server refuses.
 		ports := make([]corev1.ServicePort, 0, len(allocs))
+		seenPort := make(map[uint32]struct{}, len(allocs))
 		for _, a := range allocs {
+			if _, dup := seenPort[a.externalPort]; dup {
+				continue
+			}
+			seenPort[a.externalPort] = struct{}{}
 			portName := fmt.Sprintf("port-%d", a.externalPort)
 			ports = append(ports, corev1.ServicePort{
 				Name:       portName,

--- a/agent/internal/edge/gatewayapi/service_test.go
+++ b/agent/internal/edge/gatewayapi/service_test.go
@@ -285,6 +285,111 @@ func TestGatewayServiceShape(t *testing.T) {
 	})
 }
 
+// TestReconcileGatewayServices_MultiListenerSamePort is the end-to-end regression
+// guard for the HTTPRouteRedirectPortAndScheme conformance failure: a Gateway with
+// MULTIPLE listeners on the SAME external port (e.g. the conformance
+// `same-namespace-with-https-listener` Gateway, which has three HTTPS listeners on
+// :443) must produce a per-Gateway Service with EXACTLY ONE ServicePort for that
+// port. Per-listener Service ports yield a duplicate "port-443" entry that the API
+// server rejects ("Duplicate value: port-443"), so the Service is never created and
+// the Gateway never gets a status address — failing every test gated on readiness.
+func TestReconcileGatewayServices_MultiListenerSamePort(t *testing.T) {
+	hn := func(s string) *gatewayv1.Hostname { h := gatewayv1.Hostname(s); return &h }
+	tls := &gatewayv1.ListenerTLSConfig{}
+	gw := gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "gateway-conformance-infra", Name: "same-namespace-with-https-listener"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				// Three HTTPS listeners on :443, distinct hostnames — the conformance shape.
+				{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType, TLS: tls},
+				{Name: "https-with-hostname", Port: 443, Protocol: gatewayv1.HTTPSProtocolType, Hostname: hn("second-example.org"), TLS: tls},
+				{Name: "https-with-wildcard-hostname", Port: 443, Protocol: gatewayv1.HTTPSProtocolType, Hostname: hn("*.wildcard.org"), TLS: tls},
+			},
+		},
+	}
+	gws := []gatewayv1.Gateway{gw}
+	hostCerts := map[string]string{"": "kubernetes/cert"}
+
+	allocs, err := allocateGatewayListenerPorts(gws, hostCerts)
+	require.NoError(t, err)
+
+	fc := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	r := &Reconciler{
+		Client:          fc,
+		Namespace:       "aether-ingress",
+		EdgeServiceName: "aether-edge",
+		Log:             slog.New(slog.DiscardHandler),
+	}
+
+	_, err = r.reconcileGatewayServices(context.Background(), gws, allocs)
+	require.NoError(t, err)
+
+	svcName := gatewayServiceName("aether-edge", gw.Namespace, gw.Name)
+	got := &corev1.Service{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Namespace: "aether-ingress", Name: svcName}, got))
+
+	require.Len(t, got.Spec.Ports, 1, "exactly one ServicePort for the three :443 listeners")
+	assert.Equal(t, "port-443", got.Spec.Ports[0].Name)
+	assert.Equal(t, int32(443), got.Spec.Ports[0].Port)
+
+	// No two ServicePorts may share a (name, port) tuple — the k8s validation that
+	// rejects "Duplicate value".
+	seenName := map[string]struct{}{}
+	seenPort := map[int32]struct{}{}
+	for _, p := range got.Spec.Ports {
+		_, dupName := seenName[p.Name]
+		_, dupPort := seenPort[p.Port]
+		assert.False(t, dupName, "duplicate ServicePort name %q", p.Name)
+		assert.False(t, dupPort, "duplicate ServicePort port %d", p.Port)
+		seenName[p.Name] = struct{}{}
+		seenPort[p.Port] = struct{}{}
+	}
+}
+
+// TestReconcileGatewayServices_DedupBackstop verifies the ServicePort build dedups
+// by external port even if it is handed multiple allocations for the same external
+// port (a defensive backstop against any future regression in the upstream
+// allocator). Two allocations for :80 must collapse to ONE ServicePort "port-80".
+func TestReconcileGatewayServices_DedupBackstop(t *testing.T) {
+	gw := gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "conformance", Name: "dup"},
+		Spec: gatewayv1.GatewaySpec{
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Port: 80, Protocol: gatewayv1.HTTPProtocolType},
+			},
+		},
+	}
+	gk := gatewayKey{Namespace: "conformance", Name: "dup"}
+	// Deliberately malformed input: two allocations for the SAME external port.
+	allocs := map[gatewayKey][]gatewayListenerAllocation{
+		gk: {
+			{externalPort: 80, internalPort: 18100},
+			{externalPort: 80, internalPort: 18101},
+		},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
+	r := &Reconciler{
+		Client:          fc,
+		Namespace:       "aether-ingress",
+		EdgeServiceName: "aether-edge",
+		Log:             slog.New(slog.DiscardHandler),
+	}
+
+	_, err := r.reconcileGatewayServices(context.Background(), []gatewayv1.Gateway{gw}, allocs)
+	require.NoError(t, err)
+
+	svcName := gatewayServiceName("aether-edge", gw.Namespace, gw.Name)
+	got := &corev1.Service{}
+	require.NoError(t, fc.Get(context.Background(), types.NamespacedName{Namespace: "aether-ingress", Name: svcName}, got))
+
+	require.Len(t, got.Spec.Ports, 1, "duplicate :80 allocations must collapse to one ServicePort")
+	assert.Equal(t, "port-80", got.Spec.Ports[0].Name)
+	assert.Equal(t, int32(80), got.Spec.Ports[0].Port)
+	// First allocation wins (target 18100).
+	assert.Equal(t, intstr.FromInt32(18100), got.Spec.Ports[0].TargetPort)
+}
+
 // TestGatewayServiceGC verifies stale per-Gateway Services (whose Gateway no
 // longer exists) are deleted, while active ones are preserved.
 func TestGatewayServiceGC(t *testing.T) {


### PR DESCRIPTION
## Root cause

The Gateway API conformance test `HTTPRouteRedirectPortAndScheme` (Extended) was failing — but **not** on redirect logic (the sibling `HTTPRouteRedirectPort` passes all sub-probes). The real cause: the test's `same-namespace-with-https-listener` Gateway has **three HTTPS listeners on the same external port (:443)**. Aether's per-Gateway LoadBalancer Service allocation, in the pre-#348 form, emitted one `ServicePort` per listener → a **duplicate `port-443`** entry. The API server rejects that (`Duplicate value: port-443`), so the per-Gateway Service is never created, the Gateway never gets `status.addresses`, and every test gated on Gateway readiness times out at the 180s budget. Same class as the earlier #348 duplicate-`port-80` bug.

## Investigation

- `allocateGatewayListenerPorts` (#348) **already** groups listeners by external port into one allocation each, and the ServicePort build iterates those allocations — so the *current tree* is correct. The rev17 conformance run that observed the failure used a deployed image that predated #348.
- **Reproduced on talos-main** against the live edge: a Gateway with 3 HTTP listeners on `:80` (distinct hostnames) → the per-Gateway Service came up with a **single** `80:30789/TCP` port, got IP `192.168.100.50`, and the Gateway reached `Programmed=True` with a `status.addresses`. Confirmed the live path is already correct; cleaned up the test namespace.
- Confirmed the conformance Gateway shape: the multi-listener-on-:443 Gateway lives in the shared conformance base manifest (`base/manifests.yaml`), not the test YAML.

## Fix

Hardens the ServicePort build in `reconcileGatewayServices` with a **defensive dedup-by-external-port backstop**: at most one `ServicePort` (`port-<n>`) per distinct external port, regardless of how many listeners (any protocol/hostname) share it. The per-(Gateway, external-port) internal-port demux is unchanged. This makes the duplicate-port Service rejection unreachable even if a future caller passes un-deduped allocations.

## Tests

- `TestReconcileGatewayServices_MultiListenerSamePort` — end-to-end `reconcileGatewayServices` on the conformance 3×:443 Gateway shape, asserts exactly one `port-443` ServicePort and no duplicate (name, port) tuples.
- `TestReconcileGatewayServices_DedupBackstop` — feeds deliberately duplicate `:80` allocations, asserts they collapse to one `port-80` (first wins).

`bazel build //...`, `bazel test //...` (62/62 pass), `bazel run //:format` all clean. No chart change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)