### PR TITLE
feat(022): SO_MARK self-exclusion for redirect-all passthrough (M2-default step 3)

### DIFF
--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -6,6 +6,8 @@ import (
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	"github.com/bpalermo/aether/common/constants"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -172,6 +174,18 @@ func TestNewPassthroughOriginalDstCluster(t *testing.T) {
 	assert.Nil(t, cl.GetTransportSocket())
 	// No upstream HTTP protocol options — raw TCP.
 	assert.Empty(t, cl.GetTypedExtensionProtocolOptions())
+
+	// SO_MARK on the upstream sockets (proposal 022 M2-default): the CNI
+	// redirect-all rule RETURNs this mark so the proxy's own forwarded egress is
+	// not re-captured. Only socket_options (no source_address) so the bind/netns
+	// are unchanged.
+	opts := cl.GetUpstreamBindConfig().GetSocketOptions()
+	require.Len(t, opts, 1)
+	assert.Equal(t, int64(1), opts[0].GetLevel()) // SOL_SOCKET
+	assert.Equal(t, int64(36), opts[0].GetName()) // SO_MARK
+	assert.Equal(t, int64(constants.CapturePassthroughFwMark), opts[0].GetIntValue())
+	assert.Equal(t, corev3.SocketOption_STATE_PREBIND, opts[0].GetState())
+	assert.Nil(t, cl.GetUpstreamBindConfig().GetSourceAddress(), "no source_address — bind unchanged")
 }
 
 // TestBuildCapturePassthroughFilterChain verifies the DefaultFilterChain structure.

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -210,6 +210,13 @@ func HealthProbeClusterName(cniPod *cniv1.CNIPod) string {
 // original_dst listener filter, so no endpoint configuration is needed.
 const PassthroughClusterName = "passthrough_original_dst"
 
+// Linux socket-option numbers for the passthrough SO_MARK (proposal 022,
+// M2-default). Stable POSIX/Linux values; the data plane is Linux-only.
+const (
+	solSocket = 1  // SOL_SOCKET
+	soMark    = 36 // SO_MARK
+)
+
 // NewPassthroughOriginalDstCluster builds an ORIGINAL_DST cluster for the
 // redirect-all capture passthrough path (proposal 022, M2a spike).
 //
@@ -244,6 +251,22 @@ func NewPassthroughOriginalDstCluster() *clusterv3.Cluster {
 		LbPolicy:                      clusterv3.Cluster_CLUSTER_PROVIDED,
 		ConnectTimeout:                durationpb.New(2 * time.Second),
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		// SO_MARK the passthrough's upstream sockets (proposal 022, M2-default): the
+		// CNI redirect-all rule RETURNs connections carrying CapturePassthroughFwMark
+		// ahead of the redirect, so the proxy's OWN forwarded egress is never
+		// re-captured into a loop. Only socket_options is set (no source_address) so
+		// the bind address/netns are unchanged. STATE_PREBIND applies the mark before
+		// connect. Harmless if the passthrough egresses proxy-side (the mark just
+		// never matches a pod-netns rule); the safety net for when it does not.
+		UpstreamBindConfig: &corev3.BindConfig{
+			SocketOptions: []*corev3.SocketOption{{
+				Description: "aether passthrough fwmark (CNI redirect-all self-exclusion)",
+				Level:       solSocket,
+				Name:        soMark,
+				Value:       &corev3.SocketOption_IntValue{IntValue: constants.CapturePassthroughFwMark},
+				State:       corev3.SocketOption_STATE_PREBIND,
+			}},
+		},
 		// No TypedExtensionProtocolOptions: passthrough is plain TCP.
 		// No TransportSocket: plaintext — mesh mTLS does NOT apply here.
 		// No LbSubsetConfig / OutlierDetection: single-connection, no pool.

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -194,7 +194,19 @@ func programCaptureRedirectAll(excludePorts []uint16, logger *zap.Logger) error 
 		Priority: nftables.ChainPriorityNATDest,
 	})
 
-	// Rule 0: excluded ports (proposal 022 M2-default) — accept ahead of the broad
+	// Rule 0a: skip the proxy's OWN forwarded egress (proposal 022 M2-default).
+	// Envoy SO_MARKs the passthrough_original_dst cluster's upstream sockets with
+	// CapturePassthroughFwMark; accepting it here, ahead of the redirect, prevents
+	// the proxy's passthrough connection from being re-captured into a loop — the
+	// "breaks all egress" failure mode. SO_MARK (not a UID match) because the proxy
+	// runs as root. Harmless if the passthrough egresses proxy-side (never matches).
+	c.AddRule(&nftables.Rule{
+		Table: table,
+		Chain: chain,
+		Exprs: passthroughMarkAcceptExprs(commonconstants.CapturePassthroughFwMark),
+	})
+
+	// Rule 0b: excluded ports (proposal 022 M2-default) — accept ahead of the broad
 	// redirect so connections to these dports bypass the mesh. This is where
 	// exclusions matter most: redirect-all otherwise captures every port.
 	for _, port := range excludePorts {
@@ -300,6 +312,25 @@ func excludePortAcceptExprs(port uint16) []expr.Any {
 		// tcp dport == port
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(port)},
+		&expr.Verdict{Kind: expr.VerdictAccept},
+	}
+}
+
+// passthroughMarkAcceptExprs builds the rule:
+//
+//	meta mark <fwmark> accept
+//
+// It matches the netfilter fwmark Envoy stamps (via SO_MARK) on the
+// passthrough_original_dst cluster's upstream sockets and accepts ahead of the
+// redirect, so the proxy's own forwarded egress is not re-captured (proposal 022
+// M2-default). The mark is a u32 loaded into the register in host (little-endian)
+// byte order, matching the conntrack-state encoding used above.
+func passthroughMarkAcceptExprs(fwmark uint32) []expr.Any {
+	mark := make([]byte, 4)
+	binary.LittleEndian.PutUint32(mark, fwmark)
+	return []expr.Any{
+		&expr.Meta{Key: expr.MetaKeyMARK, Register: 1},
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: mark},
 		&expr.Verdict{Kind: expr.VerdictAccept},
 	}
 }

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -256,6 +256,22 @@ func TestPodExcludedOutboundPorts(t *testing.T) {
 	}
 }
 
+// TestPassthroughMarkAcceptExprs verifies the self-exclusion rule matches the
+// proxy's fwmark (little-endian u32) and accepts, so SO_MARK'd passthrough egress
+// bypasses the redirect (proposal 022 M2-default).
+func TestPassthroughMarkAcceptExprs(t *testing.T) {
+	exprs := passthroughMarkAcceptExprs(commonconstants.CapturePassthroughFwMark)
+	require.Len(t, exprs, 3)
+	require.IsType(t, &expr.Meta{}, exprs[0])
+	assert.Equal(t, expr.MetaKeyMARK, exprs[0].(*expr.Meta).Key)
+	require.IsType(t, &expr.Cmp{}, exprs[1])
+	assert.Equal(t, expr.CmpOpEq, exprs[1].(*expr.Cmp).Op)
+	// 0xae7e little-endian = 0x7e 0xae 0x00 0x00.
+	assert.Equal(t, []byte{0x7e, 0xae, 0x00, 0x00}, exprs[1].(*expr.Cmp).Data)
+	require.IsType(t, &expr.Verdict{}, exprs[2])
+	assert.Equal(t, expr.VerdictAccept, exprs[2].(*expr.Verdict).Kind)
+}
+
 // TestExcludePortAcceptExprs verifies the exclusion rule matches TCP to the given
 // dport and accepts (so the redirect that follows never sees it).
 func TestExcludePortAcceptExprs(t *testing.T) {

--- a/common/constants/proxy.go
+++ b/common/constants/proxy.go
@@ -21,6 +21,16 @@ const (
 	// backend pods. This is a known limitation of the UDP floor — see proposal
 	// 018 Phase 3b.
 	ProxyCapturePort = 18001
+	// CapturePassthroughFwMark is the netfilter fwmark Envoy stamps (via SO_MARK on
+	// the passthrough_original_dst cluster's upstream sockets) on connections it
+	// forwards out of the redirect-all capture (proposal 022, M2-default). The CNI
+	// matches this mark with a `meta mark → RETURN` rule ahead of the redirect, so
+	// the proxy's OWN forwarded egress is never re-captured into a loop. SO_MARK
+	// (not a UID match) is used because the proxy runs as root — a UID rule would
+	// wrongly exempt any root-running app pod. Distinct from Istio's 1337 so the two
+	// meshes' marks don't collide if they share a node. Requires CAP_NET_ADMIN
+	// (the agent/proxy container has it).
+	CapturePassthroughFwMark = 0xae7e
 	// ProxyDNSResolverPort is the host port the node agent's in-process mesh-DNS
 	// resolver listens on (UDP+TCP) at HOST_IP (proposal 018, mesh-global FQDN). The
 	// CNI DNATs each pod's outbound :53 straight to HOST_IP:ProxyDNSResolverPort. In


### PR DESCRIPTION
Implements the proxy self-exclusion (SO_MARK on the passthrough cluster + CNI meta-mark RETURN) so redirect-all can become the managed-pod default without the egress loop. SO_MARK not skuid (proxy is root). envoy-validate green. Honest caveat in the commit: the passthrough has no netns bind (code evidence it egresses proxy-side), so this is defensive — safe no-op if so, the fix if not; the on-cluster egress test (step 2) is the real confirmation. 🤖 Generated with [Claude Code](https://claude.com/claude-code)