### PR TITLE
feat(023): M2 real-Service-port routing for GAMMA route targets

### DIFF
--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/bpalermo/aether/common/serviceref"
@@ -30,6 +31,11 @@ import (
 // RouteSink receives the projected per-service GAMMA rules (the snapshot cache).
 type RouteSink interface {
 	SetServiceRoutes(routes map[string][]proxy.GammaRoute)
+	// SetRouteTargetPorts receives the real Service port(s) of each route target
+	// (proposal 023 M2), keyed by the same "<ns>/<svc>" route-target key as
+	// SetServiceRoutes. Sourced from the HTTPRoute/GRPCRoute parentRef port; lets the
+	// cap_http vhost host-match a client dialing the target's REAL port.
+	SetRouteTargetPorts(ports map[string][]uint32)
 }
 
 // Reconciler watches HTTPRoutes (parentRef=Service) cluster-wide and projects, on
@@ -86,24 +92,50 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	grants := grantList.Items
 
 	routes := map[string][]proxy.GammaRoute{}
+	// routeTargetPorts: the real Service port(s) each route target is addressed on
+	// (proposal 023 M2), accumulated from the parentRef ports. A target may be
+	// addressed on several ports across routes; collect the distinct set.
+	portSets := map[string]map[uint32]struct{}{}
+	collectPort := func(key string, port uint32) {
+		if port == 0 {
+			return
+		}
+		if portSets[key] == nil {
+			portSets[key] = map[uint32]struct{}{}
+		}
+		portSets[key][port] = struct{}{}
+	}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
-		for _, svc := range serviceParents(hr.Spec.ParentRefs, hr.Namespace) {
+		for _, p := range serviceParents(hr.Spec.ParentRefs, hr.Namespace) {
+			collectPort(p.Key, p.Port)
 			for _, rule := range hr.Spec.Rules {
-				routes[svc] = append(routes[svc], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants))
+				routes[p.Key] = append(routes[p.Key], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants))
 			}
 		}
 	}
 	for i := range grpcList.Items {
 		gr := &grpcList.Items[i]
-		for _, svc := range serviceParents(gr.Spec.ParentRefs, gr.Namespace) {
+		for _, p := range serviceParents(gr.Spec.ParentRefs, gr.Namespace) {
+			collectPort(p.Key, p.Port)
 			for _, rule := range gr.Spec.Rules {
-				routes[svc] = append(routes[svc], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants))
+				routes[p.Key] = append(routes[p.Key], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants))
 			}
 		}
 	}
 
+	routeTargetPorts := make(map[string][]uint32, len(portSets))
+	for key, set := range portSets {
+		ports := make([]uint32, 0, len(set))
+		for p := range set {
+			ports = append(ports, p)
+		}
+		slices.Sort(ports) // stable order so the cache's change-detection is deterministic
+		routeTargetPorts[key] = ports
+	}
+
 	r.Sink.SetServiceRoutes(routes)
+	r.Sink.SetRouteTargetPorts(routeTargetPorts)
 	r.Log.DebugContext(ctx, "projected gamma service routes",
 		"httpRoutes", len(httpList.Items), "grpcRoutes", len(grpcList.Items), "services", len(routes))
 
@@ -254,13 +286,21 @@ func grpcBackendRefs(rules []gatewayv1.GRPCRouteRule) []gatewayv1.BackendObjectR
 	return refs
 }
 
-// serviceParents returns the names of the Services these parentRefs attach to
-// (kind=Service, core group). Shared by HTTPRoute and GRPCRoute.
-// serviceParents returns the namespace-qualified "<ns>/<svc>" keys of the Service
-// parentRefs (020 Part 1). A parentRef without an explicit namespace inherits the
-// route's namespace (Gateway API default).
-func serviceParents(refs []gatewayv1.ParentReference, routeNamespace string) []string {
-	var svcs []string
+// serviceParent is a resolved Service parentRef: its namespace-qualified "<ns>/<svc>"
+// route-target key plus the real Service port the route attaches on (0 when the
+// parentRef omits a port). Port feeds the route target's cap_http vhost domains so a
+// client dialing the target's REAL port host-matches (proposal 023 M2).
+type serviceParent struct {
+	Key  string
+	Port uint32
+}
+
+// serviceParents returns the Service parentRefs these refs attach to (kind=Service,
+// core group), as namespace-qualified "<ns>/<svc>" keys plus the attached port (020
+// Part 1, 023 M2). A parentRef without an explicit namespace inherits the route's
+// namespace (Gateway API default). Shared by HTTPRoute and GRPCRoute.
+func serviceParents(refs []gatewayv1.ParentReference, routeNamespace string) []serviceParent {
+	var parents []serviceParent
 	for _, p := range refs {
 		if p.Group != nil && string(*p.Group) != "" {
 			continue
@@ -272,9 +312,16 @@ func serviceParents(refs []gatewayv1.ParentReference, routeNamespace string) []s
 		if p.Namespace != nil && string(*p.Namespace) != "" {
 			ns = string(*p.Namespace)
 		}
-		svcs = append(svcs, serviceref.New(ns, string(p.Name)).Key())
+		var port uint32
+		if p.Port != nil {
+			port = uint32(*p.Port)
+		}
+		parents = append(parents, serviceParent{
+			Key:  serviceref.New(ns, string(p.Name)).Key(),
+			Port: port,
+		})
 	}
-	return svcs
+	return parents
 }
 
 func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant) proxy.GammaRoute {

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -23,9 +23,13 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
-type fakeSink struct{ routes map[string][]proxy.GammaRoute }
+type fakeSink struct {
+	routes map[string][]proxy.GammaRoute
+	ports  map[string][]uint32
+}
 
 func (f *fakeSink) SetServiceRoutes(r map[string][]proxy.GammaRoute) { f.routes = r }
+func (f *fakeSink) SetRouteTargetPorts(p map[string][]uint32)        { f.ports = p }
 
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -103,6 +107,42 @@ func TestReconcile_BackendRefsResolvedByName(t *testing.T) {
 	acc := meta.FindStatusCondition(got.Status.Parents[0].Conditions, string(gatewayv1.RouteConditionAccepted))
 	require.NotNil(t, acc)
 	assert.Equal(t, metav1.ConditionTrue, acc.Status)
+}
+
+// Reconcile projects the route target's parentRef port into routeTargetPorts
+// (proposal 023 M2) so the cap_http vhost can host-match the target's REAL port.
+func TestReconcile_ProjectsRouteTargetPorts(t *testing.T) {
+	hr := httpRoute("r1", "ns", "echo", "echo-v1")
+	hr.Spec.ParentRefs[0].Port = ptr(gatewayv1.PortNumber(8080))
+	sink := &fakeSink{}
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(hr).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		Build()
+	r := &Reconciler{Client: c, Sink: sink, MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string][]uint32{"ns/echo": {8080}}, sink.ports,
+		"the route target's parentRef port is projected as a real Service port")
+}
+
+// A parentRef with no port projects no port entry for the target (M1 fallback).
+func TestReconcile_RouteTargetNoPort(t *testing.T) {
+	hr := httpRoute("r1", "ns", "echo", "echo-v1") // parentRef has no Port
+	sink := &fakeSink{}
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(hr).
+		WithStatusSubresource(&gatewayv1.HTTPRoute{}).
+		Build()
+	r := &Reconciler{Client: c, Sink: sink, MeshDomain: "mesh", Log: slog.Default()}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+
+	_, has := sink.ports["ns/echo"]
+	assert.False(t, has, "no port entry when the parentRef omits a port")
 }
 
 // backendsResolve validates the backendRef shape (aether resolves by name via the
@@ -184,14 +224,18 @@ func TestBuildGammaRoute_DropsUngrantedCrossNamespaceBackend(t *testing.T) {
 func TestServiceParents(t *testing.T) {
 	hr := &gatewayv1.HTTPRoute{Spec: gatewayv1.HTTPRouteSpec{CommonRouteSpec: gatewayv1.CommonRouteSpec{
 		ParentRefs: []gatewayv1.ParentReference{
-			{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-1"},
-			{Kind: ptr(gatewayv1.Kind("Gateway")), Name: "edge"}, // ignored
+			{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-1", Port: ptr(gatewayv1.PortNumber(8080))},
+			{Kind: ptr(gatewayv1.Kind("Service")), Name: "svc-2"}, // no port → 0
+			{Kind: ptr(gatewayv1.Kind("Gateway")), Name: "edge"},  // ignored
 			{Name: "no-kind"}, // no kind → ignored
 		},
 	}}}
 	// 020 Part 1: parentRef without a namespace inherits the route's namespace,
-	// and the key is "<ns>/<svc>".
-	assert.Equal(t, []string{"team-a/svc-1"}, serviceParents(hr.Spec.ParentRefs, "team-a"))
+	// and the key is "<ns>/<svc>". 023 M2: the parentRef port rides along.
+	assert.Equal(t, []serviceParent{
+		{Key: "team-a/svc-1", Port: 8080},
+		{Key: "team-a/svc-2", Port: 0},
+	}, serviceParents(hr.Spec.ParentRefs, "team-a"))
 }
 
 // TestBuildGammaRoute: matches → GammaMatch, weighted backendRefs → GammaBackend

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
     name = "cache_test",
     srcs = [
         "cache_test.go",
+        "capture_test.go",
         "cluster_alias_test.go",
         "cluster_test.go",
         "dependencies_test.go",

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -173,6 +173,14 @@ type SnapshotCache struct {
 	// dependency set so their EDS clusters generate; the per-service outbound vhost
 	// is enriched with the rules. Guarded by depMu (dependency state).
 	serviceRoutes map[string][]proxy.GammaRoute
+	// routeTargetPorts holds the real Service port(s) of each GAMMA route TARGET
+	// (proposal 023 M2), keyed by the same "<ns>/<svc>" route-target key as
+	// serviceRoutes. Sourced from the HTTPRoute/GRPCRoute parentRef port. captureVhosts
+	// emits a "<svc>.<ns>.svc.cluster.local:<port>" domain for each so a client dialing
+	// the route target's REAL port (not the mesh :18081) host-matches the vhost. Empty
+	// for a route target whose parentRefs declare no port (then only the portless +
+	// mesh :18081 spellings are emitted, as before). Guarded by depMu.
+	routeTargetPorts map[string][]uint32
 	// tcpServiceRoutes holds the TCPRoute L4 rules (parentRef=Service, proposal 018
 	// Phase 3b), keyed by the parent service. Empty unless --l4-routes is enabled.
 	// Guarded by depMu (same lock as serviceRoutes: dependency state).
@@ -339,6 +347,7 @@ func NewSnapshotCache(nodeName string, log *slog.Logger) *SnapshotCache {
 		observedDeps:       make(map[string]time.Time),
 		staticDeps:         make(map[string]struct{}),
 		serviceRoutes:      make(map[string][]proxy.GammaRoute),
+		routeTargetPorts:   make(map[string][]uint32),
 		tcpServiceRoutes:   make(map[string][]proxy.L4ServiceRoute),
 		tlsServiceRoutes:   make(map[string][]proxy.L4ServiceRoute),
 		udpServiceRoutes:   make(map[string][]proxy.L4Backend),

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -382,6 +382,11 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 	// default client path (mesh-DNS), so the same L7 vocabulary the outbound listener
 	// applies must apply here; no rules = passthrough to the service cluster.
 	gammaRoutes := c.serviceRoutesSnapshot()
+	// Real Service port(s) of each route target (proposal 023 M2): a client dials the
+	// route target on its REAL port (e.g. echo:8080), and Envoy includes the port in
+	// vhost host-matching — so the vhost must carry a "<fqdn>:<realPort>" domain, not
+	// just the mesh :18081 spelling, or the request 404s.
+	routeTargetPorts := c.routeTargetPortsSnapshot()
 
 	c.captureMu.RLock()
 	defer c.captureMu.RUnlock()
@@ -418,10 +423,25 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		}
 		fqdn := ref.ClusterLocalFQDN()
 		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
-		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, []string{
+		domains := []string{
 			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
 			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
-		}, gammaRoutes[svc]))
+		}
+		// proposal 023 M2: also match the route target's REAL Service port(s), the
+		// authority a client actually presents when dialing the captured ClusterIP:port
+		// (echo:8080) rather than the mesh :18081. Emit both the cluster.local and the
+		// mesh-name spellings at each real port so the request host-matches regardless
+		// of which name the client used.
+		for _, p := range routeTargetPorts[svc] {
+			if p == 0 || p == constants.ProxyOutboundPort {
+				continue // 0 = unset; :18081 already emitted above.
+			}
+			domains = append(domains,
+				fmt.Sprintf("%s:%d", fqdn, p),
+				fmt.Sprintf("%s:%d", mesh, p),
+			)
+		}
+		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc]))
 	}
 	return vhosts
 }

--- a/agent/internal/xds/cache/capture_test.go
+++ b/agent/internal/xds/cache/capture_test.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// findVHost returns the first virtual host whose domain set contains want.
+func findVHost(vhosts []*routev3.VirtualHost, want string) *routev3.VirtualHost {
+	for _, vh := range vhosts {
+		for _, d := range vh.GetDomains() {
+			if d == want {
+				return vh
+			}
+		}
+	}
+	return nil
+}
+
+// TestCaptureVhosts_RouteTargetRealPort verifies that a GAMMA route TARGET with no
+// SA-backed mesh Service of its own (proposal 023) emits a cap_http vhost whose
+// domains include the REAL Service port (M2) — not just the mesh :18081 spelling —
+// so a client dialing echo:8080 host-matches and the path-based GAMMA routing fires.
+func TestCaptureVhosts_RouteTargetRealPort(t *testing.T) {
+	c := newTestCache("node-1")
+
+	// "team-a/echo" is a pure route target: /v2 -> echo-v2, / -> echo-v1.
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"team-a/echo": {
+			{
+				Matches:  []proxy.GammaMatch{{Prefix: "/v2"}},
+				Backends: []proxy.GammaBackend{{Service: "team-a/echo-v2", Cluster: "echo-v2.team-a.aether.internal", Weight: 1}},
+			},
+			{
+				Matches:  []proxy.GammaMatch{{Prefix: "/"}},
+				Backends: []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: "echo-v1.team-a.aether.internal", Weight: 1}},
+			},
+		},
+	})
+	// M2: the route target is addressed on its real Service port 8080.
+	c.SetRouteTargetPorts(map[string][]uint32{"team-a/echo": {8080}})
+
+	vhosts := c.captureVhosts()
+
+	// The cluster.local authority at the real port must host-match.
+	vh := findVHost(vhosts, "echo.team-a.svc.cluster.local:8080")
+	require.NotNil(t, vh, "route target must carry a :realPort cluster.local domain (M2); got vhosts=%v", domainsOf(vhosts))
+
+	domains := vh.GetDomains()
+	// Both the portless + mesh :18081 spellings (M1) AND the real-port spellings (M2).
+	assert.Contains(t, domains, "echo.team-a.svc.cluster.local")
+	assert.Contains(t, domains, "echo.team-a.svc.cluster.local:18081")
+	assert.Contains(t, domains, "echo.team-a.aether.internal")
+	assert.Contains(t, domains, "echo.team-a.aether.internal:18081")
+	assert.Contains(t, domains, "echo.team-a.svc.cluster.local:8080")
+	assert.Contains(t, domains, "echo.team-a.aether.internal:8080")
+
+	// The GAMMA rules must be present and path-ordered by specificity: the most
+	// specific match (/v2, a segment-boundary prefix) is first and routes to echo-v2;
+	// the "/" rule routes to echo-v1. (Gateway API mandates specificity ordering, and
+	// "/v2" lowers to Envoy path_separated_prefix, not a raw Prefix.)
+	routes := vh.GetRoutes()
+	require.GreaterOrEqual(t, len(routes), 2, "both GAMMA rules projected onto the route target vhost")
+	assert.Equal(t, "/v2", routes[0].GetMatch().GetPathSeparatedPrefix(),
+		"the most specific match (/v2) is evaluated first")
+	assert.Equal(t, "echo-v2.team-a.aether.internal", routes[0].GetRoute().GetCluster(),
+		"/v2 routes to the echo-v2 backend cluster")
+	// The "/" GAMMA rule routes to echo-v1 (distinct from the trailing default route,
+	// which falls back to the route-target mesh cluster).
+	var sawV1 bool
+	for _, rt := range routes {
+		if rt.GetRoute().GetCluster() == "echo-v1.team-a.aether.internal" {
+			sawV1 = true
+		}
+	}
+	assert.True(t, sawV1, "the '/' rule routes to echo-v1")
+}
+
+// TestCaptureVhosts_RouteTargetNoPort verifies a route target whose parentRef
+// declares no port falls back to the M1 behavior (portless + :18081 only) — no
+// spurious :0 domain.
+func TestCaptureVhosts_RouteTargetNoPort(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"team-a/echo": {{Backends: []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: "echo-v1.team-a.aether.internal", Weight: 1}}}},
+	})
+	// No SetRouteTargetPorts (or empty) — the M1 path.
+
+	vhosts := c.captureVhosts()
+	vh := findVHost(vhosts, "echo.team-a.svc.cluster.local")
+	require.NotNil(t, vh)
+	for _, d := range vh.GetDomains() {
+		assert.NotContains(t, d, ":0", "no spurious :0 domain when the parentRef omits a port")
+	}
+}
+
+func domainsOf(vhosts []*routev3.VirtualHost) []string {
+	var out []string
+	for _, vh := range vhosts {
+		out = append(out, vh.GetDomains()...)
+	}
+	return out
+}

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -30,6 +30,55 @@ func (c *SnapshotCache) serviceRoutesSnapshot() map[string][]proxy.GammaRoute {
 	return out
 }
 
+// SetRouteTargetPorts replaces the per-route-target real Service port map (proposal
+// 023 M2). Keyed by the same "<ns>/<svc>" route-target key as SetServiceRoutes;
+// fed by the gamma reconciler from each route's parentRef port. captureVhosts emits
+// a "<svc>.<ns>.svc.cluster.local:<port>" domain per listed port so a client dialing
+// the route target's REAL port host-matches its vhost. Signals a scoped-snapshot
+// rebuild on change. A separate side-map (not folded into GammaRoute) keeps the
+// rule-equality plumbing untouched and matches the captureAuthorities pattern.
+func (c *SnapshotCache) SetRouteTargetPorts(ports map[string][]uint32) {
+	c.depMu.Lock()
+	changed := !equalRouteTargetPorts(c.routeTargetPorts, ports)
+	c.routeTargetPorts = ports
+	c.depMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// routeTargetPortsSnapshot returns a shallow copy of the route-target port map for
+// use during a snapshot rebuild (read once, outside the cluster lock).
+func (c *SnapshotCache) routeTargetPortsSnapshot() map[string][]uint32 {
+	c.depMu.RLock()
+	defer c.depMu.RUnlock()
+	out := make(map[string][]uint32, len(c.routeTargetPorts))
+	for k, v := range c.routeTargetPorts {
+		out[k] = v
+	}
+	return out
+}
+
+// equalRouteTargetPorts reports content equality of two route-target port maps
+// (order-sensitive within each value; the reconciler emits a stable order).
+func equalRouteTargetPorts(a, b map[string][]uint32) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, va := range a {
+		vb, ok := b[k]
+		if !ok || len(va) != len(vb) {
+			return false
+		}
+		for i := range va {
+			if va[i] != vb[i] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // routeBackendsLocked appends the bare backend services of a service's GAMMA rules
 // to set. Caller holds depMu (it reads c.serviceRoutes).
 func (c *SnapshotCache) routeBackendsLocked(service string, set map[string]struct{}) {

--- a/test/envoy_validate/BUILD.bazel
+++ b/test/envoy_validate/BUILD.bazel
@@ -26,6 +26,8 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/router/v3:router",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/upstreams/http/v3:http",
         "@org_golang_google_protobuf//encoding/protojson",

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -26,6 +26,8 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	routerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -134,6 +136,93 @@ func buildCaptureBootstrap() (*bootstrapv3.Bootstrap, error) {
 	return newBootstrap(
 		[]*clusterv3.Cluster{xdsCluster(), passthrough, httpSvc, tcpSvc2},
 		[]*listenerv3.Listener{captureListener},
+	), nil
+}
+
+// CaptureRouteTargetBootstrapJSON builds a bootstrap whose listener inlines the
+// cap_http RouteConfiguration for a GAMMA route TARGET addressed on its REAL
+// Service port (proposal 023 M2): the vhost carries
+// "<svc>.<ns>.svc.cluster.local:<realPort>" domains and the GAMMA rules route to
+// SA-backed backend clusters. Validating it through "envoy --mode validate" proves
+// the M2 route table (real-port domains + path-based GAMMA action) is structurally
+// accepted, complementing the Go-level captureVhosts unit test.
+func CaptureRouteTargetBootstrapJSON() ([]byte, error) {
+	bs, err := buildCaptureRouteTargetBootstrap()
+	if err != nil {
+		return nil, err
+	}
+	return marshalBootstrap(bs)
+}
+
+// buildCaptureRouteTargetBootstrap assembles the M2 route-target capture config.
+func buildCaptureRouteTargetBootstrap() (*bootstrapv3.Bootstrap, error) {
+	const (
+		targetMesh = "echo.team-a." + meshDomain
+		v1Cluster  = "echo-v1.team-a." + meshDomain
+		v2Cluster  = "echo-v2.team-a." + meshDomain
+		fqdn       = "echo.team-a.svc.cluster.local"
+		realPort   = 8080
+	)
+
+	// The route target's GAMMA rules: /v2 -> echo-v2, / -> echo-v1, plus a header
+	// modifier on the fallback (mirrors the conformance shape).
+	rules := []proxy.GammaRoute{
+		{
+			Matches:  []proxy.GammaMatch{{Prefix: "/v2"}},
+			Backends: []proxy.GammaBackend{{Service: "team-a/echo-v2", Cluster: v2Cluster, Weight: 1}},
+		},
+		{
+			Matches:        []proxy.GammaMatch{{Prefix: "/"}},
+			Backends:       []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: v1Cluster, Weight: 1}},
+			HeaderMutation: &proxy.GammaHeaderMutation{SetRequest: []proxy.GammaHeaderKV{{Name: "x-aether-route", Value: "echo-v1"}}},
+		},
+	}
+	// Real-port domains (M2) + portless + mesh-name spellings, the exact set
+	// captureVhosts emits for a route target with port 8080.
+	domains := []string{
+		fqdn, fmt.Sprintf("%s:18081", fqdn),
+		targetMesh, fmt.Sprintf("%s:18081", targetMesh),
+		fmt.Sprintf("%s:%d", fqdn, realPort),
+		fmt.Sprintf("%s:%d", targetMesh, realPort),
+	}
+	vhost := proxy.BuildOutboundServiceVirtualHost(targetMesh, domains, rules)
+	routeCfg := proxy.BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vhost}, meshDomain)
+
+	hcm := &http_connection_managerv3.HttpConnectionManager{
+		StatPrefix: "cap_http_validate",
+		RouteSpecifier: &http_connection_managerv3.HttpConnectionManager_RouteConfig{
+			RouteConfig: routeCfg,
+		},
+		HttpFilters: []*http_connection_managerv3.HttpFilter{{
+			Name: "envoy.filters.http.router",
+			ConfigType: &http_connection_managerv3.HttpFilter_TypedConfig{
+				TypedConfig: mustAny(&routerv3.Router{}),
+			},
+		}},
+	}
+	listener := &listenerv3.Listener{
+		Name: "cap_http_validate",
+		Address: &corev3.Address{Address: &corev3.Address_SocketAddress{SocketAddress: &corev3.SocketAddress{
+			Address:       "127.0.0.1",
+			PortSpecifier: &corev3.SocketAddress_PortValue{PortValue: 15011},
+		}}},
+		FilterChains: []*listenerv3.FilterChain{{
+			Filters: []*listenerv3.Filter{{
+				Name:       "envoy.filters.network.http_connection_manager",
+				ConfigType: &listenerv3.Filter_TypedConfig{TypedConfig: mustAny(hcm)},
+			}},
+		}},
+	}
+
+	// The backend clusters the GAMMA rules reference (SA-backed, mTLS) plus the
+	// route target's own mesh cluster (trailing default route falls back to it).
+	target := newServiceCluster(targetMesh, trustDomain, "team-a", "echo")
+	v1 := newServiceCluster(v1Cluster, trustDomain, "team-a", "echo-v1")
+	v2 := newServiceCluster(v2Cluster, trustDomain, "team-a", "echo-v2")
+
+	return newBootstrap(
+		[]*clusterv3.Cluster{xdsCluster(), target, v1, v2},
+		[]*listenerv3.Listener{listener},
 	), nil
 }
 

--- a/test/envoy_validate/generate/main.go
+++ b/test/envoy_validate/generate/main.go
@@ -33,6 +33,7 @@ func main() {
 	}{
 		{"node_bootstrap.json", envoy_validate.NodeBootstrapJSON},
 		{"capture_bootstrap.json", envoy_validate.CaptureBootstrapJSON},
+		{"capture_route_target_bootstrap.json", envoy_validate.CaptureRouteTargetBootstrapJSON},
 		{"edge_bootstrap.json", envoy_validate.EdgeBootstrapJSON},
 	}
 

--- a/test/envoy_validate/validate_test.go
+++ b/test/envoy_validate/validate_test.go
@@ -127,6 +127,7 @@ func TestEnvoyValidate(t *testing.T) {
 	}{
 		{"node_bootstrap.json", NodeBootstrapJSON},
 		{"capture_bootstrap.json", CaptureBootstrapJSON},
+		{"capture_route_target_bootstrap.json", CaptureRouteTargetBootstrapJSON},
 		{"edge_bootstrap.json", EdgeBootstrapJSON},
 	}
 


### PR DESCRIPTION
## What

Proposal **023 M2** — real-Service-port routing for GAMMA route targets. Builds on M1 (#403).

M1 made a GAMMA **route target** (a k8s Service an HTTPRoute `parentRefs`, captured + carrying its route table) routable without SA-backed pods, but emitted its `cap_http` vhost domains only with the mesh port `:18081` (`constants.ProxyOutboundPort`). A client dialing the target's **real** Service port (`echo:8080`, `:80` in the conformance) got a **404** — Envoy includes the port in vhost host-matching, so `:8080` matched neither the portless nor the `:18081` spelling. (`ignore_port_in_host_matching` is not a fix: it would break the per-port multi-port demux, proposal 005.)

## Data path chosen

A parallel **`routeTargetPorts map[string][]uint32`** keyed by the same `<ns>/<svc>` route-target key, guarded by `depMu` (mirrors the existing `captureAuthorities` side-map):

- **gamma reconciler** — `serviceParents` now returns the parentRef **port** alongside the key; `Reconcile` projects the distinct port set per target and feeds the cache via a new `SetRouteTargetPorts` (`RouteSink`) call.
- **cache** — `captureVhosts` emits `<svc>.<ns>.svc.cluster.local:<realPort>` and the mesh-name `:<realPort>` domains so the client's real-port `:authority` host-matches. The GAMMA rules route to the SA-backed backend clusters (identity/mTLS unchanged).

Why a side-map (not extending `GammaRoute`/`serviceRoutes`): port is a property of the route **target** (the parentRef Service), not of each rule; the side-map leaves the `GammaRoute` shape and its deep-equality plumbing (`equalGammaRoute`) untouched and keeps the SA-backed / `:18081` path working.

## Capture approach: redirect-all (not 022 Option B)

Real-port interception stays on the **redirect-all** path (`capture.aether.io/redirect-all=true`, already the talos default on rev126). 022 Option B (syncing in-mesh Service `ClusterIP:port` into the per-pod nftables) needs a Service-watch → per-pod nftables sync **and** proxy-UID exclusion (per the M2a gate) — a separate milestone, deliberately not folded in. `original_dst` passthrough (022 M2a) is intact. This PR is the routing-table fix that unblocks the conformance once the client runs with redirect-all.

## Validation

- **Unit** — `captureVhosts` emits the `:realPort` domain + path-ordered GAMMA routes (`echo:8080` → `/v2`→echo-v2, `/`→echo-v1); reconciler projects the parentRef port; no spurious `:0` when the parentRef omits a port.
- **envoy-validate** — new `capture_route_target_bootstrap.json` inlines the `cap_http` RouteConfiguration for a real-port route target; `envoy --mode validate` accepts the M2 domains + `path_separated_prefix` + header modifier. `//test/envoy_validate:envoy_validate_test` green.
- `//agent/... //controller/... --test_arg=-test.short` green.

## Pending

On-cluster **MESH-HTTP conformance** re-run is pending a **human talos deploy** of this branch (build/publish requires merge-on-main). The routing logic is fully covered by unit tests + the envoy-validate gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)