### PR TITLE
feat(020): namespace-aware services — Part 1 (registry key <ns>/<svc>)

### DIFF
--- a/agent/internal/capture/BUILD.bazel
+++ b/agent/internal/capture/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//common/constants",
         "//common/log",
+        "//common/serviceref",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/builder",

--- a/agent/internal/capture/reconciler.go
+++ b/agent/internal/capture/reconciler.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"strings"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	"github.com/bpalermo/aether/common/constants"
 	commonlog "github.com/bpalermo/aether/common/log"
 	corev1 "k8s.io/api/core/v1"
@@ -95,11 +97,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	var tcpServices []CaptureTCPService
 	for i := range list.Items {
 		s := &list.Items[i]
-		svc := s.Annotations[constants.AnnotationMeshService]
-		if svc == "" {
-			svc = s.Name
+		name := s.Annotations[constants.AnnotationMeshService]
+		if name == "" {
+			name = s.Name
 		}
-		authorities[svc] = fmt.Sprintf("%s.%s.svc.cluster.local", s.Name, s.Namespace)
+		// 020 Part 1: the service key is namespace-qualified "<ns>/<svc>"; the mesh
+		// Service lives in <ns> with the bare ServiceAccount name.
+		svc := serviceref.New(s.Namespace, name).Key()
+		authorities[svc] = fmt.Sprintf("%s.%s.svc.cluster.local", name, s.Namespace)
 		ip := s.Spec.ClusterIP
 		// The mesh-Service ClusterIP is the A record for <svc>.<meshDomain>. Skip
 		// headless/unallocated Services (no routable VIP to answer with).

--- a/agent/internal/capture/reconciler_test.go
+++ b/agent/internal/capture/reconciler_test.go
@@ -92,7 +92,7 @@ func TestReconcile_ProjectsTCPServices(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, sink.tcpServices, 1, "only the non-headless TCP service should produce a TCP floor entry")
-	assert.Equal(t, "svc-tcp", sink.tcpServices[0].ServiceName)
+	assert.Equal(t, "aether-test/svc-tcp", sink.tcpServices[0].ServiceName)
 	assert.Equal(t, "10.96.0.99", sink.tcpServices[0].ClusterIP)
 }
 
@@ -114,6 +114,6 @@ func TestReconcile_ProjectsAuthoritiesAndDNSRecords(t *testing.T) {
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})
 	require.NoError(t, err)
-	assert.Equal(t, map[string]string{"svc-1": "svc-1.aether-test.svc.cluster.local"}, sink.got)
-	assert.Equal(t, map[string]string{"svc-1": "10.96.0.42"}, sink.records, "ClusterIP -> the <svc>.<meshDomain> A record")
+	assert.Equal(t, map[string]string{"aether-test/svc-1": "svc-1.aether-test.svc.cluster.local"}, sink.got)
+	assert.Equal(t, map[string]string{"aether-test/svc-1": "10.96.0.42"}, sink.records, "ClusterIP -> the <svc>.<meshDomain> A record")
 }

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -166,7 +166,7 @@ func TestSweepRegistersMissingEndpoint(t *testing.T) {
 
 	s.sweepGhostEndpoints(ctx)
 
-	ep, ok := reg.registered["default/10.0.0.1"]
+	ep, ok := reg.registered["default/default/10.0.0.1"]
 	require.True(t, ok, "missing endpoint must be re-registered (service from SA, ip from pod)")
 	assert.Equal(t, registryv1.ServiceEndpoint_HEALTH_UNHEALTHY, ep.GetHealth(), "EDS-mode re-registration starts UNHEALTHY pending promotion")
 
@@ -282,6 +282,6 @@ func TestSweepPrefersAuthoritativeListing(t *testing.T) {
 
 	s.sweepGhostEndpoints(ctx)
 
-	_, ok := reg.registered["default/10.0.0.1"]
+	_, ok := reg.registered["default/default/10.0.0.1"]
 	require.True(t, ok, "sweep must re-register from the authoritative (empty) listing, not the stale cache")
 }

--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//api/aether/config/v1:config",
         "//common/constants",
         "//common/log",
+        "//common/serviceref",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	"github.com/bpalermo/aether/agent/internal/edge/secret"
 	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
@@ -783,8 +785,13 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 // backend is admitted) to preserve prior behavior for callers that don't wire up
 // those dependencies (e.g. unit tests that focus on other behavior).
 func (r *Reconciler) backendExists(ctx context.Context, name, namespace string) bool {
-	// Registry check first: mesh services are namespace-blind (bare name).
-	if r.Sink != nil && r.Sink.HasRegistryService(name) {
+	// Registry check first: the catalog is keyed by the namespace-qualified
+	// "<ns>/<svc>" key (020 Part 1).
+	regName := name
+	if namespace != "" {
+		regName = serviceref.New(namespace, name).Key()
+	}
+	if r.Sink != nil && r.Sink.HasRegistryService(regName) {
 		return true
 	}
 	// Fall back to k8s Service existence check.

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -1305,7 +1305,7 @@ func TestBuildHTTPRouteBackends_RegistryService_Admitted(t *testing.T) {
 	// Client has no Services — "echo" does not exist as a k8s Service.
 	c := fake.NewClientBuilder().WithScheme(statusScheme(t)).Build()
 	// Sink reports "echo" as a registry/mesh service.
-	sink := &fakeSink{hasRegistryService: func(name string) bool { return name == "echo" }}
+	sink := &fakeSink{hasRegistryService: func(name string) bool { return name == "aether-ingress/echo" }}
 	r := &Reconciler{Client: c, Sink: sink}
 
 	got := r.buildHTTPRouteBackends(

--- a/agent/internal/edge/gatewayapi/status_test.go
+++ b/agent/internal/edge/gatewayapi/status_test.go
@@ -240,7 +240,7 @@ func TestReconcile_RegistryOnlyBackend_ResolvedRefs(t *testing.T) {
 		WithStatusSubresource(&gatewayv1.GatewayClass{}, &gatewayv1.Gateway{}, &gatewayv1.HTTPRoute{}).
 		Build()
 	// Sink reports "echo" as a mesh/registry service.
-	sink := statusFakeSinkWithRegistry{registryServices: map[string]bool{"echo": true}}
+	sink := statusFakeSinkWithRegistry{registryServices: map[string]bool{"ns/echo": true}}
 	r := &Reconciler{Client: c, APIReader: c, Sink: sink, Namespace: "ns", GatewayClassName: "aether", MeshDomain: "mesh", Log: slog.Default()}
 
 	_, err := r.Reconcile(context.Background(), reconcile.Request{})

--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//agent/internal/referencegrant",
         "//agent/internal/xds/proxy",
         "//common/log",
+        "//common/serviceref",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
 	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -86,7 +88,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	routes := map[string][]proxy.GammaRoute{}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
-		for _, svc := range serviceParents(hr.Spec.ParentRefs) {
+		for _, svc := range serviceParents(hr.Spec.ParentRefs, hr.Namespace) {
 			for _, rule := range hr.Spec.Rules {
 				routes[svc] = append(routes[svc], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants))
 			}
@@ -94,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 	for i := range grpcList.Items {
 		gr := &grpcList.Items[i]
-		for _, svc := range serviceParents(gr.Spec.ParentRefs) {
+		for _, svc := range serviceParents(gr.Spec.ParentRefs, gr.Namespace) {
 			for _, rule := range gr.Spec.Rules {
 				routes[svc] = append(routes[svc], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants))
 			}
@@ -242,7 +244,10 @@ func grpcBackendRefs(rules []gatewayv1.GRPCRouteRule) []gatewayv1.BackendObjectR
 
 // serviceParents returns the names of the Services these parentRefs attach to
 // (kind=Service, core group). Shared by HTTPRoute and GRPCRoute.
-func serviceParents(refs []gatewayv1.ParentReference) []string {
+// serviceParents returns the namespace-qualified "<ns>/<svc>" keys of the Service
+// parentRefs (020 Part 1). A parentRef without an explicit namespace inherits the
+// route's namespace (Gateway API default).
+func serviceParents(refs []gatewayv1.ParentReference, routeNamespace string) []string {
 	var svcs []string
 	for _, p := range refs {
 		if p.Group != nil && string(*p.Group) != "" {
@@ -251,7 +256,11 @@ func serviceParents(refs []gatewayv1.ParentReference) []string {
 		if p.Kind == nil || string(*p.Kind) != "Service" {
 			continue
 		}
-		svcs = append(svcs, string(p.Name))
+		ns := routeNamespace
+		if p.Namespace != nil && string(*p.Namespace) != "" {
+			ns = string(*p.Namespace)
+		}
+		svcs = append(svcs, serviceref.New(ns, string(p.Name)).Key())
 	}
 	return svcs
 }

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -189,7 +189,9 @@ func TestServiceParents(t *testing.T) {
 			{Name: "no-kind"}, // no kind → ignored
 		},
 	}}}
-	assert.Equal(t, []string{"svc-1"}, serviceParents(hr.Spec.ParentRefs))
+	// 020 Part 1: parentRef without a namespace inherits the route's namespace,
+	// and the key is "<ns>/<svc>".
+	assert.Equal(t, []string{"team-a/svc-1"}, serviceParents(hr.Spec.ParentRefs, "team-a"))
 }
 
 // TestBuildGammaRoute: matches → GammaMatch, weighted backendRefs → GammaBackend

--- a/agent/internal/meshdns/BUILD.bazel
+++ b/agent/internal/meshdns/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//agent:__subpackages__"],
     deps = [
         "//common/log",
+        "//common/serviceref",
         "@com_github_miekg_dns//:dns",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel//attribute",

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	commonlog "github.com/bpalermo/aether/common/log"
 	"github.com/miekg/dns"
 )
@@ -116,19 +118,21 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	s.forward(w, r)
 }
 
-// lookup maps <svc>.<meshDomain> -> its A-record IP, or "" if not a known mesh name.
+// lookup maps <svc>.<ns>.<meshDomain> -> its A-record IP, or "" if not a known
+// mesh name (proposal 020 Part 1; records are keyed by the "<ns>/<svc>" key).
 func (s *Server) lookup(qname string) string {
 	name := strings.TrimSuffix(strings.ToLower(qname), ".")
 	suffix := "." + s.meshDomain
 	if !strings.HasSuffix(name, suffix) {
 		return ""
 	}
-	svc := strings.TrimSuffix(name, suffix)
-	if svc == "" || strings.Contains(svc, ".") {
+	// "<svc>.<ns>" — exactly two labels (service name, then namespace).
+	svc, ns, found := strings.Cut(strings.TrimSuffix(name, suffix), ".")
+	if !found || svc == "" || ns == "" || strings.Contains(ns, ".") {
 		return ""
 	}
 	s.mu.RLock()
-	ip := s.records[svc]
+	ip := s.records[serviceref.New(ns, svc).Key()]
 	s.mu.RUnlock()
 	return ip
 }

--- a/agent/internal/meshdns/server_test.go
+++ b/agent/internal/meshdns/server_test.go
@@ -9,17 +9,19 @@ import (
 
 func TestLookup(t *testing.T) {
 	s := NewServer("aether.internal", "127.0.0.1:18054", slog.New(slog.DiscardHandler))
-	s.SetRecords(map[string]string{"svc-1": "10.111.0.5", "echo": "10.111.0.6"})
+	// 020 Part 1: records keyed by "<ns>/<svc>".
+	s.SetRecords(map[string]string{"team-a/svc-1": "10.111.0.5", "default/echo": "10.111.0.6"})
 
-	// <svc>.<meshDomain> -> its record; case-insensitive; trailing dot tolerated.
-	assert.Equal(t, "10.111.0.5", s.lookup("svc-1.aether.internal."))
-	assert.Equal(t, "10.111.0.5", s.lookup("SVC-1.AETHER.INTERNAL"))
-	assert.Equal(t, "10.111.0.6", s.lookup("echo.aether.internal."))
+	// <svc>.<ns>.<meshDomain> -> its record; case-insensitive; trailing dot tolerated.
+	assert.Equal(t, "10.111.0.5", s.lookup("svc-1.team-a.aether.internal."))
+	assert.Equal(t, "10.111.0.5", s.lookup("SVC-1.TEAM-A.AETHER.INTERNAL"))
+	assert.Equal(t, "10.111.0.6", s.lookup("echo.default.aether.internal."))
 
 	// not answered -> forwarded (lookup returns ""):
 	assert.Empty(t, s.lookup("svc-1.aether-test.svc.cluster.local."), "cluster.local is not a mesh name")
-	assert.Empty(t, s.lookup("unknown.aether.internal."), "not in the record table")
-	assert.Empty(t, s.lookup("a.b.aether.internal."), "nested label under the mesh domain")
+	assert.Empty(t, s.lookup("unknown.team-a.aether.internal."), "not in the record table")
+	assert.Empty(t, s.lookup("svc-1.aether.internal."), "single label (no namespace) is not a mesh name now")
+	assert.Empty(t, s.lookup("a.b.c.aether.internal."), "three labels under the mesh domain")
 	assert.Empty(t, s.lookup("aether.internal."), "the bare mesh domain")
 	assert.Empty(t, s.lookup("google.com."), "external name")
 }

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//api/aether/registry/v1:registry",
         "//common/constants",
         "//common/log",
+        "//common/serviceref",
         "//common/telemetry",
         "//registry",
         "@com_github_envoyproxy_go_control_plane//pkg/cache/types",

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -5,6 +5,8 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
@@ -564,19 +566,24 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 // Caller must hold clusterMu.
 func (c *SnapshotCache) edgeClusterNameLocked(service, backendNamespace string, port uint32) string {
 	// Check whether the service is mesh-registered (in the registry cluster map).
-	// The registry keys services by bare name (and by per-port name), so check both
-	// the bare name and the per-port name.
-	meshFQDN := proxy.ServiceClusterName(service, c.meshDomain)
-	if _, ok := c.clusters[service]; ok {
+	// The registry keys services by the namespace-qualified "<ns>/<svc>" key (020
+	// Part 1); the mesh cluster map and ServiceClusterName/PortClusterName all use
+	// that key. The non-mesh k8s fallback below still uses the bare name + namespace.
+	key := service
+	if backendNamespace != "" {
+		key = serviceref.New(backendNamespace, service).Key()
+	}
+	meshFQDN := proxy.ServiceClusterName(key, c.meshDomain)
+	if _, ok := c.clusters[key]; ok {
 		// Mesh path: service is in the registry.
 		if port == 0 {
 			return meshFQDN
 		}
-		portName := proxy.PortClusterName(service, c.meshDomain, port)
+		portName := proxy.PortClusterName(key, c.meshDomain, port)
 		if _, ok := c.clusters[portName]; ok {
 			return portName
 		}
-		if entry, ok := c.clusters[service]; ok && entry.sni == strconv.Itoa(int(port)) {
+		if entry, ok := c.clusters[key]; ok && entry.sni == strconv.Itoa(int(port)) {
 			return meshFQDN
 		}
 		return portName
@@ -587,14 +594,14 @@ func (c *SnapshotCache) edgeClusterNameLocked(service, backendNamespace string, 
 		if port == 0 {
 			return meshFQDN
 		}
-		portName := proxy.PortClusterName(service, c.meshDomain, port)
+		portName := proxy.PortClusterName(key, c.meshDomain, port)
 		if _, ok := c.clusters[portName]; ok {
 			return portName
 		}
 		return portName
 	}
 	if port != 0 {
-		portName := proxy.PortClusterName(service, c.meshDomain, port)
+		portName := proxy.PortClusterName(key, c.meshDomain, port)
 		if _, ok := c.clusters[portName]; ok {
 			return portName
 		}
@@ -664,25 +671,28 @@ func (c *SnapshotCache) rebuildEdgeDependencies() {
 		// A hostname-less route is NOT inert: per Gateway API it matches every host
 		// on its listener (the edge serves it via the catch-all "*" vhost), so its
 		// backend services must be scoped in (their clusters loaded) too.
+		// The dependency set is matched against the registry's namespace-qualified
+		// "<ns>/<svc>" keys (020 Part 1), so scope in the key, not the bare name.
+		addDep := func(svc, ns string) {
+			if svc == "" {
+				return
+			}
+			key := svc
+			if ns != "" {
+				key = serviceref.New(ns, svc).Key()
+			}
+			if _, ok := seen[key]; !ok {
+				seen[key] = struct{}{}
+				services = append(services, key)
+			}
+		}
 		for _, r := range v.Routes {
 			// Collect from Backends (weighted multi-backend).
 			for _, b := range r.Backends {
-				if b.Service == "" {
-					continue
-				}
-				if _, ok := seen[b.Service]; !ok {
-					seen[b.Service] = struct{}{}
-					services = append(services, b.Service)
-				}
+				addDep(b.Service, b.BackendNamespace)
 			}
 			// Legacy single-backend field (also populated for single-backend routes).
-			if r.Service == "" {
-				continue
-			}
-			if _, ok := seen[r.Service]; !ok {
-				seen[r.Service] = struct{}{}
-				services = append(services, r.Service)
-			}
+			addDep(r.Service, r.BackendNamespace)
 		}
 	}
 
@@ -827,15 +837,20 @@ func (c *SnapshotCache) edgeK8sBackendClusters() []types.Resource {
 	var out []types.Resource
 	for _, bk := range backends {
 		// Only emit a cleartext cluster if the service is NOT a registry cluster.
-		// If it IS in the registry, the mesh mTLS cluster covers it.
-		if _, ok := c.clusters[bk.service]; ok {
+		// If it IS in the registry, the mesh mTLS cluster covers it. The registry
+		// keys clusters by the namespace-qualified "<ns>/<svc>" key (020 Part 1).
+		key := bk.service
+		if bk.namespace != "" {
+			key = serviceref.New(bk.namespace, bk.service).Key()
+		}
+		if _, ok := c.clusters[key]; ok {
 			continue
 		}
-		meshFQDN := proxy.ServiceClusterName(bk.service, c.meshDomain)
+		meshFQDN := proxy.ServiceClusterName(key, c.meshDomain)
 		if _, ok := c.clusters[meshFQDN]; ok {
 			continue
 		}
-		portName := proxy.PortClusterName(bk.service, c.meshDomain, bk.port)
+		portName := proxy.PortClusterName(key, c.meshDomain, bk.port)
 		if _, ok := c.clusters[portName]; ok {
 			continue
 		}

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -679,7 +679,7 @@ func TestVirtualHostVhosts_WeightedSplit(t *testing.T) {
 
 	// Register svc-a in the mesh registry; svc-b is a plain k8s Service (non-mesh).
 	c.clusterMu.Lock()
-	c.clusters["svc-a"] = clusterEntry{service: "svc-a"}
+	c.clusters["default/svc-a"] = clusterEntry{service: "default/svc-a"}
 	c.clusterMu.Unlock()
 
 	c.SetVirtualHosts([]VirtualHost{
@@ -714,7 +714,7 @@ func TestVirtualHostVhosts_WeightedSplit(t *testing.T) {
 
 	require.Len(t, wc.GetClusters(), 2)
 	// First backend: svc-a is in the registry → mesh default cluster.
-	assert.Equal(t, "svc-a.aether.internal", wc.GetClusters()[0].GetName())
+	assert.Equal(t, "svc-a.default.aether.internal", wc.GetClusters()[0].GetName())
 	assert.Equal(t, uint32(3), wc.GetClusters()[0].GetWeight().GetValue())
 	// Second backend: svc-b is NOT in the registry → edge_k8s cleartext cluster.
 	assert.Equal(t, "edge_k8s_conformance-ns_svc-b_9090", wc.GetClusters()[1].GetName())
@@ -727,7 +727,7 @@ func TestVirtualHostVhosts_SingleBackendNoWeightedClusters(t *testing.T) {
 	c := newTestCache("edge-1")
 	// Register svc-1 in mesh (default port path — no explicit per-port cluster needed).
 	c.clusterMu.Lock()
-	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
+	c.clusters["default/svc-1"] = clusterEntry{service: "default/svc-1"}
 	c.clusterMu.Unlock()
 
 	c.SetVirtualHosts([]VirtualHost{
@@ -736,7 +736,7 @@ func TestVirtualHostVhosts_SingleBackendNoWeightedClusters(t *testing.T) {
 			Routes: []Route{{
 				Prefix: "/",
 				Backends: []RouteBackend{
-					// Port 0 → default mesh cluster (svc-1.aether.internal).
+					// Port 0 → default mesh cluster (svc-1.default.aether.internal).
 					{Service: "svc-1", BackendNamespace: "default", Port: 0, Weight: 1},
 				},
 				Service:          "svc-1",
@@ -753,7 +753,7 @@ func TestVirtualHostVhosts_SingleBackendNoWeightedClusters(t *testing.T) {
 
 	ra := routes[0].GetRoute()
 	require.NotNil(t, ra)
-	assert.Equal(t, "svc-1.aether.internal", ra.GetCluster(), "single backend must use plain cluster")
+	assert.Equal(t, "svc-1.default.aether.internal", ra.GetCluster(), "single backend must use plain cluster")
 	assert.Nil(t, ra.GetWeightedClusters(), "single backend must NOT use weighted_clusters")
 }
 
@@ -766,7 +766,7 @@ func TestEdgeK8sBackendClusters_WeightedBackends(t *testing.T) {
 
 	// mesh-svc in registry; plain-svc-a and plain-svc-b are non-mesh.
 	c.clusterMu.Lock()
-	c.clusters["mesh-svc"] = clusterEntry{service: "mesh-svc"}
+	c.clusters["default/mesh-svc"] = clusterEntry{service: "default/mesh-svc"}
 	c.clusterMu.Unlock()
 
 	c.SetVirtualHosts([]VirtualHost{
@@ -810,7 +810,7 @@ func TestEdgeClusterNameLocked_MeshVsNonMesh(t *testing.T) {
 
 	// Register "mesh-svc" as a registry service.
 	c.clusterMu.Lock()
-	c.clusters["mesh-svc"] = clusterEntry{service: "mesh-svc"}
+	c.clusters["default/mesh-svc"] = clusterEntry{service: "default/mesh-svc"}
 	c.clusterMu.Unlock()
 
 	c.clusterMu.RLock()
@@ -818,7 +818,7 @@ func TestEdgeClusterNameLocked_MeshVsNonMesh(t *testing.T) {
 
 	// Mesh path: service in registry → mesh FQDN.
 	name := c.edgeClusterNameLocked("mesh-svc", "default", 0)
-	assert.Equal(t, "mesh-svc.aether.internal", name, "registry service resolves to mesh cluster")
+	assert.Equal(t, "mesh-svc.default.aether.internal", name, "registry service resolves to mesh cluster")
 
 	// Non-mesh path: service NOT in registry → edge_k8s_… cleartext name.
 	name2 := c.edgeClusterNameLocked("plain-svc", "conformance-ns", 8080)
@@ -838,7 +838,7 @@ func TestEdgeK8sBackendClusters_NonMeshOnly(t *testing.T) {
 
 	// Register "mesh-svc" as a registry service; "plain-svc" is NOT registered.
 	c.clusterMu.Lock()
-	c.clusters["mesh-svc"] = clusterEntry{service: "mesh-svc"}
+	c.clusters["default/mesh-svc"] = clusterEntry{service: "default/mesh-svc"}
 	c.clusterMu.Unlock()
 
 	c.SetVirtualHosts([]VirtualHost{

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//api/aether/cni/v1:cni",
         "//api/aether/registry/v1:registry",
         "//common/constants",
+        "//common/serviceref",
         "@com_github_cncf_xds_go//xds/core/v3:core",
         "@com_github_cncf_xds_go//xds/type/matcher/v3:matcher",
         "@com_github_cncf_xds_go//xds/type/v3:type",

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/serviceref"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -20,12 +21,17 @@ import (
 )
 
 // ServiceClusterName returns the data-plane name of a service's outbound
-// cluster: <service>.<meshDomain>. Authorities are FQDN-only, and the cluster
-// name equals the authority so the warm path (service vhost) and the cold
-// path (catch-all cluster_header: ":authority" + ODCDS) resolve the same
-// resource deterministically. The bare service name remains the
-// control-plane key (registry, watch filter, dependency set, EDS, stats).
+// cluster: <svc>.<ns>.<meshDomain> (proposal 020 Part 1). The control-plane key
+// (registry, watch filter, dependency set, EDS, stats) is the namespace-qualified
+// "<ns>/<svc>" serviceref key; this renders it as the FQDN authority, so the warm
+// path (service vhost) and the cold path (catch-all cluster_header: ":authority"
+// + ODCDS) resolve the same resource deterministically.
 func ServiceClusterName(serviceName, meshDomain string) string {
+	if ref, ok := serviceref.ParseKey(serviceName); ok {
+		return ref.FQDN(meshDomain)
+	}
+	// Defensive: a non-namespaced key must not occur post-cutover; render it flat
+	// rather than panic so a stray legacy key degrades instead of crashing.
 	return serviceName + "." + meshDomain
 }
 

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -61,12 +61,13 @@ func UDPClusterName(serviceName, meshDomain string) string {
 }
 
 // ServiceFromClusterName maps a data-plane cluster name (a mesh authority,
-// <service>.<meshDomain>) back to the bare service name. ok is false when the
-// name is not under the mesh domain or the remainder is not a single DNS
-// label (service names are ServiceAccount names — single lowercase labels),
-// so nested or foreign authorities are rejected deterministically.
+// <svc>.<ns>.<meshDomain>) back to the namespace-qualified "<ns>/<svc>" service
+// key (proposal 020 Part 1). ok is false when the name is not under the mesh
+// domain or the remainder is not exactly two DNS labels (<svc>.<ns> — service
+// names are ServiceAccount names and namespaces are both single lowercase
+// labels), so nested or foreign authorities are rejected deterministically.
 func ServiceFromClusterName(clusterName, meshDomain string) (string, bool) {
-	// Strip an optional :port (multi-port authority <svc>.<domain>:<port>).
+	// Strip an optional :port (multi-port authority <svc>.<ns>.<domain>:<port>).
 	name := clusterName
 	if i := strings.LastIndexByte(name, ':'); i >= 0 {
 		if _, err := strconv.Atoi(name[i+1:]); err == nil {
@@ -77,11 +78,12 @@ func ServiceFromClusterName(clusterName, meshDomain string) (string, bool) {
 	if !strings.HasSuffix(name, suffix) {
 		return "", false
 	}
-	service := strings.TrimSuffix(name, suffix)
-	if service == "" || strings.Contains(service, ".") {
+	// "<svc>.<ns>" — exactly two labels (service name, then namespace).
+	svc, ns, found := strings.Cut(strings.TrimSuffix(name, suffix), ".")
+	if !found || svc == "" || ns == "" || strings.Contains(ns, ".") {
 		return "", false
 	}
-	return service, true
+	return serviceref.New(ns, svc).Key(), true
 }
 
 // NewServiceCluster builds the outbound service cluster, named

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -175,9 +175,9 @@ func TestServiceClusterDrainPoolClose(t *testing.T) {
 		"drain-time reset bursts must not be sacrificed to the retry breaker")
 }
 
-// TestServiceFromClusterName pins the deterministic authority<->service
-// bijection: only single-label names directly under the mesh domain map back
-// to a service.
+// TestServiceFromClusterName pins the deterministic authority<->service-key
+// bijection (020 Part 1): a two-label <svc>.<ns> directly under the mesh domain
+// maps back to the "<ns>/<svc>" key.
 func TestServiceFromClusterName(t *testing.T) {
 	tests := []struct {
 		name string
@@ -185,11 +185,13 @@ func TestServiceFromClusterName(t *testing.T) {
 		want string
 		ok   bool
 	}{
-		{name: "mesh authority", in: "payments.aether.internal", want: "payments", ok: true},
+		{name: "mesh authority", in: "payments.team-a.aether.internal", want: "team-a/payments", ok: true},
+		{name: "default namespace", in: "echo.default.aether.internal", want: "default/echo", ok: true},
 		{name: "bare name rejected", in: "payments", ok: false},
-		{name: "nested label rejected", in: "a.b.aether.internal", ok: false},
-		{name: "empty service rejected", in: ".aether.internal", ok: false},
-		{name: "foreign domain rejected", in: "payments.example.com", ok: false},
+		{name: "single label (no ns) rejected", in: "payments.aether.internal", ok: false},
+		{name: "three labels rejected", in: "a.b.c.aether.internal", ok: false},
+		{name: "empty service rejected", in: ".team-a.aether.internal", ok: false},
+		{name: "foreign domain rejected", in: "payments.team-a.example.com", ok: false},
 		{name: "domain itself rejected", in: "aether.internal", ok: false},
 	}
 	for _, tt := range tests {

--- a/agent/internal/xds/server/odcds_test.go
+++ b/agent/internal/xds/server/odcds_test.go
@@ -25,15 +25,15 @@ func TestOnDemandObserver_RecordsNamedCDSSubscriptions(t *testing.T) {
 	// data-plane cluster name and the control-plane keys).
 	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
 		TypeUrl:                resourcev3.ClusterType,
-		ResourceNamesSubscribe: []string{"svc-on-demand.aether.internal"},
+		ResourceNamesSubscribe: []string{"svc-on-demand.team-a.aether.internal"},
 	}))
-	assert.Contains(t, c.DependencySet(), "svc-on-demand")
+	assert.Contains(t, c.DependencySet(), "team-a/svc-on-demand")
 
 	// Wildcard, per-pod names, names outside the mesh domain, and nested
 	// labels under it: all ignored.
 	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
 		TypeUrl:                resourcev3.ClusterType,
-		ResourceNamesSubscribe: []string{"*", "", "app_pod-1", "health_pod-1", "svc-bare", "a.b.aether.internal", ".aether.internal"},
+		ResourceNamesSubscribe: []string{"*", "", "app_pod-1", "health_pod-1", "svc-bare", "a.b.c.aether.internal", ".aether.internal"},
 	}))
 	deps := c.DependencySet()
 	assert.Len(t, deps, 1, "only the mesh-authority subscription is observed")
@@ -57,10 +57,10 @@ func TestCombinedCallbacks_Dispatch(t *testing.T) {
 
 	require.NoError(t, combined.OnStreamDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
 		TypeUrl:                resourcev3.ClusterType,
-		ResourceNamesSubscribe: []string{"svc-x.aether.internal"},
+		ResourceNamesSubscribe: []string{"svc-x.team-a.aether.internal"},
 	}))
-	assert.Contains(t, c1.DependencySet(), "svc-x")
-	assert.Contains(t, c2.DependencySet(), "svc-x")
+	assert.Contains(t, c1.DependencySet(), "team-a/svc-x")
+	assert.Contains(t, c2.DependencySet(), "team-a/svc-x")
 
 	// Unwired hooks are nil-safe.
 	require.NoError(t, combined.OnStreamOpen(context.Background(), 1, resourcev3.ClusterType))
@@ -79,14 +79,14 @@ func (c *catalogRegistry) HasService(name string) bool { return c.known[name] }
 // before touching the dependency set, while known services are observed.
 func TestOnDemandObserver_CatalogGate(t *testing.T) {
 	c := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
-	reg := &catalogRegistry{mockRegistry: &mockRegistry{}, known: map[string]bool{"svc-real": true}}
+	reg := &catalogRegistry{mockRegistry: &mockRegistry{}, known: map[string]bool{"team-a/svc-real": true}}
 	o := newOnDemandObserver(c, reg, slog.New(slog.DiscardHandler))
 
 	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
 		TypeUrl:                resourcev3.ClusterType,
-		ResourceNamesSubscribe: []string{"svc-real.aether.internal", "svc-ghost.aether.internal"},
+		ResourceNamesSubscribe: []string{"svc-real.team-a.aether.internal", "svc-ghost.team-a.aether.internal"},
 	}))
 	deps := c.DependencySet()
-	assert.Contains(t, deps, "svc-real", "catalog hit is observed")
-	assert.NotContains(t, deps, "svc-ghost", "catalog miss never pollutes the dependency set")
+	assert.Contains(t, deps, "team-a/svc-real", "catalog hit is observed")
+	assert.NotContains(t, deps, "team-a/svc-ghost", "catalog miss never pollutes the dependency set")
 }

--- a/common/serviceref/BUILD.bazel
+++ b/common/serviceref/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "serviceref",
+    srcs = ["serviceref.go"],
+    importpath = "github.com/bpalermo/aether/common/serviceref",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "serviceref_test",
+    srcs = ["serviceref_test.go"],
+    embed = [":serviceref"],
+)

--- a/common/serviceref/serviceref.go
+++ b/common/serviceref/serviceref.go
@@ -1,0 +1,71 @@
+// Package serviceref defines the namespace-qualified identity of a mesh service
+// (proposal 020 Part 1). A mesh service is identified by the pair
+// (namespace, name) — where name is the workload's ServiceAccount — and this
+// package is the single source of truth for how that identity is rendered as:
+//
+//   - a registry / map KEY:   "<namespace>/<name>"        (Key)
+//   - the mesh FQDN:          "<name>.<namespace>.<meshDomain>"   (FQDN)
+//   - the standard k8s FQDN:  "<name>.<namespace>.svc.cluster.local" (ClusterLocalFQDN)
+//
+// Centralizing these formats here keeps the namespace from being re-derived from
+// a union or smuggled through bare strings — the exact trap proposal 020 calls
+// out. It is a leaf package (no aether imports) so the registry, agent, CNI, and
+// registrar can all share it without import cycles.
+package serviceref
+
+import "strings"
+
+// ServiceRef is the namespace-qualified identity of a mesh service. Name is the
+// workload's ServiceAccount (aether's identity unit); Namespace is the
+// Kubernetes namespace the workload runs in.
+type ServiceRef struct {
+	Namespace string
+	Name      string
+}
+
+// New returns a ServiceRef for the given namespace and name (ServiceAccount).
+func New(namespace, name string) ServiceRef {
+	return ServiceRef{Namespace: namespace, Name: name}
+}
+
+// Key returns the registry / map key "<namespace>/<name>". This is the
+// namespace-qualified key that replaces the old namespace-free ServiceAccount
+// key (proposal 020 Part 1, hard cutover).
+func (r ServiceRef) Key() string {
+	return r.Namespace + "/" + r.Name
+}
+
+// FQDN returns the mesh fully-qualified name "<name>.<namespace>.<meshDomain>" —
+// the cluster name / SNI / route-target authority the proxy uses mesh-internally.
+func (r ServiceRef) FQDN(meshDomain string) string {
+	return r.Name + "." + r.Namespace + "." + meshDomain
+}
+
+// ClusterLocalFQDN returns the standard Kubernetes name
+// "<name>.<namespace>.svc.cluster.local", which the transparent-capture path
+// also honors so apps reaching a mesh service by its ordinary k8s DNS name are
+// captured (proposal 020 Part 1).
+func (r ServiceRef) ClusterLocalFQDN() string {
+	return r.Name + "." + r.Namespace + ".svc.cluster.local"
+}
+
+// String returns the Key form, so a ServiceRef formats sensibly in logs.
+func (r ServiceRef) String() string {
+	return r.Key()
+}
+
+// ParseKey parses a "<namespace>/<name>" key back into a ServiceRef. ok is false
+// when s is not a well-formed key (missing or empty namespace/name) — callers
+// must treat a malformed key as a hard error, never as a namespace-free name.
+func ParseKey(s string) (ref ServiceRef, ok bool) {
+	ns, name, found := strings.Cut(s, "/")
+	if !found || ns == "" || name == "" {
+		return ServiceRef{}, false
+	}
+	// A second "/" would mean an ambiguous key (namespaces and SA names are DNS
+	// labels and contain no "/"), so reject it rather than silently mis-split.
+	if strings.Contains(name, "/") {
+		return ServiceRef{}, false
+	}
+	return ServiceRef{Namespace: ns, Name: name}, true
+}

--- a/common/serviceref/serviceref_test.go
+++ b/common/serviceref/serviceref_test.go
@@ -26,11 +26,11 @@ func TestParseKey(t *testing.T) {
 	}{
 		{"team-a/echo", ServiceRef{Namespace: "team-a", Name: "echo"}, true},
 		{"default/svc-1", ServiceRef{Namespace: "default", Name: "svc-1"}, true},
-		{"echo", ServiceRef{}, false},       // namespace-free (the old key) must NOT parse
-		{"/echo", ServiceRef{}, false},      // empty namespace
-		{"team-a/", ServiceRef{}, false},    // empty name
-		{"", ServiceRef{}, false},           // empty
-		{"a/b/c", ServiceRef{}, false},      // ambiguous extra "/"
+		{"echo", ServiceRef{}, false},    // namespace-free (the old key) must NOT parse
+		{"/echo", ServiceRef{}, false},   // empty namespace
+		{"team-a/", ServiceRef{}, false}, // empty name
+		{"", ServiceRef{}, false},        // empty
+		{"a/b/c", ServiceRef{}, false},   // ambiguous extra "/"
 	}
 	for _, tt := range tests {
 		gotRef, gotOK := ParseKey(tt.in)

--- a/common/serviceref/serviceref_test.go
+++ b/common/serviceref/serviceref_test.go
@@ -1,0 +1,51 @@
+package serviceref
+
+import "testing"
+
+func TestServiceRefFormats(t *testing.T) {
+	r := New("team-a", "echo")
+	if got := r.Key(); got != "team-a/echo" {
+		t.Errorf("Key() = %q, want team-a/echo", got)
+	}
+	if got := r.FQDN("aether.internal"); got != "echo.team-a.aether.internal" {
+		t.Errorf("FQDN() = %q, want echo.team-a.aether.internal", got)
+	}
+	if got := r.ClusterLocalFQDN(); got != "echo.team-a.svc.cluster.local" {
+		t.Errorf("ClusterLocalFQDN() = %q, want echo.team-a.svc.cluster.local", got)
+	}
+	if got := r.String(); got != "team-a/echo" {
+		t.Errorf("String() = %q, want team-a/echo", got)
+	}
+}
+
+func TestParseKey(t *testing.T) {
+	tests := []struct {
+		in      string
+		wantRef ServiceRef
+		wantOK  bool
+	}{
+		{"team-a/echo", ServiceRef{Namespace: "team-a", Name: "echo"}, true},
+		{"default/svc-1", ServiceRef{Namespace: "default", Name: "svc-1"}, true},
+		{"echo", ServiceRef{}, false},       // namespace-free (the old key) must NOT parse
+		{"/echo", ServiceRef{}, false},      // empty namespace
+		{"team-a/", ServiceRef{}, false},    // empty name
+		{"", ServiceRef{}, false},           // empty
+		{"a/b/c", ServiceRef{}, false},      // ambiguous extra "/"
+	}
+	for _, tt := range tests {
+		gotRef, gotOK := ParseKey(tt.in)
+		if gotOK != tt.wantOK || gotRef != tt.wantRef {
+			t.Errorf("ParseKey(%q) = (%+v, %v), want (%+v, %v)", tt.in, gotRef, gotOK, tt.wantRef, tt.wantOK)
+		}
+	}
+}
+
+// TestRoundTrip: Key() and ParseKey are inverses for valid refs.
+func TestRoundTrip(t *testing.T) {
+	for _, r := range []ServiceRef{New("default", "echo"), New("team-a", "svc-1")} {
+		got, ok := ParseKey(r.Key())
+		if !ok || got != r {
+			t.Errorf("round-trip %+v -> %q -> (%+v, %v)", r, r.Key(), got, ok)
+		}
+	}
+}

--- a/registrar/internal/services/BUILD.bazel
+++ b/registrar/internal/services/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//api/aether/registry/v1:registry",
         "//common/constants",
         "//common/log",
+        "//common/serviceref",
         "//registrar/internal/server",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
@@ -25,6 +26,7 @@ go_test(
     deps = [
         "//api/aether/registry/v1:registry",
         "//common/constants",
+        "//common/serviceref",
         "//registrar/internal/server",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/registrar/internal/services/generator.go
+++ b/registrar/internal/services/generator.go
@@ -15,6 +15,7 @@ import (
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
 	commonlog "github.com/bpalermo/aether/common/log"
+	"github.com/bpalermo/aether/common/serviceref"
 	"github.com/bpalermo/aether/registrar/internal/server"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -79,19 +80,25 @@ func (g *Generator) reconcile(ctx context.Context) {
 	// deterministic if a name ever appeared under both.
 	for _, protocol := range []registryv1.Service_Protocol{registryv1.Service_PROTOCOL_HTTP, registryv1.Service_PROTOCOL_TCP} {
 		appProto := protocolAppProtocol[protocol]
-		for svc, eps := range g.Snapshot.GetAll(protocol) {
+		for svcKey, eps := range g.Snapshot.GetAll(protocol) {
+			// The registry key is namespace-qualified "<ns>/<svc>" (020 Part 1):
+			// the mesh VIP Service lives in <ns> with the bare ServiceAccount name.
+			ref, ok := serviceref.ParseKey(svcKey)
+			if !ok {
+				g.Log.WarnContext(ctx, "skipping malformed (non-namespaced) service key", "key", svcKey)
+				continue
+			}
 			ep := firstNamespaced(eps)
 			if ep == nil {
 				continue
 			}
-			ns := ep.GetKubernetesMetadata().GetNamespace()
-			key := client.ObjectKey{Namespace: ns, Name: svc}
+			key := client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
 			if _, exists := desired[key]; exists {
 				continue // already claimed by an earlier protocol; one Service per name
 			}
 			desired[key] = desiredService{
-				service:     svc,
-				namespace:   ns,
+				service:     ref.Name,
+				namespace:   ref.Namespace,
 				port:        ep.GetPort(),
 				appProtocol: appProto,
 			}

--- a/registrar/internal/services/generator_test.go
+++ b/registrar/internal/services/generator_test.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
 	"github.com/bpalermo/aether/registrar/internal/server"
@@ -21,7 +23,7 @@ import (
 func seed(svc, ns string, port uint32) *server.Snapshot {
 	s := server.NewSnapshot()
 	s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
-		svc: {registryv1.Service_PROTOCOL_HTTP: {{
+		serviceref.New(ns, svc).Key(): {registryv1.Service_PROTOCOL_HTTP: {{
 			Ip:                 "10.0.0.1",
 			Port:               port,
 			KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{Namespace: ns},
@@ -113,7 +115,7 @@ func TestGenerator_UpdatesStaleAppProtocol(t *testing.T) {
 func seedProtocol(svc, ns string, port uint32, protocol registryv1.Service_Protocol) *server.Snapshot {
 	s := server.NewSnapshot()
 	s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
-		svc: {protocol: {{
+		serviceref.New(ns, svc).Key(): {protocol: {{
 			Ip:                 "10.0.0.1",
 			Port:               port,
 			KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{Namespace: ns},

--- a/registry/BUILD.bazel
+++ b/registry/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//api/aether/cni/v1:cni",
         "//api/aether/registry/v1:registry",
         "//common/constants",
+        "//common/serviceref",
         "//registry/export",
         "//registry/internal/ddb",
         "//registry/internal/etcd",

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -9,6 +9,7 @@ import (
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
+	"github.com/bpalermo/aether/common/serviceref"
 )
 
 // NewServiceEndpointFromCNIPod creates a ServiceEndpoint from a CNIPod.
@@ -78,13 +79,22 @@ func ExtractCNIPodInformation(pod *cniv1.CNIPod) (string, []string, error) {
 	return serviceName, pod.GetIps(), nil
 }
 
-// getServiceName extracts the service name from the pod's service account.
+// getServiceName returns the namespace-qualified registry key for the pod's mesh
+// service: "<namespace>/<serviceAccount>" (proposal 020 Part 1). The identity
+// unit is still the ServiceAccount, but the key is now namespace-qualified so two
+// workloads sharing a ServiceAccount name across namespaces (e.g. "default") no
+// longer collapse into one service. serviceref is the single source of truth for
+// the key format.
 func getServiceName(cniPod *cniv1.CNIPod) (string, error) {
 	sa := cniPod.GetServiceAccount()
 	if sa == "" {
 		return "", fmt.Errorf("missing service account")
 	}
-	return sa, nil
+	ns := cniPod.GetNamespace()
+	if ns == "" {
+		return "", fmt.Errorf("missing namespace")
+	}
+	return serviceref.New(ns, sa).Key(), nil
 }
 
 // getProtocolFromAnnotations maps the endpoint.aether.io/protocol annotation to

--- a/registry/cni_test.go
+++ b/registry/cni_test.go
@@ -64,7 +64,8 @@ func TestNewServiceEndpointFromCNIPod_Protocol(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, "echo", service)
+			// 020 Part 1: the registry key is namespace-qualified "<ns>/<svc>".
+			assert.Equal(t, "default/echo", service)
 			assert.Equal(t, tt.want, protocol)
 			require.NotNil(t, ep)
 			assert.Equal(t, "10.0.0.1", ep.GetIp())

--- a/registry/internal/etcd/BUILD.bazel
+++ b/registry/internal/etcd/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//api/aether/registry/v1:registry",
         "//common/log",
+        "//common/serviceref",
         "//registry/export",
         "@io_etcd_go_etcd_client_v3//:client",
         "@org_golang_google_protobuf//proto",

--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -5,7 +5,7 @@
 // deterministic prefix and partitions stay disjoint regardless of pod-CIDR
 // overlap across clusters. Full key layout:
 //
-//	<root>/<region>/clusters/<cluster>/services/<service>/protocols/<protocol>/endpoints/<ip>
+//	<root>/<region>/clusters/<cluster>/ns/<namespace>/services/<service>/protocols/<protocol>/endpoints/<ip>
 //
 // A registry instance OWNS one (region, cluster): it writes/deletes only under
 // its own partition, but reads (List*, watch) range the whole root so consumers
@@ -24,6 +24,7 @@ import (
 
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	commonlog "github.com/bpalermo/aether/common/log"
+	"github.com/bpalermo/aether/common/serviceref"
 	"github.com/bpalermo/aether/registry/export"
 )
 
@@ -480,32 +481,63 @@ func (r *EtcdRegistry) Close() error {
 	return nil
 }
 
-// serviceMarker delimits the service-name segment within a key, after the
-// origin (region/cluster) prefix.
-const serviceMarker = "/services/"
+// nsMarker / serviceMarker delimit the namespace and service segments of a key,
+// after the origin (region/cluster) prefix: a service is keyed
+// .../ns/<namespace>/services/<service>/... (proposal 020 Part 1, namespace-aware).
+const (
+	nsMarker      = "/ns/"
+	serviceMarker = "/services/"
+)
+
+// serviceKeySegment renders a namespace-qualified "<ns>/<svc>" service key as the
+// etcd path segment "/ns/<ns>/services/<svc>" (proposal 020 Part 1). A malformed
+// (non-namespaced) key falls back to the legacy "/services/<key>" so a stray key
+// still produces a usable path rather than corrupting the tree.
+func serviceKeySegment(serviceName string) string {
+	if ref, ok := serviceref.ParseKey(serviceName); ok {
+		return nsMarker + ref.Namespace + serviceMarker + ref.Name
+	}
+	return serviceMarker + serviceName
+}
 
 // endpointKey builds the full key for one of THIS registry's own endpoints,
 // under its authoritative partition.
-// Format: <ownPrefix>/services/<serviceName>/protocols/<protocol>/endpoints/<ip>
+// Format: <ownPrefix>/ns/<ns>/services/<svc>/protocols/<protocol>/endpoints/<ip>
 func (r *EtcdRegistry) endpointKey(serviceName string, protocol registryv1.Service_Protocol, ip string) string {
-	return fmt.Sprintf("%s%s%s/protocols/%s/endpoints/%s", r.ownPrefix, serviceMarker, serviceName, protocol.String(), ip)
+	return fmt.Sprintf("%s%s/protocols/%s/endpoints/%s", r.ownPrefix, serviceKeySegment(serviceName), protocol.String(), ip)
 }
 
 // endpointsMatch is the substring an endpoint key carries for a given service
 // and protocol, used to filter a root-range read across all origins.
 func endpointsMatch(serviceName string, protocol registryv1.Service_Protocol) string {
-	return fmt.Sprintf("%s%s/protocols/%s/endpoints/", serviceMarker, serviceName, protocol.String())
+	return fmt.Sprintf("%s/protocols/%s/endpoints/", serviceKeySegment(serviceName), protocol.String())
 }
 
 // protocolsPrefix builds the prefix for all protocols of one of THIS registry's
 // own services (used to enumerate protocols before deleting own endpoints).
 func (r *EtcdRegistry) protocolsPrefix(serviceName string) string {
-	return fmt.Sprintf("%s%s%s/protocols/", r.ownPrefix, serviceMarker, serviceName)
+	return fmt.Sprintf("%s%s/protocols/", r.ownPrefix, serviceKeySegment(serviceName))
 }
 
-// extractServiceName extracts the service name from a full key path, regardless
-// of which origin (region/cluster) partition it lives under.
+// extractServiceName extracts the namespace-qualified "<ns>/<svc>" service key
+// from a full key path (.../ns/<ns>/services/<svc>/...), regardless of which
+// origin (region/cluster) partition it lives under. Falls back to the legacy
+// namespace-free scheme for any key without the /ns/ segment.
 func (r *EtcdRegistry) extractServiceName(key string) string {
+	if i := strings.Index(key, nsMarker); i >= 0 {
+		ns, after, found := strings.Cut(key[i+len(nsMarker):], serviceMarker)
+		if found && ns != "" {
+			svc := after
+			if j := strings.IndexByte(svc, '/'); j >= 0 {
+				svc = svc[:j]
+			}
+			if svc != "" {
+				return serviceref.New(ns, svc).Key()
+			}
+		}
+		return ""
+	}
+	// Legacy namespace-free fallback.
 	i := strings.Index(key, serviceMarker)
 	if i < 0 {
 		return ""


### PR DESCRIPTION
## Proposal 020 Part 1 — namespace-aware service identity (HARD CUTOVER)

Today two ServiceAccounts with the same name in different namespaces collide on one registry key (bare `<svc>`). This makes the registry key, mesh FQDN, and cluster names **namespace-qualified**.

**Decision (user):** hard cutover, no dual-read. The service key stays a `string`; only its *value* changes to `<ns>/<svc>` (no atomic signature break). `common/serviceref` is the single source of truth for the three forms.

### Identity (stage 0 — `common/serviceref`)
- key `<ns>/<svc>` · mesh FQDN `<svc>.<ns>.<meshDomain>` · cluster-local `<svc>.<ns>.svc.cluster.local`

### Producer + consumers
- **Produce** (stage 1): CNI `getServiceName` → `<ns>/<svc>`; `ServiceClusterName`/`ServiceFromClusterName` render/parse the FQDN.
- **etcd backend** (stage 2): keys `.../ns/<ns>/services/<svc>/...`.
- **Capture / mesh-DNS / GAMMA / ODCDS** (stage 3): authorities, A-records, route keys, on-demand CDS all keyed by `<ns>/<svc>`.
- **Edge** (stage 4): `api.palermo.dev` backend resolution + dependency set + existence check keyed by `<ns>/<svc>` (the edge is a registry client too).

Opaque-key consumers (registrar broadcaster, agent EDS map, demand-scope deps) carry the new value transparently. A defensive flat fallback in `ServiceClusterName` guards a stray non-namespaced key.

Full Go test suite green (60 packages); all affected tests migrated to the two-label authority + namespace-qualified key.

**Breaking:** registry keys change; requires a coordinated cutover (re-registration) on deploy — validated on talos before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)