### PR TITLE
fix(gamma): segment-boundary PathPrefix + Gateway API precedence ordering for mesh HTTPRoute

### DIFF
--- a/agent/internal/xds/proxy/gammaroute_test.go
+++ b/agent/internal/xds/proxy/gammaroute_test.go
@@ -291,3 +291,82 @@ func TestBuildOutboundServiceVirtualHost_URLRewrite(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildOutboundServiceVirtualHost_SegmentBoundaryPrefix: a Gateway API
+// PathPrefix "/v2" must compile to Envoy path_separated_prefix (segment-boundary),
+// NOT a raw RouteMatch_Prefix — so "/v2example" does NOT match. "/" stays a plain
+// prefix because Envoy rejects path_separated_prefix:"/".
+func TestBuildOutboundServiceVirtualHost_SegmentBoundaryPrefix(t *testing.T) {
+	rules := []GammaRoute{
+		{
+			Matches:  []GammaMatch{{Prefix: "/v2"}},
+			Backends: []GammaBackend{{Cluster: "echo-v2.mesh", Weight: 1}},
+		},
+		{
+			Matches:  []GammaMatch{{Prefix: "/"}},
+			Backends: []GammaBackend{{Cluster: "echo-v1.mesh", Weight: 1}},
+		},
+	}
+	vh := BuildOutboundServiceVirtualHost("echo.mesh", []string{"echo.mesh"}, rules)
+
+	// Find the /v2 route and assert it uses path_separated_prefix, not raw prefix.
+	var v2 *routev3.Route
+	for _, r := range vh.Routes {
+		if r.GetMatch().GetPathSeparatedPrefix() == "/v2" {
+			v2 = r
+		}
+		// A raw RouteMatch_Prefix of "/v2" would be the bug.
+		assert.NotEqual(t, "/v2", r.GetMatch().GetPrefix(),
+			"GAMMA PathPrefix /v2 must be path_separated_prefix, not raw prefix")
+	}
+	require.NotNil(t, v2, "expected a path_separated_prefix /v2 route")
+	assert.Equal(t, "echo-v2.mesh", v2.GetRoute().GetCluster())
+
+	// A trailing slash normalizes to the same segment-boundary prefix.
+	rulesSlash := []GammaRoute{{Matches: []GammaMatch{{Prefix: "/v2/"}}, Backends: []GammaBackend{{Cluster: "echo-v2.mesh", Weight: 1}}}}
+	vh2 := BuildOutboundServiceVirtualHost("echo.mesh", []string{"echo.mesh"}, rulesSlash)
+	assert.Equal(t, "/v2", vh2.Routes[0].GetMatch().GetPathSeparatedPrefix())
+}
+
+// TestBuildOutboundServiceVirtualHost_PrecedenceOrdering: routes must be emitted in
+// descending Gateway API match specificity regardless of HTTPRoute document order,
+// because Envoy is first-match. A shorter "/" prefix declared BEFORE a longer "/v2"
+// must not shadow it; an Exact match outranks any prefix; and within equal paths a
+// header-bearing match outranks a bare one.
+func TestBuildOutboundServiceVirtualHost_PrecedenceOrdering(t *testing.T) {
+	// Document order puts the least specific ("/") first; the builder must reorder.
+	rules := []GammaRoute{
+		{Matches: []GammaMatch{{Prefix: "/"}}, Backends: []GammaBackend{{Cluster: "v1.mesh", Weight: 1}}},
+		{Matches: []GammaMatch{{Prefix: "/v2/foo"}}, Backends: []GammaBackend{{Cluster: "deep.mesh", Weight: 1}}},
+		{Matches: []GammaMatch{{Exact: "/exact"}}, Backends: []GammaBackend{{Cluster: "exact.mesh", Weight: 1}}},
+		{Matches: []GammaMatch{{Prefix: "/v2"}}, Backends: []GammaBackend{{Cluster: "v2.mesh", Weight: 1}}},
+	}
+	vh := BuildOutboundServiceVirtualHost("echo.mesh", []string{"echo.mesh"}, rules)
+
+	// Collect the cluster order of the non-catch-all routes (last route is the
+	// additive "/" catch-all to the service cluster itself).
+	require.Len(t, vh.Routes, 5)
+	got := make([]string, 0, 4)
+	for _, r := range vh.Routes[:4] {
+		got = append(got, r.GetRoute().GetCluster())
+	}
+	// Exact first, then longer prefix /v2/foo, then /v2, then "/".
+	assert.Equal(t, []string{"exact.mesh", "deep.mesh", "v2.mesh", "v1.mesh"}, got)
+
+	// The trailing route is the additive default to the service's own cluster.
+	assert.Equal(t, "echo.mesh", vh.Routes[4].GetRoute().GetCluster())
+	assert.Equal(t, "/", vh.Routes[4].GetMatch().GetPrefix())
+}
+
+// TestBuildOutboundServiceVirtualHost_HeaderTieBreak: equal path length, the match
+// carrying a header is more specific and must be ordered first.
+func TestBuildOutboundServiceVirtualHost_HeaderTieBreak(t *testing.T) {
+	rules := []GammaRoute{
+		{Matches: []GammaMatch{{Prefix: "/"}}, Backends: []GammaBackend{{Cluster: "plain.mesh", Weight: 1}}},
+		{Matches: []GammaMatch{{Prefix: "/", Headers: []GammaHeaderMatch{{Name: "version", Value: "two"}}}}, Backends: []GammaBackend{{Cluster: "hdr.mesh", Weight: 1}}},
+	}
+	vh := BuildOutboundServiceVirtualHost("echo.mesh", []string{"echo.mesh"}, rules)
+	require.GreaterOrEqual(t, len(vh.Routes), 2)
+	assert.Equal(t, "hdr.mesh", vh.Routes[0].GetRoute().GetCluster(),
+		"header-bearing match must outrank the bare prefix of equal length")
+}

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -293,7 +294,18 @@ func BuildOutboundServiceVirtualHost(name string, domains []string, rules []Gamm
 	if len(rules) == 0 {
 		return BuildOutboundClusterVirtualHost(name, domains)
 	}
-	var routes []*routev3.Route
+	// One route per (rule, match). Gateway API mandates that routes be evaluated by
+	// match SPECIFICITY, not document order: a longer/exact path (and tie-broken by
+	// header-match count) wins over a shorter one regardless of where it appears in
+	// the HTTPRoute. Envoy is first-match on the route list, so we must emit the
+	// routes pre-sorted (descending specificity). Without this, an earlier rule's
+	// "/" prefix shadows every later, more-specific rule (e.g. "/v2"). The edge path
+	// already does this (sortRoutesBySpecificity); GAMMA must match.
+	type scoredRoute struct {
+		route *routev3.Route
+		key   int64
+	}
+	var scored []scoredRoute
 	for _, rule := range rules {
 		matches := rule.Matches
 		if len(matches) == 0 {
@@ -313,8 +325,23 @@ func BuildOutboundServiceVirtualHost(name string, domains []string, rules []Gamm
 			} else {
 				r.Action = gammaRouteAction(name, rule, m.Prefix)
 			}
-			routes = append(routes, r)
+			scored = append(scored, scoredRoute{route: r, key: gammaMatchSpecificity(m)})
 		}
+	}
+	// Stable sort by descending specificity: ties preserve document order (Gateway
+	// API tie-break after path/method/header is creation order, approximated here).
+	slices.SortStableFunc(scored, func(a, b scoredRoute) int {
+		if a.key != b.key {
+			if a.key > b.key {
+				return -1
+			}
+			return 1
+		}
+		return 0
+	})
+	routes := make([]*routev3.Route, 0, len(scored)+1)
+	for _, s := range scored {
+		routes = append(routes, s.route)
 	}
 	routes = append(routes, &routev3.Route{
 		Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
@@ -377,7 +404,12 @@ func gammaRouteMatch(m GammaMatch) *routev3.RouteMatch {
 			SafeRegex: &matcherv3.RegexMatcher{Regex: m.Regex},
 		}
 	case m.Prefix != "":
-		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: m.Prefix}
+		// Gateway API PathPrefix is SEGMENT-BOUNDARY: "/v2" matches "/v2" and
+		// "/v2/x" but NOT "/v2example". Envoy's path_separated_prefix implements
+		// this; a raw Prefix would mis-match "/v2example". The "/" catch-all is the
+		// exception (Envoy rejects path_separated_prefix:"/"), and a trailing slash
+		// is normalized away since it is itself only a segment boundary.
+		setGammaPrefixPathSpecifier(rm, m.Prefix)
 	default:
 		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: "/"}
 	}
@@ -392,6 +424,53 @@ func gammaRouteMatch(m GammaMatch) *routev3.RouteMatch {
 		})
 	}
 	return rm
+}
+
+// gammaMatchSpecificity scores one GammaMatch for Gateway API precedence ordering
+// (higher = more specific, evaluated first). It mirrors the edge's routeSpecificity:
+// an Exact path outranks any prefix; among prefixes a longer one outranks a shorter;
+// header-match count is the next tie-break. A Regex path (gRPC method match) is
+// treated as exact-strength since it pins a full method path.
+func gammaMatchSpecificity(m GammaMatch) int64 {
+	const exactPathKey = int64(1) << 29 // sentinel above any prefix length
+	var pathKey int64
+	switch {
+	case m.Exact != "" || m.Regex != "":
+		pathKey = exactPathKey
+	default:
+		p := m.Prefix
+		if p == "" {
+			p = "/"
+		}
+		pathKey = int64(len(strings.TrimRight(p, "/")))
+		if pathKey >= exactPathKey {
+			pathKey = exactPathKey - 1
+		}
+	}
+	hdrCount := int64(len(m.Headers))
+	if hdrCount > 0xffff {
+		hdrCount = 0xffff
+	}
+	return (pathKey << 16) | hdrCount
+}
+
+// setGammaPrefixPathSpecifier sets the PathSpecifier for a Gateway API PathPrefix
+// match using segment-boundary semantics (mirrors setEdgePrefixPathSpecifier).
+// Envoy's path_separated_prefix matches "/v2" and "/v2/x" but NOT "/v2example";
+// a raw RouteMatch_Prefix would wrongly match the latter. "/" stays a plain prefix
+// (Envoy rejects path_separated_prefix:"/"), and a trailing slash is trimmed since
+// it is itself only a segment boundary that path_separated_prefix already requires.
+func setGammaPrefixPathSpecifier(rm *routev3.RouteMatch, prefix string) {
+	if prefix == "/" {
+		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: "/"}
+		return
+	}
+	p := strings.TrimRight(prefix, "/")
+	if p == "" {
+		rm.PathSpecifier = &routev3.RouteMatch_Prefix{Prefix: "/"}
+		return
+	}
+	rm.PathSpecifier = &routev3.RouteMatch_PathSeparatedPrefix{PathSeparatedPrefix: p}
 }
 
 func gammaRouteAction(serviceCluster string, rule GammaRoute, matchPrefix string) *routev3.Route_Route {


### PR DESCRIPTION
## What

GAMMA east-west route matching (`BuildOutboundServiceVirtualHost`, which feeds **both** the outbound listener and the transparent-capture `cap_http` vhost) had two Gateway API conformance defects — both already solved on the **edge** path but never mirrored to the mesh path:

1. **Raw-string `PathPrefix`.** A Gateway API `PathPrefix: /v2` compiled to Envoy `RouteMatch_Prefix{"/v2"}`, which wrongly matches `/v2example`. Gateway API prefix matching is **segment-boundary**. Now uses `path_separated_prefix` (mirrors `setEdgePrefixPathSpecifier`); `/` stays a plain prefix (Envoy rejects `path_separated_prefix:"/"`), and a trailing slash is normalized away.

2. **Document-order routing.** Routes were emitted in HTTPRoute rule order. Envoy is first-match, so an earlier `/` prefix rule shadowed every later, more-specific rule (e.g. `/v2`). Now sorted by descending Gateway API match specificity (exact > longer prefix > header-count tie-break), mirroring the edge's `sortRoutesBySpecificity`.

## Root-cause evidence (talos-main, live)

Reproduced against **properly meshed** workloads (`aether.io/managed=true`, ServiceAccount == Service name, app on port 8080) with `echo-v1`/`echo-v2` backends and the conformance `mesh-matching` HTTPRoute:

- **Before:** every path routed to the **first** rule's backend (`/v2`, `/v2/`, `version=two` all hit `echo-v1`); reversing rule order flipped the result — proving document-order shadowing. With `/v2` first, `/v2example` still mis-routed to `echo-v2` — proving the raw-prefix bug.
- The header-modifier filter and `/` routing already worked on the capture path, confirming GAMMA *is* applied on capture; only match **semantics/ordering** were wrong.

## Important context on the MESH-HTTP conformance suite

The upstream conformance mesh manifests deploy the echo pods **without** the `aether.io/managed` label (and all share the `default` ServiceAccount). aether's CNI therefore **ignores** them (`isIgnorablePod`), so the conformance frontend traffic bypasses aether entirely and rides plain kube-proxy Service load-balancing. The recorded MESH-HTTP pass/fail flapping is a **harness/setup artifact** (random Service LB across v1+v2 pods), not aether's GAMMA path. This PR is the data-plane correctness needed once the harness meshes the pods (adds the managed label + per-Service SAs). A follow-up to the (un-committed) conformance runner is required to actually exercise aether for MESH-HTTP.

## Tests

- New `proxy_test` cases: `SegmentBoundaryPrefix`, `PrecedenceOrdering`, `HeaderTieBreak`.
- `bazel test //agent/internal/xds/...` green; `//test/envoy_validate:envoy_validate_test` green (Envoy accepts `path_separated_prefix`).

Do **not** merge before review; needs a talos deploy + a harness change to re-run MESH-HTTP conformance end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)