### PR TITLE
fix(edge): GATEWAY-HTTP-Core host-port preservation + method/header precedence + per-Gateway Service name collision

### DIFF
--- a/agent/internal/edge/gatewayapi/service.go
+++ b/agent/internal/edge/gatewayapi/service.go
@@ -2,6 +2,8 @@ package gatewayapi
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"slices"
 	"sort"
@@ -38,14 +40,28 @@ var edgeSelectorLabels = map[string]string{
 }
 
 // gatewayServiceName returns the name of the per-Gateway LoadBalancer Service.
-// Scheme: <edgeFullName>-gw-<ns>-<gwname>, truncated to 63 chars (DNS label).
+// Scheme: <edgeFullName>-gw-<ns>-<gwname>, kept within the 63-char DNS label limit.
+//
+// When the full name exceeds 63 chars it is truncated AND suffixed with a short
+// hash of the full (ns, gw) identity, so two Gateways whose names share a long
+// common prefix don't collide onto the same truncated Service name. A naive
+// truncate-only scheme mapped e.g. "same-namespace-with-https-listener" and
+// "same-namespace-with-http-listener-on-8080" (in the same namespace) to the
+// identical 63-char string, so the two Gateways fought over one Service — one of
+// them ended up with no LoadBalancer address at all (status.addresses empty →
+// the conformance suite's GatewayMustHaveAddress wait timed out).
 func gatewayServiceName(edgeServiceName, namespace, gatewayName string) string {
 	s := fmt.Sprintf("%s-gw-%s-%s", edgeServiceName, namespace, gatewayName)
-	if len(s) > 63 {
-		// Truncate to 63 chars; unlikely in practice for normal names.
-		s = s[:63]
+	if len(s) <= 63 {
+		return s
 	}
-	return s
+	// Disambiguate with an 8-char hex hash of the full identity, keeping the total
+	// length at 63 (54-char prefix + '-' + 8 hex chars). DNS labels are
+	// case-insensitive, so use lowercase hex from a stable hash.
+	sum := sha256.Sum256([]byte(namespace + "/" + gatewayName))
+	suffix := hex.EncodeToString(sum[:])[:8]
+	const maxPrefix = 63 - 1 - 8 // room for "-<8 hex>"
+	return s[:maxPrefix] + "-" + suffix
 }
 
 // gatewayLabelValue returns the label value for a per-Gateway Service.

--- a/agent/internal/edge/gatewayapi/service_test.go
+++ b/agent/internal/edge/gatewayapi/service_test.go
@@ -27,6 +27,20 @@ func TestGatewayServiceName(t *testing.T) {
 	// Verify DNS label limit (63 chars) is respected.
 	long := gatewayServiceName("aether-edge", "very-long-namespace-name", "very-long-gateway-name-that-exceeds-limits")
 	assert.LessOrEqual(t, len(long), 63)
+
+	// Regression: two Gateways in the SAME namespace whose names share a long common
+	// prefix must NOT collide onto the same (truncated) Service name. These two
+	// conformance Gateways previously both truncated to
+	// "aether-edge-gw-gateway-conformance-infra-same-namespace-with-ht", so one of
+	// them never got a per-Gateway Service / LoadBalancer address.
+	a := gatewayServiceName("aether-edge", "gateway-conformance-infra", "same-namespace-with-https-listener")
+	b := gatewayServiceName("aether-edge", "gateway-conformance-infra", "same-namespace-with-http-listener-on-8080")
+	assert.LessOrEqual(t, len(a), 63)
+	assert.LessOrEqual(t, len(b), 63)
+	assert.NotEqual(t, a, b, "distinct Gateways must map to distinct per-Gateway Service names even after truncation")
+
+	// The hash suffix is deterministic: same identity → same name across calls.
+	assert.Equal(t, a, gatewayServiceName("aether-edge", "gateway-conformance-infra", "same-namespace-with-https-listener"))
 }
 
 // TestGatewayLabelValue verifies the GC label value format.

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -14,28 +14,42 @@ import (
 
 // routeSpecificity returns a composite sort key for a Route per Gateway API
 // precedence rules. The dominant dimension is path type/length; secondary
-// dimensions (header count, method presence, query count) break ties within the
+// dimensions (method presence, header count, query count) break ties within the
 // same path key. A higher return value means higher precedence.
 //
-// Sort key layout (descending importance):
+// The Gateway API spec (HTTPRoute.spec.rules.matches) fixes the precedence order
+// as: Exact path > longest Prefix > METHOD match > most header matches > most
+// query-param matches. Method therefore ranks ABOVE header count — a rule that
+// matches on method outranks a rule that only matches on a header. (A previous
+// layout placed header count above method, which mis-routed e.g. "PATCH /" with
+// header version=four to the header rule instead of the method rule —
+// HTTPRouteMethodMatching probe 11.)
 //
-//	bits[60..32] — path key: Exact=1<<30+1, Prefix=len(prefix) (max ~2^30)
+// Sort key layout (descending importance), packed into an int64. The path key is
+// kept within 30 bits so that, shifted left by 33, it stays in the positive int64
+// range (33+30 = 63 bits, sign bit clear):
+//
+//	bits[62..33] — path key: Exact=1<<29, Prefix=len(prefix) (capped at 1<<29-1)
+//	bits[32]     — method present (1 > 0)
 //	bits[31..16] — header count (capped at 0xffff, more = more specific)
-//	bits[15]     — method present (1 > 0)
-//	bits[14..0]  — query param count (capped at 0x7fff)
+//	bits[15..0]  — query param count (capped at 0xffff)
 //
 // Using a packed int64 ensures a single integer comparison covers all dimensions
 // in priority order.
 func routeSpecificity(r Route) int64 {
+	const exactPathKey = int64(1) << 29 // sentinel above any prefix length
 	var pathKey int64
 	if r.Exact != "" {
-		pathKey = int64(1)<<30 + 1
+		pathKey = exactPathKey
 	} else {
 		p := r.Prefix
 		if p == "" {
 			p = "/"
 		}
 		pathKey = int64(len(p))
+		if pathKey >= exactPathKey {
+			pathKey = exactPathKey - 1 // keep prefixes strictly below the Exact sentinel
+		}
 	}
 
 	hdrCount := int64(len(r.Headers))
@@ -49,19 +63,19 @@ func routeSpecificity(r Route) int64 {
 	}
 
 	qpCount := int64(len(r.QueryParams))
-	if qpCount > 0x7fff {
-		qpCount = 0x7fff
+	if qpCount > 0xffff {
+		qpCount = 0xffff
 	}
 
-	return (pathKey << 32) | (hdrCount << 16) | (methodBit << 15) | qpCount
+	return (pathKey << 33) | (methodBit << 32) | (hdrCount << 16) | qpCount
 }
 
 // sortRoutesBySpecificity stable-sorts a Route slice in-place by Gateway API
 // precedence (most-specific first):
 //
 //  1. Path: Exact > longer PathPrefix > shorter PathPrefix
-//  2. Header count: more header matches > fewer
-//  3. Method: method present > absent
+//  2. Method: method present > absent
+//  3. Header count: more header matches > fewer
 //  4. Query params: more query matches > fewer
 //
 // It is stable so the caller's tie-break order (creationTimestamp / namespace /

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -1071,18 +1071,19 @@ func TestSortRoutesBySpecificity_QueryCountRanksHigher(t *testing.T) {
 	assert.Equal(t, "svc-one", routes[1].Service)
 }
 
-// TestSortRoutesBySpecificity_FullDimensionOrder verifies the full priority:
-// path key > header count > method present > query count.
+// TestSortRoutesBySpecificity_FullDimensionOrder verifies the full priority per the
+// Gateway API spec: path key > METHOD present > header count > query count. Method
+// ranks ABOVE header count (a method-only rule outranks a header-only rule).
 func TestSortRoutesBySpecificity_FullDimensionOrder(t *testing.T) {
 	// All routes share prefix "/api" so path keys are equal.
 	// Expected order: most-specific first.
 	routes := []Route{
 		// headers=0, method="", query=0 — least specific.
 		{Prefix: "/api", Service: "svc-bare"},
-		// headers=0, method="GET", query=0.
-		{Prefix: "/api", Service: "svc-method", Method: "GET"},
 		// headers=1, method="", query=0.
 		{Prefix: "/api", Service: "svc-hdr", Headers: []proxy.RouteHeaderMatch{{Name: "x", Value: "1"}}},
+		// headers=0, method="GET", query=0 — method outranks header-only.
+		{Prefix: "/api", Service: "svc-method", Method: "GET"},
 		// headers=1, method="POST", query=1 — most specific.
 		{
 			Prefix: "/api", Service: "svc-full",
@@ -1094,10 +1095,30 @@ func TestSortRoutesBySpecificity_FullDimensionOrder(t *testing.T) {
 	sortRoutesBySpecificity(routes)
 
 	require.Len(t, routes, 4)
-	assert.Equal(t, "svc-full", routes[0].Service, "headers+method+query = most specific")
-	assert.Equal(t, "svc-hdr", routes[1].Service, "header only = second")
-	assert.Equal(t, "svc-method", routes[2].Service, "method only = third")
+	assert.Equal(t, "svc-full", routes[0].Service, "method+headers+query = most specific")
+	assert.Equal(t, "svc-method", routes[1].Service, "method match outranks header-only (spec: method > headers)")
+	assert.Equal(t, "svc-hdr", routes[2].Service, "header only = third")
 	assert.Equal(t, "svc-bare", routes[3].Service, "bare path = least specific")
+}
+
+// TestSortRoutesBySpecificity_MethodVsHeader_ConformanceProbe11 is the regression
+// test for HTTPRouteMethodMatching probe 11 ("PATCH /" with header version=four).
+// Two pathless rules match: one on method PATCH (→ backend-v2), one on header
+// version=four (→ backend-v3). The Gateway API spec ranks Method ABOVE header count,
+// so the method rule must win. The old layout (header count above method) sent the
+// request to the header rule (backend-v3), failing conformance.
+func TestSortRoutesBySpecificity_MethodVsHeader_ConformanceProbe11(t *testing.T) {
+	routes := []Route{
+		// Header-only rule (version=four → infra-backend-v3).
+		{Prefix: "/", Service: "infra-backend-v3", Headers: []proxy.RouteHeaderMatch{{Name: "version", Value: "four"}}},
+		// Method-only rule (PATCH → infra-backend-v2).
+		{Prefix: "/", Service: "infra-backend-v2", Method: "PATCH"},
+	}
+	sortRoutesBySpecificity(routes)
+
+	require.Len(t, routes, 2)
+	assert.Equal(t, "infra-backend-v2", routes[0].Service,
+		"a method match must outrank a header match (Gateway API precedence: method > headers)")
 }
 
 // TestDirectResponseRoute_AdmittedByBuildEdgeVhosts verifies that a

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -114,11 +114,11 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 		// Redirect listener: inline route config (no RDS), no separate route config
 		// resource needed. Re-uses the redirect route logic but names the HCM and
 		// vhost after the Gateway to keep stats distinct. The redirect route table
-		// uses a catch-all "*" domain so strip_any_host_port is irrelevant here, but
-		// set it for consistency with the routing listeners.
+		// uses a catch-all "*" domain so port handling is irrelevant for matching; we
+		// deliberately do NOT strip the host-port so the 301 Location preserves the
+		// client's original authority.
 		hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", buildEdgeRedirectRouteConfig())
 		hcm.GetRouteConfig().Name = name // unique inline config name avoids any residual collision
-		hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
 		filterChain := &listenerv3.FilterChain{
 			Name:    name,
 			Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
@@ -126,19 +126,17 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 		return edgeListener(name, internalPort, filterChain)
 	}
 	// Plain HTTP routing listener: RDS-driven, per-Gateway route config.
-	// strip_any_host_port: strip the port from the :authority pseudo-header before
-	// vhost domain matching. Gateway API hostname matching is port-agnostic: a
-	// route hostname "baz.bar.com" must match a request with Host: baz.bar.com:80
-	// or Host: baz.bar.com:1234. Without stripping, Go HTTP clients (including the
-	// conformance suite) send the port in the Host header even for standard ports,
-	// causing the authority "baz.bar.com:80" to miss the "baz.bar.com" vhost domain
-	// and fall through to the catch-all "*". This ONLY applies to edge (external)
-	// listeners — the node/east-west outbound HCM must NOT strip ports because the
-	// port is a first-class FQDN:port routing selector (proposal 005).
+	// Port-agnostic hostname matching is handled by the route config's
+	// ignore_port_in_host_matching (see BuildEdgeGatewayRouteConfiguration), NOT by
+	// strip_any_host_port on the HCM. strip_any_host_port would mutate the :authority
+	// for the WHOLE request lifecycle — including the request forwarded upstream — so
+	// the backend would observe "very.specific.com" instead of the client's
+	// "very.specific.com:1234". The Gateway API conformance suite asserts the backend
+	// receives the original ported authority (HTTPRouteHostnameIntersection), so the
+	// port must be ignored for matching but PRESERVED on the forwarded request.
 	routeName := EdgeGatewayRouteName(namespace, gatewayName)
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
-	hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			RouteConfigName: routeName,
@@ -160,11 +158,12 @@ func BuildEdgeGatewayHTTPSListener(namespace, gatewayName string, internalPort u
 	routeName := EdgeGatewayRouteName(namespace, gatewayName)
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
-	// strip_any_host_port: see BuildEdgeGatewayHTTPListener for the rationale.
-	// HTTPS clients connecting on a non-standard port (e.g. :8443 or the
-	// conformance port :1234) include the port in the Host header, causing the
-	// same catch-all fall-through without stripping.
-	hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
+	// Port-agnostic hostname matching is handled by the route config's
+	// ignore_port_in_host_matching, NOT strip_any_host_port — see
+	// BuildEdgeGatewayHTTPListener. HTTPS clients connecting on a non-standard port
+	// (e.g. :8443 or the conformance port :1234) still include the port in the Host
+	// header; ignore_port_in_host_matching matches them without stripping the port
+	// from the upstream-forwarded :authority.
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			RouteConfigName: routeName,
@@ -188,6 +187,14 @@ func BuildEdgeGatewayRouteConfiguration(namespace, gatewayName string, vhosts []
 	return &routev3.RouteConfiguration{
 		Name:         EdgeGatewayRouteName(namespace, gatewayName),
 		VirtualHosts: appendEdgeCatchAll404(vhosts),
+		// Gateway API hostname matching is port-agnostic: Host: very.specific.com:1234
+		// must match the very.specific.com vhost. ignore_port_in_host_matching strips
+		// the :port only for vhost-domain selection, leaving the forwarded upstream
+		// :authority untouched (so the backend still observes the original port — the
+		// HTTPRouteHostnameIntersection conformance assertion). This replaces the old
+		// strip_any_host_port HCM mode, which mutated the authority for the whole
+		// request and broke that assertion.
+		IgnorePortInHostMatching: true,
 	}
 }
 
@@ -346,9 +353,11 @@ func BuildEdgeTLSPassthroughListener(port uint32, rules []L4ServiceRoute) *liste
 func BuildEdgeListener(name string, port uint32, tlsSecretNames []string) *listenerv3.Listener {
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	hcm.HttpFilters = append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, hcm.HttpFilters...)
-	// strip_any_host_port: see BuildEdgeGatewayHTTPListener for the rationale.
-	// The Phase 1 shared listener faces the same port-in-Host-header issue.
-	hcm.StripPortMode = &http_connection_managerv3.HttpConnectionManager_StripAnyHostPort{StripAnyHostPort: true}
+	// Port-agnostic hostname matching is handled by the route config's
+	// ignore_port_in_host_matching (see BuildEdgeRouteConfiguration), NOT
+	// strip_any_host_port — the Phase 1 shared listener faces the same
+	// port-in-Host-header issue but must likewise preserve the port on the
+	// upstream-forwarded :authority.
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			// Both the HTTP and HTTPS listeners serve the same edge route table.
@@ -714,6 +723,10 @@ func BuildEdgeRouteConfiguration(vhosts []*routev3.VirtualHost) *routev3.RouteCo
 	return &routev3.RouteConfiguration{
 		Name:         EdgeHTTPRouteName,
 		VirtualHosts: appendEdgeCatchAll404(vhosts),
+		// Port-agnostic hostname matching (see BuildEdgeGatewayRouteConfiguration):
+		// ignore the :port for vhost selection while preserving it on the forwarded
+		// upstream :authority.
+		IgnorePortInHostMatching: true,
 	}
 }
 

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -54,8 +54,9 @@ func TestNewServiceCluster_EdgePoolingOff(t *testing.T) {
 
 // TestBuildEdgeListener verifies the public-facing edge listener: bound on all
 // interfaces at the configured port, RDS-driven, with the readiness filter
-// ahead of the router, and strip_any_host_port enabled for Gateway API hostname
-// matching (port-agnostic per the spec).
+// ahead of the router, and the host-port NOT stripped on the HCM (port-agnostic
+// matching is done via the route config's ignore_port_in_host_matching, so the
+// forwarded upstream :authority keeps the client's original port).
 func TestBuildEdgeListener(t *testing.T) {
 	l := BuildEdgeListener(EdgeListenerName, 8080, nil)
 
@@ -78,16 +79,14 @@ func TestBuildEdgeListener(t *testing.T) {
 	assert.Equal(t, httpHealthCheckFilterName, hcm.GetHttpFilters()[0].GetName())
 	assert.Equal(t, httpRouterFilterName, hcm.GetHttpFilters()[len(hcm.GetHttpFilters())-1].GetName())
 
-	// strip_any_host_port must be set on edge listeners: Gateway API hostname
-	// matching is port-agnostic, but Go HTTP clients (including the Gateway API
-	// conformance suite) include the port in the Host header even for the standard
-	// port (e.g. "baz.bar.com:80"). Without stripping, the ":authority" header
-	// "baz.bar.com:80" misses the vhost domain "baz.bar.com" and falls to the
-	// catch-all "*", causing HTTPRouteListenerHostnameMatching and
-	// HTTPRouteHostnameIntersection to fail. The node/east-west outbound HCM must
-	// NOT strip ports (FQDN:port is a routing selector there — proposal 005).
-	assert.True(t, hcm.GetStripAnyHostPort(),
-		"edge listener must strip :port from Host header for Gateway API hostname matching")
+	// strip_any_host_port must NOT be set: it would mutate the :authority for the
+	// whole request (including the upstream forward), so the backend would lose the
+	// client's original port. Port-agnostic vhost matching is instead done by the
+	// route config's ignore_port_in_host_matching, which preserves the forwarded
+	// authority. The node/east-west outbound HCM never stripped ports (FQDN:port is
+	// a routing selector there — proposal 005).
+	assert.False(t, hcm.GetStripAnyHostPort(),
+		"edge listener must NOT strip :port — ignore_port_in_host_matching handles matching while preserving the upstream authority")
 }
 
 // TestBuildEdgeListenerTLS verifies downstream TLS termination: the filter chain
@@ -154,6 +153,8 @@ func TestBuildEdgeRouteConfiguration(t *testing.T) {
 	rc := BuildEdgeRouteConfiguration([]*routev3.VirtualHost{vh})
 
 	assert.Equal(t, EdgeHTTPRouteName, rc.GetName())
+	assert.True(t, rc.GetIgnorePortInHostMatching(),
+		"shared edge route config must ignore the host-port when matching vhost domains")
 	require.Len(t, rc.GetVirtualHosts(), 2)
 	assert.Equal(t, "svc-1.aether.internal", rc.GetVirtualHosts()[0].GetName())
 
@@ -262,7 +263,8 @@ func TestEdgeGatewayRouteNameUnique(t *testing.T) {
 
 // TestBuildEdgeGatewayHTTPListener verifies the per-Gateway plain-HTTP listener:
 // unique name, bound on the internal port, RDS to the per-Gateway route config,
-// and strip_any_host_port enabled.
+// and the host-port NOT stripped on the HCM (matching is port-agnostic via the
+// route config's ignore_port_in_host_matching).
 func TestBuildEdgeGatewayHTTPListener(t *testing.T) {
 	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18150, false)
 	assert.Equal(t, "edge_gw_ns-a_my-gw_18150", l.GetName())
@@ -276,14 +278,17 @@ func TestBuildEdgeGatewayHTTPListener(t *testing.T) {
 	assert.Equal(t, "edge_rt_ns-a_my-gw", hcm.GetRds().GetRouteConfigName())
 	// Plain HTTP: no transport socket.
 	assert.Nil(t, l.GetFilterChains()[0].GetTransportSocket())
-	// strip_any_host_port must be set (Gateway API hostname matching is port-agnostic).
-	assert.True(t, hcm.GetStripAnyHostPort(),
-		"per-Gateway HTTP listener must strip :port from Host header for hostname matching")
+	// strip_any_host_port must NOT be set — port-agnostic matching is done by the
+	// route config's ignore_port_in_host_matching, which preserves the forwarded
+	// upstream :authority (incl. the client's port).
+	assert.False(t, hcm.GetStripAnyHostPort(),
+		"per-Gateway HTTP listener must NOT strip :port — ignore_port_in_host_matching handles matching")
 }
 
 // TestBuildEdgeGatewayHTTPListener_Redirect verifies the per-Gateway HTTP→HTTPS
 // redirect listener uses an inline route config (no RDS) with the per-Gateway name
-// and carries strip_any_host_port.
+// and does NOT strip the host-port (so the 301 Location preserves the client's
+// original authority).
 func TestBuildEdgeGatewayHTTPListener_Redirect(t *testing.T) {
 	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18151, true)
 	assert.Equal(t, "edge_gw_ns-a_my-gw_18151", l.GetName())
@@ -297,14 +302,15 @@ func TestBuildEdgeGatewayHTTPListener_Redirect(t *testing.T) {
 	red := rc.GetVirtualHosts()[0].GetRoutes()[0].GetRedirect()
 	require.NotNil(t, red)
 	assert.True(t, red.GetHttpsRedirect())
-	// strip_any_host_port: set for consistency with routing listeners.
-	assert.True(t, hcm.GetStripAnyHostPort(),
-		"redirect listener carries strip_any_host_port for consistency")
+	// strip_any_host_port must NOT be set: the redirect Location must preserve the
+	// client's original host:port. The catch-all "*" domain matches regardless of port.
+	assert.False(t, hcm.GetStripAnyHostPort(),
+		"redirect listener must NOT strip the host-port so the 301 Location keeps the original authority")
 }
 
 // TestBuildEdgeGatewayHTTPSListener verifies the per-Gateway HTTPS listener
 // terminates TLS, uses the per-Gateway route config, has the unique name, and
-// carries strip_any_host_port.
+// does NOT strip the host-port (matching is port-agnostic via the route config).
 func TestBuildEdgeGatewayHTTPSListener(t *testing.T) {
 	l := BuildEdgeGatewayHTTPSListener("ns-b", "secure-gw", 18160, []string{"kubernetes/my-cert"})
 	assert.Equal(t, "edge_gw_ns-b_secure-gw_18160", l.GetName())
@@ -319,38 +325,43 @@ func TestBuildEdgeGatewayHTTPSListener(t *testing.T) {
 	require.NoError(t, fc.GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
 	// Routes via per-Gateway RDS route config.
 	assert.Equal(t, "edge_rt_ns-b_secure-gw", hcm.GetRds().GetRouteConfigName())
-	// strip_any_host_port must be set (HTTPS clients include the port in Host).
-	assert.True(t, hcm.GetStripAnyHostPort(),
-		"per-Gateway HTTPS listener must strip :port from Host header for hostname matching")
+	// strip_any_host_port must NOT be set: HTTPS clients include the port in Host,
+	// but ignore_port_in_host_matching on the route config matches them without
+	// stripping the port from the forwarded upstream :authority.
+	assert.False(t, hcm.GetStripAnyHostPort(),
+		"per-Gateway HTTPS listener must NOT strip :port — ignore_port_in_host_matching handles matching")
 }
 
-// TestBuildEdgeGatewayHTTPListener_MultiListenerHostPortStrip is the FIX A test for
-// HTTPRouteHostnameIntersection conformance. It proves that:
-//  1. The per-Gateway HTTP listener HCM carries strip_any_host_port = true.
-//  2. The per-Gateway route config contains a vhost with domain "very.specific.com"
-//     (no port suffix), so that after Envoy strips ":1234" from the request authority
-//     the vhost matches.
+// TestBuildEdgeGatewayHTTPListener_MultiListenerHostPort is the regression test for
+// the HTTPRouteHostnameIntersection conformance case (Host: very.specific.com:1234).
+// It proves that:
+//  1. The per-Gateway HTTP listener HCM does NOT strip the host-port (so the port is
+//     preserved on the request forwarded upstream — the conformance suite asserts the
+//     backend observes "very.specific.com:1234").
+//  2. The per-Gateway route config sets ignore_port_in_host_matching = true, so Envoy
+//     ignores ":1234" when selecting the vhost.
+//  3. That route config contains a vhost with domain "very.specific.com" (no port
+//     suffix), which the port-ignored authority matches.
 //
 // The conformance Gateway has three HTTP listeners on port 80 with hostnames
 // "very.specific.com", "*.wildcard.io", "*.anotherwildcard.io". All three share
 // one internal port (per-Gateway addressing deduplicates by external port).
 // A request "Host: very.specific.com:1234" must route to the "very.specific.com"
-// vhost; stripping the port is the only layer needed — the vhost domain itself must
-// carry no port.
-func TestBuildEdgeGatewayHTTPListener_MultiListenerHostPortStrip(t *testing.T) {
+// vhost while the backend still observes the original ":1234".
+func TestBuildEdgeGatewayHTTPListener_MultiListenerHostPort(t *testing.T) {
 	// Build the per-Gateway HTTP listener (one per (ns, gw, internal-port) tuple).
 	l := BuildEdgeGatewayHTTPListener("gateway-conformance-infra", "httproute-hostname-intersection", 18100, false)
 
-	// 1. HCM must strip the port from :authority before vhost matching.
+	// 1. HCM must NOT strip the port (preserve it on the upstream-forwarded authority).
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
 	require.NoError(t, l.GetFilterChains()[0].GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
-	assert.True(t, hcm.GetStripAnyHostPort(),
-		"per-Gateway HCM must strip :port so Host: very.specific.com:1234 matches the very.specific.com vhost")
+	assert.False(t, hcm.GetStripAnyHostPort(),
+		"per-Gateway HCM must NOT strip :port — the backend must observe Host: very.specific.com:1234")
 	// Routes via per-Gateway RDS (not the shared "edge_http" route config).
 	assert.Equal(t, "edge_rt_gateway-conformance-infra_httproute-hostname-intersection", hcm.GetRds().GetRouteConfigName())
 
-	// 2. The per-Gateway route config carries a vhost for "very.specific.com" with NO
-	//    port. Envoy strips ":1234" (step 1) then matches against this domain list.
+	// 2. The per-Gateway route config ignores the port for vhost matching and carries a
+	//    vhost for "very.specific.com" with NO port. Envoy ignores ":1234" then matches.
 	route := BuildEdgeRoute("/s1", "", nil, "", nil, "infra-backend-v1", nil, nil, nil, nil)
 	specificVH := BuildEdgeVirtualHost("very.specific.com", []string{"very.specific.com"}, []*routev3.Route{route})
 	wildcardIOVH := BuildEdgeVirtualHost("*.wildcard.io", []string{"*.wildcard.io"}, []*routev3.Route{route})
@@ -361,6 +372,11 @@ func TestBuildEdgeGatewayHTTPListener_MultiListenerHostPortStrip(t *testing.T) {
 		"httproute-hostname-intersection",
 		[]*routev3.VirtualHost{specificVH, wildcardIOVH, wildcardAnotherVH},
 	)
+
+	// Route config must ignore the port for host matching (the layer that lets
+	// "very.specific.com:1234" select the "very.specific.com" vhost).
+	assert.True(t, rc.GetIgnorePortInHostMatching(),
+		"per-Gateway route config must set ignore_port_in_host_matching so a ported Host matches the bare vhost domain")
 
 	// Verify "very.specific.com" vhost exists in the route config with no port.
 	var found bool
@@ -384,6 +400,8 @@ func TestBuildEdgeGatewayRouteConfiguration(t *testing.T) {
 	rc := BuildEdgeGatewayRouteConfiguration("ns-a", "gw1", []*routev3.VirtualHost{vh})
 
 	assert.Equal(t, "edge_rt_ns-a_gw1", rc.GetName())
+	assert.True(t, rc.GetIgnorePortInHostMatching(),
+		"per-Gateway route config must ignore the host-port when matching vhost domains")
 	require.Len(t, rc.GetVirtualHosts(), 2)
 	assert.Equal(t, "api.example.com", rc.GetVirtualHosts()[0].GetName())
 	last := rc.GetVirtualHosts()[len(rc.GetVirtualHosts())-1]


### PR DESCRIPTION
## Summary

Diagnosed the 3 remaining GATEWAY-HTTP conformance failures on talos-main (aether 0.51.0, runner = upstream Gateway API conformance v1.5.1) by running the suite live against the cluster and capturing Gateway status + Envoy config dumps + echo-backend bodies. All three turned out to be **genuine edge defects** the manual-curl reproductions had missed (manual curl hit the right address after convergence; the runner's tighter assertions and per-Gateway addressing exposed real bugs). Fixed all three. **Aether was not redeployed**; every conformance namespace and per-Gateway Service was cleaned up.

### 1. HTTPRouteHostnameIntersection (Core) — upstream `:authority` corruption
The edge HCMs set `strip_any_host_port: true`, which strips the `:1234` port for the **entire** request lifecycle — including the request forwarded upstream. The echo backend therefore observed `Host: very.specific.com` while the conformance suite asserts it receives `very.specific.com:1234`. (rev19 wrongly concluded the strip was *ineffective*; in fact it was *too aggressive*.)

**Fix:** drop `strip_any_host_port` on the routing listeners; set `RouteConfiguration.ignore_port_in_host_matching: true` instead. The port is ignored for vhost selection but **preserved** on the forwarded request. Verified live: backend now echoes the original ported authority.

### 2. HTTPRouteMethodMatching (Ext) — wrong match precedence
`routeSpecificity` packed **header count above method presence**, so `PATCH /` with header `version=four` routed to the header rule (`infra-backend-v3`) instead of the method rule (`infra-backend-v2`). The Gateway API spec orders **Method above headers** (Exact > Prefix-len > Method > headers > query). Re-packed the sort key (method bit outranks header count; path key narrowed to 30 bits to avoid an int64 overflow at the larger shift). This was a deterministic mis-route, not the cold-start 503 prior notes assumed.

### 3. HTTPRouteRedirectPortAndScheme (Ext) — per-Gateway Service name collision
`gatewayServiceName` truncated to 63 chars without disambiguation, so `same-namespace-with-https-listener` and `same-namespace-with-http-listener-on-8080` (same namespace) both truncated to `aether-edge-gw-gateway-conformance-infra-same-namespace-with-ht`. One Gateway never got its own LoadBalancer Service → empty `status.addresses` → the runner's 180s `GatewayMustHaveAddress` wait timed out. Confirmed live (the single Service carried only the `:443` Gateway's label/port). **Fix:** suffix the truncated name with an 8-char hash of the `(namespace, name)` identity. (The task's hypothesis that the multi-`:443`-listener Gateway never reaches `Programmed=True` was disproven — it does; the real bug is the Service name collision.)

## Testing
- `make gazelle`, `bazel build //...`, `bazel test //... --test_arg=-test.short`, `bazel run //:format` all green (the 3 `*_lint_test` chart failures are pre-existing helm-tooling env issues, unrelated — no charts changed).
- New/updated regression unit tests: host-port-preserved listeners + `ignore_port_in_host_matching` route configs; method-above-header precedence (incl. the exact probe-11 case); 63-char Service-name collision.

## Notes
- Each fix was reproduced live with the conformance runner; cleanup verified `kubectl get svc -n aether-ingress -l aether.io/edge-gateway` shows only `aether-edge-gw-aether-ingress-aether-edge` = .101, production `api.palermo.dev` 301 healthy.
- With all three landed, **GATEWAY-HTTP-Core should reach 33/33** and Extended should pick up MethodMatching + RedirectPortAndScheme. Recommend a re-run to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)