### PR TITLE
fix(ci): server-side apply for gateway-api CRDs

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -99,7 +99,11 @@ jobs:
       # --- Gateway API CRDs (standard channel, matching the suite version) ---
       - name: Install Gateway API CRDs
         run: |
-          kubectl apply -f \
+          # Server-side apply: the gateway-api CRD bundle is large, and client-side
+          # apply is fragile on it (the last-applied annotation can exceed limits and
+          # fall back to a CREATE that then trips on AlreadyExists). --server-side is
+          # the recommended, idempotent way to install CRDs.
+          kubectl apply --server-side --force-conflicts -f \
             "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
           kubectl wait --for=condition=Established crd/gateways.gateway.networking.k8s.io --timeout=60s
           kubectl wait --for=condition=Established crd/httproutes.gateway.networking.k8s.io --timeout=60s


### PR DESCRIPTION
Client-side apply of the large CRD bundle flaked (AlreadyExists). Use --server-side --force-conflicts. 🤖 Generated with [Claude Code](https://claude.com/claude-code)