### PR TITLE
feat(020): namespace-qualify GAMMA backendRef cluster + dependency keys

### DIFF
--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -202,6 +202,18 @@ func (r *Reconciler) backendsResolve(_ context.Context, routeNamespace, routeKin
 	return true, string(gatewayv1.RouteReasonResolvedRefs), "All backend references resolved"
 }
 
+// backendServiceKey resolves a backendRef to its namespace-qualified "<ns>/<svc>"
+// registry key (020 Part 1): the backendRef's own namespace when set, else the
+// route's namespace. The resulting key feeds both the data-plane cluster name
+// (ServiceClusterName) and the node dependency set (routeBackendsLocked).
+func backendServiceKey(backendNamespace *gatewayv1.Namespace, routeNamespace, name string) string {
+	ns := routeNamespace
+	if bn := derefBackendNamespace(backendNamespace); bn != "" {
+		ns = bn
+	}
+	return serviceref.New(ns, name).Key()
+}
+
 // derefBackendNamespace returns the backendRef namespace ("" when unset).
 func derefBackendNamespace(ns *gatewayv1.Namespace) string {
 	if ns == nil {
@@ -290,9 +302,13 @@ func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule, routeNamespac
 		if b.Weight != nil {
 			weight = uint32(*b.Weight)
 		}
+		// 020 Part 1: the backend's data-plane cluster and dependency-set key are
+		// namespace-qualified "<ns>/<svc>". A canary/split to a different backend
+		// service therefore resolves the right registry cluster.
+		key := backendServiceKey(b.Namespace, routeNamespace, name)
 		gr.Backends = append(gr.Backends, proxy.GammaBackend{
-			Service: name,
-			Cluster: proxy.ServiceClusterName(name, r.MeshDomain),
+			Service: key,
+			Cluster: proxy.ServiceClusterName(key, r.MeshDomain),
 			Weight:  weight,
 		})
 	}
@@ -500,9 +516,13 @@ func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule, route
 		if b.Weight != nil {
 			weight = uint32(*b.Weight)
 		}
+		// 020 Part 1: the backend's data-plane cluster and dependency-set key are
+		// namespace-qualified "<ns>/<svc>". A canary/split to a different backend
+		// service therefore resolves the right registry cluster.
+		key := backendServiceKey(b.Namespace, routeNamespace, name)
 		gr.Backends = append(gr.Backends, proxy.GammaBackend{
-			Service: name,
-			Cluster: proxy.ServiceClusterName(name, r.MeshDomain),
+			Service: key,
+			Cluster: proxy.ServiceClusterName(key, r.MeshDomain),
 			Weight:  weight,
 		})
 	}

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -167,7 +167,7 @@ func TestBuildGammaRoute_DropsUngrantedCrossNamespaceBackend(t *testing.T) {
 	// No grants: the cross-ns "remote" backend is dropped.
 	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil)
 	require.Len(t, gr.Backends, 1)
-	assert.Equal(t, "local", gr.Backends[0].Service)
+	assert.Equal(t, "ns/local", gr.Backends[0].Service)
 
 	// With a matching grant: both backends are kept.
 	grants := []gatewayv1beta1.ReferenceGrant{{
@@ -217,7 +217,7 @@ func TestBuildGammaRoute(t *testing.T) {
 	assert.Equal(t, proxy.GammaHeaderMatch{Name: "x-env", Value: "beta"}, gr.Matches[0].Headers[0])
 
 	require.Len(t, gr.Backends, 2)
-	assert.Equal(t, proxy.GammaBackend{Service: "svc-1-v1", Cluster: proxy.ServiceClusterName("svc-1-v1", "mesh"), Weight: 90}, gr.Backends[0])
+	assert.Equal(t, proxy.GammaBackend{Service: "ns/svc-1-v1", Cluster: proxy.ServiceClusterName("ns/svc-1-v1", "mesh"), Weight: 90}, gr.Backends[0])
 	assert.Equal(t, uint32(10), gr.Backends[1].Weight)
 
 	require.NotNil(t, gr.Timeout)
@@ -242,8 +242,8 @@ func TestBuildGammaRouteFromGRPC(t *testing.T) {
 	assert.Equal(t, "/foo.Bar/Baz", gr.Matches[0].Exact, "service+method -> exact path")
 	assert.Equal(t, "/foo.Bar/", gr.Matches[1].Prefix, "service-only -> prefix path")
 	require.Len(t, gr.Backends, 1)
-	assert.Equal(t, "svc-2", gr.Backends[0].Service)
-	assert.Equal(t, "svc-2.aether.internal", gr.Backends[0].Cluster)
+	assert.Equal(t, "ns/svc-2", gr.Backends[0].Service)
+	assert.Equal(t, "svc-2.ns.aether.internal", gr.Backends[0].Cluster)
 	assert.Equal(t, uint32(7), gr.Backends[0].Weight)
 }
 


### PR DESCRIPTION
Closes the GAMMA gap the #395 audit surfaced. The gamma reconciler passed **bare** backendRef names to `ServiceClusterName` → flat `<name>.<meshDomain>` (via the fallback), which doesn't match the `<svc>.<ns>.<meshDomain>` registry clusters under 020. So **GAMMA weighted/canary splits to a different backend service referenced a non-existent cluster**, and that bare name also failed to scope the backend's EDS into the node dependency set.

Resolves each backendRef to `<ns>/<svc>` (backendRef ns if set, else route ns) via a new `backendServiceKey` helper, used for both `GammaBackend.Cluster` and `GammaBackend.Service`. HTTPRoute + GRPCRoute; tests migrated. Full agent+registrar suite green.

This was the **last bare-key caller of `ServiceClusterName`** — the defensive fallback is now removable in a follow-up (true cutover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)