### PR TITLE
fix(edge): scope per-Gateway hostCerts to prevent cert cross-contamination

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -148,7 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 	grants := grantList.Items
 
-	gateways, ourGateways, gatewayListeners, hostCerts, certs, tlsResults, err := r.resolveGateways(ctx, grants)
+	gateways, ourGateways, gatewayListeners, perGWHostCerts, hostCerts, certs, tlsResults, err := r.resolveGateways(ctx, grants)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -309,7 +309,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// Phase 1 (shared SetVirtualHosts path).
 	var perGWAssignedIPs map[gatewayKey]string
 	if r.PerGatewayAddressing && r.EdgeServiceName != "" && len(ourGateways) > 0 {
-		allocations, allocErr := allocateGatewayListenerPorts(ourGateways, hostCerts)
+		allocations, allocErr := allocateGatewayListenerPorts(ourGateways, perGWHostCerts)
 		if allocErr != nil {
 			r.Log.WarnContext(ctx, "per-Gateway port allocation failed, falling back to Phase 1",
 				"error", allocErr.Error())
@@ -411,20 +411,38 @@ type listenerTLSResult struct {
 // resolveGateways lists the Gateways of our GatewayClass CLUSTER-WIDE and resolves
 // each TLS listener's cert. It returns the set of our Gateways (by namespaced
 // name), the Gateway objects themselves (for status), a set of listener keys (for
-// TCPRoute/TLSRoute port matching), a hostname→SDS-name map for HTTP cert
-// selection, and the SDS-name→bytes map to push. Selection is by
-// GatewayClassName: every Gateway whose gatewayClassName is the class this edge
-// serves (whose controllerName is gateway.aether.io/edge) is ours, regardless of
-// namespace.
-func (r *Reconciler) resolveGateways(ctx context.Context, grants []gatewayv1beta1.ReferenceGrant) (map[gatewayKey]struct{}, []gatewayv1.Gateway, map[gatewayListenerKey]struct{}, map[string]string, map[string]cache.EdgeTLSCert, map[listenerStatusKey]listenerTLSResult, error) {
+// TCPRoute/TLSRoute port matching), a per-Gateway hostname→SDS-name map (for
+// per-Gateway cert selection in Phase 2), a merged hostname→SDS-name map (for
+// Phase 1 / VirtualHost cert tagging), and the SDS-name→bytes map to push.
+// Selection is by GatewayClassName: every Gateway whose gatewayClassName is the
+// class this edge serves (whose controllerName is gateway.aether.io/edge) is ours,
+// regardless of namespace.
+//
+// The per-Gateway hostCerts map is keyed by gatewayKey; each value is the
+// hostname→SDS-name map for that Gateway's listeners only. This prevents cert
+// cross-contamination when multiple Gateways share a catch-all TLS listener (empty
+// hostname): the shared flat map would let a later-resolved Gateway overwrite the
+// catch-all entry and cause an earlier Gateway's listeners to reference the wrong
+// cert (presenting a cert for a different domain → TLS handshake failure).
+func (r *Reconciler) resolveGateways(ctx context.Context, grants []gatewayv1beta1.ReferenceGrant) (map[gatewayKey]struct{}, []gatewayv1.Gateway, map[gatewayListenerKey]struct{}, map[gatewayKey]map[string]string, map[string]string, map[string]cache.EdgeTLSCert, map[listenerStatusKey]listenerTLSResult, error) {
 	list := &gatewayv1.GatewayList{}
 	if err := r.List(ctx, list); err != nil {
-		return nil, nil, nil, nil, nil, nil, err
+		return nil, nil, nil, nil, nil, nil, nil, err
 	}
 	gateways := map[gatewayKey]struct{}{}
 	var ourGateways []gatewayv1.Gateway
 	listenerKeys := map[gatewayListenerKey]struct{}{}
-	hostCerts := map[string]string{} // listener hostname ("" = catch-all) -> SDS name
+	// perGWHostCerts is keyed per Gateway: each Gateway's TLS listeners populate only
+	// their own entry. allocateGatewayListenerPorts uses this map so that cert
+	// selection is scoped to the Gateway whose listener is being allocated — not
+	// contaminated by another Gateway's certs that happen to share the same hostname
+	// key (e.g., the catch-all "").
+	perGWHostCerts := map[gatewayKey]map[string]string{}
+	// mergedHostCerts is the flat union of all Gateways' hostCerts, used for Phase 1
+	// VirtualHost cert tagging (buildVirtualHost) where the exact-gateway scope is
+	// not required. Last-writer-wins on key collisions here is acceptable because
+	// Phase 1 VirtualHost.TLSSecret is not used in Phase 2 listener selection.
+	mergedHostCerts := map[string]string{}
 	certs := map[string]cache.EdgeTLSCert{}
 	tlsResults := map[listenerStatusKey]listenerTLSResult{}
 	for i := range list.Items {
@@ -442,16 +460,25 @@ func (r *Reconciler) resolveGateways(ctx context.Context, grants []gatewayv1beta
 				Protocol: ln.Protocol,
 			}] = struct{}{}
 		}
+		// Resolve TLS for each listener into a per-Gateway hostCerts map and the
+		// global certs map (SDS secret bytes). Use a fresh per-Gateway hostCerts so
+		// that resolveListenerTLS writes only into this Gateway's own scope.
+		gwHostCerts := map[string]string{}
 		for _, ln := range gw.Spec.Listeners {
 			if ln.TLS == nil {
 				continue
 			}
 			lk := listenerStatusKey{Gateway: gk, Name: ln.Name}
-			res := r.resolveListenerTLS(ctx, gw, ln, hostCerts, certs, grants)
+			res := r.resolveListenerTLS(ctx, gw, ln, gwHostCerts, certs, grants)
 			tlsResults[lk] = res
 		}
+		perGWHostCerts[gk] = gwHostCerts
+		// Merge into the flat map for Phase 1 / buildVirtualHost usage.
+		for k, v := range gwHostCerts {
+			mergedHostCerts[k] = v
+		}
 	}
-	return gateways, ourGateways, listenerKeys, hostCerts, certs, tlsResults, nil
+	return gateways, ourGateways, listenerKeys, perGWHostCerts, mergedHostCerts, certs, tlsResults, nil
 }
 
 // resolveListenerTLS resolves a single TLS listener's certificateRefs, recording

--- a/agent/internal/edge/gatewayapi/service.go
+++ b/agent/internal/edge/gatewayapi/service.go
@@ -101,7 +101,13 @@ type gatewayListenerAllocation struct {
 // port with the listeners' TLS certs merged. Listeners sharing an external port
 // share one internal port + one edge listener; allocating per listener would emit
 // duplicate Service ports (rejected by k8s) and drop the Gateway.
-func allocateGatewayListenerPorts(gws []gatewayv1.Gateway, hostCerts map[string]string) (map[gatewayKey][]gatewayListenerAllocation, error) {
+//
+// perGWHostCerts maps each Gateway key to its own hostname→SDS-name map, built by
+// resolveGateways. Using a per-Gateway map prevents cert cross-contamination: when
+// multiple Gateways each have a catch-all TLS listener (empty hostname), they all
+// write to hostCerts[""], and the catch-all listener of any given Gateway would
+// end up referencing another Gateway's cert if a shared map were used.
+func allocateGatewayListenerPorts(gws []gatewayv1.Gateway, perGWHostCerts map[gatewayKey]map[string]string) (map[gatewayKey][]gatewayListenerAllocation, error) {
 	portKey := func(ns, name string, port uint32) portalloc.Key {
 		return portalloc.Key{Namespace: ns, GatewayName: name, ListenerName: fmt.Sprintf("port-%d", port)}
 	}
@@ -126,6 +132,11 @@ func allocateGatewayListenerPorts(gws []gatewayv1.Gateway, hostCerts map[string]
 	result := make(map[gatewayKey][]gatewayListenerAllocation, len(gws))
 	for _, gw := range gws {
 		gk := gatewayKey{Namespace: gw.Namespace, Name: gw.Name}
+		// Use this Gateway's own hostCerts map so cert lookup is scoped to certs
+		// resolved for THIS Gateway only. A shared map would let a later-resolved
+		// Gateway overwrite the catch-all entry ("") and contaminate the cert set of
+		// an earlier-resolved Gateway that also had a catch-all TLS listener.
+		gwHostCerts := perGWHostCerts[gk] // nil-safe: listenerCert handles nil map
 		// Group listeners by external port, unioning their certs (an HTTPS port may
 		// host several listeners with different hostnames/certs — SNI selects).
 		certsByPort := map[uint32]map[string]struct{}{}
@@ -136,7 +147,7 @@ func allocateGatewayListenerPorts(gws []gatewayv1.Gateway, hostCerts map[string]
 				certsByPort[ep] = map[string]struct{}{}
 				portOrder = append(portOrder, ep)
 			}
-			if c := listenerCert(ln, hostCerts); c != "" {
+			if c := listenerCert(ln, gwHostCerts); c != "" {
 				certsByPort[ep][c] = struct{}{}
 			}
 		}

--- a/agent/internal/edge/gatewayapi/service_test.go
+++ b/agent/internal/edge/gatewayapi/service_test.go
@@ -157,11 +157,14 @@ func TestAllocateGatewayListenerPorts_MultiListenerSamePort(t *testing.T) {
 			},
 		},
 	}
-	hostCerts := map[string]string{"a.example.com": "kubernetes/cert-a", "b.example.com": "kubernetes/cert-b"}
-
-	allocs, err := allocateGatewayListenerPorts(gws, hostCerts)
-	require.NoError(t, err)
+	// perGWHostCerts scopes certs to the single gateway under test.
 	gk := gatewayKey{Namespace: "conformance", Name: "multi"}
+	perGWHostCerts := map[gatewayKey]map[string]string{
+		gk: {"a.example.com": "kubernetes/cert-a", "b.example.com": "kubernetes/cert-b"},
+	}
+
+	allocs, err := allocateGatewayListenerPorts(gws, perGWHostCerts)
+	require.NoError(t, err)
 	require.Len(t, allocs[gk], 2, "one allocation per external port (80, 443), not per listener")
 
 	byPort := map[uint32]gatewayListenerAllocation{}
@@ -174,6 +177,60 @@ func TestAllocateGatewayListenerPorts_MultiListenerSamePort(t *testing.T) {
 	assert.Equal(t, []string{"kubernetes/cert-a", "kubernetes/cert-b"}, byPort[443].tlsSecretNames,
 		"both :443 listeners' certs merge onto the one port (SNI selects)")
 	assert.NotEqual(t, byPort[80].internalPort, byPort[443].internalPort, "distinct internal ports per external port")
+}
+
+// TestAllocateGatewayListenerPorts_NoCertCrossContamination is the regression guard
+// for the cert cross-contamination bug: when two Gateways each have a catch-all TLS
+// listener (empty hostname → hostCerts[""] key), a shared hostCerts map lets the
+// later-resolved Gateway's cert overwrite the catch-all entry and contaminate the
+// earlier Gateway's listener. The fix scopes hostCerts per-Gateway so each Gateway's
+// allocations only see certs resolved for that Gateway.
+//
+// Scenario: GW-A (ns-a/gw-a) has a catch-all HTTPS listener with "cert-a".
+// GW-B (ns-b/gw-b) has a catch-all HTTPS listener with "cert-b".
+// GW-A's port-443 allocation must reference only "cert-a", and GW-B's only "cert-b".
+func TestAllocateGatewayListenerPorts_NoCertCrossContamination(t *testing.T) {
+	tlsCfg := &gatewayv1.ListenerTLSConfig{}
+	gws := []gatewayv1.Gateway{
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns-a", Name: "gw-a"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType, TLS: tlsCfg},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns-b", Name: "gw-b"},
+			Spec: gatewayv1.GatewaySpec{
+				Listeners: []gatewayv1.Listener{
+					{Name: "https", Port: 443, Protocol: gatewayv1.HTTPSProtocolType, TLS: tlsCfg},
+				},
+			},
+		},
+	}
+	// Per-Gateway hostCerts: each Gateway has its own catch-all cert.
+	gkA := gatewayKey{Namespace: "ns-a", Name: "gw-a"}
+	gkB := gatewayKey{Namespace: "ns-b", Name: "gw-b"}
+	perGWHostCerts := map[gatewayKey]map[string]string{
+		gkA: {"": "kubernetes/ns-a/cert-a"},
+		gkB: {"": "kubernetes/ns-b/cert-b"},
+	}
+
+	allocs, err := allocateGatewayListenerPorts(gws, perGWHostCerts)
+	require.NoError(t, err)
+
+	require.Len(t, allocs[gkA], 1, "gw-a: one allocation for port 443")
+	require.Len(t, allocs[gkB], 1, "gw-b: one allocation for port 443")
+
+	allocA := allocs[gkA][0]
+	allocB := allocs[gkB][0]
+
+	// Each Gateway must reference ONLY its own cert — not the other Gateway's.
+	assert.Equal(t, []string{"kubernetes/ns-a/cert-a"}, allocA.tlsSecretNames,
+		"gw-a must reference only its own cert, not gw-b's cert-b")
+	assert.Equal(t, []string{"kubernetes/ns-b/cert-b"}, allocB.tlsSecretNames,
+		"gw-b must reference only its own cert, not gw-a's cert-a")
 }
 
 // TestBuildEdgeGatewayEntries_AssignByAttachment verifies vhosts are assigned to a
@@ -337,9 +394,12 @@ func TestReconcileGatewayServices_MultiListenerSamePort(t *testing.T) {
 		},
 	}
 	gws := []gatewayv1.Gateway{gw}
-	hostCerts := map[string]string{"": "kubernetes/cert"}
+	gwKey := gatewayKey{Namespace: "gateway-conformance-infra", Name: "same-namespace-with-https-listener"}
+	perGWHostCerts := map[gatewayKey]map[string]string{
+		gwKey: {"": "kubernetes/cert"},
+	}
 
-	allocs, err := allocateGatewayListenerPorts(gws, hostCerts)
+	allocs, err := allocateGatewayListenerPorts(gws, perGWHostCerts)
 	require.NoError(t, err)
 
 	fc := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()


### PR DESCRIPTION
## Root cause

`resolveGateways` populated a **single shared `hostCerts map[string]string`** for all Gateways. Every call to `resolveListenerTLS` for a catch-all TLS listener (no hostname) wrote to the `""` key. The last Gateway processed in the reconcile loop won, silently overwriting every earlier Gateway's catch-all cert entry.

`allocateGatewayListenerPorts` then used this shared (and now cross-contaminated) map to select certs for each Gateway's listeners. A Gateway's own catch-all listener would pick up a completely different Gateway's cert.

## Failure mode in conformance

The `HTTPRouteRedirectPortAndScheme` Extended test uses `same-namespace-with-https-listener` (4 listeners on :443, `tls-validity-checks-certificate` as the cert) alongside other Gateways with catch-all TLS listeners (e.g. `aether-edge` with `*.palermo.dev`).

Depending on reconcile order, `hostCerts[""]` was overwritten by the last-processed gateway. `allocateGatewayListenerPorts` for `same-namespace-with-https-listener` then included **both** the contaminating cert (*.palermo.dev) and the correct conformance cert in `tlsSecretNames`. Envoy's multi-cert selection fell back to the palermo.dev cert for `SNI=example.org` (no SAN match → first cert in list). The conformance runner trusted only `tls-validity-checks-certificate` as the CA → TLS handshake rejected → all `https-listener-on-443/*` subtests timed out at 60s.

Confirmed on talos-main via `config_dump`: the conformance listener had `certs: ['kubernetes/edge-https-test/test-tls-cert', 'kubernetes/gateway-conformance-infra/tls-validity-checks-certificate']` and `openssl s_client` showed Envoy presenting `*.palermo.dev` for SNI `example.org`.

## Fix

`resolveGateways` now allocates a **fresh `gwHostCerts` map per Gateway** before passing it to `resolveListenerTLS`, and returns a `map[gatewayKey]map[string]string` (per-Gateway scope) alongside the merged flat map (for Phase 1 / `buildVirtualHost`).

`allocateGatewayListenerPorts` now takes `perGWHostCerts map[gatewayKey]map[string]string` and looks up each Gateway's own hostCerts when selecting certs — no cross-Gateway contamination possible.

## Test

`TestAllocateGatewayListenerPorts_NoCertCrossContamination`: two Gateways each with a catch-all TLS listener and distinct certs. Asserts each Gateway's allocation references **only its own cert**.

## Scope

- `agent/internal/edge/gatewayapi/reconciler.go` — `resolveGateways` return type + per-Gateway map construction
- `agent/internal/edge/gatewayapi/service.go` — `allocateGatewayListenerPorts` signature + per-Gateway lookup
- `agent/internal/edge/gatewayapi/service_test.go` — updated existing callers + new regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S