### PR TITLE
feat(test): offline Envoy-config-validation via envoy --mode validate

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -164,6 +164,33 @@ buildbuddy = use_extension("@toolchains_buildbuddy//:extensions.bzl", "buildbudd
 buildbuddy.platform(buildbuddy_container_image = "UBUNTU22_04_IMAGE")
 use_repo(buildbuddy, "buildbuddy_toolchain")
 
+# ---------------------------------------------------------------------------
+# Pinned stock Envoy binary — used by //test/envoy_validate to run
+# "envoy --mode validate" over aether-generated bootstrap configs without
+# building Envoy from source.  Pinned to v1.38.0, matching the custom proxy
+# workspace (proxy/bazel/envoy/repository.bzl ENVOY_SHA).
+# SHA-256 values from the upstream checksums.txt.asc release asset.
+#
+# ENVOY_VERSION = "1.38.0"
+# ---------------------------------------------------------------------------
+http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+http_file(
+    name = "envoy_binary_linux_amd64",
+    downloaded_file_path = "envoy",
+    executable = True,
+    sha256 = "cca312a7c3f91852f2849995c895130c59842e21ba787dc90bafa4026d6c5ecc",
+    urls = ["https://github.com/envoyproxy/envoy/releases/download/v1.38.0/envoy-1.38.0-linux-x86_64"],
+)
+
+http_file(
+    name = "envoy_binary_linux_arm64",
+    downloaded_file_path = "envoy",
+    executable = True,
+    sha256 = "9f00678c0cc433d7a342c422415eb3fdd163e77414aee5c5b57c04bd7d579454",
+    urls = ["https://github.com/envoyproxy/envoy/releases/download/v1.38.0/envoy-1.38.0-linux-aarch_64"],
+)
+
 pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")
 
 pull(

--- a/agent/internal/xds/config/BUILD.bazel
+++ b/agent/internal/xds/config/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
         "http.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/xds/config",
-    visibility = ["//agent:__subpackages__"],
+    visibility = [
+        "//agent:__subpackages__",
+        "//test:__subpackages__",  # envoy_validate bootstrap generator
+    ],
     deps = [
         "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/upstreams/http/v3:http",

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -26,7 +26,10 @@ go_library(
         "upstreams.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/xds/proxy",
-    visibility = ["//agent:__subpackages__"],
+    visibility = [
+        "//agent:__subpackages__",
+        "//test:__subpackages__",  # envoy_validate bootstrap generator
+    ],
     deps = [
         "//agent/internal/xds/config",
         "//api/aether/cni/v1:cni",

--- a/test/envoy_validate/BUILD.bazel
+++ b/test/envoy_validate/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+# Arch-appropriate Envoy binary, selected at analysis time.
+# The http_file repos are declared in MODULE.bazel pinned to ENVOY_VERSION = 1.38.0
+# (matching the custom proxy workspace).
+# SHA-256 values come from the upstream release checksums.txt.asc.
+alias(
+    name = "envoy_bin",
+    actual = select({
+        "@platforms//cpu:x86_64": "@envoy_binary_linux_amd64//file",
+        "@platforms//cpu:aarch64": "@envoy_binary_linux_arm64//file",
+    }),
+)
+
+go_library(
+    name = "envoy_validate",
+    srcs = ["builders.go"],
+    importpath = "github.com/bpalermo/aether/test/envoy_validate",
+    visibility = ["//test/envoy_validate:__subpackages__"],
+    deps = [
+        "//agent/internal/xds/config",
+        "//agent/internal/xds/proxy",
+        "//api/aether/cni/v1:cni",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/bootstrap/v3:bootstrap",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/cluster/v3:cluster",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/upstreams/http/v3:http",
+        "@org_golang_google_protobuf//encoding/protojson",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
+    ],
+)
+
+# Runs "envoy --mode validate" over aether-generated bootstrap configs.
+#
+# What it catches (examples from production incidents):
+#   - ORIGINAL_DST cluster with ROUND_ROBIN lb_policy (CDS NACK)
+#   - Listener with no address field (LDS NACK)
+#   - Malformed or missing SAN in TLS validation context
+#   - Unknown TypedConfig @type URL / missing extension
+#
+# Run with:
+#   bazel test //test/envoy_validate:envoy_validate_test
+#   bazel test //test/envoy_validate:envoy_validate_test --test_output=all
+#
+# Tagged "envoy-validate" (not "integration") — no Docker daemon required.
+# size=medium: 3 Envoy validation processes, ~5 s wall time.
+go_test(
+    name = "envoy_validate_test",
+    size = "medium",
+    srcs = ["validate_test.go"],
+    data = [":envoy_bin"],
+    embed = [":envoy_validate"],
+    tags = [
+        "envoy-validate",
+        # The Envoy binary reads /proc on startup; run outside strict sandbox.
+        "no-sandbox",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+    ],
+)

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -1,0 +1,398 @@
+// Package envoy_validate provides functions to build representative Envoy
+// bootstrap JSON configurations derived from the aether node-agent's actual
+// xDS proxy builders.  The resulting configs are validated with
+// "envoy --mode validate" in the test to catch structural regressions before
+// production.
+//
+// Three scenarios are modelled:
+//
+//  1. Node proxy  – per-pod inbound (mTLS) + outbound HTTP listener, ORIGINAL_DST
+//     passthrough cluster, per-pod app cluster, EDS service cluster with SPIRE mTLS.
+//  2. Capture     – transparent-capture listener, HTTP + TCP service clusters,
+//     passthrough chain.
+//  3. Edge        – service EDS cluster with direct-to-SPIRE SDS, spire_agent
+//     static cluster.
+//
+// Custom extensions (aether_stats) that require the custom Envoy binary are
+// stripped before serialisation so that stock Envoy can validate the structural
+// correctness of the config.
+package envoy_validate
+
+import (
+	"fmt"
+
+	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/bpalermo/aether/agent/internal/xds/config"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+)
+
+const (
+	// trustDomain is the SPIFFE trust domain used in generated resource names.
+	trustDomain = "aether.internal"
+	// meshDomain is the DNS-style suffix for mesh service cluster names.
+	meshDomain = "mesh.local"
+	// fakeNetns is a placeholder netns path.  Envoy --mode validate checks
+	// field presence, not whether the path exists on disk.
+	fakeNetns = "/proc/1/ns/net"
+	// xdsSockPath is the agent's UDS; the static xds_cluster points here so all
+	// ADS config-source references resolve when Envoy validates the bootstrap.
+	xdsSockPath = "/var/run/aether/xds.sock"
+
+	// aetherStatsFilterName mirrors the unexported statsFilterName constant in
+	// agent/internal/xds/proxy/stats_filter.go.  This filter requires the custom
+	// C++ extension compiled into the proxy workspace Envoy (proposal 012); it is
+	// stripped before stock-Envoy validation.  Keep in sync if the constant changes.
+	aetherStatsFilterName = "aether.filters.http.aether_stats"
+)
+
+// NodeBootstrapJSON builds the core node-proxy bootstrap config and returns
+// its JSON representation (after stripping custom extensions).
+func NodeBootstrapJSON() ([]byte, error) {
+	bs, err := buildNodeBootstrap()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBootstrap(bs)
+}
+
+// CaptureBootstrapJSON builds the transparent-capture bootstrap config and
+// returns its JSON representation.
+func CaptureBootstrapJSON() ([]byte, error) {
+	bs, err := buildCaptureBootstrap()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBootstrap(bs)
+}
+
+// EdgeBootstrapJSON builds the edge proxy bootstrap config and returns its
+// JSON representation.
+func EdgeBootstrapJSON() ([]byte, error) {
+	bs, err := buildEdgeBootstrap()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBootstrap(bs)
+}
+
+// buildNodeBootstrap builds the core node-proxy bootstrap config.
+func buildNodeBootstrap() (*bootstrapv3.Bootstrap, error) {
+	pod := testPod()
+
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateListenersFromRegistryPod: %w", err)
+	}
+
+	passthrough := proxy.NewPassthroughOriginalDstCluster()
+	svcCluster := newServiceCluster("echo."+meshDomain, trustDomain, "default", "echo")
+
+	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster}
+	staticClusters = append(staticClusters, appClusters...)
+	staticClusters = append(staticClusters, healthCluster)
+
+	return newBootstrap(staticClusters, []*listenerv3.Listener{inbound, outbound}), nil
+}
+
+// buildCaptureBootstrap builds the transparent-capture bootstrap config.
+func buildCaptureBootstrap() (*bootstrapv3.Bootstrap, error) {
+	pod := testPod()
+
+	tcpSvc := proxy.CaptureTCPService{
+		ClusterName: "redis." + meshDomain,
+		ClusterIP:   "10.96.1.10",
+	}
+	captureListener, err := proxy.GenerateCaptureListener(
+		pod,
+		15006,
+		meshDomain,
+		false, // emitStatsPod
+		[]proxy.CaptureTCPService{tcpSvc},
+		true, // withPassthrough
+	)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateCaptureListener: %w", err)
+	}
+
+	passthrough := proxy.NewPassthroughOriginalDstCluster()
+	httpSvc := newServiceCluster("echo."+meshDomain, trustDomain, "default", "echo")
+	tcpSvc2 := newServiceCluster("redis."+meshDomain, trustDomain, "default", "redis")
+
+	return newBootstrap(
+		[]*clusterv3.Cluster{xdsCluster(), passthrough, httpSvc, tcpSvc2},
+		[]*listenerv3.Listener{captureListener},
+	), nil
+}
+
+// buildEdgeBootstrap builds the edge (north-south ingress) proxy bootstrap.
+func buildEdgeBootstrap() (*bootstrapv3.Bootstrap, error) {
+	edgeSvc := newEdgeServiceCluster("echo."+meshDomain, trustDomain, "default", "echo")
+	spire := newSpireAgentCluster()
+
+	return newBootstrap(
+		[]*clusterv3.Cluster{xdsCluster(), spire, edgeSvc},
+		nil,
+	), nil
+}
+
+// marshalBootstrap serialises a Bootstrap proto to protojson, stripping
+// custom extensions that require the proxy-workspace Envoy binary.
+func marshalBootstrap(bs *bootstrapv3.Bootstrap) ([]byte, error) {
+	stripCustomFilters(bs)
+	opts := protojson.MarshalOptions{
+		Multiline:     true,
+		Indent:        "  ",
+		UseProtoNames: true,
+	}
+	data, err := opts.Marshal(bs)
+	if err != nil {
+		return nil, fmt.Errorf("marshal bootstrap: %w", err)
+	}
+	return data, nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// testPod returns a minimal CNIPod for proxy builder calls.
+func testPod() *cniv1.CNIPod {
+	return &cniv1.CNIPod{
+		Name:             "test-pod",
+		Namespace:        "default",
+		NetworkNamespace: fakeNetns,
+		ContainerId:      "abc123",
+		Ips:              []string{"10.96.0.1"},
+		ServiceAccount:   "default",
+	}
+}
+
+// newBootstrap assembles a Bootstrap proto with static resources and ADS-backed
+// dynamic_resources pointing at the static xds_cluster.
+func newBootstrap(clusters []*clusterv3.Cluster, listeners []*listenerv3.Listener) *bootstrapv3.Bootstrap {
+	return &bootstrapv3.Bootstrap{
+		Node: &corev3.Node{Id: "test-node", Cluster: "aether"},
+		StaticResources: &bootstrapv3.Bootstrap_StaticResources{
+			Clusters:  clusters,
+			Listeners: listeners,
+		},
+		DynamicResources: &bootstrapv3.Bootstrap_DynamicResources{
+			AdsConfig: &corev3.ApiConfigSource{
+				ApiType:             corev3.ApiConfigSource_GRPC,
+				TransportApiVersion: corev3.ApiVersion_V3,
+				GrpcServices: []*corev3.GrpcService{{
+					TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+						EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: "xds_cluster"},
+					},
+				}},
+			},
+			CdsConfig: &corev3.ConfigSource{ConfigSourceSpecifier: &corev3.ConfigSource_Ads{}},
+			LdsConfig: &corev3.ConfigSource{ConfigSourceSpecifier: &corev3.ConfigSource_Ads{}},
+		},
+		Admin: &bootstrapv3.Admin{
+			Address: &corev3.Address{
+				Address: &corev3.Address_SocketAddress{
+					SocketAddress: &corev3.SocketAddress{
+						Address:       "127.0.0.1",
+						PortSpecifier: &corev3.SocketAddress_PortValue{PortValue: 19000},
+					},
+				},
+			},
+		},
+	}
+}
+
+// xdsCluster is the static cluster the agent's xDS server listens on (UDS).
+// All ADS config-source references inside generated resources resolve to it.
+func xdsCluster() *clusterv3.Cluster {
+	return &clusterv3.Cluster{
+		Name:           "xds_cluster",
+		ConnectTimeout: durationpb.New(5e9), // 5 s
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_STATIC,
+		},
+		LoadAssignment: pipeEndpoint("xds_cluster", xdsSockPath),
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustAny(
+				config.Http2ProtocolOptions(),
+			),
+		},
+	}
+}
+
+// newServiceCluster builds an EDS cluster with SPIRE mTLS upstream transport
+// socket — the exact shape the agent distributes to node proxies.
+func newServiceCluster(clusterName, td, namespace, svcName string) *clusterv3.Cluster {
+	tlsCertName := fmt.Sprintf("spiffe://%s/node/test-node", td)
+	validationCtxName := fmt.Sprintf("spiffe://%s", td)
+	sanURI := fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", td, namespace, svcName)
+
+	ts := proxy.UpstreamTransportSocket(tlsCertName, validationCtxName, []string{sanURI}, clusterName)
+
+	return &clusterv3.Cluster{
+		Name:           clusterName,
+		ConnectTimeout: durationpb.New(5e9),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_EDS,
+		},
+		EdsClusterConfig: &clusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: config.XDSConfigSourceADS(),
+		},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(32 * 1024),
+		TransportSocket:               ts,
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustAny(
+				config.Http2ProtocolOptions(),
+			),
+		},
+	}
+}
+
+// newEdgeServiceCluster is like newServiceCluster but fetches SDS certs from
+// the static spire_agent cluster (edge proxy shape: direct-SPIRE, not ADS).
+func newEdgeServiceCluster(clusterName, td, namespace, svcName string) *clusterv3.Cluster {
+	tlsCertName := fmt.Sprintf("spiffe://%s/edge/aether-ingress/edge", td)
+	validationCtxName := fmt.Sprintf("spiffe://%s", td)
+	sanURI := fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", td, namespace, svcName)
+
+	ts := proxy.EdgeUpstreamTransportSocket(tlsCertName, validationCtxName, []string{sanURI}, clusterName)
+
+	return &clusterv3.Cluster{
+		Name:           clusterName,
+		ConnectTimeout: durationpb.New(5e9),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_EDS,
+		},
+		EdsClusterConfig: &clusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: config.XDSConfigSourceADS(),
+		},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(32 * 1024),
+		TransportSocket:               ts,
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustAny(
+				config.Http2ProtocolOptions(),
+			),
+		},
+	}
+}
+
+// newSpireAgentCluster is the static cluster the edge proxy uses to reach the
+// SPIRE Agent's native SDS API (Workload API Unix socket).
+func newSpireAgentCluster() *clusterv3.Cluster {
+	return &clusterv3.Cluster{
+		Name:           "spire_agent",
+		ConnectTimeout: durationpb.New(5e9),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_STATIC,
+		},
+		LoadAssignment: pipeEndpoint("spire_agent", "/run/spire/sockets/agent.sock"),
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustAny(
+				&httpv3.HttpProtocolOptions{
+					UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_{
+						ExplicitHttpConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig{
+							ProtocolConfig: &httpv3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+								Http2ProtocolOptions: &corev3.Http2ProtocolOptions{},
+							},
+						},
+					},
+				},
+			),
+		},
+	}
+}
+
+// pipeEndpoint builds a ClusterLoadAssignment with a single Unix-socket endpoint.
+func pipeEndpoint(clusterName, path string) *endpointv3.ClusterLoadAssignment {
+	return &endpointv3.ClusterLoadAssignment{
+		ClusterName: clusterName,
+		Endpoints: []*endpointv3.LocalityLbEndpoints{{
+			LbEndpoints: []*endpointv3.LbEndpoint{{
+				HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+					Endpoint: &endpointv3.Endpoint{
+						Address: &corev3.Address{
+							Address: &corev3.Address_Pipe{
+								Pipe: &corev3.Pipe{Path: path},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+}
+
+// stripCustomFilters removes HTTP filters that require the custom aether_stats
+// C++ extension compiled into the proxy workspace Envoy (proposal 012).
+// Stock Envoy does not have this extension and would fail --mode validate.
+// All other structural elements (TLS, addresses, cluster types, SAN matchers)
+// remain and are validated; aether_stats is tested by the proxy workspace's
+// envoy_cc_test targets.
+func stripCustomFilters(bs *bootstrapv3.Bootstrap) {
+	for _, lis := range bs.GetStaticResources().GetListeners() {
+		for _, fc := range lis.GetFilterChains() {
+			stripHCMCustomFilters(fc)
+		}
+		if fc := lis.GetDefaultFilterChain(); fc != nil {
+			stripHCMCustomFilters(fc)
+		}
+	}
+}
+
+// stripHCMCustomFilters removes the aether_stats HTTP filter from a
+// FilterChain's HttpConnectionManager.  Other network filter types are unchanged.
+func stripHCMCustomFilters(fc *listenerv3.FilterChain) {
+	for _, f := range fc.GetFilters() {
+		// aether uses the legacy name "envoy.http_connection_manager".
+		// Check both the legacy and canonical names for safety.
+		name := f.GetName()
+		if name != "envoy.http_connection_manager" &&
+			name != "envoy.filters.network.http_connection_manager" {
+			continue
+		}
+		hcmAny := f.GetTypedConfig()
+		if hcmAny == nil {
+			continue
+		}
+		hcm := &http_connection_managerv3.HttpConnectionManager{}
+		if err := hcmAny.UnmarshalTo(hcm); err != nil {
+			continue
+		}
+		filtered := make([]*http_connection_managerv3.HttpFilter, 0, len(hcm.GetHttpFilters()))
+		for _, hf := range hcm.GetHttpFilters() {
+			if hf.GetName() == aetherStatsFilterName {
+				continue // strip: requires custom binary
+			}
+			filtered = append(filtered, hf)
+		}
+		hcm.HttpFilters = filtered
+		packed, err := anypb.New(hcm)
+		if err != nil {
+			panic(fmt.Sprintf("re-pack HCM: %v", err))
+		}
+		f.ConfigType = &listenerv3.Filter_TypedConfig{TypedConfig: packed}
+	}
+}
+
+// mustAny packs a proto.Message into anypb.Any, panicking on error.
+// All types used here are well-formed static configs.
+func mustAny(m proto.Message) *anypb.Any {
+	a, err := anypb.New(m)
+	if err != nil {
+		panic(fmt.Sprintf("mustAny: %v", err))
+	}
+	return a
+}

--- a/test/envoy_validate/generate/BUILD.bazel
+++ b/test/envoy_validate/generate/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "generate_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/bpalermo/aether/test/envoy_validate/generate",
+    visibility = ["//visibility:private"],
+    deps = ["//test/envoy_validate"],
+)
+
+go_binary(
+    name = "generate",
+    embed = [":generate_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/test/envoy_validate/generate/main.go
+++ b/test/envoy_validate/generate/main.go
@@ -1,0 +1,50 @@
+// Command generate-envoy-bootstrap emits representative Envoy bootstrap JSON
+// files into --out for offline inspection or CI artifact storage.
+//
+// The bootstrap configs are the same as those validated by
+// //test/envoy_validate:envoy_validate_test.  Running the generator standalone
+// is useful for inspecting the produced JSON before changing the proxy builders.
+//
+// Usage:
+//
+//	bazel run //test/envoy_validate/generate -- --out /tmp/envoy-validate
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"path/filepath"
+
+	envoy_validate "github.com/bpalermo/aether/test/envoy_validate"
+)
+
+func main() {
+	outDir := flag.String("out", ".", "directory to write bootstrap JSON files into")
+	flag.Parse()
+
+	if err := os.MkdirAll(*outDir, 0o755); err != nil {
+		log.Fatalf("create output dir: %v", err)
+	}
+
+	tasks := []struct {
+		name string
+		fn   func() ([]byte, error)
+	}{
+		{"node_bootstrap.json", envoy_validate.NodeBootstrapJSON},
+		{"capture_bootstrap.json", envoy_validate.CaptureBootstrapJSON},
+		{"edge_bootstrap.json", envoy_validate.EdgeBootstrapJSON},
+	}
+
+	for _, t := range tasks {
+		data, err := t.fn()
+		if err != nil {
+			log.Fatalf("build %s: %v", t.name, err)
+		}
+		out := filepath.Join(*outDir, t.name)
+		if err := os.WriteFile(out, data, 0o644); err != nil {
+			log.Fatalf("write %s: %v", t.name, err)
+		}
+		log.Printf("wrote %s", out)
+	}
+}

--- a/test/envoy_validate/validate_test.go
+++ b/test/envoy_validate/validate_test.go
@@ -1,0 +1,157 @@
+// Package envoy_validate runs "envoy --mode validate" over aether-generated
+// bootstrap configs to catch "Envoy would NACK this" regressions before they
+// reach production.
+//
+// The Envoy binary is provided as a Bazel data dependency (http_file in
+// MODULE.bazel, pinned to ENVOY_VERSION = 1.38.0).  To run the test:
+//
+//	bazel test //test/envoy_validate:envoy_validate_test
+//	bazel test //test/envoy_validate:envoy_validate_test --test_output=all
+//
+// What the test catches (examples from production incidents):
+//   - ORIGINAL_DST cluster with ROUND_ROBIN lb_policy      → CDS NACK, exit 1
+//   - Listener with no address field                        → LDS NACK, exit 1
+//   - Malformed / missing SAN in TLS validation context     → config rejected
+//   - Unknown TypedConfig @type URL (non-stripped filter)   → config rejected
+package envoy_validate
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// envoyBinary returns the path to the Envoy binary from the Bazel runfiles tree.
+//
+// In Bazel 9 bzlmod, http_file repos created via use_repo_rule have a canonical
+// name like "+http_file+<repo-name>" rather than just "<repo-name>".  The repo
+// mapping file (runfiles/_repo_mapping or .runfiles.repo_mapping) translates the
+// user-visible name to the canonical name.  This function reads that mapping so
+// the lookup is robust across Bazel versions.
+func envoyBinary(t *testing.T) string {
+	t.Helper()
+
+	// Determine the architecture-specific user-visible repo name.
+	var repoName string
+	switch runtime.GOARCH {
+	case "amd64":
+		repoName = "envoy_binary_linux_amd64"
+	case "arm64":
+		repoName = "envoy_binary_linux_arm64"
+	default:
+		t.Skipf("envoy binary not available for GOARCH=%s", runtime.GOARCH)
+	}
+
+	runfiles := os.Getenv("RUNFILES_DIR")
+	if runfiles == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			t.Fatalf("os.Executable: %v", err)
+		}
+		runfiles = exe + ".runfiles"
+	}
+
+	// Resolve the canonical repo name from the repo mapping file.
+	// Format: "<from-canonical>,<apparent>,<to-canonical>"
+	// We want lines starting with "," (main repo context) mapping our user name.
+	canonical := canonicalRepo(t, runfiles, repoName)
+
+	p := filepath.Join(runfiles, canonical, "file", "envoy")
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("envoy binary not found at %s: %v\n(RUNFILES_DIR=%s)", p, err, runfiles)
+	}
+	return p
+}
+
+// canonicalRepo resolves a user-visible repository name to its canonical bzlmod
+// name by reading the _repo_mapping file in the runfiles directory.
+func canonicalRepo(t *testing.T, runfiles, apparent string) string {
+	t.Helper()
+
+	// Try the direct path first (for when the file is in the runfiles root).
+	for _, name := range []string{"_repo_mapping", filepath.Join("_main", "_repo_mapping")} {
+		mappingPath := filepath.Join(runfiles, name)
+		canonical, ok := lookupMapping(t, mappingPath, apparent)
+		if ok {
+			return canonical
+		}
+	}
+
+	// Fall back to the direct name (pre-bzlmod or old Bazel versions).
+	t.Logf("no repo mapping found for %q; falling back to direct name", apparent)
+	return apparent
+}
+
+// lookupMapping reads a Bazel repo mapping file and returns the canonical name
+// for the given apparent name in the main workspace context ("" or "_main").
+func lookupMapping(t *testing.T, path, apparent string) (string, bool) {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		return "", false
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.SplitN(line, ",", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		from, app, to := parts[0], parts[1], parts[2]
+		// Lines with empty from-canonical are from the main workspace context.
+		if from == "" && app == apparent {
+			return to, true
+		}
+	}
+	return "", false
+}
+
+// TestEnvoyValidate generates three representative aether bootstrap configs
+// and validates each one with "envoy --mode validate".
+//
+// Envoy exits 0 when the config is structurally valid; exits 1 on any error.
+func TestEnvoyValidate(t *testing.T) {
+	envoy := envoyBinary(t)
+
+	outDir := t.TempDir()
+
+	builders := []struct {
+		name string
+		fn   func() ([]byte, error)
+	}{
+		{"node_bootstrap.json", NodeBootstrapJSON},
+		{"capture_bootstrap.json", CaptureBootstrapJSON},
+		{"edge_bootstrap.json", EdgeBootstrapJSON},
+	}
+
+	// Write all bootstrap files.
+	for _, b := range builders {
+		data, err := b.fn()
+		if err != nil {
+			t.Fatalf("build %s: %v", b.name, err)
+		}
+		if err := os.WriteFile(filepath.Join(outDir, b.name), data, 0o644); err != nil {
+			t.Fatalf("write %s: %v", b.name, err)
+		}
+	}
+
+	// Validate each bootstrap with Envoy.
+	for _, b := range builders {
+		b := b
+		t.Run(b.name, func(t *testing.T) {
+			path := filepath.Join(outDir, b.name)
+			cmd := exec.Command(envoy, "--mode", "validate", "-c", path)
+			out, err := cmd.CombinedOutput()
+			t.Logf("envoy --mode validate %s:\n%s", b.name, out)
+			if err != nil {
+				t.Fatalf("envoy --mode validate failed for %s: %v", b.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `//test/envoy_validate:envoy_validate_test` — a hermetic `go_test` that runs `envoy --mode validate` over three representative aether-generated bootstrap configs, catching Envoy NACK regressions before they reach production
- Bootstrap configs are generated by calling the real proxy builders (`GenerateListenersFromRegistryPod`, `GenerateCaptureListener`, etc.) so the test stays in sync with production codepaths automatically
- The `aether_stats` C++ extension (which requires the custom proxy-workspace Envoy binary) is stripped before serialisation so stock Envoy can validate the structural correctness of the rest of the config

## What it catches (examples from production incidents)

- `ORIGINAL_DST` cluster with `ROUND_ROBIN` lb_policy → CDS NACK, exit 1
- Listener with no address field → LDS NACK, exit 1
- Malformed or missing SAN in TLS validation context → config rejected
- Unknown TypedConfig `@type` URL (e.g. non-stripped custom filter) → config rejected

## Implementation

- **`MODULE.bazel`**: two `http_file` repos pinned to `envoy-1.38.0-linux-{x86_64,aarch_64}` with SHA-256 from upstream `checksums.txt.asc`; comment `# ENVOY_VERSION = "1.38.0"` to match the proxy workspace
- **`test/envoy_validate/BUILD.bazel`**: arch-select `alias(:envoy_bin)`, `go_library(:envoy_validate)`, `go_test(:envoy_validate_test, size=medium, tags=[envoy-validate, no-sandbox])`
- **`test/envoy_validate/builders.go`**: exported `NodeBootstrapJSON`, `CaptureBootstrapJSON`, `EdgeBootstrapJSON`; `stripCustomFilters` post-processes the proto before `protojson.Marshal`
- **`test/envoy_validate/validate_test.go`**: resolves the bzlmod canonical repo name (`+http_file+envoy_binary_linux_amd64`) via `_repo_mapping` without adding any new Go dependency
- **`test/envoy_validate/generate/`**: thin CLI to emit bootstrap JSON files for offline inspection (`bazel run //test/envoy_validate/generate -- --out /tmp/envoy-validate`)
- `target_compatible_with = [@platforms//os:linux]`; skips on unsupported GOARCH

## Test plan

- [x] `bazel test //test/envoy_validate:envoy_validate_test --test_output=errors` — PASSED (all 3 subtests: node, capture, edge)
- [x] `bazel test --test_output=errors --test_tag_filters=-integration,-e2e,-envoy-validate //...` — 59/59 pass (no regressions)
- [x] `make format` — clean
- [x] `bazel build --config=lint //test/envoy_validate/... //agent/internal/xds/proxy:proxy //agent/internal/xds/config:config` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S