### PR TITLE
feat(cni): exclude-outbound-ports annotation (022 M2-default, step 1)

### DIFF
--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -31,8 +31,8 @@ const captureRedirectAllTableName = "aether_capture_all"
 // It enters the netns by setns on a locked OS thread (matching netnsDialContext): the
 // netlink socket nftables opens then lives in the pod netns. A failed restore leaves
 // the thread locked so the Go runtime destroys it rather than reusing a poisoned one.
-func installCaptureRedirect(netnsPath string, logger *zap.Logger) error {
-	return withPodNetns(netnsPath, func() error { return programCaptureRedirect(logger) })
+func installCaptureRedirect(netnsPath string, excludePorts []uint16, logger *zap.Logger) error {
+	return withPodNetns(netnsPath, func() error { return programCaptureRedirect(excludePorts, logger) })
 }
 
 // programCaptureRedirect adds the nat/output REDIRECT rules in the CURRENT netns:
@@ -50,7 +50,7 @@ func installCaptureRedirect(netnsPath string, logger *zap.Logger) error {
 // dropped until the agent creates the listener, which is correct behaviour
 // (UDPRoute without --l4-routes = no listener = datagrams discarded rather than
 // sent to an unexpected destination).
-func programCaptureRedirect(logger *zap.Logger) error {
+func programCaptureRedirect(excludePorts []uint16, logger *zap.Logger) error {
 	meshPort := uint16(commonconstants.ProxyOutboundPort)
 	capturePort := uint16(commonconstants.ProxyCapturePort)
 
@@ -67,6 +67,11 @@ func programCaptureRedirect(logger *zap.Logger) error {
 		Hooknum:  nftables.ChainHookOutput,
 		Priority: nftables.ChainPriorityNATDest,
 	})
+	// Excluded ports (proposal 022 M2-default): accept (RETURN) ahead of the
+	// redirect so connections to these dports bypass capture entirely.
+	for _, port := range excludePorts {
+		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludePortAcceptExprs(port)})
+	}
 	// TCP: outbound TCP to ClusterIP:meshPort → capturePort (Phase 3a).
 	c.AddRule(&nftables.Rule{
 		Table: table,
@@ -157,8 +162,8 @@ func beUint16(v uint16) []byte {
 // CaptureRedirectAllEnabled is true AND TransparentCaptureEnabled is false, only
 // the broad rule is installed. When both are true, both tables exist and the
 // redirect-all subsumes the scoped rule (all traffic is already captured).
-func installCaptureRedirectAll(netnsPath string, logger *zap.Logger) error {
-	return withPodNetns(netnsPath, func() error { return programCaptureRedirectAll(logger) })
+func installCaptureRedirectAll(netnsPath string, excludePorts []uint16, logger *zap.Logger) error {
+	return withPodNetns(netnsPath, func() error { return programCaptureRedirectAll(excludePorts, logger) })
 }
 
 // programCaptureRedirectAll adds the redirect-all nat/output rule in the CURRENT
@@ -172,7 +177,7 @@ func installCaptureRedirectAll(netnsPath string, logger *zap.Logger) error {
 // it in a separate higher-priority "conntrack" chain to avoid coupling to
 // rule position, but for a single-table approach both rules go in "output" with
 // the conntrack rule first (lower rule index wins in nft).
-func programCaptureRedirectAll(logger *zap.Logger) error {
+func programCaptureRedirectAll(excludePorts []uint16, logger *zap.Logger) error {
 	capturePort := uint16(commonconstants.ProxyCapturePort)
 
 	c, err := nftables.New()
@@ -188,6 +193,13 @@ func programCaptureRedirectAll(logger *zap.Logger) error {
 		Hooknum:  nftables.ChainHookOutput,
 		Priority: nftables.ChainPriorityNATDest,
 	})
+
+	// Rule 0: excluded ports (proposal 022 M2-default) — accept ahead of the broad
+	// redirect so connections to these dports bypass the mesh. This is where
+	// exclusions matter most: redirect-all otherwise captures every port.
+	for _, port := range excludePorts {
+		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludePortAcceptExprs(port)})
+	}
 
 	// Rule 1: skip established/related connections (conntrack).
 	// ct state {established, related} -> accept
@@ -270,6 +282,24 @@ func skipCaptureSelfExprs(capturePort uint16) []expr.Any {
 		// tcp dport == capturePort
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(capturePort)},
+		&expr.Verdict{Kind: expr.VerdictAccept},
+	}
+}
+
+// excludePortAcceptExprs builds the rule:
+//
+//	meta l4proto tcp · tcp dport <port> · accept
+//
+// Placed ahead of the redirect, it carves a single outbound TCP destination port
+// OUT of capture (proposal 022 M2-default, the exclude-outbound-ports annotation):
+// connections to <port> bypass the mesh and reach their real destination directly.
+func excludePortAcceptExprs(port uint16) []expr.Any {
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyL4PROTO, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
+		// tcp dport == port
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(port)},
 		&expr.Verdict{Kind: expr.VerdictAccept},
 	}
 }

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -227,3 +227,46 @@ func TestRedirectAllVsScopedDifference(t *testing.T) {
 	// Scoped has 9, broad has 7: 2 fewer (the dport Payload + dport Cmp).
 	assert.Equal(t, len(scoped)-2, len(broad), "redirect-all omits the dport match expressions")
 }
+
+// TestPodExcludedOutboundPorts verifies the exclude-outbound-ports annotation
+// (proposal 022 M2-default) parses into a deduplicated port list and degrades
+// gracefully on malformed/blank/out-of-range entries.
+func TestPodExcludedOutboundPorts(t *testing.T) {
+	anno := func(v string) config.AetherConf {
+		m := map[string]string{commonconstants.AnnotationCaptureExcludeOutboundPorts: v}
+		return config.AetherConf{RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &m}}
+	}
+	tests := []struct {
+		name string
+		conf config.AetherConf
+		want []uint16
+	}{
+		{name: "single port", conf: anno("5432"), want: []uint16{5432}},
+		{name: "list with whitespace", conf: anno("5432, 9000 ,80"), want: []uint16{5432, 9000, 80}},
+		{name: "dedup", conf: anno("80,80,443"), want: []uint16{80, 443}},
+		{name: "skips blank/zero/non-numeric/over-range", conf: anno("80,,0,foo,70000,443"), want: []uint16{80, 443}},
+		{name: "empty value", conf: anno(""), want: nil},
+		{name: "nil annotations", conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{}}, want: nil},
+		{name: "nil runtime config", conf: config.AetherConf{}, want: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, podExcludedOutboundPorts(tc.conf))
+		})
+	}
+}
+
+// TestExcludePortAcceptExprs verifies the exclusion rule matches TCP to the given
+// dport and accepts (so the redirect that follows never sees it).
+func TestExcludePortAcceptExprs(t *testing.T) {
+	exprs := excludePortAcceptExprs(5432)
+	require.Len(t, exprs, 5)
+	require.IsType(t, &expr.Meta{}, exprs[0])
+	assert.Equal(t, []byte{unix.IPPROTO_TCP}, exprs[1].(*expr.Cmp).Data)
+	// dport payload (transport header offset 2) compared to 5432 big-endian.
+	require.IsType(t, &expr.Payload{}, exprs[2])
+	assert.Equal(t, uint32(2), exprs[2].(*expr.Payload).Offset)
+	assert.Equal(t, []byte{0x15, 0x38}, exprs[3].(*expr.Cmp).Data) // 5432 = 0x1538
+	require.IsType(t, &expr.Verdict{}, exprs[4])
+	assert.Equal(t, expr.VerdictAccept, exprs[4].(*expr.Verdict).Kind)
+}

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -104,8 +104,13 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 	// to the pod-local capture listener. Best-effort — a failure leaves the explicit
 	// fast-lane working, so it must not fail the pod's networking. Uses the runtime
 	// netns path (the rule lives in the kernel netns, not the bind-mount pin).
+	// Ports the pod excludes from capture (proposal 022, M2-default; Istio parity):
+	// connections to these dports bypass the mesh via an nft RETURN ahead of the
+	// redirect, in whichever capture path is active.
+	excludePorts := podExcludedOutboundPorts(netConf)
+
 	if netConf.TransparentCaptureEnabled {
-		if err := installCaptureRedirect(args.Netns, p.logger); err != nil {
+		if err := installCaptureRedirect(args.Netns, excludePorts, p.logger); err != nil {
 			p.logger.Warn("failed to install transparent-capture redirect; continuing without capture",
 				zap.String("netns", args.Netns), zap.Error(err))
 		}
@@ -123,7 +128,7 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 	// CaptureRedirectAllEnabled netconf flag is retained as an optional node-wide
 	// override (off by default).
 	if netConf.CaptureRedirectAllEnabled || podWantsRedirectAll(netConf) {
-		if err := installCaptureRedirectAll(args.Netns, p.logger); err != nil {
+		if err := installCaptureRedirectAll(args.Netns, excludePorts, p.logger); err != nil {
 			p.logger.Warn("failed to install redirect-all capture (spike/M2a); continuing without redirect-all",
 				zap.String("netns", args.Netns), zap.Error(err))
 		}
@@ -624,4 +629,36 @@ func podWantsRedirectAll(conf config.AetherConf) bool {
 		return false
 	}
 	return (*conf.RuntimeConfig.PodAnnotations)[constants.AnnotationCaptureRedirectAll] == "true"
+}
+
+// podExcludedOutboundPorts parses the capture.aether.io/exclude-outbound-ports
+// annotation (proposal 022, M2-default; Istio parity) into a deduplicated list of
+// TCP destination ports to carve OUT of capture. The value is comma-separated
+// (e.g. "5432, 9000"); blanks and out-of-range/non-numeric entries are skipped so
+// a malformed annotation degrades to "exclude what parses" rather than failing the
+// pod's networking. Reaches the CNI via the same pod-annotations runtime config as
+// podWantsRedirectAll. Returns nil when unset.
+func podExcludedOutboundPorts(conf config.AetherConf) []uint16 {
+	if conf.RuntimeConfig == nil || conf.RuntimeConfig.PodAnnotations == nil {
+		return nil
+	}
+	raw := (*conf.RuntimeConfig.PodAnnotations)[constants.AnnotationCaptureExcludeOutboundPorts]
+	if raw == "" {
+		return nil
+	}
+	seen := make(map[uint16]struct{})
+	var ports []uint16
+	for _, f := range strings.Split(raw, ",") {
+		n, err := strconv.ParseUint(strings.TrimSpace(f), 10, 16)
+		if err != nil || n == 0 {
+			continue
+		}
+		p := uint16(n)
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		ports = append(ports, p)
+	}
+	return ports
 }

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -25,6 +25,17 @@ const (
 	// any value other than "true" leaves the pod on the scoped :18081 redirect.
 	AnnotationCaptureRedirectAll = annotationAetherCapturePrefix + "redirect-all"
 
+	// AnnotationCaptureExcludeOutboundPorts carves specific outbound TCP
+	// destination ports OUT of transparent capture (proposal 022, M2-default,
+	// Istio parity with traffic.sidecar.istio.io/excludeOutboundPorts). The value
+	// is a comma-separated list of ports (e.g. "5432,9000"); the CNI emits an
+	// nft RETURN for each, ahead of the redirect rule, so connections to those
+	// ports bypass the mesh entirely (a DB, a scrape target, an external
+	// dependency). Applies to both the scoped and redirect-all capture paths.
+	// Invalid/empty entries are ignored. Independent of the redirect mode — it is
+	// the operator's escape hatch once redirect-all is the managed-pod default.
+	AnnotationCaptureExcludeOutboundPorts = annotationAetherCapturePrefix + "exclude-outbound-ports"
+
 	// AnnotationConfigUpstreams is the pod annotation declaring the upstream
 	// services the pod calls, as a comma-separated list of service names
 	// (e.g. "svc-payments,svc-ledger"). The agent unions the annotations of

--- a/docs/proposals/022_arbitrary-service-interception.md
+++ b/docs/proposals/022_arbitrary-service-interception.md
@@ -116,9 +116,64 @@ on 020 Part 1: the mesh Service becomes the real Service, captured by its Cluste
 - A **non-mesh** destination → passes through unaffected.
 - Demand-scoped: only dependency-set services are captured/served on a given node.
 
+## M2-default: redirect-all by default for managed pods (amendment, 2026-06-28)
+
+The `(i)` scoped vs `(ii)` redirect-all fork is **decided: redirect-all** (the only model
+that captures the *real* `ClusterIP:port` a client actually dials — which is what proposal
+023's route targets need). Today redirect-all is a per-pod **opt-in** annotation
+(`capture.aether.io/redirect-all`, the M2a spike). This amendment makes it the **default for
+managed pods**, Istio-style, so route targets and arbitrary Services are captured with zero
+per-pod config:
+
+- **Default on.** A pod with `aether.io/managed=true` (label or namespace auto-injection)
+  gets redirect-all from the CNI by default. The annotation flips to an **opt-out**
+  (`capture.aether.io/redirect-all=false`) for pods that must not be captured (infra, the
+  prober, hostNetwork workloads).
+- **Port/range exclusions (Istio parity).** `aether.io/exclude-outbound-ports` and
+  `aether.io/exclude-outbound-ip-ranges` annotations carve out destinations that must bypass
+  the mesh (a DB port, a metrics scrape target, an external dependency). The CNI emits
+  `RETURN` rules ahead of the redirect. This is safe and verification-independent — implement
+  first.
+
+### Proxy self-traffic: netns scoping makes this narrow (don't over-exclude)
+
+The redirect rule lives in the **pod netns `nat/output` hook**, so it only fires on traffic
+*originating in that pod's netns*. The node proxy's own traffic is mostly out of scope:
+
+- **Mesh upstreams egress proxy-side, not the pod netns** — proven empirically: the scoped
+  rule (`dport == 18081`) runs hitless in production soaks; if the proxy's mesh mTLS upstream
+  originated in the pod netns it would self-match and loop, and it doesn't. So mesh upstreams
+  need no exclusion.
+- **Local-app delivery (`127.x`)** is already excluded by the loopback carve-out, and the
+  response path by the conntrack-established accept.
+- **The one open risk is the redirect-all `original_dst` passthrough**: non-mesh egress is
+  captured in the pod netns and forwarded to the real (non-loopback) destination. The
+  redirect-all rule has **no dport match**, so *if* that passthrough connection egresses from
+  the pod netns it self-matches → loop → and since all non-mesh egress uses passthrough, that
+  is the "breaks all egress" the M2a gate flagged. **This must be verified, not assumed**
+  (the in-netns listener model makes it plausible but not certain).
+
+### Self-exclusion mechanism: SO_MARK, not UID
+
+If the passthrough loops, exclude **only** the proxy's own forwarded sockets. **Not `meta
+skuid`**: the proxy runs as `runAsUser: 0`, so a UID match would also exempt any root-running
+*app* pod's egress and silently break its capture. Use **`SO_MARK`**: Envoy stamps a fixed
+mark on the passthrough cluster's upstream sockets (`upstream_bind_config.socket_options`
+`SOL_SOCKET`/`SO_MARK`), and the CNI adds `meta mark <value> → RETURN` ahead of the redirect.
+The mark is unique to the proxy's passthrough — no UID collision, app-UID-agnostic.
+
 ## Sequencing
 
-The big architectural item, after the near-term GATEWAY-HTTP work (proposal 021) and
-proposal 020 Part 1. Decide the **`(i)` scoped-redirect vs `(ii)` redirect-all** fork with
-a spike first — it shapes the CNI rules and the Envoy pass-through path, and it's the
-highest-risk change in the proposal.
+1. **Exclusion annotations** (`exclude-outbound-ports` / `-ip-ranges`) — safe, additive,
+   verification-independent. **Implement first.**
+2. **Passthrough-loop verification spike** — confirm whether the redirect-all `original_dst`
+   passthrough upstream socket egresses from the pod netns (and thus self-matches the
+   redirect). The gate for the default flip.
+3. **SO_MARK self-exclusion** (agent xDS `socket_options` + CNI `meta mark RETURN`) — only if
+   (2) shows a loop. Makes the default flip safe.
+4. **Flip redirect-all to default-on for managed pods** behind a chart value (default off
+   until validated on talos), annotation as opt-out. Validate egress volume on the
+   node-shared proxy + the non-mesh cleartext catch-all passthrough (the #288 failure mode).
+
+This is the big architectural item; the CNI redirect change is the riskiest blast radius
+(every meshed pod's egress), which is why the default flip is last and gated on the spike.


### PR DESCRIPTION
Folds the redirect-all-default direction into proposal 022 + implements the first verification-independent step: the `capture.aether.io/exclude-outbound-ports` annotation (Istio parity). CNI emits nft RETURN ahead of the redirect in both capture paths. Proposal records the corrected self-traffic analysis (netns-scoped; only the original_dst passthrough is a loop risk, must verify; SO_MARK not skuid since the proxy is root). 🤖 Generated with [Claude Code](https://claude.com/claude-code)