### PR TITLE
fix(edge): preStop drain for hitless edge pod rollouts under load

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.53.0-{GIT_COMMIT}"
+version: "0.54.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -30,6 +30,14 @@ spec:
         aether.io/managed: "false"
     spec:
       serviceAccountName: {{ include "aether.edge.serviceAccountName" . }}
+      # Hitless rollouts: the per-Gateway LoadBalancer Services use
+      # externalTrafficPolicy: Cluster, so kube-proxy keeps routing to a terminating
+      # pod for the endpoint-propagation window. The preStop `sleep` below holds
+      # SIGTERM off both containers while the pod is already Terminating, so the
+      # endpoint is withdrawn before Envoy stops accepting; this grace period must
+      # comfortably exceed that sleep plus Envoy's own graceful drain so the kubelet
+      # SIGKILL never lands mid-drain. See edge.drain in values.yaml.
+      terminationGracePeriodSeconds: {{ .Values.edge.drain.terminationGracePeriodSeconds }}
       # Tolerate the aether startup taint: the edge is an ingress gateway, not a
       # mesh workload — it dials pods directly and never uses the node proxy, so it
       # must not wait for a node's agent to become ready. (Its own CNI ADD goes
@@ -142,6 +150,16 @@ spec:
               port: health
             initialDelaySeconds: 5
             periodSeconds: 10
+          {{- if gt (int .Values.edge.drain.preStopSeconds) 0 }}
+          # Keep the xDS control plane alive through the drain window so Envoy never
+          # loses its config source mid-drain. Native `sleep` action (no shell in the
+          # distroless agent image). The kubelet runs preStop on every container in
+          # parallel on pod deletion.
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: {{ .Values.edge.drain.preStopSeconds }}
+          {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -215,6 +233,20 @@ spec:
             initialDelaySeconds: 2
             periodSeconds: 2
             failureThreshold: 3
+          {{- if gt (int .Values.edge.drain.preStopSeconds) 0 }}
+          # Two-phase drain, mirroring the node proxy (proxy.hotRestart.drainTime).
+          # The pod is Terminating the moment deletion begins, so kube-proxy starts
+          # withdrawing this pod's Service endpoint. This native `sleep` preStop holds
+          # SIGTERM off Envoy for that propagation window WHILE Envoy keeps accepting
+          # and serving (no shell in the distroless proxy image, so the native
+          # lifecycle action is used, not exec). Only after the sleep does Envoy get
+          # SIGTERM and drain in-flight requests gracefully — by which point kube-proxy
+          # no longer routes new connections here.
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: {{ .Values.edge.drain.preStopSeconds }}
+          {{- end }}
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -302,6 +302,30 @@ edge:
   overload:
     enabled: true
     maxHeapSizeBytes: 201326592 # 192Mi = 75% of 256Mi
+  # Hitless-rollout drain. The per-Gateway LoadBalancer Services use
+  # externalTrafficPolicy: Cluster, so on a rollout kube-proxy keeps routing to a
+  # terminating pod for the endpoint-propagation window. Without a drain, the edge
+  # Envoy receives SIGTERM and stops accepting BEFORE that endpoint is withdrawn,
+  # so connections kube-proxy still steers to it are reset (measured ~0.25%/roll).
+  #
+  # Mirrors the node proxy's two-phase drain (proxy.hotRestart.drainTime = 10s, the
+  # empirically 0-fail value): a native kubelet `sleep` preStop holds SIGTERM off
+  # both containers for preStopSeconds. The pod is already Terminating, so kube-proxy
+  # withdraws its endpoint during the sleep WHILE Envoy keeps accepting and serving
+  # in-flight requests. Only after the sleep does Envoy get SIGTERM and drain
+  # gracefully. terminationGracePeriodSeconds must comfortably exceed the sleep plus
+  # Envoy's own graceful-shutdown drain. The native `sleep` lifecycle action (GA
+  # k8s 1.30+) is used so no in-container shell is required — the edge Envoy/agent
+  # images are distroless (no /bin/sleep, curl, or wget).
+  drain:
+    # Seconds the preStop sleep holds off SIGTERM so kube-proxy propagates the
+    # endpoint removal while Envoy still serves. Matches proxy.hotRestart.drainTime.
+    # 0 disables the preStop hook entirely.
+    preStopSeconds: 10
+    # Pod terminationGracePeriodSeconds. Must exceed preStopSeconds plus Envoy's
+    # graceful drain so SIGKILL never lands mid-drain. Default 30 = 10s sleep +
+    # ~15s Envoy drain + buffer.
+    terminationGracePeriodSeconds: 30
   # SPIRE identity for the edge (when spire.enabled): create a ClusterSPIFFEID so
   # SPIRE issues the edge pod its SVID. Mirrors controller.webhook.clusterSpiffeID.
   spire:


### PR DESCRIPTION
## Problem (measured)

A k6 soak (100 req/s) against an edge Gateway found steady-state + gateway churn = **0/42000** drops, but **edge pod rollouts drop ~0.25% (77/30000 across 2 `kubectl rollout restart`s, ~38/roll)**, concentrated in the rollout transition.

Root cause: `charts/aether/templates/edge-deployment.yaml` had **no `preStop` hook** on the agent/envoy containers, and the per-Gateway LoadBalancer Services use `externalTrafficPolicy: Cluster`. On a roll, a terminating pod's Envoy receives SIGTERM and stops accepting **before** kube-proxy withdraws its Service endpoint, so connections kube-proxy still routes to it during the endpoint-propagation window are reset.

## How the node proxy drains (reference)

The node proxy (`agent-proxy-daemonset.yaml`) has **no** preStop either — its two-phase drain is internal to the `proxy-supervisor`, which intercepts SIGTERM, drains Envoy gracefully over `proxy.hotRestart.drainTime` (**10s**, the empirically 0-fail value) while Envoy keeps serving, then exits; `terminationGracePeriodSeconds: 180` covers it. The edge Envoy is plain Envoy (no supervisor) — nothing holds SIGTERM off during the kube-proxy propagation window.

## What this adds

A native kubelet `sleep` preStop on **both** edge containers (agent + envoy), mirroring the node proxy's "delay then drain" intent:

- The pod is **Terminating** the moment deletion begins, so kube-proxy starts withdrawing this pod's endpoint.
- The `sleep` preStop holds SIGTERM off for `edge.drain.preStopSeconds` **while Envoy keeps accepting and serving** in-flight.
- Only after the sleep does Envoy get SIGTERM and drain gracefully (its drain-aware `/aether/readyz` health_check filter already flips 200→503).
- `terminationGracePeriodSeconds` is now set on the Deployment and comfortably exceeds the sleep + Envoy drain.
- The agent container gets the same preStop so the xDS source stays alive through the drain window.

The **native `sleep` lifecycle action** (GA k8s 1.30+; talos-main is v1.36.1) is used because the edge Envoy/agent images are **distroless** — no shell, curl, or wget for an `exec`/`httpGet` preStop.

## Config (new `edge.drain`)

| key | default | note |
|---|---|---|
| `edge.drain.preStopSeconds` | `10` | matches `proxy.hotRestart.drainTime`; `0` disables the hook |
| `edge.drain.terminationGracePeriodSeconds` | `30` | 10s sleep + ~15s Envoy drain + buffer |

Chart bumped **0.53.0 → 0.54.0**.

## Verify (no deploy)

`helm template` with `edge.enabled=true` (TLS on, mirroring talos-main):
- default → grace `30`, `preStop.sleep.seconds: 10` on both `agent` and `envoy`;
- `edge.drain.preStopSeconds=0` → no `lifecycle` block rendered, grace still set;
- override (`preStopSeconds=15`, `terminationGracePeriodSeconds=45`) → renders 45 / 15;
- full render parses as valid YAML; `helm lint` passes.

Chart-only change — no Go/templating helpers touched.

**Not deployed.** Deploy + soak re-validation left to the maintainer (the edge fronts production `api.palermo.dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)