### PR TITLE
fix(020): ns-aware cold-path catch-all regex + own-service dependency key

### DIFF
--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 )
@@ -32,7 +34,10 @@ type podDependencies struct {
 // the registry refresher rebuilds the scoped cluster snapshot.
 func (c *SnapshotCache) setPodDependencies(netns string, cniPod *cniv1.CNIPod) {
 	deps := podDependencies{
-		service:   cniPod.GetServiceAccount(),
+		// 020 Part 1: the dependency set is keyed by the namespace-qualified
+		// "<ns>/<svc>" service key (matching the registry / cluster map), so the
+		// pod's own service is keyed by <ns>/<sa>, not the bare ServiceAccount.
+		service:   serviceref.New(cniPod.GetNamespace(), cniPod.GetServiceAccount()).Key(),
 		upstreams: proxy.UpstreamsFromPod(cniPod),
 	}
 

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -44,11 +44,13 @@ func TestDependencySet_UnionsPodsAndOwnServices(t *testing.T) {
 	c := newTestCache("node-1")
 	ctx := context.Background()
 
-	require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "svc-x, svc-y"), "example.org"))
-	require.NoError(t, c.AddPod(ctx, makeDepPod("b-1", "svc-b", "/proc/2/ns/net", "svc-y,svc-z"), "example.org"))
+	// 020 Part 1: own services are keyed <ns>/<sa>; declared upstreams are the
+	// namespace-qualified keys the annotation now carries.
+	require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/svc-x, default/svc-y"), "example.org"))
+	require.NoError(t, c.AddPod(ctx, makeDepPod("b-1", "svc-b", "/proc/2/ns/net", "default/svc-y,default/svc-z"), "example.org"))
 
 	deps := c.DependencySet()
-	for _, want := range []string{"svc-a", "svc-b", "svc-x", "svc-y", "svc-z"} {
+	for _, want := range []string{"default/svc-a", "default/svc-b", "default/svc-x", "default/svc-y", "default/svc-z"} {
 		assert.Contains(t, deps, want)
 	}
 	assert.Len(t, deps, 5)
@@ -60,16 +62,16 @@ func TestDependencySet_PodRemovalShrinks(t *testing.T) {
 	c := newTestCache("node-1")
 	ctx := context.Background()
 
-	require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "svc-x,svc-shared"), "example.org"))
-	require.NoError(t, c.AddPod(ctx, makeDepPod("b-1", "svc-b", "/proc/2/ns/net", "svc-shared"), "example.org"))
+	require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/svc-x,default/svc-shared"), "example.org"))
+	require.NoError(t, c.AddPod(ctx, makeDepPod("b-1", "svc-b", "/proc/2/ns/net", "default/svc-shared"), "example.org"))
 
 	require.NoError(t, c.RemovePod(ctx, "/proc/1/ns/net"))
 
 	deps := c.DependencySet()
-	assert.NotContains(t, deps, "svc-a", "removed pod's own service leaves the set")
-	assert.NotContains(t, deps, "svc-x", "removed pod's exclusive upstream leaves the set")
-	assert.Contains(t, deps, "svc-shared", "upstream still declared by another pod survives")
-	assert.Contains(t, deps, "svc-b")
+	assert.NotContains(t, deps, "default/svc-a", "removed pod's own service leaves the set")
+	assert.NotContains(t, deps, "default/svc-x", "removed pod's exclusive upstream leaves the set")
+	assert.Contains(t, deps, "default/svc-shared", "upstream still declared by another pod survives")
+	assert.Contains(t, deps, "default/svc-b")
 }
 
 // TestDependencyChanges_SignalsOnRealChangesOnly verifies the coalesced change
@@ -104,24 +106,24 @@ func TestLoadClustersFromRegistry_ScopesToDependencySet(t *testing.T) {
 	ctx := context.Background()
 
 	// Local pod: own service svc-self, declared upstream svc-dep.
-	require.NoError(t, c.AddPod(ctx, makeDepPod("self-1", "svc-self", "/proc/1/ns/net", "svc-dep"), "example.org"))
+	require.NoError(t, c.AddPod(ctx, makeDepPod("self-1", "svc-self", "/proc/1/ns/net", "default/svc-dep"), "example.org"))
 
 	reg := &mockRegistry{
 		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 			return map[string][]*registryv1.ServiceEndpoint{
-				"svc-self":  {makeEndpoint("10.0.0.1", "cluster-1", "node-1", 8080)},
-				"svc-dep":   {makeEndpoint("10.0.0.2", "cluster-1", "node-2", 8080)},
-				"svc-other": {makeEndpoint("10.0.0.3", "cluster-1", "node-3", 8080)},
-				"svc-more":  {makeEndpoint("10.0.0.4", "cluster-1", "node-4", 8080)},
+				"default/svc-self":  {makeEndpoint("10.0.0.1", "cluster-1", "node-1", 8080)},
+				"default/svc-dep":   {makeEndpoint("10.0.0.2", "cluster-1", "node-2", 8080)},
+				"default/svc-other": {makeEndpoint("10.0.0.3", "cluster-1", "node-3", 8080)},
+				"default/svc-more":  {makeEndpoint("10.0.0.4", "cluster-1", "node-4", 8080)},
 			}, nil
 		},
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
 
-	assert.Contains(t, c.clusters, "svc-self", "a pod's own service is always in scope")
-	assert.Contains(t, c.clusters, "svc-dep", "declared upstreams are in scope")
-	assert.NotContains(t, c.clusters, "svc-other", "undeclared services are not distributed")
-	assert.NotContains(t, c.clusters, "svc-more", "undeclared services are not distributed")
+	assert.Contains(t, c.clusters, "default/svc-self", "a pod's own service is always in scope")
+	assert.Contains(t, c.clusters, "default/svc-dep", "declared upstreams are in scope")
+	assert.NotContains(t, c.clusters, "default/svc-other", "undeclared services are not distributed")
+	assert.NotContains(t, c.clusters, "default/svc-more", "undeclared services are not distributed")
 }
 
 // TestLoadClustersFromRegistry_EmptyDependencySet verifies a node with no

--- a/agent/internal/xds/cache/outbound_mtls_test.go
+++ b/agent/internal/xds/cache/outbound_mtls_test.go
@@ -37,7 +37,7 @@ func TestServiceClusterMTLSInjected(t *testing.T) {
 	reg := &mockRegistry{
 		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 			return map[string][]*registryv1.ServiceEndpoint{
-				"echo": {makeEndpoint("10.0.0.9", "cluster-1", "node-1", 18080)},
+				"aether-test/echo": {makeEndpoint("10.0.0.9", "cluster-1", "node-1", 18080)},
 			}, nil
 		},
 	}
@@ -47,7 +47,7 @@ func TestServiceClusterMTLSInjected(t *testing.T) {
 	require.NoError(t, err)
 	clusters := snap.GetResources(resourcev3.ClusterType)
 
-	echo, ok := clusters["echo.aether.internal"].(*clusterv3.Cluster)
+	echo, ok := clusters["echo.aether-test.aether.internal"].(*clusterv3.Cluster)
 	require.True(t, ok, "echo cluster must be present")
 	require.NotNil(t, echo.GetTransportSocketMatcher(), "service cluster must carry the per-source mTLS matcher")
 
@@ -74,13 +74,13 @@ func TestServiceClusterMTLSInjected(t *testing.T) {
 // identity).
 func TestServiceClusterNoMTLSWithoutNodeIdentity(t *testing.T) {
 	c := newTestCache("node-1")
-	declareDeps(c, "echo")
+	declareDeps(c, "aether-test/echo")
 	ctx := context.Background()
 
 	reg := &mockRegistry{
 		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 			return map[string][]*registryv1.ServiceEndpoint{
-				"echo": {makeEndpoint("10.0.0.9", "cluster-1", "node-2", 18080)},
+				"aether-test/echo": {makeEndpoint("10.0.0.9", "cluster-1", "node-2", 18080)},
 			}, nil
 		},
 	}
@@ -88,7 +88,7 @@ func TestServiceClusterNoMTLSWithoutNodeIdentity(t *testing.T) {
 
 	snap, err := c.GetSnapshot("node-1")
 	require.NoError(t, err)
-	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo.aether.internal"].(*clusterv3.Cluster)
+	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo.aether-test.aether.internal"].(*clusterv3.Cluster)
 	require.True(t, ok, "echo cluster must be present")
 	assert.Nil(t, echo.GetTransportSocketMatcher(), "no mTLS matcher before the node SVID is served")
 }
@@ -116,14 +116,14 @@ func TestServiceClusterSANPinning(t *testing.T) {
 	ep2.KubernetesMetadata.Namespace = "aether-test"
 	reg := &mockRegistry{
 		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
-			return map[string][]*registryv1.ServiceEndpoint{"echo": {ep1, ep2}}, nil
+			return map[string][]*registryv1.ServiceEndpoint{"aether-test/echo": {ep1, ep2}}, nil
 		},
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
 
 	snap, err := c.GetSnapshot("node-1")
 	require.NoError(t, err)
-	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo.aether.internal"].(*clusterv3.Cluster)
+	echo, ok := snap.GetResources(resourcev3.ClusterType)["echo.aether-test.aether.internal"].(*clusterv3.Cluster)
 	require.True(t, ok)
 
 	wantSANs := []string{

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -70,7 +70,10 @@ const onDemandClusterHeader = ":authority"
 // Envoy 1.38) while supporting FQDN:port (proposal 005). Nonexistent in-domain
 // services/ports fail when the ODCDS timeout expires.
 func buildOnDemandCatchAllVirtualHost(meshDomain string) *routev3.VirtualHost {
-	meshAuthorityRegex := "^[a-z0-9-]+\\." + regexp.QuoteMeta(meshDomain) + "(:[0-9]+)?$"
+	// 020 Part 1: mesh authorities are <svc>.<ns>.<meshDomain> (two labels before the
+	// mesh domain), with an optional :port. Cold/off-node services that miss the
+	// scoped vhost fall here and resolve via ODCDS (ClusterHeader=:authority).
+	meshAuthorityRegex := "^[a-z0-9-]+\\.[a-z0-9-]+\\." + regexp.QuoteMeta(meshDomain) + "(:[0-9]+)?$"
 	return &routev3.VirtualHost{
 		Name:    "on_demand_catch_all",
 		Domains: []string{"*"},


### PR DESCRIPTION
**Second M1 cutover hotfix** (after #392 SAN). The transparent-capture client→service path 404'd on talos. Two gaps:

1. **Cold-path catch-all regex** matched mesh authorities as `^[a-z0-9-]+\.<meshDomain>` (single label). M1 authorities are `<svc>.<ns>.<meshDomain>` (two labels) → cold/off-node capture fell through to 404, never reaching ODCDS. Now matches two labels.
2. **Own-service dependency key**: `setPodDependencies` used the bare ServiceAccount, but the dependency set is matched against the registry `<ns>/<svc>` keys → a pod's own service + its scoped cluster/cap_http vhost never resolved. Now keyed `<ns>/<sa>`.

Dependency + mTLS-SAN tests migrated. Full agent+registrar suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)