### PR TITLE
fix(mesh): cleartext mesh data path on kind (SPIRE-off) — proxy boot + capture passthrough + route-target short names

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -388,6 +388,22 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 	// just the mesh :18081 spelling, or the request 404s.
 	routeTargetPorts := c.routeTargetPortsSnapshot()
 
+	// Bare route-target names (the same-namespace short dial, e.g. "echo") are only
+	// unambiguous when a single namespace owns that name. If two namespaces each have
+	// an "echo" route target, emitting "echo" as a domain twice makes Envoy NACK the
+	// whole route config. Count bare names across in-scope route targets so the bare
+	// spelling is emitted only when globally unique; the namespace-qualified spellings
+	// (<name>.<ns>...) are always unambiguous and always emitted.
+	bareNameCount := make(map[string]int)
+	for svc := range gammaRoutes {
+		if _, ok := deps[svc]; !ok {
+			continue
+		}
+		if ref, ok := serviceref.ParseKey(svc); ok {
+			bareNameCount[ref.Name]++
+		}
+	}
+
 	c.captureMu.RLock()
 	defer c.captureMu.RUnlock()
 	vhosts := make([]*routev3.VirtualHost, 0, len(c.captureAuthorities)+len(gammaRoutes))
@@ -423,23 +439,43 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		}
 		fqdn := ref.ClusterLocalFQDN()
 		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
-		domains := []string{
-			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
-			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
+		// A captured request carries whatever authority the client used to dial the
+		// route target. Kubernetes search-domain resolution lets a client reach a
+		// Service by any of its short names — the bare name (same namespace), the
+		// <name>.<namespace> form, and the <name>.<namespace>.svc form — in addition
+		// to the full cluster.local FQDN and aether's mesh name. The captured request's
+		// :authority is exactly the (un-resolved) name the client typed, so cap_http
+		// must host-match every spelling or a same-namespace `echo` dial misses the
+		// route-target vhost and falls through to the kube-proxy passthrough (round
+		// robin), bypassing the GAMMA rules. Emit all spellings; real-port variants
+		// are added per port below.
+		baseNames := []string{
+			ref.Name + "." + ref.Namespace,          // <name>.<namespace>
+			ref.Name + "." + ref.Namespace + ".svc", // <name>.<namespace>.svc
+			fqdn,                                    // <name>.<namespace>.svc.cluster.local
+			mesh,                                    // <svc>.<ns>.<meshDomain>
+		}
+		// The bare same-namespace name is only collision-free when one namespace owns it.
+		if bareNameCount[ref.Name] == 1 {
+			baseNames = append(baseNames, ref.Name)
+		}
+		domains := make([]string, 0, len(baseNames)*2)
+		for _, n := range baseNames {
+			// Portless + the mesh :18081 spelling (the mesh-DNS path uses the latter).
+			domains = append(domains, n, fmt.Sprintf("%s:%d", n, constants.ProxyOutboundPort))
 		}
 		// proposal 023 M2: also match the route target's REAL Service port(s), the
 		// authority a client actually presents when dialing the captured ClusterIP:port
-		// (echo:8080) rather than the mesh :18081. Emit both the cluster.local and the
-		// mesh-name spellings at each real port so the request host-matches regardless
-		// of which name the client used.
+		// (echo:80 / echo:8080) rather than the mesh :18081. Emit every short-name and
+		// FQDN spelling at each real port so the request host-matches regardless of
+		// which name the client used.
 		for _, p := range routeTargetPorts[svc] {
 			if p == 0 || p == constants.ProxyOutboundPort {
 				continue // 0 = unset; :18081 already emitted above.
 			}
-			domains = append(domains,
-				fmt.Sprintf("%s:%d", fqdn, p),
-				fmt.Sprintf("%s:%d", mesh, p),
-			)
+			for _, n := range baseNames {
+				domains = append(domains, fmt.Sprintf("%s:%d", n, p))
+			}
 		}
 		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc]))
 	}

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -130,7 +130,7 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 		// carries the on-demand catch-all) so the listeners' RDS resolves even with no
 		// in-scope authorities yet, and cold/off-node services recover via ODCDS.
 		if c.captureEnabled {
-			routes = append(routes, proxy.BuildCaptureRouteConfiguration(c.captureVhosts(), c.meshDomain))
+			routes = append(routes, proxy.BuildCaptureRouteConfiguration(c.captureVhosts(), c.meshDomain, c.captureRedirectAll))
 		}
 		if len(routes) > 0 {
 			resources[resourcev3.RouteType] = routes

--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -284,13 +284,18 @@ func BuildCapturePassthroughFilterChain() *listenerv3.FilterChain {
 // from the generated mesh Services, scoped to the node dependency set), plus the
 // same on-demand catch-all the outbound listener uses. A captured request for a mesh
 // authority (<svc>.<meshDomain>) with no scoped vhost — a cold or off-node service —
-// then resolves via ODCDS (proposal 004 cold path) instead of a dead 404; anything
-// outside the mesh domain still 404s. This makes capture symmetric with outbound:
-// without it, a service whose pods all leave this node drops from the dependency set
-// and its scoped vhost vanishes, leaving it stuck 404 until something re-reconciles.
-func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost, meshDomain string) *routev3.RouteConfiguration {
+// then resolves via ODCDS (proposal 004 cold path) instead of a dead 404.
+//
+// When redirectAll is true (proposal 022 redirect-all capture), the catch-all's final
+// fallthrough — a non-mesh authority in no dependency set, e.g. a real Kubernetes
+// Service name a client dials with no HTTPRoute/upstream declaration — routes to the
+// ORIGINAL_DST passthrough instead of 404'ing, so plain Service-to-Service
+// reachability is preserved (the passthrough_original_dst cluster is only emitted in
+// this mode). With scoped capture (redirectAll false) the catch-all keeps its hard
+// 404: only mesh VIPs are captured, so a non-mesh authority is genuinely foreign.
+func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost, meshDomain string, redirectAll bool) *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name:         CaptureHTTPRouteName,
-		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain)),
+		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain, redirectAll)),
 	}
 }

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -211,7 +211,7 @@ func TestBuildCaptureRouteConfiguration(t *testing.T) {
 		ServiceClusterName("aether-test/svc-1", "aether.internal"),
 		[]string{"svc-1.aether-test.svc.cluster.local", "svc-1.aether-test.svc.cluster.local:18081"},
 	)
-	rc := BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vh}, "aether.internal")
+	rc := BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vh}, "aether.internal", false)
 	assert.Equal(t, CaptureHTTPRouteName, rc.GetName())
 	require.Len(t, rc.GetVirtualHosts(), 2, "the service vhost + the on-demand catch-all")
 
@@ -233,5 +233,31 @@ func TestBuildCaptureRouteConfiguration(t *testing.T) {
 		}
 	}
 	assert.True(t, hasOnDemand, "catch-all routes mesh authorities to ODCDS via :authority")
-	assert.True(t, has404, "catch-all 404s non-mesh authorities")
+	assert.True(t, has404, "scoped-capture catch-all 404s non-mesh authorities")
+}
+
+// TestBuildCaptureRouteConfigurationRedirectAll verifies that with redirect-all
+// capture the catch-all's final fallthrough routes to the ORIGINAL_DST passthrough
+// (so a captured request to a real Kubernetes Service with no mesh authority and no
+// dependency-set vhost still reaches its backend via kube-proxy) instead of 404'ing.
+func TestBuildCaptureRouteConfigurationRedirectAll(t *testing.T) {
+	rc := BuildCaptureRouteConfiguration(nil, "aether.internal", true)
+	require.Len(t, rc.GetVirtualHosts(), 1, "just the on-demand catch-all")
+	catchAll := rc.GetVirtualHosts()[0]
+
+	var hasOnDemand, hasPassthrough, has404 bool
+	for _, r := range catchAll.GetRoutes() {
+		if r.GetRoute().GetClusterHeader() == ":authority" {
+			hasOnDemand = true
+		}
+		if r.GetRoute().GetCluster() == PassthroughClusterName {
+			hasPassthrough = true
+		}
+		if r.GetDirectResponse().GetStatus() == 404 {
+			has404 = true
+		}
+	}
+	assert.True(t, hasOnDemand, "mesh authorities still resolve via ODCDS")
+	assert.True(t, hasPassthrough, "redirect-all fallthrough routes to the ORIGINAL_DST passthrough")
+	assert.False(t, has404, "redirect-all catch-all does not hard-404 non-mesh authorities")
 }

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -70,11 +70,39 @@ const onDemandClusterHeader = ":authority"
 // 404s immediately. This keeps instant foreign-404 determinism (spike-verified,
 // Envoy 1.38) while supporting FQDN:port (proposal 005). Nonexistent in-domain
 // services/ports fail when the ODCDS timeout expires.
-func buildOnDemandCatchAllVirtualHost(meshDomain string) *routev3.VirtualHost {
+func buildOnDemandCatchAllVirtualHost(meshDomain string, passthrough bool) *routev3.VirtualHost {
 	// 020 Part 1: mesh authorities are <svc>.<ns>.<meshDomain> (two labels before the
 	// mesh domain), with an optional :port. Cold/off-node services that miss the
 	// scoped vhost fall here and resolve via ODCDS (ClusterHeader=:authority).
 	meshAuthorityRegex := "^[a-z0-9-]+\\.[a-z0-9-]+\\." + regexp.QuoteMeta(meshDomain) + "(:[0-9]+)?$"
+	// Final fallthrough for a non-mesh authority. Normally a hard 404 (foreign egress,
+	// typos). But with redirect-all capture (proposal 022) ALL of the pod's egress is
+	// intercepted — including requests to real Kubernetes Service names
+	// (<svc>.<ns>.svc.cluster.local / a bare ClusterIP) that carry no mesh authority
+	// and are in no node dependency set (a client dialing a Service with no
+	// HTTPRoute/upstream declaration). A 404 there breaks plain Service-to-Service
+	// reachability, so route those to the ORIGINAL_DST passthrough (the original
+	// pre-REDIRECT destination, reached in plain HTTP), symmetric with the L4
+	// cap_passthrough default chain. The capture HCM's set_filter_state filter
+	// preserves the original destination for the ORIGINAL_DST cluster. Without
+	// redirect-all (scoped capture / outbound) the 404 is kept — there is no
+	// passthrough cluster to route to.
+	fallthrough_ := &routev3.Route{
+		Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
+		Action: &routev3.Route_DirectResponse{
+			DirectResponse: &routev3.DirectResponseAction{Status: 404},
+		},
+	}
+	if passthrough {
+		fallthrough_ = &routev3.Route{
+			Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: PassthroughClusterName},
+				},
+			},
+		}
+	}
 	return &routev3.VirtualHost{
 		Name:    "on_demand_catch_all",
 		Domains: []string{"*"},
@@ -118,23 +146,20 @@ func buildOnDemandCatchAllVirtualHost(meshDomain string) *routev3.VirtualHost {
 					},
 				},
 			},
-			{
-				Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"}},
-				Action: &routev3.Route_DirectResponse{
-					DirectResponse: &routev3.DirectResponseAction{Status: 404},
-				},
-			},
+			fallthrough_,
 		},
 	}
 }
 
 // BuildOutboundRouteConfiguration creates a route configuration for outbound traffic.
 // It includes the provided virtual hosts plus the universal on-demand catch-all
-// virtual host (mesh-shaped authorities → ODCDS, everything else → 404).
+// virtual host (mesh-shaped authorities → ODCDS, everything else → 404). The outbound
+// listener never passes through (it only sees mesh-DNS authorities), so the catch-all
+// keeps its hard-404 fallthrough.
 func BuildOutboundRouteConfiguration(vhosts []*routev3.VirtualHost, meshDomain string) *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name:         OutboundHTTPRouteName,
-		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain)),
+		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain, false)),
 	}
 }
 

--- a/agent/internal/xds/proxy/route_test.go
+++ b/agent/internal/xds/proxy/route_test.go
@@ -91,7 +91,7 @@ func TestBuildOutboundClusterVirtualHost(t *testing.T) {
 func TestOutboundRetryPolicy(t *testing.T) {
 	for name, vh := range map[string]*routev3.VirtualHost{
 		"cluster vhost":   BuildOutboundClusterVirtualHost("svc-1.aether.internal", []string{"svc-1.aether.internal"}),
-		"catch-all vhost": buildOnDemandCatchAllVirtualHost("aether.internal"),
+		"catch-all vhost": buildOnDemandCatchAllVirtualHost("aether.internal", false),
 	} {
 		// Find the routed (non-direct-response) route; the catch-all leads with a
 		// liveness direct_response route (see TestEgressLivenessRoute).
@@ -115,7 +115,7 @@ func TestOutboundRetryPolicy(t *testing.T) {
 // MeshLivePath (proposal 013 prober), matched by exact path before the
 // authority-regex/404 routes, so it wins regardless of authority.
 func TestEgressLivenessRoute(t *testing.T) {
-	vh := buildOnDemandCatchAllVirtualHost("aether.internal")
+	vh := buildOnDemandCatchAllVirtualHost("aether.internal", false)
 	require.NotEmpty(t, vh.GetRoutes())
 	live := vh.GetRoutes()[0]
 	assert.Equal(t, MeshLivePath, live.GetMatch().GetPath(), "liveness must be an exact-path match")

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.55.2-{GIT_COMMIT}"
+version: "0.55.3-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-proxy-daemonset.yaml
+++ b/charts/aether/templates/agent-proxy-daemonset.yaml
@@ -186,9 +186,16 @@ spec:
             - name: netns-dir
               mountPath: /var/run/netns
               mountPropagation: HostToContainer
+            {{- if .Values.spire.enabled }}
+            # The SPIRE workload UDS is mounted from the csi.spiffe.io CSI driver,
+            # which only exists when SPIRE is deployed. With spire.enabled=false the
+            # mesh runs cleartext (no SDS), so mounting it would wedge the proxy pod
+            # in FailedMount ("driver name csi.spiffe.io not found"). Gate it exactly
+            # like the agent DaemonSet does.
             - name: workload-socket
               mountPath: /run/secrets/workload-spiffe-uds
               readOnly: true
+            {{- end }}
             - name: supervisor-bin
               mountPath: /opt/aether
               readOnly: true
@@ -223,8 +230,10 @@ spec:
           hostPath:
             path: /run/aether
             type: DirectoryOrCreate
+        {{- if .Values.spire.enabled }}
         - name: workload-socket
           csi:
             driver: "csi.spiffe.io"
             readOnly: true
+        {{- end }}
 {{- end }}

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -219,7 +219,7 @@ func buildCaptureRouteTargetBootstrap() (*bootstrapv3.Bootstrap, error) {
 		fmt.Sprintf("%s:%d", targetMesh, realPort),
 	}
 	vhost := proxy.BuildOutboundServiceVirtualHost(targetMesh, domains, rules)
-	routeCfg := proxy.BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vhost}, meshDomain)
+	routeCfg := proxy.BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vhost}, meshDomain, true)
 
 	hcm := &http_connection_managerv3.HttpConnectionManager{
 		StatPrefix: "cap_http_validate",
@@ -252,9 +252,12 @@ func buildCaptureRouteTargetBootstrap() (*bootstrapv3.Bootstrap, error) {
 	target := newServiceCluster(targetMesh, trustDomain, "team-a", "echo")
 	v1 := newServiceCluster(v1Cluster, trustDomain, "team-a", "echo-v1")
 	v2 := newServiceCluster(v2Cluster, trustDomain, "team-a", "echo-v2")
+	// The redirect-all capture catch-all routes its final fallthrough to the
+	// ORIGINAL_DST passthrough cluster, so include it for the validate.
+	passthrough := proxy.NewPassthroughOriginalDstCluster()
 
 	return newBootstrap(
-		[]*clusterv3.Cluster{xdsCluster(), target, v1, v2},
+		[]*clusterv3.Cluster{xdsCluster(), target, v1, v2, passthrough},
 		[]*listenerv3.Listener{listener},
 	), nil
 }


### PR DESCRIPTION
## Summary

The MESH-HTTP (east-west GAMMA) conformance suite never completed a single pod-to-pod request on kind with SPIRE off — it hung at setup and emitted **zero** per-test results. This PR traces and fixes the broken hops so a meshed client actually reaches a meshed backend cleartext, the suite gets **past setup**, and the data path is exercised end-to-end. Production (SPIRE-on mTLS) posture is untouched — every SPIRE-off-only behavior is guarded.

Reproduced directly on a local kind cluster (cloud-provider-kind not needed — mesh is east-west), installing aether exactly as the `mesh-http` job does (`spire.enabled=false`, `agent.gamma=true`, `agent.captureRedirectAll=true`), then deploying the conformance mesh overlay and tracing a single request.

## Which hops broke (trace evidence)

**Hop 1 — the node proxy could not start with SPIRE off.** The `aether-proxy` DaemonSet wedged in `Init:0/1`:
```
MountVolume.SetUp failed for volume "workload-socket":
kubernetes.io/csi: driver name csi.spiffe.io not found in the list of registered CSI drivers
```
`agent-proxy-daemonset.yaml` mounted the SPIRE workload UDS (`csi.spiffe.io`) **unconditionally**, while the sibling `agent-daemonset.yaml` already gates the identical mount on `.Values.spire.enabled`. With SPIRE off there is no CSI driver → no Envoy data plane at all → nothing routes. **Fix:** gate the `workload-socket` mount + volume on `.Values.spire.enabled`.

**Hop 2 — cap_http hard-404'd real Kubernetes Service names.** Once the proxy ran, a meshed client → `echo` returned a fast `HTTP 404` (captured, but no route). The `cap_http` on-demand catch-all only matched mesh authorities (`^…\.…\.aether\.internal(:port)?$`) and `direct_response: 404`'d everything else. With **redirect-all** capture, *all* pod egress is intercepted — including requests to real Service names (`echo.<ns>.svc.cluster.local` / a bare ClusterIP) that carry no mesh authority and are in no node dependency set (e.g. the `MeshBasic` "no configuration applied" case). **Fix:** in redirect-all mode, route the catch-all's final fallthrough to the `passthrough_original_dst` ORIGINAL_DST cluster (symmetric with the L4 `cap_passthrough` default chain) instead of 404. Scoped capture keeps the hard 404.

**Hop 3 — route-target vhosts only carried FQDN spellings.** With an HTTPRoute applied, the `echo` route-target vhost listed only `echo.<ns>.svc.cluster.local` / mesh-name domains. The conformance client dials the **bare** Service name (`Host: echo`), so its `:authority` (`echo`) missed the vhost and fell through to the kube-proxy passthrough — round-robining echo-v1/echo-v2 and **bypassing the GAMMA rules**. **Fix:** emit every Kubernetes short-name spelling (`<name>`, `<name>.<ns>`, `<name>.<ns>.svc`) at the portless, mesh-port, and real-port forms. The bare name is emitted only when globally unique among in-scope route targets, so two namespaces with the same Service name can't collide into a duplicate domain (Envoy would NACK the route config).

The cleartext inbound from #421 was already correct — once the proxy ran, a request to an in-dependency-set service returned `HTTP 200` delivered via the cleartext inbound (`IP=127.0.0.1`, the loopback app cluster).

## Proof on kind (SPIRE off)

- Node proxy: `Init:0/1 → 1/1 Running` after the mount gate.
- `MeshBasic` (no config), `Host: echo`, client → `echo:80`: **HTTP 200** (passthrough to a real echo pod, `Server: envoy`, `X-Envoy-*` headers).
- With the simple HTTPRoute applied, `Host: echo` → **echo-v1 only** 5/5 (GAMMA path-routing, not round-robin).
- The MESH-HTTP suite now gets **past setup** and emits per-test results (it previously hung at setup with 0 results).

## Score: MESH-HTTP 4 PASS / 3 FAIL (was 0 — suite hung at setup)

Full suite run on kind (gateway-api v1.5.1, experimental channel). Official `ConformanceReport`:

```
profiles:
- name: MESH-HTTP
  core:
    result: failure
    statistics: {Passed: 4, Failed: 3, Skipped: 0}
    failedTests:
    - MeshHTTPRouteRedirectHostAndStatus
    - MeshHTTPRouteRequestHeaderModifier
    - MeshHTTPRouteWeight
```

- **PASS (4):** `MeshBasic`, `MeshHTTPRouteMatching`, `MeshHTTPRouteSimpleSameNamespace`, `MeshTrafficSplit`.
- **FAIL (3):** `MeshHTTPRouteRedirectHostAndStatus`, `MeshHTTPRouteRequestHeaderModifier`, `MeshHTTPRouteWeight` — all GAMMA-**feature**-on-capture gaps (see below).

Before this PR the suite produced **zero** per-test results (hung at "Ensuring Gateways and Pods from mesh manifests are ready" until the test timeout). It now gets fully past setup and the core mesh routing (basic reachability, path matching, traffic split, simple same-namespace) **passes**.

## Remaining gap (documented, not a regression)

GAMMA **feature** application on the capture path (request-header-modifier, redirect, weight) is still incomplete — those tests reach echo but the filter isn't applied. This is the pre-existing M3 GAMMA-on-capture gap (`project_m3_mesh_http_conformance.md`), independent of this PR, which only restores the **data path**. The `mesh-http` job stays soft.

## Tests
- `agent/internal/xds/proxy:proxy_test` — new `TestBuildCaptureRouteConfigurationRedirectAll`.
- `agent/internal/xds/cache:cache_test`.
- `test/envoy_validate` — the capture bootstrap now exercises the redirect-all passthrough catch-all (`envoy --mode validate`).
- Chart bumped 0.55.2 → 0.55.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
