### PR TITLE
fix(edge): effectiveHostnames catch-all suppressed by multi-listener Gateway (HTTPS 404)

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -1368,11 +1368,21 @@ func effectiveHostnames(routeHosts []string, gwKeys []string, gwListenerHostname
 			if lh == "" {
 				// Listener has no hostname restriction: admit all route hostnames.
 				if len(routeHosts) == 0 {
-					// route "" + listener "" = "*" (true catch-all). Represent as empty
-					// slice so buildEdgeVhostsLocked emits the "*" catch-all vhost.
-					// We signal this by NOT adding anything — the caller keeps vh.Hosts
-					// nil/empty → cache catch-all path.
-					continue
+					// route "" + listener "" = "*" (true catch-all). A no-hostname
+					// listener with a no-hostname route admits ALL hosts. Return nil
+					// immediately — no specific hostname from any other listener in
+					// this key's union can narrow a catch-all back down. The caller
+					// treats nil/empty Hosts as the "*" catch-all vhost.
+					//
+					// Previously this was `continue` (add nothing and keep processing),
+					// which caused a multi-listener Gateway (e.g. one listener with no
+					// hostname + two listeners with specific hostnames) to produce a
+					// Hosts set of only the specific listener hostnames — silently
+					// dropping the catch-all listener's "admit all" contribution. A
+					// request like Host:example.org matched neither specific hostname,
+					// fell through to the 404 catch-all vhost, and returned 404 instead
+					// of the expected redirect. (HTTPRouteRedirectPortAndScheme, 443 subtests)
+					return nil
 				}
 				for _, rh := range routeHosts {
 					add(rh)

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -852,6 +852,57 @@ func TestEffectiveHostnames_ListenerNoHostname(t *testing.T) {
 	assert.Empty(t, got2, "hostname-less route on no-hostname listener → catch-all (empty)")
 }
 
+// TestEffectiveHostnames_MultiListenerCatchAllOverrides is the regression test for
+// HTTPRouteRedirectPortAndScheme (https-listener-on-443 subtests).
+//
+// A Gateway with three HTTPS listeners on port 443:
+//   - "https"                  hostname: "" (no restriction)
+//   - "https-with-hostname"    hostname: "second-example.org"
+//   - "https-with-wildcard"    hostname: "*.wildcard.org"
+//
+// An HTTPRoute with no hostnames attaches without a sectionName (gateway-level key).
+// buildGatewayListenerHostnames produces a gateway-level union of
+// ["", "second-example.org", "*.wildcard.org"].
+//
+// Before the fix, effectiveHostnames processed all three entries:
+//   - lh="" + routeHosts=[] → continue (adds nothing)
+//   - lh="second-example.org" → add "second-example.org"
+//   - lh="*.wildcard.org" → add "*.wildcard.org"
+//
+// Result: ["second-example.org", "*.wildcard.org"] — the no-hostname listener's
+// "admit all" semantics were silently dropped. A request with Host: example.org
+// matched neither, fell to the 404 catch-all vhost, and returned 404 instead of
+// the expected 302 redirect.
+//
+// After the fix, the first lh="" hit immediately returns nil (true catch-all),
+// so the vhost receives empty Hosts → the "*" catch-all vhost → correct match.
+func TestEffectiveHostnames_MultiListenerCatchAllOverrides(t *testing.T) {
+	// Build a Gateway matching same-namespace-with-https-listener from the
+	// conformance suite: three HTTPS listeners, first has no hostname.
+	gw := makeGateway("ns", "gw", "", "second-example.org", "*.wildcard.org")
+	m := buildGatewayListenerHostnames([]gatewayv1.Gateway{gw})
+
+	gwKeys := []string{"ns/gw"} // gateway-level key (no sectionName in parentRef)
+
+	// Route with no hostnames: must be catch-all (nil) regardless of the other
+	// listeners' specific hostnames.
+	got := effectiveHostnames(nil, gwKeys, m)
+	assert.Nil(t, got,
+		"no-hostname route on a Gateway with a no-hostname listener must be catch-all (nil), "+
+			"not narrowed to the other listeners' specific hostnames")
+
+	// Route with explicit hostnames: the no-hostname listener admits them unchanged.
+	got2 := effectiveHostnames([]string{"example.org"}, gwKeys, m)
+	assert.ElementsMatch(t, []string{"example.org"}, got2,
+		"route with explicit hostname 'example.org' should be admitted by the no-hostname listener")
+
+	// Attaching to only the specific-hostname section must still scope correctly.
+	sectionKey := "ns/gw/ll" // "https-with-hostname" is the second listener → "ll"
+	got3 := effectiveHostnames(nil, []string{sectionKey}, m)
+	assert.ElementsMatch(t, []string{"second-example.org"}, got3,
+		"no-hostname route scoped to the 'second-example.org' section must inherit that hostname")
+}
+
 // TestEffectiveHostnames_MultiGatewayUnion verifies the multi-Gateway union
 // semantics: a route attaching to two Gateways with different listener hostnames
 // gets the union of both intersections.

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -8,6 +8,7 @@ import (
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	hcmv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -555,6 +556,119 @@ func TestPerGatewayCertWired(t *testing.T) {
 	assert.Equal(t, "edge_gw_ns-tls_secure-gw_18110", l.GetName())
 	// TLS transport socket must be wired (not nil).
 	require.NotNil(t, l.GetFilterChains()[0].GetTransportSocket(), "per-Gateway HTTPS listener must terminate TLS")
+}
+
+// TestPerGatewayHTTPSListenerRoutesMatchHTTP is the regression guard for
+// HTTPRouteRedirectPortAndScheme (https-listener-on-443 subtests returning 404).
+//
+// When a Gateway has an HTTPS listener (TLSSecretNames set) AND a catch-all
+// virtual host (Hosts: nil/empty, i.e. the "*" vhost from effectiveHostnames
+// returning nil for a no-hostname route on a no-hostname HTTPS listener), the
+// per-Gateway route config must include the redirect routes in the "*" catch-all
+// vhost — not only in named-hostname vhosts. Without this, a request like
+// "Host: example.org" falls through to the 404 catch-all and returns 404 instead
+// of the expected redirect.
+//
+// This test verifies that:
+//  1. The HTTPS per-Gateway listener uses RDS (not inline route config) and
+//     references the same route config name as the HTTP case.
+//  2. The per-Gateway route config built from a catch-all VirtualHost (empty Hosts)
+//     carrying redirect routes exposes those routes in the "*" vhost domain — so
+//     any Host header matches and gets the redirect, not the 404.
+func TestPerGatewayHTTPSListenerRoutesMatchHTTP(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+
+	// Simulate the effective hostname computation result for a route with no
+	// hostnames attached to a Gateway with a no-hostname HTTPS listener: Hosts=nil
+	// (true catch-all). The redirect route must survive into the route config.
+	entry := EdgeGatewayEntry{
+		Namespace: "ns-https",
+		Name:      "tls-gw",
+		Listeners: []EdgeGatewayListenerEntry{
+			// HTTPS listener: TLSSecretNames set, ExternalPort 443.
+			{ExternalPort: 443, InternalPort: 18300, TLSSecretNames: []string{"ns-https/tls-cert"}},
+		},
+		// VirtualHost with empty Hosts (catch-all): produced when
+		// effectiveHostnames returns nil for no-hostname route on no-hostname HTTPS listener.
+		VirtualHosts: []VirtualHost{
+			{
+				Hosts: nil, // catch-all — must produce "*" vhost domain in Envoy
+				Routes: []Route{
+					{
+						Prefix:   "/scheme-nil-and-port-nil",
+						Redirect: &proxy.GammaRedirect{Hostname: "example.org"},
+					},
+					{
+						Prefix:   "/scheme-http-and-port-80",
+						Redirect: &proxy.GammaRedirect{Scheme: "http", Port: 80, Hostname: "example.org"},
+					},
+				},
+			},
+		},
+	}
+	c.SetEdgeGateways([]EdgeGatewayEntry{entry})
+
+	// 1. Listener check: the HTTPS listener must use RDS (not inline route config)
+	//    and reference edge_rt_ns-https_tls-gw.
+	ls := stripReadiness(t, c.Listeners())
+	require.Len(t, ls, 1)
+	l := ls[0]
+	assert.Equal(t, "edge_gw_ns-https_tls-gw_18300", l.GetName())
+	require.NotNil(t, l.GetFilterChains()[0].GetTransportSocket(), "HTTPS listener must terminate TLS")
+
+	hcm := extractHCM(t, l.GetFilterChains()[0])
+	rds := hcm.GetRds()
+	require.NotNil(t, rds, "per-Gateway HTTPS listener must use RDS (not inline route config)")
+	assert.Equal(t, proxy.EdgeGatewayRouteName("ns-https", "tls-gw"), rds.GetRouteConfigName(),
+		"HTTPS listener RDS must reference the per-Gateway route config")
+
+	// 2. Route config check: the "*" catch-all vhost must contain the redirect routes,
+	//    not only a 404. This is the root cause of the 404 regression:
+	//    effectiveHostnames was incorrectly returning ["second-example.org", "*.wildcard.org"]
+	//    instead of nil for a no-hostname route on a no-hostname HTTPS listener.
+	rcs := c.edgeGatewayRouteConfigs()
+	require.Len(t, rcs, 1)
+	rc, ok := rcs[0].(*routev3.RouteConfiguration)
+	require.True(t, ok)
+	assert.Equal(t, proxy.EdgeGatewayRouteName("ns-https", "tls-gw"), rc.GetName())
+	assert.True(t, rc.GetIgnorePortInHostMatching(), "IgnorePortInHostMatching must be set")
+
+	// The catch-all vhost ("*") must exist and carry the redirect routes.
+	var catchAllVH *routev3.VirtualHost
+	for _, vh := range rc.GetVirtualHosts() {
+		if len(vh.GetDomains()) == 1 && vh.GetDomains()[0] == "*" {
+			catchAllVH = vh
+			break
+		}
+	}
+	require.NotNil(t, catchAllVH, "route config must have a '*' catch-all virtual host (from empty Hosts)")
+
+	// The "*" vhost must contain the redirect routes before the terminal 404.
+	routes := catchAllVH.GetRoutes()
+	require.GreaterOrEqual(t, len(routes), 3, "catch-all vhost must have the 2 redirect routes + the 404 route")
+
+	// Verify at least one redirect action (not a direct-response 404) is present.
+	var hasRedirect bool
+	for _, r := range routes {
+		if r.GetRedirect() != nil {
+			hasRedirect = true
+			break
+		}
+	}
+	assert.True(t, hasRedirect,
+		"'*' catch-all vhost must contain redirect route actions, not only the 404 terminal route")
+}
+
+// extractHCM extracts the HttpConnectionManager from a filter chain's first
+// network filter. Fails the test if the filter is absent or the wrong type.
+func extractHCM(t *testing.T, fc *listenerv3.FilterChain) *hcmv3.HttpConnectionManager {
+	t.Helper()
+	require.NotEmpty(t, fc.GetFilters(), "filter chain must have at least one filter")
+	f := fc.GetFilters()[0]
+	hcm := &hcmv3.HttpConnectionManager{}
+	require.NoError(t, f.GetTypedConfig().UnmarshalTo(hcm), "first filter must be HttpConnectionManager")
+	return hcm
 }
 
 // TestVirtualHostVhosts_WeightedSplit verifies end-to-end that a route with


### PR DESCRIPTION
## Root cause

`effectiveHostnames` builds the *effective hostname set* for a route by iterating over the listener hostnames stored under the gateway-level map key. For the conformance Gateway `same-namespace-with-https-listener`, that key contains:

```
["", "second-example.org", "*.wildcard.org"]
```

(the union of all three HTTPS listeners: one with no hostname, one with `second-example.org`, one with `*.wildcard.org`).

When `http-route-for-listener-on-port-443` (a redirect HTTPRoute with **no hostnames**, attached with no `sectionName`) is processed, the old code did:

| listener hostname | route hosts | action |
|---|---|---|
| `""` | `[]` | `continue` (catch-all signal — adds nothing) |
| `"second-example.org"` | `[]` | adds `"second-example.org"` |
| `"*.wildcard.org"` | `[]` | adds `"*.wildcard.org"` |

Result: `vh.Hosts = ["second-example.org", "*.wildcard.org"]` — the no-hostname listener's "admit all hosts" semantics were silently lost. The test sends `Host: example.org`, which matches neither specific hostname, falls through to the `*` 404 catch-all vhost, and returns **404** instead of **302**.

## Fix

When `lh == ""` and `routeHosts == []` (no-hostname listener + no-hostname route = true catch-all), **return `nil` immediately**. A no-hostname listener admits ALL hosts — it supersedes any specific hostname contributions from other listeners in the same gateway-level union. The caller treats `nil`/empty `Hosts` as the `"*"` catch-all vhost in Envoy, which then matches `example.org` and applies the correct redirect route.

The one-line behavioral change is in `agent/internal/edge/gatewayapi/reconciler.go`:

```go
// Before (adds nothing and continues processing — other listeners pollute result):
continue

// After (catch-all is a superset; return immediately):
return nil
```

## Tests added

- **`TestEffectiveHostnames_MultiListenerCatchAllOverrides`** (`reconciler_test.go`): directly exercises `effectiveHostnames` with the 3-listener Gateway structure from the conformance manifest. Asserts `nil` result (catch-all) for a no-hostname route and correct per-section scoping for section-specific parentRefs.
- **`TestPerGatewayHTTPSListenerRoutesMatchHTTP`** (`cache/edge_test.go`): end-to-end assertion via `edgeGatewayRouteConfigs()` and `Listeners()`. Verifies that the HTTPS per-Gateway listener (a) uses RDS (not inline route config), (b) references the correct per-Gateway route config name, and (c) the resulting `"*"` catch-all vhost contains redirect route actions — not only the 404 terminal route.

## Second defect (connection-refused intermittent)

Not addressed in this PR. The intermittent `:443 connection refused` is a listener-binding race: the per-Gateway HTTPS listener on the allocated internal port isn't bound when the first request arrives. This is likely caused by the xDS snapshot being set before the listener finishes programming (or a re-reconcile that briefly removes and re-adds the listener). Should be diagnosed separately — the 404 fix is deterministic and higher priority.

## Validation

```
make gazelle
bazel build //agent/...
bazel test //agent/internal/edge/... //agent/internal/xds/... --test_output=errors
make format
```

All pass. No talos-main deploy (user owns deploys, do not merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S