### PR TITLE
feat(023): Service-based routing — GAMMA route targets without SA-backed pods

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/bpalermo/aether/common/serviceref"
+
 	"github.com/bpalermo/aether/agent/internal/capture"
 	"github.com/bpalermo/aether/agent/internal/meshdns"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -383,7 +385,7 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 
 	c.captureMu.RLock()
 	defer c.captureMu.RUnlock()
-	vhosts := make([]*routev3.VirtualHost, 0, len(c.captureAuthorities))
+	vhosts := make([]*routev3.VirtualHost, 0, len(c.captureAuthorities)+len(gammaRoutes))
 	for svc, fqdn := range c.captureAuthorities {
 		if _, ok := deps[svc]; !ok {
 			continue
@@ -392,6 +394,30 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		// Route both the cluster.local authority and the mesh-global <svc>.<meshDomain>
 		// authority (portless + :meshPort) to the service cluster, so a captured
 		// request reaches it under either name (the mesh-DNS path uses the latter).
+		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, []string{
+			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
+			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
+		}, gammaRoutes[svc]))
+	}
+	// Service-based routing (proposal 023): a GAMMA route TARGET with no SA-backed
+	// mesh Service of its own (the versioned-fanout shape — an "echo" target routed
+	// to echo-v1/echo-v2) still needs a cap_http vhost. Its cluster.local authority
+	// is derived from the namespace-qualified key, and the GAMMA rules route to the
+	// backendRef (SA-backed) clusters. Skip targets already handled as SA-backed
+	// authorities above (a Service that is both a target and its own backend).
+	for svc := range gammaRoutes {
+		if _, ok := c.captureAuthorities[svc]; ok {
+			continue
+		}
+		if _, ok := deps[svc]; !ok {
+			continue
+		}
+		ref, ok := serviceref.ParseKey(svc)
+		if !ok {
+			continue
+		}
+		fqdn := ref.ClusterLocalFQDN()
+		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
 		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, []string{
 			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
 			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -158,6 +158,15 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 			set[svc] = struct{}{}
 		}
 	}
+	// Service-based routing (proposal 023): a GAMMA route TARGET — the k8s Service an
+	// HTTPRoute/GRPCRoute is attached to (parentRef) — is always in scope, so its
+	// cap_http vhost builds even when the target Service has no ServiceAccount-backed
+	// pods of its own (the versioned-fanout shape: an "echo" target routed to
+	// echo-v1/echo-v2). Its backendRefs are unioned in by routeBackendsLocked below.
+	// GAMMA routes are explicit, cluster-wide config (few), so global scope is fine.
+	for svc := range c.serviceRoutes {
+		set[svc] = struct{}{}
+	}
 	// GAMMA (proposal 018 Phase 2): a depended-on service's L7 rule backends must
 	// also be resolvable, so union them in (their EDS clusters then generate).
 	// L4 routes (proposal 018 Phase 3b): same principle for TCP/TLS/UDP backends.

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
@@ -437,4 +439,17 @@ func TestLoadClustersFromRegistry_MultiPort(t *testing.T) {
 	// No spurious :8080 (default) port cluster — the default vhost owns it.
 	_, has8080 := c.clusters["svc-mp.ns.aether.internal:8080"]
 	assert.False(t, has8080, "default port is not a separate cluster")
+}
+
+// TestDependencySet_IncludesGammaRouteTargets verifies a GAMMA route TARGET (an
+// HTTPRoute parentRef Service) is in scope even with no local pod declaring it and
+// no SA-backed pods of its own — so its cap_http vhost builds (proposal 023).
+func TestDependencySet_IncludesGammaRouteTargets(t *testing.T) {
+	c := newTestCache("node-1")
+	// A route target "team-a/echo" routing to a backend "team-a/echo-v1".
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"team-a/echo": {{Backends: []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: "echo-v1.team-a.example.org", Weight: 1}}}},
+	})
+	deps := c.DependencySet()
+	assert.Contains(t, deps, "team-a/echo", "the route target is always in scope")
 }


### PR DESCRIPTION
Proposal **023** M1 (see #402). A GAMMA route **target** — the k8s Service an HTTPRoute/GRPCRoute parentRef names — now gets a `cap_http` vhost and is routed even when it has **no ServiceAccount-backed pods of its own** (the versioned-fanout shape: an `echo` target routed by path/weight to `echo-v1`/`echo-v2`). Identity (mTLS/SAN) stays SA-based on the backend hop, unchanged — this adds a routing layer in front of the identity model, not a change to it.

- **dependencies.go**: every GAMMA route-target key joins the node dependency set, so its vhost builds and its backendRef clusters are unioned into scope.
- **capture.go `captureVhosts`**: builds a vhost per route target lacking an SA-backed authority, deriving the cluster.local authority from the `<ns>/<svc>` key and applying the GAMMA rules → backendRef (SA-backed) clusters. Skips targets that are also their own SA-backed backend.

Unblocks meaningful MESH-HTTP conformance; pairs with redirect-all (022 M2) + namespace injection (#401). Full agent suite green + a dependency-set route-target test. e2e (conformance re-run) to follow on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)