### PR TITLE
fix(capture): ORIGINAL_DST passthrough cluster must use CLUSTER_PROVIDED LB

### DIFF
--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -3,6 +3,8 @@ package proxy
 import (
 	"testing"
 
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -157,6 +159,9 @@ func TestNewPassthroughOriginalDstCluster(t *testing.T) {
 	assert.Equal(t, PassthroughClusterName, cl.GetName())
 	// Must be ORIGINAL_DST type (4).
 	assert.Equal(t, int32(4), int32(cl.GetType()))
+	// ORIGINAL_DST REQUIRES CLUSTER_PROVIDED LB — any other policy (the
+	// ROUND_ROBIN default) makes Envoy reject the cluster and NACK CDS.
+	assert.Equal(t, clusterv3.Cluster_CLUSTER_PROVIDED, cl.GetLbPolicy())
 	// No transport socket — passthrough is plaintext.
 	assert.Nil(t, cl.GetTransportSocket())
 	// No upstream HTTP protocol options — raw TCP.

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -237,6 +237,11 @@ func NewPassthroughOriginalDstCluster() *clusterv3.Cluster {
 		ClusterDiscoveryType: &clusterv3.Cluster_Type{
 			Type: clusterv3.Cluster_ORIGINAL_DST,
 		},
+		// ORIGINAL_DST clusters MUST use CLUSTER_PROVIDED LB — the upstream host is
+		// resolved per-connection from SO_ORIGINAL_DST, not a load-balanced pool.
+		// Any other policy (the ROUND_ROBIN default) makes Envoy reject the cluster
+		// and NACK the entire CDS update.
+		LbPolicy:                      clusterv3.Cluster_CLUSTER_PROVIDED,
 		ConnectTimeout:                durationpb.New(2 * time.Second),
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
 		// No TypedExtensionProtocolOptions: passthrough is plain TCP.


### PR DESCRIPTION
The M2a passthrough cluster (`Cluster_ORIGINAL_DST`) set no `LbPolicy`, defaulting to `ROUND_ROBIN`, which Envoy rejects for `ORIGINAL_DST` (`Only 'CLUSTER_PROVIDED' is allowed`) — **NACKing the entire delta CDS update** on every node where `--capture-redirect-all` is enabled. Sets `LbPolicy=CLUSTER_PROVIDED` and asserts it in the unit test.

**Found by the on-cluster M2a e2e** — unit tests don't run Envoy's cluster validation. (This was the 2nd spike bug the e2e surfaced; the 1st was #389, the cni-install flag.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)