### PR TITLE
feat(controller): namespace auto-injection (Istio-style mesh onboarding)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.55.1-{GIT_COMMIT}"
+version: "0.55.2-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-webhook.yaml
+++ b/charts/aether/templates/controller-webhook.yaml
@@ -85,7 +85,7 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["httproutes"]
         scope: "Namespaced"
-{{- if .Values.controller.injectPodNdots }}
+{{- if or .Values.controller.namespaceInjection .Values.controller.injectPodNdots }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -94,7 +94,44 @@ metadata:
   labels:
     {{- include "aether.controller.labels" . | nindent 4 }}
 webhooks:
-  # Inject dnsConfig ndots into MANAGED pods so a mesh FQDN (<svc>.<meshDomain>) is
+  {{- if .Values.controller.namespaceInjection }}
+  # Namespace auto-injection (Istio-style): pods created in a namespace labeled
+  # aether.io/managed=true get the aether.io/managed=true POD label so the CNI
+  # meshes them — no per-pod label needed. A pod with aether.io/managed=false opts
+  # out. The handler also injects ndots into the now-managed pod.
+  - name: namespace-inject.pods.aether.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    # Ignore: a down webhook must never block pod scheduling (a fail-closed pod
+    # webhook is a cluster-wide outage). A missed injection just leaves a pod
+    # unmeshed until its next admission.
+    failurePolicy: Ignore
+    timeoutSeconds: 5
+    reinvocationPolicy: Never
+    # Fire on every pod in a managed namespace; the handler honors a per-pod
+    # aether.io/managed=false opt-out.
+    namespaceSelector:
+      matchLabels:
+        aether.io/managed: "true"
+    clientConfig:
+      service:
+        name: {{ $svc }}
+        namespace: {{ $ns }}
+        path: /mutate
+        port: 443
+      {{- if not .Values.controller.webhook.spire }}
+      caBundle: {{ $caBundle }}
+      {{- end }}
+    rules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["pods"]
+        scope: "Namespaced"
+  {{- end }}
+  {{- if .Values.controller.injectPodNdots }}
+  # Inject dnsConfig ndots into pods ALREADY labeled aether.io/managed=true (the
+  # explicit-label path, in any namespace) so a mesh FQDN (<svc>.<meshDomain>) is
   # resolved absolute-first, before the cluster.local search list — musl clients
   # otherwise fail to resolve mesh names (proposal 018, mesh-global FQDN).
   - name: ndots.pods.aether.io
@@ -124,4 +161,5 @@ webhooks:
         operations: ["CREATE"]
         resources: ["pods"]
         scope: "Namespaced"
+  {{- end }}
 {{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -408,6 +408,12 @@ controller:
   # list — without it, musl/Alpine clients fail to resolve mesh names. Scoped to
   # aether.io/managed pods, failurePolicy=Ignore. Default ON; pairs with mesh DNS.
   injectPodNdots: true
+  # Namespace auto-injection (Istio-style): a pod created in a namespace labeled
+  # aether.io/managed=true is given the aether.io/managed=true POD label by the
+  # pod-mutating webhook, so the CNI meshes it without a per-pod label. A pod that
+  # sets aether.io/managed=false opts out. Only acts on explicitly-labeled
+  # namespaces (no-op otherwise), failurePolicy=Ignore. Default ON.
+  namespaceInjection: true
   webhook:
     # Webhook serving cert source — DECOUPLED from mesh SPIRE (spire.enabled).
     #   false (default): a Helm self-signed cert (genSignedCert, caBundle baked

--- a/controller/internal/podmutate/BUILD.bazel
+++ b/controller/internal/podmutate/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bpalermo/aether/controller/internal/podmutate",
     visibility = ["//controller:__subpackages__"],
     deps = [
+        "//common/constants",
         "//common/log",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
@@ -17,6 +18,7 @@ go_test(
     srcs = ["mutator_test.go"],
     embed = [":podmutate"],
     deps = [
+        "//common/constants",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_k8s_api//admission/v1:admission",

--- a/controller/internal/podmutate/mutator.go
+++ b/controller/internal/podmutate/mutator.go
@@ -1,10 +1,21 @@
-// Package podmutate contains the controller's pod-mutating admission webhook: it
-// injects a low dnsConfig `ndots` into managed pods so a mesh FQDN
-// (<svc>.<meshDomain>, e.g. 2 dots) is tried as an absolute name BEFORE the
-// cluster.local search list. Without it, the k8s default ndots:5 makes the resolver
-// apply the search domains first; glibc tolerates the fall-through to the bare name,
-// but musl (Alpine) trips on the churn and fails to resolve mesh names. Mirrors how
-// Istio's sidecar injector sets dnsConfig. Default off; opt-in alongside mesh DNS.
+// Package podmutate contains the controller's pod-mutating admission webhook. It
+// does two things on pod CREATE, mirroring Istio's sidecar injector:
+//
+//   - Namespace auto-injection: a pod created in a namespace labeled
+//     aether.io/managed=true is given the aether.io/managed=true POD label so the
+//     CNI meshes it — no per-pod label needed. A pod that explicitly sets
+//     aether.io/managed=false opts OUT (left unmanaged), so individual workloads
+//     (Jobs, the prober, infra) can be excluded from an otherwise-managed namespace.
+//   - dnsConfig ndots: injects a low ndots into managed pods so a mesh FQDN
+//     (<svc>.<meshDomain>, e.g. 2 dots) is tried as an absolute name BEFORE the
+//     cluster.local search list. Without it the k8s default ndots:5 makes the
+//     resolver apply the search domains first; glibc tolerates the fall-through to
+//     the bare name, but musl (Alpine) trips on the churn and fails to resolve mesh
+//     names. ndots is opt-in (default off) alongside mesh DNS.
+//
+// The webhook is wired with two rules: an objectSelector (aether.io/managed=true
+// pods, in any namespace) and a namespaceSelector (pods in aether.io/managed=true
+// namespaces). Both dispatch here; Handle is idempotent for either entry point.
 package podmutate
 
 import (
@@ -13,6 +24,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/bpalermo/aether/common/constants"
 	commonlog "github.com/bpalermo/aether/common/log"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -34,29 +46,50 @@ func NewMutator(ndots string, log *slog.Logger) *Mutator {
 	return &Mutator{NDots: ndots, Log: commonlog.Named(log, "pod-ndots")}
 }
 
-// Handle injects the ndots option unless the pod already sets one. The webhook's
-// objectSelector scopes it to managed pods; this stays a no-op otherwise.
+// Handle reaches here for a pod matched either by the managed-pod objectSelector
+// or the managed-namespace namespaceSelector. It (1) ensures the aether.io/managed
+// label so the CNI meshes the pod — unless the pod explicitly opts out with
+// aether.io/managed=false — and (2) injects ndots into managed pods. A pod that
+// opts out is left entirely untouched. Idempotent: re-admission (or a pod that
+// already carries the label / ndots) produces no spurious patch.
 func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 	if err := json.Unmarshal(req.Object.Raw, pod); err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if hasNdots(pod) {
-		return admission.Allowed("pod already sets dnsConfig ndots")
+	// Explicit opt-out: a pod in a managed namespace can exclude itself.
+	if v, ok := pod.Labels[constants.LabelAetherManaged]; ok && v != "true" {
+		return admission.Allowed("pod opted out of mesh management (aether.io/managed!=true)")
 	}
 
-	if pod.Spec.DNSConfig == nil {
-		pod.Spec.DNSConfig = &corev1.PodDNSConfig{}
+	changed := false
+	if pod.Labels[constants.LabelAetherManaged] != "true" {
+		if pod.Labels == nil {
+			pod.Labels = map[string]string{}
+		}
+		pod.Labels[constants.LabelAetherManaged] = "true"
+		changed = true
 	}
-	v := m.NDots
-	pod.Spec.DNSConfig.Options = append(pod.Spec.DNSConfig.Options, corev1.PodDNSConfigOption{Name: ndotsOption, Value: &v})
+
+	if m.NDots != "" && !hasNdots(pod) {
+		if pod.Spec.DNSConfig == nil {
+			pod.Spec.DNSConfig = &corev1.PodDNSConfig{}
+		}
+		v := m.NDots
+		pod.Spec.DNSConfig.Options = append(pod.Spec.DNSConfig.Options, corev1.PodDNSConfigOption{Name: ndotsOption, Value: &v})
+		changed = true
+	}
+
+	if !changed {
+		return admission.Allowed("pod already managed with ndots")
+	}
 
 	marshaled, err := json.Marshal(pod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	m.Log.DebugContext(ctx, "injected dnsConfig ndots into managed pod", "namespace", req.Namespace, "ndots", v)
+	m.Log.DebugContext(ctx, "mesh-injected pod (managed label + ndots)", "namespace", req.Namespace, "ndots", m.NDots)
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
 }
 

--- a/controller/internal/podmutate/mutator_test.go
+++ b/controller/internal/podmutate/mutator_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 
+	"github.com/bpalermo/aether/common/constants"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -20,20 +22,69 @@ func request(pod *corev1.Pod) admission.Request {
 	return admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{Object: runtime.RawExtension{Raw: raw}}}
 }
 
-func TestMutator_InjectsNdotsWhenAbsent(t *testing.T) {
+// patchesLabel reports whether the response carries a JSON-patch op that sets the
+// managed label — either as a per-key add (path "/metadata/labels/aether.io~1managed")
+// or as a whole-map add (path "/metadata/labels", key in the value) when labels
+// started nil. Checking the marshaled patch covers both.
+func patchesLabel(resp admission.Response) bool {
+	b, _ := json.Marshal(resp.Patches)
+	return strings.Contains(string(b), constants.LabelAetherManaged)
+}
+
+// TestMutator_InjectsLabelAndNdots: a pod with neither the managed label nor ndots
+// (the namespace-injection entry point) gets both.
+func TestMutator_InjectsLabelAndNdots(t *testing.T) {
 	m := NewMutator("2", slog.New(slog.DiscardHandler))
 	resp := m.Handle(context.Background(), request(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}))
 	require.True(t, resp.Allowed)
-	require.NotEmpty(t, resp.Patches, "a dnsConfig patch is produced")
+	require.NotEmpty(t, resp.Patches, "label + dnsConfig patch produced")
+	assert.True(t, patchesLabel(resp), "the aether.io/managed label is added")
 }
 
+// TestMutator_RespectsOptOut: a pod explicitly setting aether.io/managed=false is
+// left untouched even in a managed namespace.
+func TestMutator_RespectsOptOut(t *testing.T) {
+	m := NewMutator("2", slog.New(slog.DiscardHandler))
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Labels: map[string]string{constants.LabelAetherManaged: "false"}}}
+	resp := m.Handle(context.Background(), request(pod))
+	require.True(t, resp.Allowed)
+	assert.Empty(t, resp.Patches, "opt-out pod gets no patch")
+}
+
+// TestMutator_NoOpWhenAlreadyManagedWithNdots: an already-labeled pod that already
+// sets ndots needs no patch (idempotent / the explicit-label ndots path steady state).
+func TestMutator_NoOpWhenAlreadyManagedWithNdots(t *testing.T) {
+	m := NewMutator("2", slog.New(slog.DiscardHandler))
+	v := "2"
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Labels: map[string]string{constants.LabelAetherManaged: "true"}},
+		Spec:       corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &v}}}},
+	}
+	resp := m.Handle(context.Background(), request(pod))
+	require.True(t, resp.Allowed)
+	assert.Empty(t, resp.Patches, "no patch when already managed and ndots set")
+}
+
+// TestMutator_LabelOnlyWhenNdotsDisabled: with ndots disabled (NDots=""), a managed
+// namespace still gets the label, just no dnsConfig.
+func TestMutator_LabelOnlyWhenNdotsDisabled(t *testing.T) {
+	m := NewMutator("", slog.New(slog.DiscardHandler))
+	resp := m.Handle(context.Background(), request(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}))
+	require.True(t, resp.Allowed)
+	require.NotEmpty(t, resp.Patches)
+	assert.True(t, patchesLabel(resp), "label added even with ndots disabled")
+}
+
+// TestMutator_RespectsExistingNdots: an already-managed pod that sets its own ndots
+// keeps it (no ndots churn), and needs no other change.
 func TestMutator_RespectsExistingNdots(t *testing.T) {
 	m := NewMutator("2", slog.New(slog.DiscardHandler))
 	v := "1"
-	pod := &corev1.Pod{Spec: corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{
-		Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &v}},
-	}}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{constants.LabelAetherManaged: "true"}},
+		Spec:       corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &v}}}},
+	}
 	resp := m.Handle(context.Background(), request(pod))
 	require.True(t, resp.Allowed)
-	assert.Empty(t, resp.Patches, "no patch when the pod already sets ndots")
+	assert.Empty(t, resp.Patches, "no patch when already managed and ndots set")
 }


### PR DESCRIPTION
Adds Istio-style namespace auto-injection. A pod created in a namespace labeled `aether.io/managed=true` is given the `aether.io/managed=true` **pod** label by the controller's pod-mutating webhook, so the CNI meshes it — no per-pod label needed. A pod that sets `aether.io/managed=false` opts out (Jobs, probers, infra). The existing explicit-per-pod-label path is unchanged.

**Why (M3):** the Gateway API MESH-HTTP conformance suite — and real onboarding — assume namespace auto-injection. aether previously required an explicit per-pod label, so the conformance suite's unlabeled pods were silently ignored by the CNI and the suite never exercised aether (see the M3 investigation). This is the meshing half; the conformance runner also needs per-version ServiceAccounts to satisfy aether's SA-identity model (separate follow-up).

**Changes:**
- `podmutate.Mutator.Handle` ensures the managed label (honoring the opt-out) in addition to ndots; idempotent for either webhook entry point.
- The pod `MutatingWebhookConfiguration` gains a `namespaceSelector` entry (`namespace-inject.pods.aether.io`) alongside the existing `objectSelector` ndots entry; both dispatch to `/mutate`. Gated by `controller.namespaceInjection` (default on; no-op unless a namespace is explicitly labeled). Chart 0.55.1→0.55.2.
- 5 mutator unit tests (inject, opt-out, no-op, label-only-when-ndots-disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)