### PR TITLE
fix(capture): --capture-redirect-all is an agent flag, not cni-install

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.55.0-{GIT_COMMIT}"
+version: "0.55.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -45,9 +45,6 @@ spec:
             {{- end }}
             {{- if .Values.agent.transparentCapture }}
             - "--transparent-capture"
-            {{- if .Values.agent.captureRedirectAll }}
-            - "--capture-redirect-all"
-            {{- end }}
             {{- end }}
             {{- if .Values.agent.meshDns }}
             - "--mesh-dns"


### PR DESCRIPTION
#388's chart wiring added `--capture-redirect-all` to **both** `--transparent-capture` blocks in `agent-daemonset.yaml`, but the first is the **cni-install** init container, which rejects the unknown flag and crash-loops the agent rollout (`Error: unknown flag: --capture-redirect-all`). The flag belongs only on the **agent** container — the CNI redirect-all is gated by the `capture.aether.io/redirect-all` pod annotation at plugin runtime, not a cni-install flag.

Chart 0.55.0 → 0.55.1. Verified via `helm template`: cni-install gets only `--transparent-capture`; the agent container gets both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)