### PR TITLE
fix(edge): preserve external port in RequestRedirect with no port/scheme

### DIFF
--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -327,18 +327,42 @@ func (c *SnapshotCache) edgeGatewayRouteConfigs() []types.Resource {
 
 	var out []types.Resource
 	for _, gw := range gws {
-		vhosts := c.gatewayVhostsLocked(gw.VirtualHosts)
+		// Find the external port for this Gateway's primary (non-redirect) HTTP listener.
+		// This is needed so that RequestRedirect filters with no explicit port can encode
+		// the correct external port in the Location header — Envoy's port_redirect=0 would
+		// otherwise use the listener's bound (internal) port instead.
+		// When a Gateway has multiple non-redirect listeners (unusual), we use the first
+		// one; the redirect route cannot be simultaneously correct for two different ports
+		// on a shared route config, so we favour the first declared port.
+		listenerPort := gatewayExternalHTTPPort(gw.Listeners)
+		vhosts := c.gatewayVhostsLocked(gw.VirtualHosts, listenerPort)
 		rc := proxy.BuildEdgeGatewayRouteConfiguration(gw.Namespace, gw.Name, vhosts)
 		out = append(out, rc)
 	}
 	return out
 }
 
+// gatewayExternalHTTPPort returns the external port of the first non-redirect,
+// non-TLS listener entry in the given list. This is the port clients connect to
+// when the Gateway exposes an HTTP listener (e.g. 8080). Returns 0 when there is
+// no such listener (TLS-only or redirect-only Gateways).
+func gatewayExternalHTTPPort(listeners []EdgeGatewayListenerEntry) uint32 {
+	for _, ln := range listeners {
+		if !ln.HTTPRedirect && len(ln.TLSSecretNames) == 0 {
+			return ln.ExternalPort
+		}
+	}
+	return 0
+}
+
 // gatewayVhostsLocked builds Envoy virtual hosts for one Gateway's VirtualHost
-// slice. It is identical to virtualHostVhosts but scoped to one Gateway's vhosts.
+// slice. listenerPort is the external port of the Gateway's primary HTTP listener
+// (0 when unknown) and is used to populate GammaRedirect.ListenerPort on redirect
+// routes so that port-preserving redirects emit the correct external port in
+// Location (not the internal/container port the listener is bound to).
 // Caller must hold clusterMu.
-func (c *SnapshotCache) gatewayVhostsLocked(vhosts []VirtualHost) []*routev3.VirtualHost {
-	return c.buildEdgeVhostsLocked(vhosts)
+func (c *SnapshotCache) gatewayVhostsLocked(vhosts []VirtualHost, listenerPort uint32) []*routev3.VirtualHost {
+	return c.buildEdgeVhostsLocked(vhosts, listenerPort)
 }
 
 // buildEdgeVhostsLocked converts cache VirtualHosts into Envoy virtual hosts.
@@ -355,8 +379,14 @@ func (c *SnapshotCache) gatewayVhostsLocked(vhosts []VirtualHost) []*routev3.Vir
 // hostname set spans all of the listener's hostnames; they are merged into the
 // single catch-all "*" vhost (there can be only one "*" per route table).
 //
+// listenerPort is the external port of the Gateway listener this route config
+// serves (e.g. 8080). It is injected into redirect routes' GammaRedirect.ListenerPort
+// so that a RequestRedirect with no explicit port or scheme emits the correct
+// external port in the Location header. Pass 0 for the Phase 1 shared listener
+// (external port = 80 = default, port_redirect=0 is correct).
+//
 // Caller must hold clusterMu.
-func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.VirtualHost {
+func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost, listenerPort uint32) []*routev3.VirtualHost {
 	// domain → []Route accumulator; ordered first-seen for domain name ordering.
 	domainRoutes := make(map[string][]Route)
 	var domainOrder []string // first-seen order for deterministic output
@@ -408,6 +438,19 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 		if r.DirectResponseStatus != 0 {
 			return proxy.BuildEdgeDirectResponseRoute(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, r.DirectResponseStatus)
 		}
+
+		// Inject the listener's external port into redirect routes when the redirect
+		// filter specifies neither Port nor Scheme (pure "preserve original" semantics).
+		// Without this, gammaRedirectAction leaves port_redirect=0, which makes Envoy
+		// use the listener's bound (internal) port — not the external port the client
+		// connected to. See GammaRedirect.ListenerPort for the full explanation.
+		redirect := r.Redirect
+		if redirect != nil && listenerPort != 0 && redirect.Port == 0 && redirect.Scheme == "" {
+			cp := *redirect
+			cp.ListenerPort = listenerPort
+			redirect = &cp
+		}
+
 		// Weighted multi-backend path: when Backends is populated use it.
 		if len(r.Backends) > 0 {
 			weighted := make([]proxy.WeightedRouteBackend, 0, len(r.Backends))
@@ -415,14 +458,14 @@ func (c *SnapshotCache) buildEdgeVhostsLocked(vhosts []VirtualHost) []*routev3.V
 				cn := c.edgeClusterNameLocked(b.Service, b.BackendNamespace, b.Port)
 				weighted = append(weighted, proxy.WeightedRouteBackend{Cluster: cn, Weight: b.Weight})
 			}
-			return proxy.BuildEdgeRouteWeighted(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, weighted, r.HeaderMutation, r.Redirect, r.URLRewrite, r.Timeout)
+			return proxy.BuildEdgeRouteWeighted(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, weighted, r.HeaderMutation, redirect, r.URLRewrite, r.Timeout)
 		}
 		// Legacy single-backend path (backward compat).
 		cluster := ""
 		if r.Service != "" {
 			cluster = c.edgeClusterNameLocked(r.Service, r.BackendNamespace, r.Port)
 		}
-		return proxy.BuildEdgeRoute(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, cluster, r.HeaderMutation, r.Redirect, r.URLRewrite, r.Timeout)
+		return proxy.BuildEdgeRoute(r.Prefix, r.Exact, r.Headers, r.Method, r.QueryParams, cluster, r.HeaderMutation, redirect, r.URLRewrite, r.Timeout)
 	}
 
 	// Emit one Envoy virtual host per domain group, sorted by path specificity.
@@ -491,6 +534,9 @@ func (c *SnapshotCache) SetVirtualHosts(vhosts []VirtualHost) {
 // earlier vhost is dropped (keep-first; Envoy NACKs duplicate domains) — the
 // runtime backstop to the controller webhook's duplicate-FQDN rejection — and
 // hostname-less routes are merged into a single catch-all "*" vhost.
+// Phase 1 (shared listener): listener port is 0 — no redirect port injection needed
+// because the shared listener is on the default HTTP port (80) and port_redirect=0
+// is correct for default ports (Location omits ":80").
 func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 	c.edgeMu.RLock()
 	vhosts := slices.Clone(c.virtualHosts)
@@ -499,7 +545,7 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 	c.clusterMu.RLock()
 	defer c.clusterMu.RUnlock()
 
-	return c.buildEdgeVhostsLocked(vhosts)
+	return c.buildEdgeVhostsLocked(vhosts, 0)
 }
 
 // edgeClusterNameLocked resolves a (service, backendNamespace, port) backend to

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -1367,3 +1367,174 @@ func TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated(t *testing.T) {
 	// Confirm no catch-all "*" was emitted.
 	assert.Nil(t, byName["*"], "no hostname-less routes → no catch-all * vhost")
 }
+
+// TestPerGatewayRedirectPreservesExternalPort is the regression test for
+// HTTPRouteRedirectPortAndScheme subtest "scheme-nil-and-port-nil" on a
+// http-listener-on-8080 Gateway (the LONE remaining Extended conformance fail
+// before this fix).
+//
+// Root cause: edgeGatewayRouteConfigs builds the per-Gateway route config without
+// passing the listener's ExternalPort. A redirect route with neither Port nor Scheme
+// (pure "preserve original port" semantics) ends up with GammaRedirect.Port=0 and
+// GammaRedirect.Scheme="". gammaRedirectAction then leaves port_redirect=0, which
+// makes Envoy use the listener's BOUND (internal) port — not the external port 8080
+// the client connected to via the LB Service. The Location header becomes
+// "http://host:18101/path" instead of "http://host:8080/path".
+//
+// Fix: gatewayExternalHTTPPort finds the external port of the non-redirect, non-TLS
+// listener. buildEdgeVhostsLocked injects it into GammaRedirect.ListenerPort for
+// redirect routes with Port=0 and Scheme="". gammaRedirectAction emits
+// port_redirect=8080 for non-standard ports; for default ports (80, 443) it leaves
+// port_redirect=0 so the port is correctly omitted from Location.
+func TestPerGatewayRedirectPreservesExternalPort(t *testing.T) {
+	c := newTestCache("edge-1")
+	c.SetEdgeMode(80)
+
+	// Gateway with HTTP listener on external port 8080, internal port 18101.
+	// This is the per-Gateway addressing pattern: LB Service maps 8080 → 18101.
+	entry := EdgeGatewayEntry{
+		Namespace: "gateway-conformance-infra",
+		Name:      "http-gateway-8080",
+		Listeners: []EdgeGatewayListenerEntry{
+			{ExternalPort: 8080, InternalPort: 18101, HTTPRedirect: false},
+		},
+		VirtualHosts: []VirtualHost{
+			{
+				// Catch-all: no hostname, matches all requests.
+				Hosts: nil,
+				Routes: []Route{
+					{
+						// scheme-nil-and-port-nil: no Scheme, no Port → must emit port_redirect=8080.
+						Prefix:   "/scheme-nil-and-port-nil",
+						Redirect: &proxy.GammaRedirect{StatusCode: 302},
+					},
+					{
+						// scheme-nil-and-port-80: explicit Port=80 → port_redirect=80 always.
+						Prefix:   "/scheme-nil-and-port-80",
+						Redirect: &proxy.GammaRedirect{Port: 80, StatusCode: 302},
+					},
+					{
+						// scheme-https-and-port-nil: Scheme=https → port_redirect=443 (scheme default).
+						Prefix:   "/scheme-https-and-port-nil",
+						Redirect: &proxy.GammaRedirect{Scheme: "https", StatusCode: 302},
+					},
+				},
+			},
+		},
+	}
+	c.SetEdgeGateways([]EdgeGatewayEntry{entry})
+
+	rcs := c.edgeGatewayRouteConfigs()
+	require.Len(t, rcs, 1)
+	rc, ok := rcs[0].(*routev3.RouteConfiguration)
+	require.True(t, ok)
+	assert.Equal(t, proxy.EdgeGatewayRouteName("gateway-conformance-infra", "http-gateway-8080"), rc.GetName())
+
+	// Find the "*" catch-all vhost (from nil Hosts).
+	var catchAll *routev3.VirtualHost
+	for _, vh := range rc.GetVirtualHosts() {
+		if len(vh.GetDomains()) == 1 && vh.GetDomains()[0] == "*" {
+			catchAll = vh
+			break
+		}
+	}
+	require.NotNil(t, catchAll, "catch-all '*' vhost must be present for the hostname-less VirtualHost")
+
+	// Index redirect routes by path prefix for easy lookup.
+	redirectByPath := make(map[string]*routev3.RedirectAction)
+	for _, r := range catchAll.GetRoutes() {
+		rd := r.GetRedirect()
+		if rd == nil {
+			continue
+		}
+		// Extract the path matcher to key the result.
+		path := r.GetMatch().GetPrefix()
+		if path == "" {
+			path = r.GetMatch().GetPathSeparatedPrefix()
+		}
+		redirectByPath[path] = rd
+	}
+
+	// scheme-nil-and-port-nil on 8080 listener → port_redirect MUST be 8080.
+	// This is the conformance-failing case before the fix.
+	nilNil := redirectByPath["/scheme-nil-and-port-nil"]
+	require.NotNil(t, nilNil, "scheme-nil-and-port-nil route must be present")
+	assert.Equal(t, uint32(8080), nilNil.GetPortRedirect(),
+		"scheme-nil-and-port-nil on 8080 listener must set port_redirect=8080 so Location contains :8080")
+	assert.Empty(t, nilNil.GetSchemeRedirect(), "no scheme change")
+
+	// scheme-nil-and-port-80 → explicit port=80 is preserved as-is.
+	nilPort80 := redirectByPath["/scheme-nil-and-port-80"]
+	require.NotNil(t, nilPort80, "scheme-nil-and-port-80 route must be present")
+	assert.Equal(t, uint32(80), nilPort80.GetPortRedirect(),
+		"explicit port=80 must be preserved")
+
+	// scheme-https-and-port-nil → scheme change uses scheme default (443).
+	httpsNil := redirectByPath["/scheme-https-and-port-nil"]
+	require.NotNil(t, httpsNil, "scheme-https-and-port-nil route must be present")
+	assert.Equal(t, uint32(443), httpsNil.GetPortRedirect(),
+		"https scheme-only redirect must use port 443, not the listener port 8080")
+	assert.Equal(t, "https", httpsNil.GetSchemeRedirect())
+}
+
+// TestGatewayExternalHTTPPort verifies gatewayExternalHTTPPort returns the correct
+// port for various listener configurations.
+func TestGatewayExternalHTTPPort(t *testing.T) {
+	tests := []struct {
+		name      string
+		listeners []EdgeGatewayListenerEntry
+		want      uint32
+	}{
+		{
+			name:      "single HTTP listener on 8080",
+			listeners: []EdgeGatewayListenerEntry{{ExternalPort: 8080, InternalPort: 18101}},
+			want:      8080,
+		},
+		{
+			name:      "default HTTP listener on 80",
+			listeners: []EdgeGatewayListenerEntry{{ExternalPort: 80, InternalPort: 18100}},
+			want:      80,
+		},
+		{
+			name: "TLS listener only — no HTTP port",
+			listeners: []EdgeGatewayListenerEntry{
+				{ExternalPort: 443, InternalPort: 18102, TLSSecretNames: []string{"my/cert"}},
+			},
+			want: 0,
+		},
+		{
+			name: "redirect listener only — no routable port",
+			listeners: []EdgeGatewayListenerEntry{
+				{ExternalPort: 80, InternalPort: 18100, HTTPRedirect: true},
+			},
+			want: 0,
+		},
+		{
+			name: "redirect + TLS — no plain HTTP port",
+			listeners: []EdgeGatewayListenerEntry{
+				{ExternalPort: 80, InternalPort: 18100, HTTPRedirect: true},
+				{ExternalPort: 443, InternalPort: 18101, TLSSecretNames: []string{"my/cert"}},
+			},
+			want: 0,
+		},
+		{
+			name: "HTTP + TLS mixed — returns HTTP port",
+			listeners: []EdgeGatewayListenerEntry{
+				{ExternalPort: 8080, InternalPort: 18100},
+				{ExternalPort: 8443, InternalPort: 18101, TLSSecretNames: []string{"my/cert"}},
+			},
+			want: 8080,
+		},
+		{
+			name:      "empty listeners",
+			listeners: nil,
+			want:      0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gatewayExternalHTTPPort(tc.listeners)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -997,6 +997,87 @@ func TestBuildEdgeRoute_Redirect_ExplicitPortOverridesSchemeDefault(t *testing.T
 		"explicit port must override scheme default")
 }
 
+// --- FIX 4b: HTTPRouteRedirectPortAndScheme — non-standard listener port preservation ---
+
+// TestBuildEdgeRoute_Redirect_NonDefaultListenerPort_PreservesPort verifies that a
+// redirect with neither scheme nor explicit port (pure "preserve original" semantics)
+// sets port_redirect to the ListenerPort when the listener is on a non-standard port
+// (not 80 or 443). This is the fix for HTTPRouteRedirectPortAndScheme subtest
+// "scheme-nil-and-port-nil" on an http-listener-on-8080 Gateway.
+//
+// Root cause: Envoy's port_redirect=0 uses the listener's bound port — which for
+// aether's per-Gateway addressing is the INTERNAL container port (e.g. 18101), not
+// the external port (8080) the client connected to via the LB Service.
+func TestBuildEdgeRoute_Redirect_NonDefaultListenerPort_PreservesPort(t *testing.T) {
+	tests := []struct {
+		name         string
+		listenerPort uint32
+		wantPort     uint32
+		desc         string
+	}{
+		{
+			name:         "non-standard port 8080",
+			listenerPort: 8080,
+			wantPort:     8080,
+			desc:         "non-standard port must appear in port_redirect so Location contains :8080",
+		},
+		{
+			name:         "port 80 is default — omit from Location",
+			listenerPort: 80,
+			wantPort:     0,
+			desc:         "default HTTP port 80 must NOT set port_redirect (Location omits :80 per RFC 3986)",
+		},
+		{
+			name:         "port 443 is default — omit from Location",
+			listenerPort: 443,
+			wantPort:     0,
+			desc:         "default HTTPS port 443 must NOT set port_redirect (Location omits :443 per RFC 3986)",
+		},
+		{
+			name:         "listener port 0 (unknown) — no injection",
+			listenerPort: 0,
+			wantPort:     0,
+			desc:         "listener port 0 (Phase 1 shared listener) must not inject port_redirect",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// No Scheme, no Port: pure "preserve original port" redirect.
+			rd := &GammaRedirect{StatusCode: 302, ListenerPort: tc.listenerPort}
+			r := BuildEdgeRoute("/", "", nil, "", nil, "", nil, rd, nil, nil)
+			require.NotNil(t, r)
+			rdr := r.GetRedirect()
+			require.NotNil(t, rdr)
+			assert.Equal(t, tc.wantPort, rdr.GetPortRedirect(), tc.desc)
+		})
+	}
+}
+
+// TestBuildEdgeRoute_Redirect_ExplicitPortBeatsListenerPort verifies that an explicit
+// Port on the GammaRedirect takes precedence over ListenerPort (explicit wins always).
+func TestBuildEdgeRoute_Redirect_ExplicitPortBeatsListenerPort(t *testing.T) {
+	rd := &GammaRedirect{Port: 9090, ListenerPort: 8080, StatusCode: 302}
+	r := BuildEdgeRoute("/", "", nil, "", nil, "", nil, rd, nil, nil)
+	require.NotNil(t, r)
+	rdr := r.GetRedirect()
+	require.NotNil(t, rdr)
+	assert.Equal(t, uint32(9090), rdr.GetPortRedirect(),
+		"explicit Port must override ListenerPort")
+}
+
+// TestBuildEdgeRoute_Redirect_SchemeBeatsListenerPort verifies that when Scheme is set
+// (no explicit Port), the scheme-default port is used even if ListenerPort is set.
+func TestBuildEdgeRoute_Redirect_SchemeBeatsListenerPort(t *testing.T) {
+	// Scheme https + ListenerPort 8080 — scheme wins; port_redirect should be 443.
+	rd := &GammaRedirect{Scheme: "https", ListenerPort: 8080, StatusCode: 302}
+	r := BuildEdgeRoute("/", "", nil, "", nil, "", nil, rd, nil, nil)
+	require.NotNil(t, r)
+	rdr := r.GetRedirect()
+	require.NotNil(t, rdr)
+	assert.Equal(t, uint32(443), rdr.GetPortRedirect(),
+		"scheme https must use port 443 even when ListenerPort is set")
+}
+
 // --- FIX 4: HTTPRouteTimeoutRequest enforcement in BuildEdgeRoute ---
 
 // TestBuildEdgeRoute_Timeout verifies that a non-nil timeout is wired onto

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -190,7 +190,7 @@ type GammaRedirect struct {
 	Scheme string
 	// Hostname is the target hostname. Empty = unchanged.
 	Hostname string
-	// Port is the target port (0 = unchanged).
+	// Port is the target port (0 = unchanged / preserve original).
 	Port uint32
 	// StatusCode is the HTTP redirect code (301 or 302; default 301).
 	StatusCode int
@@ -198,6 +198,17 @@ type GammaRedirect struct {
 	// "ReplaceFullPath" → Envoy PathRedirect; "ReplacePrefixMatch" → PrefixRewrite.
 	PathType  string
 	PathValue string
+	// ListenerPort is the external port of the Gateway listener serving this route
+	// (e.g. 8080 when the Gateway declares port: 8080 and the LB Service maps
+	// 8080 → some internal port). It is set by the per-Gateway route builder and
+	// ONLY used when Port == 0 and Scheme == "" (i.e. the redirect preserves the
+	// original port). Without this, Envoy's RedirectAction with port_redirect=0
+	// emits the listener's bound (internal) port in the Location header — not the
+	// external port the client connected to. For default HTTP ports (80, 443) this
+	// field is left 0 so the port is omitted from Location (correct for default
+	// ports). For non-default ports it is set to ExternalPort so Envoy encodes the
+	// correct port in Location.
+	ListenerPort uint32
 }
 
 // GammaURLRewrite describes a URLRewrite filter: rewrites the request host
@@ -407,12 +418,21 @@ func gammaRouteAction(serviceCluster string, rule GammaRoute, matchPrefix string
 // gammaRedirectAction converts a GammaRedirect into an Envoy Route_Redirect action.
 // The returned action replaces the RouteAction entirely — no backend cluster is used.
 //
-// Port semantics (Gateway API compliance): when an explicit Port is set, it is used
-// directly. When Port is 0 (not set in the filter) but Scheme is set, we must NOT
-// preserve the original request port — Envoy's default (port_redirect = 0) copies the
-// original request port, which violates Gateway API semantics where a scheme change
-// implies the scheme's default port. We emit the scheme-default port explicitly so
-// the redirect URL uses the correct port for the new scheme.
+// Port semantics (Gateway API compliance):
+//
+//   - Explicit Port set: use it directly (rd.Port != 0).
+//
+//   - Scheme changed but no explicit Port: use the scheme-default port (443 for https,
+//     80 for http). Without this, Envoy's port_redirect=0 would copy the original
+//     request port — wrong when changing scheme (e.g. https://host:80/path).
+//
+//   - No Port, no Scheme (pure "preserve original"): rd.ListenerPort carries the
+//     external port the Gateway listener declared (e.g. 8080). Envoy's port_redirect=0
+//     emits the listener's BOUND port, which is the internal/container port allocated
+//     by aether's port allocator — NOT the external port the client used. For a
+//     non-standard port (not 80 or 443) we must set port_redirect explicitly so the
+//     Location reflects the external port. For default ports (80/443) we leave
+//     port_redirect=0 so the port is omitted from Location (correct per RFC 3986).
 func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
 	a := &routev3.RedirectAction{}
 	if rd.Scheme != "" {
@@ -423,7 +443,7 @@ func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
 	}
 	switch {
 	case rd.Port != 0:
-		// Explicit port: use as specified.
+		// Explicit port from the HTTPRoute RequestRedirect filter: use as specified.
 		a.PortRedirect = rd.Port
 	case rd.Scheme == "https":
 		// Scheme changed to https, no explicit port: use the https default (443) so
@@ -432,6 +452,13 @@ func gammaRedirectAction(rd *GammaRedirect) *routev3.Route_Redirect {
 	case rd.Scheme == "http":
 		// Scheme changed to http, no explicit port: use the http default (80).
 		a.PortRedirect = 80
+	case rd.ListenerPort != 0 && rd.ListenerPort != 80 && rd.ListenerPort != 443:
+		// No explicit port, no scheme change, non-standard listener port: set
+		// port_redirect to the external port so Location carries the right port.
+		// Envoy's port_redirect=0 would use the listener's bound (internal) port
+		// instead. For default ports (80/443) we leave port_redirect=0 so the port
+		// is omitted from Location (browsers treat absent port as the scheme default).
+		a.PortRedirect = rd.ListenerPort
 	}
 	switch rd.StatusCode {
 	case 302:


### PR DESCRIPTION
## Summary

- **Root cause confirmed:** `RequestRedirect` filters with neither `Port` nor `Scheme` set left `GammaRedirect.Port=0` and `Scheme=""`, so `gammaRedirectAction` emitted `port_redirect=0` to Envoy. Envoy interprets `port_redirect=0` as "use the listener's bound port" — which for aether's per-Gateway addressing is the **internal** container port (e.g. `18101`), not the external port `8080` the client connected to via the LB Service. The `Location` header contained `:18101` instead of `:8080`.
- Default ports (80/443) were unaffected because `port_redirect=0` with a default port correctly omits the port from `Location`. Non-default ports require an explicit value.
- **Fix:** Three-part change in `proxy/route.go` and `cache/edge.go`:
  1. `GammaRedirect` gains `ListenerPort uint32` — the external port of the Gateway listener, injected at route-config build time when `Port=0` and `Scheme=""`.
  2. `gammaRedirectAction`: new switch case — when `Port=0`, `Scheme=""`, and `ListenerPort` is a non-default port (≠80, ≠443) — sets `port_redirect` to `ListenerPort`. Default ports leave `port_redirect=0` (correct per RFC 3986).
  3. New helper `gatewayExternalHTTPPort` finds the first non-redirect, non-TLS listener's `ExternalPort`; `buildEdgeVhostsLocked` receives it as `listenerPort` and injects it into a copy of `GammaRedirect` for redirect routes where `Port=0` and `Scheme=""`.

## Test plan

- [ ] `TestPerGatewayRedirectPreservesExternalPort` (new, `cache/edge_test.go`): end-to-end cache test asserting the generated Envoy `RedirectAction.port_redirect` is `8080` for the no-port/no-scheme case on a Gateway with `ExternalPort=8080`, `443` for the scheme-https case, and `80` for an explicit `port=80` redirect — exactly mirroring the three HTTPRouteRedirectPortAndScheme `http-listener-on-8080` subtests
- [ ] `TestGatewayExternalHTTPPort` (new, `cache/edge_test.go`): unit tests for the helper covering HTTP-only, TLS-only, redirect-only, and mixed listener configurations
- [ ] `TestBuildEdgeRoute_Redirect_NonDefaultListenerPort_PreservesPort` (new, `proxy/edge_test.go`): unit test for `gammaRedirectAction` with `ListenerPort` set — 8080 injects, 80/443 are suppressed (default), 0 is a no-op
- [ ] `TestBuildEdgeRoute_Redirect_ExplicitPortBeatsListenerPort` and `TestBuildEdgeRoute_Redirect_SchemeBeatsListenerPort` (new): precedence guard — explicit port always wins over `ListenerPort`; scheme changes use scheme-default port even when `ListenerPort` is set
- [ ] All 21 `//agent/internal/...` tests pass (`bazel test //agent/internal/... --test_output=errors`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S