### PR TITLE
feat(020): namespace-qualify L4-route + edge-L4 cluster keys, drop ServiceClusterName fallback

### DIFF
--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -1018,6 +1018,11 @@ func gatewayParentPorts(
 // cluster names. Refs with a non-core group or non-Service kind are skipped, as are
 // ungranted cross-namespace refs (RefNotPermitted: dropped from the data plane).
 // routeKind is the referring route's kind (TCPRoute/TLSRoute).
+//
+// Edge L4 backends are mesh-only (the cache's edgeTCPClusters builds a registry
+// TCP cluster per backend), so the backend's data-plane cluster and dependency key
+// are the namespace-qualified "<ns>/<svc>" serviceref key (020 Part 1): the
+// backendRef's own namespace when set, else the route's namespace.
 func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
 	backends := make([]proxy.L4Backend, 0, len(refs))
 	for _, b := range refs {
@@ -1038,9 +1043,14 @@ func (r *Reconciler) buildL4Backends(refs []gatewayv1.BackendRef, routeNamespace
 		if b.Weight != nil {
 			weight = uint32(*b.Weight)
 		}
+		ns := routeNamespace
+		if bn := derefBackendNamespace(b.Namespace); bn != "" {
+			ns = bn
+		}
+		key := serviceref.New(ns, name).Key()
 		backends = append(backends, proxy.L4Backend{
-			Service: name,
-			Cluster: proxy.TCPClusterName(name, r.MeshDomain),
+			Service: key,
+			Cluster: proxy.TCPClusterName(key, r.MeshDomain),
 			Weight:  weight,
 		})
 	}

--- a/agent/internal/edge/gatewayapi/reconciler_test.go
+++ b/agent/internal/edge/gatewayapi/reconciler_test.go
@@ -292,10 +292,11 @@ func TestBuildL4Backends(t *testing.T) {
 	}
 	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 2)
-	assert.Equal(t, "pg", backends[0].Service)
-	assert.Equal(t, proxy.TCPClusterName("pg", "aether.internal"), backends[0].Cluster)
+	assert.Equal(t, "ns/pg", backends[0].Service)
+	assert.Equal(t, proxy.TCPClusterName("ns/pg", "aether.internal"), backends[0].Cluster)
+	assert.Equal(t, "tcp:pg.ns.aether.internal", backends[0].Cluster)
 	assert.Equal(t, uint32(1), backends[0].Weight)
-	assert.Equal(t, "cache", backends[1].Service)
+	assert.Equal(t, "ns/cache", backends[1].Service)
 	assert.Equal(t, uint32(2), backends[1].Weight)
 }
 
@@ -310,7 +311,7 @@ func TestBuildL4Backends_ForeignGroupSkipped(t *testing.T) {
 	}
 	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 1)
-	assert.Equal(t, "keep", backends[0].Service)
+	assert.Equal(t, "ns/keep", backends[0].Service)
 }
 
 // TestAttachedToOurGateway_L4 verifies the refactored attachedToOurGateway accepts

--- a/agent/internal/l4route/BUILD.bazel
+++ b/agent/internal/l4route/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//agent/internal/referencegrant",
         "//agent/internal/xds/proxy",
         "//common/log",
+        "//common/serviceref",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",

--- a/agent/internal/l4route/reconciler.go
+++ b/agent/internal/l4route/reconciler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/referencegrant"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	commonlog "github.com/bpalermo/aether/common/log"
+	"github.com/bpalermo/aether/common/serviceref"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,8 +35,8 @@ import (
 // reconciler. Typically implemented by the snapshot cache.
 type L4RouteSink interface {
 	// SetTCPServiceRoutes replaces the TCPRoute-derived per-service L4 rules.
-	// Each key is the bare service name (parentRef.Name); values are the ordered
-	// rules from all TCPRoutes attached to that service.
+	// Each key is the namespace-qualified "<ns>/<svc>" serviceref key (020 Part 1);
+	// values are the ordered rules from all TCPRoutes attached to that service.
 	SetTCPServiceRoutes(routes map[string][]proxy.L4ServiceRoute)
 	// SetTLSServiceRoutes replaces the TLSRoute-derived per-service L4 rules.
 	SetTLSServiceRoutes(routes map[string][]proxy.L4ServiceRoute)
@@ -100,7 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	tcpRoutes := map[string][]proxy.L4ServiceRoute{}
 	for i := range tcpList.Items {
 		tr := &tcpList.Items[i]
-		for _, svc := range serviceParents(tr.Spec.ParentRefs) {
+		for _, svc := range serviceParents(tr.Spec.ParentRefs, tr.Namespace) {
 			for _, rule := range tr.Spec.Rules {
 				tcpRoutes[svc] = append(tcpRoutes[svc], r.buildTCPRoute(rule, tr.Namespace, "TCPRoute", grants))
 			}
@@ -110,7 +111,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	tlsRoutes := map[string][]proxy.L4ServiceRoute{}
 	for i := range tlsList.Items {
 		tr := &tlsList.Items[i]
-		for _, svc := range serviceParents(tr.Spec.ParentRefs) {
+		for _, svc := range serviceParents(tr.Spec.ParentRefs, tr.Namespace) {
 			hostnames := make([]string, 0, len(tr.Spec.Hostnames))
 			for _, h := range tr.Spec.Hostnames {
 				hostnames = append(hostnames, string(h))
@@ -124,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	udpRoutes := map[string][]proxy.L4Backend{}
 	for i := range udpList.Items {
 		ur := &udpList.Items[i]
-		for _, svc := range serviceParents(ur.Spec.ParentRefs) {
+		for _, svc := range serviceParents(ur.Spec.ParentRefs, ur.Namespace) {
 			for _, rule := range ur.Spec.Rules {
 				udpRoutes[svc] = append(udpRoutes[svc], r.buildUDPBackends(rule, ur.Namespace, "UDPRoute", grants)...)
 			}
@@ -296,9 +297,11 @@ func udpBackendRefs(rules []gatewayv1alpha2.UDPRouteRule) []gatewayv1.BackendObj
 	return refs
 }
 
-// serviceParents returns the names of the Services these parentRefs attach to
-// (kind=Service, core group — empty group string or nil group).
-func serviceParents(refs []gatewayv1alpha2.ParentReference) []string {
+// serviceParents returns the namespace-qualified "<ns>/<svc>" keys of the Service
+// parentRefs (kind=Service, core group — empty group string or nil group; 020
+// Part 1). A parentRef without an explicit namespace inherits the route's
+// namespace (Gateway API default).
+func serviceParents(refs []gatewayv1alpha2.ParentReference, routeNamespace string) []string {
 	var svcs []string
 	for _, p := range refs {
 		if p.Group != nil && string(*p.Group) != "" {
@@ -307,9 +310,25 @@ func serviceParents(refs []gatewayv1alpha2.ParentReference) []string {
 		if p.Kind == nil || string(*p.Kind) != "Service" {
 			continue
 		}
-		svcs = append(svcs, string(p.Name))
+		ns := routeNamespace
+		if p.Namespace != nil && string(*p.Namespace) != "" {
+			ns = string(*p.Namespace)
+		}
+		svcs = append(svcs, serviceref.New(ns, string(p.Name)).Key())
 	}
 	return svcs
+}
+
+// backendServiceKey resolves a backendRef to its namespace-qualified "<ns>/<svc>"
+// registry key (020 Part 1): the backendRef's own namespace when set, else the
+// route's namespace. The resulting key feeds both the data-plane cluster name
+// (TCP/TLS/UDP ClusterName) and the node dependency set (L4Backend.Service).
+func backendServiceKey(backendNamespace *gatewayv1.Namespace, routeNamespace, name string) string {
+	ns := routeNamespace
+	if bn := derefBackendNamespace(backendNamespace); bn != "" {
+		ns = bn
+	}
+	return serviceref.New(ns, name).Key()
 }
 
 // buildTCPRoute translates a TCPRouteRule into an L4ServiceRoute (no SNI match).
@@ -340,11 +359,12 @@ func (r *Reconciler) buildUDPBackends(rule gatewayv1alpha2.UDPRouteRule, routeNa
 // buildL4Backends converts a BackendRef slice into L4Backends with resolved
 // TCP cluster names. Refs with a non-core group or non-Service kind are skipped.
 func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
-	return r.buildBackendsWithCluster(refs, routeNamespace, routeKind, grants, func(name string) string {
+	return r.buildBackendsWithCluster(refs, routeNamespace, routeKind, grants, func(key string) string {
 		// TCP clusters share the same EDS endpoints as HTTP clusters but use
 		// ALPN "aether-tcp" (see TCPClusterName). The capture TCP floor chains
-		// already reference "tcp:<svc>.<domain>" clusters.
-		return proxy.TCPClusterName(name, r.MeshDomain)
+		// already reference "tcp:<svc>.<ns>.<domain>" clusters. The key is the
+		// backend's namespace-qualified "<ns>/<svc>" (020 Part 1).
+		return proxy.TCPClusterName(key, r.MeshDomain)
 	})
 }
 
@@ -352,8 +372,9 @@ func (r *Reconciler) buildL4Backends(refs []gatewayv1alpha2.BackendRef, routeNam
 // UDP cluster names ("udp:<svc>.<domain>"). These clusters are plain EDS without
 // a transport socket — UDP traffic is not covered by mesh mTLS.
 func (r *Reconciler) buildUDPL4Backends(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) []proxy.L4Backend {
-	return r.buildBackendsWithCluster(refs, routeNamespace, routeKind, grants, func(name string) string {
-		return proxy.UDPClusterName(name, r.MeshDomain)
+	return r.buildBackendsWithCluster(refs, routeNamespace, routeKind, grants, func(key string) string {
+		// key is the backend's namespace-qualified "<ns>/<svc>" (020 Part 1).
+		return proxy.UDPClusterName(key, r.MeshDomain)
 	})
 }
 
@@ -361,7 +382,7 @@ func (r *Reconciler) buildUDPL4Backends(refs []gatewayv1alpha2.BackendRef, route
 // the cluster name via clusterNameFn. Refs with a non-core group or non-Service
 // kind are skipped, as are ungranted cross-namespace refs (RefNotPermitted: dropped
 // from the data plane, mirroring the route's ResolvedRefs status).
-func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, clusterNameFn func(name string) string) []proxy.L4Backend {
+func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, clusterNameFn func(key string) string) []proxy.L4Backend {
 	backends := make([]proxy.L4Backend, 0, len(refs))
 	for _, b := range refs {
 		if b.Group != nil && string(*b.Group) != "" {
@@ -381,9 +402,14 @@ func (r *Reconciler) buildBackendsWithCluster(refs []gatewayv1alpha2.BackendRef,
 		if b.Weight != nil {
 			weight = uint32(*b.Weight)
 		}
+		// 020 Part 1: the backend's data-plane cluster and dependency-set key are
+		// namespace-qualified "<ns>/<svc>" (backendRef namespace if set, else the
+		// route's). A split to a different backend service therefore resolves the
+		// right registry cluster.
+		key := backendServiceKey(b.Namespace, routeNamespace, name)
 		backends = append(backends, proxy.L4Backend{
-			Service: name,
-			Cluster: clusterNameFn(name),
+			Service: key,
+			Cluster: clusterNameFn(key),
 			Weight:  weight,
 		})
 	}

--- a/agent/internal/l4route/reconciler_test.go
+++ b/agent/internal/l4route/reconciler_test.go
@@ -14,16 +14,20 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
-// TestServiceParents verifies that only Service-kind, core-group parentRefs are kept.
+// TestServiceParents verifies that only Service-kind, core-group parentRefs are
+// kept, and that each is rendered as a namespace-qualified "<ns>/<svc>" key:
+// parentRef namespace if set, else the route's namespace (020 Part 1).
 func TestServiceParents(t *testing.T) {
+	otherNs := gatewayv1.Namespace("other")
 	refs := []gatewayv1.ParentReference{
 		{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-1"},
 		{Kind: ptr(gatewayv1.Kind("Gateway")), Name: "edge"}, // wrong kind
 		{Group: ptr(gatewayv1.Group("apps")), Name: "svc-2"}, // non-core group
 		{Name: "no-kind"}, // no kind → skip
-		{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-3"},
+		{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-3", Namespace: &otherNs},
 	}
-	assert.Equal(t, []string{"svc-1", "svc-3"}, serviceParents(refs))
+	// svc-1 inherits the route namespace "ns"; svc-3 uses its explicit "other".
+	assert.Equal(t, []string{"ns/svc-1", "other/svc-3"}, serviceParents(refs, "ns"))
 }
 
 // TestBuildTCPRoute_SingleBackend verifies basic TCPRouteRule translation.
@@ -40,8 +44,9 @@ func TestBuildTCPRoute_SingleBackend(t *testing.T) {
 	route := r.buildTCPRoute(rule, "ns", "TCPRoute", nil)
 	assert.Empty(t, route.SNIHostnames, "TCPRoute must not set SNI hostnames")
 	require.Len(t, route.Backends, 1)
-	assert.Equal(t, "svc-a", route.Backends[0].Service)
-	assert.Equal(t, proxy.TCPClusterName("svc-a", "aether.internal"), route.Backends[0].Cluster)
+	assert.Equal(t, "ns/svc-a", route.Backends[0].Service)
+	assert.Equal(t, proxy.TCPClusterName("ns/svc-a", "aether.internal"), route.Backends[0].Cluster)
+	assert.Equal(t, "tcp:svc-a.ns.aether.internal", route.Backends[0].Cluster)
 	assert.Equal(t, uint32(1), route.Backends[0].Weight)
 }
 
@@ -56,9 +61,9 @@ func TestBuildTCPRoute_WeightedBackends(t *testing.T) {
 	}
 	route := r.buildTCPRoute(rule, "ns", "TCPRoute", nil)
 	require.Len(t, route.Backends, 2)
-	assert.Equal(t, "tcp:svc-v1.mesh", route.Backends[0].Cluster)
+	assert.Equal(t, "tcp:svc-v1.ns.mesh", route.Backends[0].Cluster)
 	assert.Equal(t, uint32(90), route.Backends[0].Weight)
-	assert.Equal(t, "tcp:svc-v2.mesh", route.Backends[1].Cluster)
+	assert.Equal(t, "tcp:svc-v2.ns.mesh", route.Backends[1].Cluster)
 	assert.Equal(t, uint32(10), route.Backends[1].Weight)
 }
 
@@ -74,7 +79,8 @@ func TestBuildTLSRoute_WithHostnames(t *testing.T) {
 	route := r.buildTLSRoute(rule, hostnames, "ns", "TLSRoute", nil)
 	assert.Equal(t, hostnames, route.SNIHostnames)
 	require.Len(t, route.Backends, 1)
-	assert.Equal(t, proxy.TCPClusterName("svc-b", "aether.internal"), route.Backends[0].Cluster)
+	assert.Equal(t, "ns/svc-b", route.Backends[0].Service)
+	assert.Equal(t, proxy.TCPClusterName("ns/svc-b", "aether.internal"), route.Backends[0].Cluster)
 }
 
 // TestBuildUDPBackends verifies UDPRouteRule backend translation.
@@ -87,7 +93,9 @@ func TestBuildUDPBackends(t *testing.T) {
 	}
 	backends := r.buildUDPBackends(rule, "ns", "UDPRoute", nil)
 	require.Len(t, backends, 1)
-	assert.Equal(t, "svc-c", backends[0].Service)
+	assert.Equal(t, "ns/svc-c", backends[0].Service)
+	assert.Equal(t, proxy.UDPClusterName("ns/svc-c", "aether.internal"), backends[0].Cluster)
+	assert.Equal(t, "udp:svc-c.ns.aether.internal", backends[0].Cluster)
 	assert.Equal(t, uint32(5), backends[0].Weight)
 }
 
@@ -106,7 +114,7 @@ func TestBuildL4Backends_ForeignGroupSkipped(t *testing.T) {
 	}
 	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 1)
-	assert.Equal(t, "keep-me", backends[0].Service)
+	assert.Equal(t, "ns/keep-me", backends[0].Service)
 }
 
 // TestBuildL4Backends_DefaultWeight verifies that nil weight becomes 1.
@@ -133,9 +141,10 @@ func TestBuildL4Backends_DropsUngrantedCrossNamespace(t *testing.T) {
 	// No grants: cross-ns "remote" dropped.
 	backends := r.buildL4Backends(refs, "ns", "TCPRoute", nil)
 	require.Len(t, backends, 1)
-	assert.Equal(t, "local", backends[0].Service)
+	assert.Equal(t, "ns/local", backends[0].Service)
 
-	// Matching grant: both kept.
+	// Matching grant: both kept. The cross-namespace backend resolves to its own
+	// "other/remote" key (backendRef namespace), not the route's "ns" (020 Part 1).
 	grants := []gatewayv1beta1.ReferenceGrant{{
 		ObjectMeta: metav1.ObjectMeta{Namespace: "other"},
 		Spec: gatewayv1beta1.ReferenceGrantSpec{
@@ -145,4 +154,7 @@ func TestBuildL4Backends_DropsUngrantedCrossNamespace(t *testing.T) {
 	}}
 	backends = r.buildL4Backends(refs, "ns", "TCPRoute", grants)
 	require.Len(t, backends, 2)
+	assert.Equal(t, "ns/local", backends[0].Service)
+	assert.Equal(t, "other/remote", backends[1].Service)
+	assert.Equal(t, proxy.TCPClusterName("other/remote", "aether.internal"), backends[1].Cluster)
 }

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -399,7 +399,8 @@ func TestLoadClustersFromRegistry_RPCFillsColdDependency(t *testing.T) {
 func TestLoadClustersFromRegistry_MultiPort(t *testing.T) {
 	c := newTestCache("node-1")
 	c.SetMeshDomain("aether.internal")
-	declareDeps(c, "svc-mp")
+	// Registry keys are namespace-qualified "<ns>/<svc>" (020 Part 1).
+	declareDeps(c, "ns/svc-mp")
 	ctx := context.Background()
 
 	// ep1 serves 8080 (default) + 9090; ep2 serves only 8080 (old version).
@@ -409,30 +410,31 @@ func TestLoadClustersFromRegistry_MultiPort(t *testing.T) {
 	ep2.Ports = []uint32{8080}
 	reg := &mockRegistry{
 		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
-			return map[string][]*registryv1.ServiceEndpoint{"svc-mp": {ep1, ep2}}, nil
+			return map[string][]*registryv1.ServiceEndpoint{"ns/svc-mp": {ep1, ep2}}, nil
 		},
 	}
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
 
-	// Default cluster: dual-domain vhost, all endpoints.
-	def, ok := c.clusters["svc-mp"]
+	// Default cluster: dual-domain vhost, all endpoints. The "<ns>/<svc>" key
+	// renders to the FQDN authority <svc>.<ns>.<meshDomain>.
+	def, ok := c.clusters["ns/svc-mp"]
 	require.True(t, ok)
-	assert.Equal(t, "svc-mp.aether.internal", def.cluster.GetName())
-	assert.ElementsMatch(t, []string{"svc-mp.aether.internal", "svc-mp.aether.internal:8080"}, def.vhost.GetDomains())
+	assert.Equal(t, "svc-mp.ns.aether.internal", def.cluster.GetName())
+	assert.ElementsMatch(t, []string{"svc-mp.ns.aether.internal", "svc-mp.ns.aether.internal:8080"}, def.vhost.GetDomains())
 	assert.Len(t, def.loadAssignment.GetEndpoints(), 2, "default cluster carries all endpoints")
 	assert.Equal(t, "8080", def.sni)
 
 	// Per-port :9090 cluster: only ep1 (which advertises 9090).
-	port, ok := c.clusters["svc-mp.aether.internal:9090"]
+	port, ok := c.clusters["svc-mp.ns.aether.internal:9090"]
 	require.True(t, ok, "non-default port gets its own cluster")
-	assert.Equal(t, []string{"svc-mp.aether.internal:9090"}, port.vhost.GetDomains())
+	assert.Equal(t, []string{"svc-mp.ns.aether.internal:9090"}, port.vhost.GetDomains())
 	assert.Equal(t, "9090", port.sni)
 	require.Len(t, port.loadAssignment.GetEndpoints(), 1, "per-port EDS = pods advertising the port")
 	assert.Equal(t, "10.0.0.1",
 		port.loadAssignment.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
-	assert.Equal(t, "svc-mp", port.service, "per-port cluster maps back to bare service (SAN/retention)")
+	assert.Equal(t, "ns/svc-mp", port.service, "per-port cluster maps back to the service key (SAN/retention)")
 
 	// No spurious :8080 (default) port cluster — the default vhost owns it.
-	_, has8080 := c.clusters["svc-mp.aether.internal:8080"]
+	_, has8080 := c.clusters["svc-mp.ns.aether.internal:8080"]
 	assert.False(t, has8080, "default port is not a separate cluster")
 }

--- a/agent/internal/xds/cache/edge_test.go
+++ b/agent/internal/xds/cache/edge_test.go
@@ -135,18 +135,20 @@ func TestVirtualHostVhosts(t *testing.T) {
 	c := newTestCache("edge-1")
 
 	// Register services as mesh-registered so edgeClusterNameLocked uses the mesh path.
-	// A per-port cluster must also exist for the explicit-port backend to resolve to it.
+	// Registry/cluster keys are namespace-qualified "<ns>/<svc>" (020 Part 1); the
+	// route carries the backend namespace so the key resolves. A per-port cluster
+	// must also exist for the explicit-port backend to resolve to it.
 	c.clusterMu.Lock()
-	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
-	c.clusters["svc-3"] = clusterEntry{service: "svc-3"}
-	c.clusters["svc-2"] = clusterEntry{service: "svc-2"}
-	c.clusters["svc-2.aether.internal:9090"] = clusterEntry{service: "svc-2", sni: "9090"}
+	c.clusters["ns/svc-1"] = clusterEntry{service: "ns/svc-1"}
+	c.clusters["ns/svc-3"] = clusterEntry{service: "ns/svc-3"}
+	c.clusters["ns/svc-2"] = clusterEntry{service: "ns/svc-2"}
+	c.clusters["svc-2.ns.aether.internal:9090"] = clusterEntry{service: "ns/svc-2", sni: "9090"}
 	c.clusterMu.Unlock()
 
 	c.SetVirtualHosts([]VirtualHost{
-		{Hosts: []string{"api.example.com", "api2.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-1"}}},
-		{Routes: []Route{{Prefix: "/", Service: "svc-3"}}}, // no hosts -> catch-all "*"
-		{Hosts: []string{"grpc.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-2", Port: 9090}}},
+		{Hosts: []string{"api.example.com", "api2.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-1", BackendNamespace: "ns"}}},
+		{Routes: []Route{{Prefix: "/", Service: "svc-3", BackendNamespace: "ns"}}}, // no hosts -> catch-all "*"
+		{Hosts: []string{"grpc.example.com"}, Routes: []Route{{Prefix: "/", Service: "svc-2", BackendNamespace: "ns", Port: 9090}}},
 	})
 
 	vhosts := c.virtualHostVhosts()
@@ -162,20 +164,20 @@ func TestVirtualHostVhosts(t *testing.T) {
 
 	require.NotNil(t, byName["api.example.com"])
 	assert.Equal(t, []string{"api.example.com"}, byName["api.example.com"].GetDomains())
-	assert.Equal(t, "svc-1.aether.internal", byName["api.example.com"].GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-1.ns.aether.internal", byName["api.example.com"].GetRoutes()[0].GetRoute().GetCluster())
 
 	require.NotNil(t, byName["api2.example.com"], "api2.example.com gets its own Envoy vhost (one per domain)")
 	assert.Equal(t, []string{"api2.example.com"}, byName["api2.example.com"].GetDomains())
-	assert.Equal(t, "svc-1.aether.internal", byName["api2.example.com"].GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-1.ns.aether.internal", byName["api2.example.com"].GetRoutes()[0].GetRoute().GetCluster())
 
 	require.NotNil(t, byName["grpc.example.com"])
 	assert.Equal(t, []string{"grpc.example.com"}, byName["grpc.example.com"].GetDomains())
-	assert.Equal(t, "svc-2.aether.internal:9090", byName["grpc.example.com"].GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-2.ns.aether.internal:9090", byName["grpc.example.com"].GetRoutes()[0].GetRoute().GetCluster())
 
 	// The hostname-less route is served by the catch-all "*" vhost.
 	require.NotNil(t, byName["*"], "a hostname-less route must produce the catch-all * vhost")
 	assert.Equal(t, []string{"*"}, byName["*"].GetDomains())
-	assert.Equal(t, "svc-3.aether.internal", byName["*"].GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-3.ns.aether.internal", byName["*"].GetRoutes()[0].GetRoute().GetCluster())
 }
 
 // TestVirtualHostVhostsHostlessMerge verifies that MULTIPLE hostname-less routes
@@ -215,19 +217,20 @@ func TestVirtualHostPathRoutes(t *testing.T) {
 	c := newTestCache("edge-1")
 
 	// Register services as mesh so edgeClusterNameLocked resolves to mesh names.
+	// Registry/cluster keys are namespace-qualified "<ns>/<svc>" (020 Part 1).
 	c.clusterMu.Lock()
-	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
-	c.clusters["svc-2"] = clusterEntry{service: "svc-2"}
-	c.clusters["svc-3"] = clusterEntry{service: "svc-3"}
+	c.clusters["ns/svc-1"] = clusterEntry{service: "ns/svc-1"}
+	c.clusters["ns/svc-2"] = clusterEntry{service: "ns/svc-2"}
+	c.clusters["ns/svc-3"] = clusterEntry{service: "ns/svc-3"}
 	c.clusterMu.Unlock()
 
 	// Input order: /users (prefix, len 6), /healthz (exact), / (prefix, len 1).
 	// Expected output order: /healthz (exact) → /users (prefix len 6) → / (prefix len 1).
 	c.SetVirtualHosts([]VirtualHost{
 		{Hosts: []string{"api.example.com"}, Routes: []Route{
-			{Prefix: "/users", Service: "svc-1"},
-			{Exact: "/healthz", Service: "svc-2"},
-			{Prefix: "/", Service: "svc-3"},
+			{Prefix: "/users", Service: "svc-1", BackendNamespace: "ns"},
+			{Exact: "/healthz", Service: "svc-2", BackendNamespace: "ns"},
+			{Prefix: "/", Service: "svc-3", BackendNamespace: "ns"},
 		}},
 	})
 
@@ -238,13 +241,13 @@ func TestVirtualHostPathRoutes(t *testing.T) {
 
 	// Exact match first (highest Gateway API precedence).
 	assert.Equal(t, "/healthz", routes[0].GetMatch().GetPath())
-	assert.Equal(t, "svc-2.aether.internal", routes[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-2.ns.aether.internal", routes[0].GetRoute().GetCluster())
 	// Longer prefix second: FIX 1 — non-"/" prefix uses path_separated_prefix.
 	assert.Equal(t, "/users", routes[1].GetMatch().GetPathSeparatedPrefix())
-	assert.Equal(t, "svc-1.aether.internal", routes[1].GetRoute().GetCluster())
+	assert.Equal(t, "svc-1.ns.aether.internal", routes[1].GetRoute().GetCluster())
 	// Catch-all prefix last: "/" stays as plain prefix.
 	assert.Equal(t, "/", routes[2].GetMatch().GetPrefix())
-	assert.Equal(t, "svc-3.aether.internal", routes[2].GetRoute().GetCluster())
+	assert.Equal(t, "svc-3.ns.aether.internal", routes[2].GetRoute().GetCluster())
 }
 
 // TestVirtualHostVhostsMergeSharedDomains verifies that a host appearing in
@@ -257,9 +260,10 @@ func TestVirtualHostVhostsMergeSharedDomains(t *testing.T) {
 	c := newTestCache("edge-1")
 
 	// Register services as mesh so edgeClusterNameLocked resolves to mesh names.
+	// Registry/cluster keys are namespace-qualified "<ns>/<svc>" (020 Part 1).
 	c.clusterMu.Lock()
-	c.clusters["svc-1"] = clusterEntry{service: "svc-1"}
-	c.clusters["svc-2"] = clusterEntry{service: "svc-2"}
+	c.clusters["ns/svc-1"] = clusterEntry{service: "ns/svc-1"}
+	c.clusters["ns/svc-2"] = clusterEntry{service: "ns/svc-2"}
 	c.clusterMu.Unlock()
 
 	// First vhost: only a.example.com → svc-1.
@@ -267,8 +271,8 @@ func TestVirtualHostVhostsMergeSharedDomains(t *testing.T) {
 	// Expected: a.example.com gets routes from BOTH vhosts merged; b.example.com
 	// gets only svc-2.
 	c.SetVirtualHosts([]VirtualHost{
-		{Hosts: []string{"a.example.com"}, Routes: []Route{{Prefix: "/a1", Service: "svc-1"}}},
-		{Hosts: []string{"a.example.com", "b.example.com"}, Routes: []Route{{Prefix: "/a2", Service: "svc-2"}}},
+		{Hosts: []string{"a.example.com"}, Routes: []Route{{Prefix: "/a1", Service: "svc-1", BackendNamespace: "ns"}}},
+		{Hosts: []string{"a.example.com", "b.example.com"}, Routes: []Route{{Prefix: "/a2", Service: "svc-2", BackendNamespace: "ns"}}},
 	})
 
 	vhosts := c.virtualHostVhosts()
@@ -288,14 +292,14 @@ func TestVirtualHostVhostsMergeSharedDomains(t *testing.T) {
 		aVH.GetRoutes()[0].GetRoute().GetCluster(),
 		aVH.GetRoutes()[1].GetRoute().GetCluster(),
 	}
-	assert.ElementsMatch(t, []string{"svc-1.aether.internal", "svc-2.aether.internal"}, clusters)
+	assert.ElementsMatch(t, []string{"svc-1.ns.aether.internal", "svc-2.ns.aether.internal"}, clusters)
 
 	// b.example.com: only the second vhost's route.
 	bVH := byDomain["b.example.com"]
 	require.NotNil(t, bVH)
 	assert.Equal(t, []string{"b.example.com"}, bVH.GetDomains())
 	require.Len(t, bVH.GetRoutes(), 1)
-	assert.Equal(t, "svc-2.aether.internal", bVH.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-2.ns.aether.internal", bVH.GetRoutes()[0].GetRoute().GetCluster())
 }
 
 func TestPerDownstreamConnectionPool(t *testing.T) {
@@ -1267,17 +1271,17 @@ func TestDirectResponseRoute_AdmittedByBuildEdgeVhosts(t *testing.T) {
 func TestBuildEdgeVhostsLocked_SpecificHostUnderWildcard(t *testing.T) {
 	c := newTestCache("edge-1")
 	c.clusterMu.Lock()
-	c.clusters["svc-v3"] = clusterEntry{service: "svc-v3"}
-	c.clusters["svc-v1"] = clusterEntry{service: "svc-v1"}
+	c.clusters["ns/svc-v3"] = clusterEntry{service: "ns/svc-v3"}
+	c.clusters["ns/svc-v1"] = clusterEntry{service: "ns/svc-v1"}
 	c.clusterMu.Unlock()
 
 	// effectiveHostnames("baz.bar.com", listener "*.bar.com") = "baz.bar.com".
 	// The vhost is given the intersection result as its Hosts.
 	c.SetVirtualHosts([]VirtualHost{
 		// v3 backend: specific intersection host baz.bar.com (from *.bar.com ∩ baz.bar.com).
-		{Hosts: []string{"baz.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-v3"}}},
+		{Hosts: []string{"baz.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-v3", BackendNamespace: "ns"}}},
 		// v1 catch-all: hostname-less route → "*" catch-all.
-		{Routes: []Route{{Prefix: "/", Service: "svc-v1"}}},
+		{Routes: []Route{{Prefix: "/", Service: "svc-v1", BackendNamespace: "ns"}}},
 	})
 
 	vhosts := c.virtualHostVhosts()
@@ -1293,12 +1297,12 @@ func TestBuildEdgeVhostsLocked_SpecificHostUnderWildcard(t *testing.T) {
 	bazVH := byDomain["baz.bar.com"]
 	require.NotNil(t, bazVH, "baz.bar.com must get its own named vhost (intersection result)")
 	assert.Equal(t, []string{"baz.bar.com"}, bazVH.GetDomains())
-	assert.Equal(t, "svc-v3.aether.internal", bazVH.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-v3.ns.aether.internal", bazVH.GetRoutes()[0].GetRoute().GetCluster())
 
 	// The catch-all "*" holds the v1 backend.
 	starVH := byDomain["*"]
 	require.NotNil(t, starVH)
-	assert.Equal(t, "svc-v1.aether.internal", starVH.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-v1.ns.aether.internal", starVH.GetRoutes()[0].GetRoute().GetCluster())
 }
 
 // TestBuildEdgeVhostsLocked_WildcardDomain verifies that when the effective
@@ -1309,12 +1313,12 @@ func TestBuildEdgeVhostsLocked_SpecificHostUnderWildcard(t *testing.T) {
 func TestBuildEdgeVhostsLocked_WildcardDomain(t *testing.T) {
 	c := newTestCache("edge-1")
 	c.clusterMu.Lock()
-	c.clusters["svc-backend"] = clusterEntry{service: "svc-backend"}
+	c.clusters["ns/svc-backend"] = clusterEntry{service: "ns/svc-backend"}
 	c.clusterMu.Unlock()
 
 	// effectiveHostnames("*.bar.com", listener "*.bar.com") = "*.bar.com".
 	c.SetVirtualHosts([]VirtualHost{
-		{Hosts: []string{"*.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-backend"}}},
+		{Hosts: []string{"*.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-backend", BackendNamespace: "ns"}}},
 	})
 
 	vhosts := c.virtualHostVhosts()
@@ -1323,7 +1327,7 @@ func TestBuildEdgeVhostsLocked_WildcardDomain(t *testing.T) {
 	vh := vhosts[0]
 	assert.Equal(t, "*.bar.com", vh.GetName(), "wildcard hostname must produce named vhost, NOT catch-all *")
 	assert.Equal(t, []string{"*.bar.com"}, vh.GetDomains())
-	assert.Equal(t, "svc-backend.aether.internal", vh.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-backend.ns.aether.internal", vh.GetRoutes()[0].GetRoute().GetCluster())
 }
 
 // TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated verifies the full
@@ -1335,15 +1339,15 @@ func TestBuildEdgeVhostsLocked_WildcardDomain(t *testing.T) {
 func TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated(t *testing.T) {
 	c := newTestCache("edge-1")
 	c.clusterMu.Lock()
-	c.clusters["svc-specific"] = clusterEntry{service: "svc-specific"}
-	c.clusters["svc-wildcard"] = clusterEntry{service: "svc-wildcard"}
+	c.clusters["ns/svc-specific"] = clusterEntry{service: "ns/svc-specific"}
+	c.clusters["ns/svc-wildcard"] = clusterEntry{service: "ns/svc-wildcard"}
 	c.clusterMu.Unlock()
 
 	c.SetVirtualHosts([]VirtualHost{
 		// baz.bar.com route: intersection of *.bar.com listener ∩ baz.bar.com route.
-		{Hosts: []string{"baz.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-specific"}}},
+		{Hosts: []string{"baz.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-specific", BackendNamespace: "ns"}}},
 		// *.bar.com route: intersection of *.bar.com listener ∩ *.bar.com route.
-		{Hosts: []string{"*.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-wildcard"}}},
+		{Hosts: []string{"*.bar.com"}, Routes: []Route{{Prefix: "/", Service: "svc-wildcard", BackendNamespace: "ns"}}},
 	})
 
 	vhosts := c.virtualHostVhosts()
@@ -1357,12 +1361,12 @@ func TestBuildEdgeVhostsLocked_WildcardAndSpecificIsolated(t *testing.T) {
 
 	bazVH := byName["baz.bar.com"]
 	require.NotNil(t, bazVH, "baz.bar.com must be a named vhost")
-	assert.Equal(t, "svc-specific.aether.internal", bazVH.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-specific.ns.aether.internal", bazVH.GetRoutes()[0].GetRoute().GetCluster())
 
 	wildVH := byName["*.bar.com"]
 	require.NotNil(t, wildVH, "*.bar.com must be a named vhost (not catch-all *)")
 	assert.Equal(t, []string{"*.bar.com"}, wildVH.GetDomains())
-	assert.Equal(t, "svc-wildcard.aether.internal", wildVH.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-wildcard.ns.aether.internal", wildVH.GetRoutes()[0].GetRoute().GetCluster())
 
 	// Confirm no catch-all "*" was emitted.
 	assert.Nil(t, byName["*"], "no hostname-less routes → no catch-all * vhost")

--- a/agent/internal/xds/cache/l4route.go
+++ b/agent/internal/xds/cache/l4route.go
@@ -96,8 +96,9 @@ func (c *SnapshotCache) udpServiceRoutesSnapshot() map[string][]proxy.L4Backend 
 	return out
 }
 
-// l4RouteBackendsLocked appends the bare backend services of a service's L4
-// routes (TCP + TLS + UDP) to set. Caller holds depMu.
+// l4RouteBackendsLocked appends the namespace-qualified "<ns>/<svc>" backend
+// service keys of a service's L4 routes (TCP + TLS + UDP) to set (020 Part 1).
+// Caller holds depMu.
 func (c *SnapshotCache) l4RouteBackendsLocked(service string, set map[string]struct{}) {
 	for _, r := range c.tcpServiceRoutes[service] {
 		for _, b := range r.Backends {

--- a/agent/internal/xds/cache/tcp_service_test.go
+++ b/agent/internal/xds/cache/tcp_service_test.go
@@ -38,14 +38,16 @@ func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
 	}
 	require.NoError(t, c.AddPod(ctx, pod, "aether.internal"))
 	require.NoError(t, c.SetNodeIdentity(ctx, nodeIdentity))
-	declareDeps(c, "echo-tcp")
+	// Registry/dependency/capture keys are namespace-qualified "<ns>/<svc>"
+	// (020 Part 1): aether-test/echo-tcp.
+	declareDeps(c, "aether-test/echo-tcp")
 
 	reg := &mockRegistry{
 		tcpAware: true,
 		listAllEndpointsFunc: func(_ context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 			if protocol == registryv1.Service_PROTOCOL_TCP {
 				return map[string][]*registryv1.ServiceEndpoint{
-					"echo-tcp": {makeEndpoint("10.0.0.9", "cluster-1", "node-2", 9000)},
+					"aether-test/echo-tcp": {makeEndpoint("10.0.0.9", "cluster-1", "node-2", 9000)},
 				}, nil
 			}
 			return map[string][]*registryv1.ServiceEndpoint{}, nil
@@ -54,7 +56,7 @@ func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
 
 	// The capture reconciler classified echo-tcp as a TCP service (annotation
 	// "tcp" on its mesh Service) and projected its ClusterIP.
-	c.SetCaptureTCPServices([]capture.CaptureTCPService{{ServiceName: "echo-tcp", ClusterIP: "10.96.0.50"}})
+	c.SetCaptureTCPServices([]capture.CaptureTCPService{{ServiceName: "aether-test/echo-tcp", ClusterIP: "10.96.0.50"}})
 
 	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
 
@@ -62,11 +64,11 @@ func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
 	require.NoError(t, err)
 
 	clusters := snap.GetResources(resourcev3.ClusterType)
-	// The TCP floor cluster is present, named tcp:<svc>.<domain>.
-	tcpCluster, ok := clusters["tcp:echo-tcp.aether.internal"].(*clusterv3.Cluster)
+	// The TCP floor cluster is present, named tcp:<svc>.<ns>.<domain>.
+	tcpCluster, ok := clusters["tcp:echo-tcp.aether-test.aether.internal"].(*clusterv3.Cluster)
 	require.True(t, ok, "tcp floor cluster must be present")
-	assert.Equal(t, "echo-tcp", tcpCluster.GetEdsClusterConfig().GetServiceName(),
-		"tcp cluster EDS resource is the bare service name")
+	assert.Equal(t, "aether-test/echo-tcp", tcpCluster.GetEdsClusterConfig().GetServiceName(),
+		"tcp cluster EDS resource is the namespace-qualified service key")
 	// With a local pod present, the per-source mTLS transport socket is injected
 	// via the matcher (not a single TransportSocket).
 	require.NotNil(t, tcpCluster.GetTransportSocketMatcher(), "tcp floor cluster must carry the per-source mTLS matcher")
@@ -84,14 +86,14 @@ func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
 		"TCP floor cluster transport_socket_matcher must use envoy.matching.inputs.transport_socket_filter_state")
 
 	// No HTTP cluster/vhost for a TCP-only service.
-	_, hasHTTP := clusters["echo-tcp.aether.internal"]
+	_, hasHTTP := clusters["echo-tcp.aether-test.aether.internal"]
 	assert.False(t, hasHTTP, "a TCP service must not also emit an HTTP cluster")
 
-	// EDS for the bare service name carries the endpoint (the tcp: cluster
-	// references it by ServiceName).
+	// EDS for the service key carries the endpoint (the tcp: cluster references it
+	// by ServiceName).
 	endpoints := snap.GetResources(resourcev3.EndpointType)
-	cla, ok := endpoints["echo-tcp"].(*endpointv3.ClusterLoadAssignment)
-	require.True(t, ok, "bare-name EDS load assignment must be present for the tcp cluster")
+	cla, ok := endpoints["aether-test/echo-tcp"].(*endpointv3.ClusterLoadAssignment)
+	require.True(t, ok, "service-key EDS load assignment must be present for the tcp cluster")
 	require.NotEmpty(t, cla.GetEndpoints(), "tcp cluster EDS must carry the registry endpoint")
 	require.NotEmpty(t, cla.GetEndpoints()[0].GetLbEndpoints())
 	addr := cla.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -185,8 +185,10 @@ func TestBuildCapturePassthroughFilterChain(t *testing.T) {
 
 func TestBuildCaptureRouteConfiguration(t *testing.T) {
 	// cluster.local authority -> service cluster, reusing the outbound vhost builder.
+	// The service key is the namespace-qualified "<ns>/<svc>" (020 Part 1), rendered
+	// as the FQDN authority svc-1.aether-test.aether.internal.
 	vh := BuildOutboundClusterVirtualHost(
-		ServiceClusterName("svc-1", "aether.internal"),
+		ServiceClusterName("aether-test/svc-1", "aether.internal"),
 		[]string{"svc-1.aether-test.svc.cluster.local", "svc-1.aether-test.svc.cluster.local:18081"},
 	)
 	rc := BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vh}, "aether.internal")
@@ -195,7 +197,7 @@ func TestBuildCaptureRouteConfiguration(t *testing.T) {
 
 	got := rc.GetVirtualHosts()[0]
 	assert.Contains(t, got.GetDomains(), "svc-1.aether-test.svc.cluster.local:18081")
-	assert.Equal(t, "svc-1.aether.internal", got.GetRoutes()[0].GetRoute().GetCluster())
+	assert.Equal(t, "svc-1.aether-test.aether.internal", got.GetRoutes()[0].GetRoute().GetCluster())
 
 	// The catch-all recovers cold/off-node mesh services via ODCDS (ClusterHeader
 	// on :authority) and 404s only non-mesh authorities — symmetric with outbound.

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -26,38 +26,58 @@ import (
 // "<ns>/<svc>" serviceref key; this renders it as the FQDN authority, so the warm
 // path (service vhost) and the cold path (catch-all cluster_header: ":authority"
 // + ODCDS) resolve the same resource deterministically.
+//
+// The cutover is complete (GAMMA #397, l4route + edge L4): every caller passes a
+// namespace-qualified key. A bare (non-namespaced) name therefore can't occur in
+// production; rather than render a flat <name>.<meshDomain> that would silently
+// mis-route, it returns "" — an empty cluster name matches no cluster, so a stray
+// bare key degrades to a clean no-route instead of a wrong route.
 func ServiceClusterName(serviceName, meshDomain string) string {
-	if ref, ok := serviceref.ParseKey(serviceName); ok {
-		return ref.FQDN(meshDomain)
+	ref, ok := serviceref.ParseKey(serviceName)
+	if !ok {
+		return ""
 	}
-	// Defensive: a non-namespaced key must not occur post-cutover; render it flat
-	// rather than panic so a stray legacy key degrades instead of crashing.
-	return serviceName + "." + meshDomain
+	return ref.FQDN(meshDomain)
 }
 
 // PortClusterName returns the data-plane name of a service's per-port cluster:
-// <service>.<meshDomain>:<port>. Equals the FQDN:port authority a client
-// addresses, so the catch-all cluster_header resolves it directly.
+// <svc>.<ns>.<meshDomain>:<port>. Equals the FQDN:port authority a client
+// addresses, so the catch-all cluster_header resolves it directly. Returns ""
+// when the service key is not namespace-qualified (see ServiceClusterName).
 func PortClusterName(serviceName, meshDomain string, port uint32) string {
-	return fmt.Sprintf("%s:%d", ServiceClusterName(serviceName, meshDomain), port)
+	base := ServiceClusterName(serviceName, meshDomain)
+	if base == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s:%d", base, port)
 }
 
 // TCPClusterName returns the data-plane name of a service's TCP-floor cluster:
-// "tcp:<service>.<meshDomain>". This cluster is identical to the HTTP cluster
-// (<service>.<meshDomain>) except it uses ALPN "aether-tcp" on its upstream
+// "tcp:<svc>.<ns>.<meshDomain>". This cluster is identical to the HTTP cluster
+// (<svc>.<ns>.<meshDomain>) except it uses ALPN "aether-tcp" on its upstream
 // transport socket so the destination inbound demuxes to the TCP floor chain.
 // The capture TCP floor filter chains reference this cluster by this name.
+// Returns "" when the service key is not namespace-qualified.
 func TCPClusterName(serviceName, meshDomain string) string {
-	return "tcp:" + ServiceClusterName(serviceName, meshDomain)
+	base := ServiceClusterName(serviceName, meshDomain)
+	if base == "" {
+		return ""
+	}
+	return "tcp:" + base
 }
 
 // UDPClusterName returns the data-plane name of a service's UDP-floor cluster:
-// "udp:<service>.<meshDomain>". This cluster carries the same backend endpoints
+// "udp:<svc>.<ns>.<meshDomain>". This cluster carries the same backend endpoints
 // as the HTTP cluster but is a plain EDS cluster with no transport socket (UDP
 // datagrams are not wrapped in mTLS — mesh mTLS is a TCP/TLS construct and
 // DTLS is not supported). The udp_proxy capture listener references this cluster.
+// Returns "" when the service key is not namespace-qualified.
 func UDPClusterName(serviceName, meshDomain string) string {
-	return "udp:" + ServiceClusterName(serviceName, meshDomain)
+	base := ServiceClusterName(serviceName, meshDomain)
+	if base == "" {
+		return ""
+	}
+	return "udp:" + base
 }
 
 // ServiceFromClusterName maps a data-plane cluster name (a mesh authority,

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -360,15 +360,42 @@ func TestNewUDPServiceCluster(t *testing.T) {
 }
 
 // TestUDPClusterName verifies the naming scheme and that it does not collide with
-// the TCP or HTTP cluster names for the same service.
+// the TCP or HTTP cluster names for the same service. The input is the
+// namespace-qualified "<ns>/<svc>" key (020 Part 1); the rendered FQDN is
+// <svc>.<ns>.<meshDomain>.
 func TestUDPClusterName(t *testing.T) {
-	udp := UDPClusterName("payments", "aether.internal")
-	tcp := TCPClusterName("payments", "aether.internal")
-	http := ServiceClusterName("payments", "aether.internal")
+	udp := UDPClusterName("team-a/payments", "aether.internal")
+	tcp := TCPClusterName("team-a/payments", "aether.internal")
+	http := ServiceClusterName("team-a/payments", "aether.internal")
 
-	assert.Equal(t, "udp:payments.aether.internal", udp)
-	assert.Equal(t, "tcp:payments.aether.internal", tcp)
-	assert.Equal(t, "payments.aether.internal", http)
+	assert.Equal(t, "udp:payments.team-a.aether.internal", udp)
+	assert.Equal(t, "tcp:payments.team-a.aether.internal", tcp)
+	assert.Equal(t, "payments.team-a.aether.internal", http)
 	assert.NotEqual(t, udp, tcp, "UDP and TCP clusters must have distinct names")
 	assert.NotEqual(t, udp, http, "UDP and HTTP clusters must have distinct names")
+}
+
+// TestClusterNamesStrict verifies the post-cutover strict behavior: a bare
+// (non-namespaced) key renders to "" across all cluster-name helpers — an empty
+// name matches no cluster (clean no-route), never a silent mis-route — while a
+// namespace-qualified "<ns>/<svc>" key renders the FQDN and round-trips back
+// through ServiceFromClusterName.
+func TestClusterNamesStrict(t *testing.T) {
+	const meshDomain = "aether.internal"
+
+	// Bare key: no namespace separator → "" everywhere.
+	assert.Empty(t, ServiceClusterName("payments", meshDomain))
+	assert.Empty(t, PortClusterName("payments", meshDomain, 8080))
+	assert.Empty(t, TCPClusterName("payments", meshDomain))
+	assert.Empty(t, UDPClusterName("payments", meshDomain))
+
+	// Namespace-qualified key: rendered FQDN, and a clean round-trip.
+	key := "team-a/payments"
+	fqdn := ServiceClusterName(key, meshDomain)
+	assert.Equal(t, "payments.team-a.aether.internal", fqdn)
+	assert.Equal(t, "payments.team-a.aether.internal:8080", PortClusterName(key, meshDomain, 8080))
+
+	got, ok := ServiceFromClusterName(fqdn, meshDomain)
+	require.True(t, ok)
+	assert.Equal(t, key, got, "FQDN must round-trip back to the <ns>/<svc> key")
 }

--- a/agent/internal/xds/proxy/l4route.go
+++ b/agent/internal/xds/proxy/l4route.go
@@ -52,9 +52,11 @@ type L4ServiceRoute struct {
 
 // L4Backend is one weighted backend of an L4 route.
 type L4Backend struct {
-	// Service is the bare service name (for dependency-set tracking).
+	// Service is the namespace-qualified "<ns>/<svc>" serviceref key (020 Part 1,
+	// for dependency-set tracking).
 	Service string
-	// Cluster is the resolved data-plane TCP cluster name ("tcp:<svc>.<meshDomain>").
+	// Cluster is the resolved data-plane TCP cluster name
+	// ("tcp:<svc>.<ns>.<meshDomain>").
 	Cluster string
 	// Weight is the load-balancing weight (1 when unset).
 	Weight uint32


### PR DESCRIPTION
## What

Completes the proposal **020 Part 1** namespace-qualified-service-key cutover for the remaining service-key callers (L4 routes + edge L4), then removes the now-unneeded `ServiceClusterName` fallback — the "true cutover" capstone. GAMMA was already migrated in #397; this is the rest.

The control-plane key (registry, watch filter, dependency set, EDS, stats) is the namespace-qualified `<ns>/<svc>` `serviceref` key; `proxy.ServiceClusterName` renders it as `<svc>.<ns>.<meshDomain>`.

## Task 1 — L4-route reconciler (`agent/internal/l4route`)

Mirrors the GAMMA template (#397):
- `serviceParents` now takes the route namespace and returns `<ns>/<svc>` parent keys (parentRef namespace if set, else route namespace). The `tcpRoutes`/`tlsRoutes`/`udpRoutes` maps now key by `<ns>/<svc>`, matching the cache's `tcpServiceRoutes`/`tlsServiceRoutes`/`udpServiceRoutes` consumers and the capture reconciler keys (already `<ns>/<svc>`).
- The TCP/TLS/UDP backend builders resolve each backendRef to its `<ns>/<svc>` key (new `backendServiceKey` helper) and feed it to `TCPClusterName`/`UDPClusterName` and `L4Backend.Service` (the node dependency-set key).

This was a **real bug under 020**: bare keys never matched the post-020 registry/cluster keys, so L4 routes were broken. The talos e2e missed it (no L4 routes there).

### Edge L4 (`agent/internal/edge/gatewayapi`)

The edge TCP/TLS `buildL4Backends` had the identical bug (bare `name` into `TCPClusterName` + `L4Backend.Service`). Edge L4 backends are **mesh-only** (`edgeTCPClusters` builds a registry TCP cluster per backend keyed by `c.clusters[<ns>/<svc>]`), so they now resolve the `<ns>/<svc>` key. The edge **HTTP** path was already migrated (it defers cluster naming to `edgeClusterNameLocked`, which serviceref-keys).

## Task 2 — strict `ServiceClusterName` (`agent/internal/xds/proxy/egress.go`)

Re-audited every caller of `ServiceClusterName`/`PortClusterName`/`TCPClusterName`/`TLSClusterName`/`UDPClusterName`. After Task 1, all pass `<ns>/<svc>`: gamma, l4route, edge L4, edge HTTP (`edgeClusterNameLocked`), and `cache/cluster.go` + `cache/capture.go` (registry/capture keys). So the defensive bare-name fallback is removed:
- a non-namespaced key now returns `""` (an empty name matches no cluster → clean **no-route**, never a silent **mis-route**) instead of a flat `<name>.<meshDomain>`.
- `PortClusterName`/`TCPClusterName`/`UDPClusterName` short-circuit to `""` when the base is `""`. No panic.

## Tests

- l4route + edge L4 builder tests assert `<ns>/<svc>` keys and `<svc>.<ns>.<meshDomain>` FQDNs.
- `egress_test.go`: new strict case — bare key → `""`, `<ns>/<svc>` key → FQDN that round-trips through `ServiceFromClusterName`.
- Cache tests (multi-port, TCP-cluster, edge vhost builders) migrated their fixtures to namespace-qualified registry/cluster keys — they passed before **only because the fallback masked stale bare keys**.

## Verification

- `bazel test //agent/... //registrar/... --test_arg=-test.short` — all 28 targets pass.
- `bazel test //test/envoy_validate:envoy_validate_test` — passes (offline Envoy gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)