### PR TITLE
fix(conformance): enable edge downstream-TLS so HTTPS Gateways program on kind

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -132,6 +132,23 @@ jobs:
       # GATEWAY-HTTP needs (the edge dials conformance backends over cleartext; the mTLS
       # branch is never taken). registryBackend defaults to kubernetes already.
       #
+      # edge.tls.enabled=true wires the edge's downstream-TLS Secret provider (the
+      # Kubernetes provider — reads kubernetes.io/tls Secrets via the API server, NO
+      # SPIRE) and grants the cluster-wide `secrets` get/list/watch RBAC. The
+      # GATEWAY-HTTP base manifests include `same-namespace-with-https-listener`, a
+      # Gateway with HTTPS listeners whose certificateRefs point at a TLS Secret in
+      # gateway-conformance-infra. Without the Secret provider the edge cannot resolve
+      # those certs, marks the listeners (and so the whole Gateway) Programmed=False
+      # /ListenersNotValid, and the suite's "Ensuring Gateways ready" setup wait times
+      # out (307s) before any test runs — the last-mile blocker. (It is NOT an
+      # addressing problem: Accepted=True is set within ~1s and the per-Gateway LB
+      # Services get IPs from cloud-provider-kind fine.)
+      #
+      # edge.gateway.create=false disables the chart's OWN edge Gateway, which is
+      # unnecessary for conformance (the suite brings its own Gateways) and otherwise
+      # makes edge.tls.enabled=true `required` an edge.gateway.tlsSecretName (the
+      # chart-managed HTTPS Gateway needs a cert), failing the helm install.
+      #
       # Point the chart at the kind-loaded :latest images: the chart pins agent/cni/
       # registrar/controller to the publish-time `@digest` placeholders, which take
       # precedence over `tag` in the aether.image helper — so each must override
@@ -154,6 +171,8 @@ jobs:
             --set namespace.create=false \
             --set spire.enabled=false \
             --set edge.enabled=true \
+            --set edge.tls.enabled=true \
+            --set edge.gateway.create=false \
             $(img agent agent) \
             $(img cniInstall cni-install) \
             $(img registrar registrar) \


### PR DESCRIPTION
## What

Close the GATEWAY-HTTP conformance last-mile blocker: the conformance Gateways stayed `not Programmed` on kind, so the suite timed out (307s) at "Ensuring Gateways and Pods from base manifests are ready" before running any test.

## Which link in the address chain was broken (with evidence)

Not addressing — **TLS listener cert resolution**. From the latest `workflow_dispatch` run's collected logs, the failing Gateway is `gateway-conformance-infra/same-namespace-with-https-listener` with:

```
Programmed False ListenersNotValid "One or more listeners are not programmed (invalid TLS or route kinds)"
... Accepted True (set at 17:44:35, ~1s after Gateway creation)
```

That Gateway (a GATEWAY-HTTP **base** manifest) has HTTPS listeners whose `certificateRefs` point at a TLS Secret in `gateway-conformance-infra`. The workflow installed aether **without** `edge.tls.enabled`, so the edge's `Secrets` provider is `nil` (`agent/internal/cmd/edge.go`: `secretRegistry` is only built when `--edge-tls` is set). With no provider, `resolveListenerTLS` returns `resolved=false` → every HTTPS listener is marked not-programmed → the Gateway's top-level `Programmed=False/ListenersNotValid` → the suite's setup wait never passes → `context deadline exceeded`.

The prior notes assumed a LoadBalancer-addressing failure; the logs disprove that — `Accepted=True` is set within ~1s and the per-Gateway LB Services get IPs from cloud-provider-kind fine. The edge already reconciles cross-namespace conformance Gateways correctly.

## The fix (workflow-only)

- `edge.tls.enabled=true` — wires the edge's **Kubernetes** Secret provider (reads `kubernetes.io/tls` Secrets via the API server, **no SPIRE**) and grants the cluster-wide `secrets` get/list/watch RBAC, so the edge resolves the conformance cert and programs the HTTPS listeners.
- `edge.gateway.create=false` — disables the chart's own edge Gateway (not needed for conformance; otherwise `edge.tls.enabled=true` makes `edge.gateway.tlsSecretName` `required` and fails the helm install).

No edge code or chart change — the edge already supports this on talos (43/43, where it runs TLS + per-Gateway addressing). The talos pinned-IP path is untouched.

## How I validated it (local kind repro)

Built+loaded the agent image, installed experimental Gateway API CRDs + aether MeshConfig CRD + the edge with these exact settings, then applied the 4 GATEWAY-HTTP base Gateways (`gatewayClassName: aether`) plus a valid `tls-validity-checks-certificate` Secret:

- **All 4 base Gateways reach `Programmed=True` / reason `Programmed`** — including `same-namespace-with-https-listener`.
- That Gateway's 4 HTTPS listeners: **`programmed=True resolvedRefs=True`** (was `ListenersNotValid` in CI).
- The edge created a **per-Gateway `type: LoadBalancer` Service** for each of the 4 Gateways (no MetalLB pin annotation, since the conformance Gateways set no `spec.addresses`).

This is exactly the condition the suite's "Ensuring Gateways ready" wait requires; addresses populate from cloud-provider-kind in CI (confirmed working in the run logs).

## Gate

The suite step stays `continue-on-error` (gated on the `gate` input). Validate this branch via `workflow_dispatch` once it's on the default branch (note: `gh workflow run --ref` requires the workflow on the default branch). Once a dispatch run gets past setup and the real GATEWAY-HTTP tests run green, flip the `gate` input to make it a hard gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
