### PR TITLE
feat(020): namespace-qualify the demand-scope upstreams annotation

### DIFF
--- a/agent/internal/xds/proxy/upstreams.go
+++ b/agent/internal/xds/proxy/upstreams.go
@@ -5,6 +5,7 @@ import (
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	"github.com/bpalermo/aether/common/constants"
+	"github.com/bpalermo/aether/common/serviceref"
 )
 
 // UpstreamsFromPod returns the upstream services the pod declares it consumes,
@@ -12,12 +13,28 @@ import (
 // service names; surrounding whitespace is trimmed, empty items are dropped).
 // Returns nil when the annotation is absent or empty — such a pod relies
 // entirely on the on-demand cold path for its upstreams.
+//
+// Each value is normalized to a namespace-qualified "<ns>/<svc>" serviceref key
+// (proposal 020 Part 1) so it matches the registry / dependency-set keys
+// (cache.setPodDependencies keys the pod's own service via serviceref too) —
+// otherwise a bare upstream name like "echo" never matches the registry's
+// "<ns>/echo" key, so the demand-scoped cluster (and its cap_http route) never
+// resolves:
+//
+//   - A bare name (no "/") is qualified with the POD's own namespace, so the
+//     common same-namespace case keeps the ergonomic bare-name annotation.
+//   - An already-qualified "<ns>/<svc>" value (containing "/") passes through
+//     unchanged, for cross-namespace upstreams.
+//
+// Trimming, empty-item dropping, and dedup operate on the normalized keys so a
+// bare name and its explicit "<pod-ns>/<name>" form collapse to one entry.
 func UpstreamsFromPod(cniPod *cniv1.CNIPod) []string {
 	raw, ok := cniPod.GetAnnotations()[constants.AnnotationConfigUpstreams]
 	if !ok || raw == "" {
 		return nil
 	}
 
+	podNamespace := cniPod.GetNamespace()
 	parts := strings.Split(raw, ",")
 	upstreams := make([]string, 0, len(parts))
 	seen := make(map[string]struct{}, len(parts))
@@ -26,11 +43,17 @@ func UpstreamsFromPod(cniPod *cniv1.CNIPod) []string {
 		if name == "" {
 			continue
 		}
-		if _, dup := seen[name]; dup {
+		// Already namespace-qualified (cross-namespace upstream): pass through.
+		// Otherwise qualify the bare name with the pod's own namespace.
+		key := name
+		if !strings.Contains(name, "/") {
+			key = serviceref.New(podNamespace, name).Key()
+		}
+		if _, dup := seen[key]; dup {
 			continue
 		}
-		seen[name] = struct{}{}
-		upstreams = append(upstreams, name)
+		seen[key] = struct{}{}
+		upstreams = append(upstreams, key)
 	}
 	if len(upstreams) == 0 {
 		return nil

--- a/agent/internal/xds/proxy/upstreams_test.go
+++ b/agent/internal/xds/proxy/upstreams_test.go
@@ -10,53 +10,82 @@ import (
 
 // TestUpstreamsFromPod verifies parsing of the config.aether.io/upstreams
 // annotation: comma separation, whitespace trimming, empty-item and duplicate
-// dropping, and nil for absent/empty annotations.
+// dropping, nil for absent/empty annotations, and namespace-qualification of the
+// resulting keys (bare name -> "<pod-ns>/<name>", already-qualified value passes
+// through) so they match the "<ns>/<svc>" registry / dependency-set keys
+// (proposal 020 Part 1).
 func TestUpstreamsFromPod(t *testing.T) {
 	tests := []struct {
 		name       string
+		namespace  string
 		annotation *string
 		want       []string
 	}{
 		{
 			name:       "absent annotation yields nil",
+			namespace:  "default",
 			annotation: nil,
 			want:       nil,
 		},
 		{
 			name:       "empty annotation yields nil",
+			namespace:  "default",
 			annotation: ptr(""),
 			want:       nil,
 		},
 		{
-			name:       "single service",
+			name:       "bare single service qualified with pod namespace",
+			namespace:  "default",
 			annotation: ptr("svc-payments"),
-			want:       []string{"svc-payments"},
+			want:       []string{"default/svc-payments"},
 		},
 		{
-			name:       "comma-separated list",
+			name:       "bare comma-separated list qualified with pod namespace",
+			namespace:  "aether-test",
 			annotation: ptr("svc-payments,svc-ledger,svc-audit"),
-			want:       []string{"svc-payments", "svc-ledger", "svc-audit"},
+			want:       []string{"aether-test/svc-payments", "aether-test/svc-ledger", "aether-test/svc-audit"},
 		},
 		{
-			name:       "whitespace is trimmed",
+			name:       "whitespace is trimmed then qualified",
+			namespace:  "default",
 			annotation: ptr(" svc-a , svc-b ,svc-c"),
-			want:       []string{"svc-a", "svc-b", "svc-c"},
+			want:       []string{"default/svc-a", "default/svc-b", "default/svc-c"},
 		},
 		{
 			name:       "empty items and duplicates dropped",
+			namespace:  "default",
 			annotation: ptr("svc-a,,svc-a, ,svc-b"),
-			want:       []string{"svc-a", "svc-b"},
+			want:       []string{"default/svc-a", "default/svc-b"},
 		},
 		{
 			name:       "only separators yields nil",
+			namespace:  "default",
 			annotation: ptr(", ,,"),
 			want:       nil,
+		},
+		{
+			name:       "already-qualified cross-namespace value passes through",
+			namespace:  "default",
+			annotation: ptr("other-ns/echo"),
+			want:       []string{"other-ns/echo"},
+		},
+		{
+			name:       "mix of bare and cross-namespace upstreams",
+			namespace:  "aether-test",
+			annotation: ptr("echo, billing-ns/billing , audit"),
+			want:       []string{"aether-test/echo", "billing-ns/billing", "aether-test/audit"},
+		},
+		{
+			name:       "bare name and its explicit pod-namespace form collapse to one",
+			namespace:  "aether-test",
+			annotation: ptr("echo,aether-test/echo"),
+			want:       []string{"aether-test/echo"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pod := &cniv1.CNIPod{Name: "p", Namespace: "default"}
+			pod := &cniv1.CNIPod{Name: "p", Namespace: tt.namespace}
 			if tt.annotation != nil {
 				pod.Annotations = map[string]string{constants.AnnotationConfigUpstreams: *tt.annotation}
 			}

--- a/agent/internal/xds/server/refresh_test.go
+++ b/agent/internal/xds/server/refresh_test.go
@@ -30,7 +30,10 @@ func TestRegistryRefresher_ReloadsOnChange(t *testing.T) {
 	c := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
 
 	// A local pod declaring "echo" as an upstream puts it in the node
-	// dependency set — only in-scope services are distributed.
+	// dependency set — only in-scope services are distributed. The bare
+	// annotation is namespace-qualified to the pod's namespace, so the
+	// dependency-set key (and the registry key it matches) is "default/echo"
+	// (proposal 020 Part 1).
 	require.NoError(t, c.AddPod(context.Background(), &cniv1.CNIPod{
 		Name:             "client-1",
 		Namespace:        "default",
@@ -61,17 +64,17 @@ func TestRegistryRefresher_ReloadsOnChange(t *testing.T) {
 	go func() { done <- r.Start(ctx) }()
 
 	// No clusters until a change is published.
-	require.Nil(t, c.Endpoints("echo"))
+	require.Nil(t, c.Endpoints("default/echo"))
 
 	mu.Lock()
 	data = map[string][]*registryv1.ServiceEndpoint{
-		"echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
+		"default/echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
 	}
 	mu.Unlock()
 	reg.ch <- struct{}{}
 
 	require.Eventually(t, func() bool {
-		return c.Endpoints("echo") != nil
+		return c.Endpoints("default/echo") != nil
 	}, 2*time.Second, 10*time.Millisecond, "refresher should rebuild the cluster after a change signal")
 
 	cancel()
@@ -90,7 +93,7 @@ func TestRegistryRefresher_ReloadsOnDependencyChange(t *testing.T) {
 	c := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
 
 	data := map[string][]*registryv1.ServiceEndpoint{
-		"echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
+		"default/echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
 	}
 	reg := &notifyRegistry{
 		mockRegistry: &mockRegistry{
@@ -109,10 +112,11 @@ func TestRegistryRefresher_ReloadsOnDependencyChange(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- r.Start(ctx) }()
 
-	// "echo" is in the registry but not in the (empty) dependency set.
-	require.Nil(t, c.Endpoints("echo"))
+	// "default/echo" is in the registry but not in the (empty) dependency set.
+	require.Nil(t, c.Endpoints("default/echo"))
 
 	// A pod declaring echo lands: the dependency change alone must surface it.
+	// The bare annotation qualifies to "default/echo" (the registry key).
 	require.NoError(t, c.AddPod(ctx, &cniv1.CNIPod{
 		Name:             "client-1",
 		Namespace:        "default",
@@ -122,7 +126,7 @@ func TestRegistryRefresher_ReloadsOnDependencyChange(t *testing.T) {
 	}, "example.org"))
 
 	require.Eventually(t, func() bool {
-		return c.Endpoints("echo") != nil
+		return c.Endpoints("default/echo") != nil
 	}, 2*time.Second, 10*time.Millisecond, "refresher should rebuild the scoped snapshot after a dependency change")
 
 	cancel()
@@ -159,7 +163,7 @@ func TestRegistryRefresher_LeadingEdgeDependencyChange(t *testing.T) {
 	c := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
 
 	data := map[string][]*registryv1.ServiceEndpoint{
-		"echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
+		"default/echo": {{Ip: "10.0.0.1", ClusterName: "cluster-1", Port: 8080}},
 	}
 	reg := &notifyRegistry{
 		mockRegistry: &mockRegistry{
@@ -179,6 +183,7 @@ func TestRegistryRefresher_LeadingEdgeDependencyChange(t *testing.T) {
 	go func() { done <- r.Start(ctx) }()
 
 	start := time.Now()
+	// Bare annotation qualifies to the "default/echo" registry key.
 	require.NoError(t, c.AddPod(ctx, &cniv1.CNIPod{
 		Name:             "client-1",
 		Namespace:        "default",
@@ -188,7 +193,7 @@ func TestRegistryRefresher_LeadingEdgeDependencyChange(t *testing.T) {
 	}, "example.org"))
 
 	require.Eventually(t, func() bool {
-		return c.Endpoints("echo") != nil
+		return c.Endpoints("default/echo") != nil
 	}, time.Second, 5*time.Millisecond, "dependency change must reload on the leading edge")
 	assert.Less(t, time.Since(start), r.debounce, "must not have waited out the debounce")
 


### PR DESCRIPTION
## Task 1 — namespace-qualify the upstreams annotation

`UpstreamsFromPod` (`agent/internal/xds/proxy/listener.go` → `upstreams.go`) returned the `config.aether.io/upstreams` values **verbatim**. After 020 Part 1 the node dependency set is matched against the registry's `<ns>/<svc>` keys (and `setPodDependencies` already keys the pod's *own* service via `serviceref` — confirmed at `agent/internal/xds/cache/dependencies.go`), so a bare upstream name like `echo` no longer matched `aether-test/echo`: the demand-scoped cluster and its `cap_http` route never resolved.

Now each value is normalized to a `<ns>/<svc>` `serviceref` key:
- **bare name** (no `/`) → qualified with the **pod's own namespace** (`serviceref.New(cniPod.GetNamespace(), name).Key()`), so same-namespace upstreams keep the ergonomic bare-name annotation;
- **already-qualified** `<ns>/<svc>` (contains `/`) → passes through unchanged, for cross-namespace upstreams.

Trim / empty-drop / dedup now operate on the normalized key, so a bare name and its explicit `<pod-ns>/<name>` form collapse to one entry. No `BUILD.bazel` change needed — `//common/serviceref` was already a `proxy` dep.

### Tests
- Extended the `UpstreamsFromPod` table: qualification with the pod namespace, cross-namespace pass-through, a bare/cross-namespace mix, and bare+explicit collapse.
- Migrated the three `RegistryRefresher` tests (`agent/internal/xds/server/refresh_test.go`) — they declared a bare `echo` upstream; their registry mock keys and `Endpoints` lookups now use the qualified `default/echo` to match.
- `bazel test //agent/... --test_arg=-test.short` → **23/23 green**.

## Task 2 — audit: is removing the `ServiceClusterName` fallback safe yet? (assessment only — no code change)

`ServiceClusterName` (`egress.go`) has a defensive fallback: when `serviceref.ParseKey(serviceName)` fails (a non-namespaced / legacy key) it returns `serviceName + "." + meshDomain` instead of the namespace-qualified FQDN.

**Verdict: NOT safe to remove yet.** A bare/legacy key can still reach it.

Callers of `ServiceClusterName` (and `PortClusterName`/`TCPClusterName`/`UDPClusterName`, which delegate to it):

| Caller | Input | Namespace-qualified? |
|---|---|---|
| `cache/cluster.go:322` | `serviceName` = registry listing key, gated by `deps[serviceName]` | ✅ `<ns>/<svc>` (registry + dependency set are both serviceref-keyed) |
| `cache/capture.go:375` | service key from the registry-derived cluster map | ✅ |
| `cache/edge.go:576,849` | `serviceref.New(backendNamespace, service).Key()` when `backendNamespace != ""` | ✅ when a backend namespace is present |
| **`gamma/reconciler.go:295` (HTTPRoute) & `:505` (GRPCRoute)** | **`name := string(b.Name)` — the bare backendRef `Service` name** | ❌ **BARE** |

The GAMMA reconciler is the live gap. `buildGammaRoute*` passes the raw Gateway API backend `name` straight into `ServiceClusterName` with **no namespace**, so today it hits the fallback and renders `echo.mesh` instead of `echo.<ns>.mesh`. The same bare `b.Service` is also added to the node dependency `set` via `routeBackendsLocked` (`cache/gamma.go:35`) — so the GAMMA path is **not** on the 020 `<ns>/<svc>` cutover yet (consistent with proposal 020's remaining-work list: `…/GAMMA/…`).

**Conclusion:** removing the fallback now would make every GAMMA backend a hard `ParseKey` failure. The fallback must stay until the GAMMA reconciler is migrated to emit namespace-qualified backend keys (resolve `b.Namespace` / route namespace into a `serviceref` for both `GammaBackend.Service` and `.Cluster`, mirroring `edgeClusterNameLocked`). Once that lands — and the dependency-set `routeBackendsLocked` keys are likewise qualified — the fallback can be deleted and `ServiceClusterName` made strict (panic / explicit error on a non-namespaced key). The registry / capture / edge callers are already strictly-qualified and would be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)