### PR TITLE
fix(022): scope capture HCM chain to cleartext so TLS egress passes through (M2a)

### DIFF
--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -107,7 +107,7 @@ func GenerateCaptureListener(cniPod *cniv1.CNIPod, capturePort uint32, meshDomai
 			chains = append(chains, tc)
 		}
 	}
-	chains = append(chains, buildCaptureHTTPFilterChain(cniPod, meshDomain, emitStatsPod))
+	chains = append(chains, buildCaptureHTTPFilterChain(cniPod, meshDomain, emitStatsPod, withPassthrough))
 
 	l := &listenerv3.Listener{
 		Name: CaptureListenerName(cniPod),
@@ -202,7 +202,18 @@ func buildCaptureTCPFloorFilterChain(svc CaptureTCPService) *listenerv3.FilterCh
 // buildCaptureHTTPFilterChain mirrors the outbound HTTP chain but serves the capture
 // route table (cluster.local authorities) over RDS. Same readiness/subset/on-demand/
 // stats filters and per-source mTLS egress path.
-func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool) *listenerv3.FilterChain {
+//
+// scopeToCleartext (redirect-all / withPassthrough, proposal 022 M2a): match the
+// chain on transport_protocol="raw_buffer" so it catches ONLY cleartext traffic —
+// mesh egress is cleartext to this listener (the proxy adds mTLS upstream). TLS
+// egress (external HTTPS, kube-apiserver) is detected by tls_inspector as
+// transport_protocol="tls", does NOT match here, and falls to the DefaultFilterChain
+// ORIGINAL_DST passthrough. Without this the no-match HCM chain catches the TLS
+// stream and the handshake fails (it tries to parse TLS as HTTP). Scoping by
+// application_protocol does NOT work — a TLS ClientHello's ALPN (h2/http/1.1) looks
+// like HTTP. In scoped (non-redirect-all) mode the chain stays a catch-all: only
+// mesh ClusterIPs are captured (all cleartext) and there is no passthrough fallback.
+func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool, scopeToCleartext bool) *listenerv3.FilterChain {
 	hcm := buildHTTPConnectionManager("capture_http", ReporterSource, cniPod.GetName(), cniPod.GetNamespace(), nil)
 
 	prefix := []*http_connection_managerv3.HttpFilter{
@@ -220,13 +231,19 @@ func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitSt
 		},
 	}
 
-	return &listenerv3.FilterChain{
+	fc := &listenerv3.FilterChain{
 		Name: fmt.Sprintf("capture_%s", cniPod.GetName()),
 		Filters: []*listenerv3.Filter{
 			buildNetworkNamespaceFilterState(),
 			buildHTTPConnectionManagerFilter(hcm),
 		},
 	}
+	if scopeToCleartext {
+		// raw_buffer = cleartext (tls_inspector marks TLS streams "tls"). TLS egress
+		// then misses this chain and falls to the passthrough DefaultFilterChain.
+		fc.FilterChainMatch = &listenerv3.FilterChainMatch{TransportProtocol: "raw_buffer"}
+	}
+	return fc
 }
 
 // BuildCapturePassthroughFilterChain returns the DefaultFilterChain for the

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -116,8 +116,14 @@ func TestGenerateCaptureListener_WithPassthrough(t *testing.T) {
 	l, err := GenerateCaptureListener(pod, 15001, "aether.internal", false, nil, true)
 	require.NoError(t, err)
 
-	// Named filter_chains: only the HCM catch-all (no TCP services).
+	// Named filter_chains: only the HCM chain (no TCP services).
 	require.Len(t, l.GetFilterChains(), 1, "one HCM chain, passthrough is in DefaultFilterChain")
+
+	// With passthrough, the HCM chain is scoped to cleartext (transport_protocol=
+	// raw_buffer) so TLS egress (transport_protocol=tls) misses it and falls to the
+	// DefaultFilterChain passthrough instead of failing in the HTTP codec.
+	assert.Equal(t, "raw_buffer", l.GetFilterChains()[0].GetFilterChainMatch().GetTransportProtocol(),
+		"HCM chain must match raw_buffer so TLS egress falls through to the passthrough")
 
 	// DefaultFilterChain must be set.
 	require.NotNil(t, l.GetDefaultFilterChain(), "DefaultFilterChain must be set when withPassthrough=true")


### PR DESCRIPTION
**M2a egress e2e finding.** The redirect-all `original_dst` passthrough (proposal 022) never engaged for TLS egress: the capture listener's HCM filter chain had **no `filter_chain_match`**, so it caught *every* captured connection — including external HTTPS and kube-apiserver TLS. The HCM tried to parse the TLS stream as HTTP → handshake failed (curl exit 35), and the `DefaultFilterChain` ORIGINAL_DST passthrough never fired.

Fix: when `withPassthrough`, match the HCM chain on `transport_protocol="raw_buffer"` (cleartext). Mesh egress is cleartext to this listener (the proxy adds mTLS upstream) so it still hits the HCM; TLS egress is marked `tls` by `tls_inspector`, misses the HCM, and falls to the passthrough. Scoping by `application_protocol` does **not** work — a TLS ClientHello's ALPN (`h2`/`http/1.1`) looks like HTTP. Scoped (non-redirect-all) mode unchanged.

Capture unit test + offline `envoy --mode validate` (which builds the withPassthrough capture) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)