### PR TITLE
fix(mesh): MeshFrontend — host-match short names for SA-backed GAMMA route targets

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -412,13 +412,35 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 			continue
 		}
 		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
-		// Route both the cluster.local authority and the mesh-global <svc>.<meshDomain>
-		// authority (portless + :meshPort) to the service cluster, so a captured
-		// request reaches it under either name (the mesh-DNS path uses the latter).
-		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, []string{
-			fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
-			mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
-		}, gammaRoutes[svc]))
+		rules := gammaRoutes[svc]
+		// An SA-backed mesh Service can ALSO be a GAMMA route target — the
+		// MeshFrontend shape, where an HTTPRoute attaches (parentRef) to a Service
+		// that is its own backend (e.g. "echo-v2"). When it carries GAMMA rules, a
+		// client dials it by whatever short name Kubernetes search-domain resolution
+		// allows (the bare same-namespace name, <name>.<ns>, <name>.<ns>.svc) on its
+		// REAL Service port — so the vhost must host-match every spelling, exactly
+		// like a pure (no-own-SA) route target. Without the short-name + real-port
+		// domains the dial misses this vhost, falls through to passthrough, and the
+		// GAMMA filters (e.g. ResponseHeaderModifier) are never applied. When there
+		// are no GAMMA rules the minimal cluster.local + mesh spellings suffice (a
+		// plain mesh service has nothing to apply and passthrough reaches the same
+		// backend), and emitting bare short names for every mesh service would risk
+		// cross-namespace bare-name collisions (an NACK) — so only enrich the domain
+		// set for authorities that actually have rules.
+		var domains []string
+		if len(rules) > 0 {
+			domains = c.routeTargetDomains(svc, fqdn, mesh, bareNameCount, routeTargetPorts[svc])
+		} else {
+			// Route both the cluster.local authority and the mesh-global
+			// <svc>.<meshDomain> authority (portless + :meshPort) to the service
+			// cluster, so a captured request reaches it under either name (the
+			// mesh-DNS path uses the latter).
+			domains = []string{
+				fqdn, fmt.Sprintf("%s:%d", fqdn, constants.ProxyOutboundPort),
+				mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
+			}
+		}
+		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, rules))
 	}
 	// Service-based routing (proposal 023): a GAMMA route TARGET with no SA-backed
 	// mesh Service of its own (the versioned-fanout shape — an "echo" target routed
@@ -439,47 +461,54 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		}
 		fqdn := ref.ClusterLocalFQDN()
 		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
-		// A captured request carries whatever authority the client used to dial the
-		// route target. Kubernetes search-domain resolution lets a client reach a
-		// Service by any of its short names — the bare name (same namespace), the
-		// <name>.<namespace> form, and the <name>.<namespace>.svc form — in addition
-		// to the full cluster.local FQDN and aether's mesh name. The captured request's
-		// :authority is exactly the (un-resolved) name the client typed, so cap_http
-		// must host-match every spelling or a same-namespace `echo` dial misses the
-		// route-target vhost and falls through to the kube-proxy passthrough (round
-		// robin), bypassing the GAMMA rules. Emit all spellings; real-port variants
-		// are added per port below.
-		baseNames := []string{
-			ref.Name + "." + ref.Namespace,          // <name>.<namespace>
-			ref.Name + "." + ref.Namespace + ".svc", // <name>.<namespace>.svc
-			fqdn,                                    // <name>.<namespace>.svc.cluster.local
-			mesh,                                    // <svc>.<ns>.<meshDomain>
-		}
+		domains := c.routeTargetDomains(svc, fqdn, mesh, bareNameCount, routeTargetPorts[svc])
+		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc]))
+	}
+	return vhosts
+}
+
+// routeTargetDomains builds the cap_http host-match domains for a GAMMA route
+// target keyed "<ns>/<name>". A captured request carries whatever authority the
+// client used to dial the target. Kubernetes search-domain resolution lets a
+// client reach a Service by any of its short names — the bare name (same
+// namespace), the <name>.<namespace> form, and the <name>.<namespace>.svc form —
+// in addition to the full cluster.local FQDN and aether's mesh name. The captured
+// request's :authority is exactly the (un-resolved) name the client typed, so
+// cap_http must host-match every spelling or a same-namespace dial misses the
+// route-target vhost and falls through to the kube-proxy passthrough (round
+// robin), bypassing the GAMMA rules. Both portless and the mesh :18081 spellings
+// are emitted, plus each real Service port (proposal 023 M2) so a client dialing
+// the captured ClusterIP:port (echo:80 / echo:8080) host-matches too. The bare
+// same-namespace name is emitted only when a single namespace owns it
+// (bareNameCount==1), since a duplicate bare domain makes Envoy NACK the route
+// config.
+func (c *SnapshotCache) routeTargetDomains(svc, fqdn, mesh string, bareNameCount map[string]int, ports []uint32) []string {
+	baseNames := []string{fqdn, mesh}
+	if ref, ok := serviceref.ParseKey(svc); ok {
+		baseNames = append(baseNames,
+			ref.Name+"."+ref.Namespace,        // <name>.<namespace>
+			ref.Name+"."+ref.Namespace+".svc", // <name>.<namespace>.svc
+		)
 		// The bare same-namespace name is only collision-free when one namespace owns it.
 		if bareNameCount[ref.Name] == 1 {
 			baseNames = append(baseNames, ref.Name)
 		}
-		domains := make([]string, 0, len(baseNames)*2)
-		for _, n := range baseNames {
-			// Portless + the mesh :18081 spelling (the mesh-DNS path uses the latter).
-			domains = append(domains, n, fmt.Sprintf("%s:%d", n, constants.ProxyOutboundPort))
-		}
-		// proposal 023 M2: also match the route target's REAL Service port(s), the
-		// authority a client actually presents when dialing the captured ClusterIP:port
-		// (echo:80 / echo:8080) rather than the mesh :18081. Emit every short-name and
-		// FQDN spelling at each real port so the request host-matches regardless of
-		// which name the client used.
-		for _, p := range routeTargetPorts[svc] {
-			if p == 0 || p == constants.ProxyOutboundPort {
-				continue // 0 = unset; :18081 already emitted above.
-			}
-			for _, n := range baseNames {
-				domains = append(domains, fmt.Sprintf("%s:%d", n, p))
-			}
-		}
-		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc]))
 	}
-	return vhosts
+	domains := make([]string, 0, len(baseNames)*2)
+	for _, n := range baseNames {
+		// Portless + the mesh :18081 spelling (the mesh-DNS path uses the latter).
+		domains = append(domains, n, fmt.Sprintf("%s:%d", n, constants.ProxyOutboundPort))
+	}
+	// proposal 023 M2: also match the route target's REAL Service port(s).
+	for _, p := range ports {
+		if p == 0 || p == constants.ProxyOutboundPort {
+			continue // 0 = unset; :18081 already emitted above.
+		}
+		for _, n := range baseNames {
+			domains = append(domains, fmt.Sprintf("%s:%d", n, p))
+		}
+	}
+	return domains
 }
 
 func equalStringMaps(a, b map[string]string) bool {

--- a/agent/internal/xds/cache/capture_test.go
+++ b/agent/internal/xds/cache/capture_test.go
@@ -80,6 +80,72 @@ func TestCaptureVhosts_RouteTargetRealPort(t *testing.T) {
 	assert.True(t, sawV1, "the '/' rule routes to echo-v1")
 }
 
+// TestCaptureVhosts_SABackedRouteTargetShortNames reproduces the MESH-HTTP
+// MeshFrontend scenario: an HTTPRoute (with a ResponseHeaderModifier filter)
+// whose parentRef is a Service that IS its own SA-backed mesh Service and its own
+// backend (the "echo-v2" route target — a real backend, not a versioned-fanout
+// pseudo-target). The client dials the route target by its BARE short name
+// ("echo-v2", port 80 implied) so the captured :authority is "echo-v2". The
+// cap_http vhost that carries the GAMMA rules must host-match every short-name +
+// real-port spelling, exactly like a pure route target — otherwise the dial misses
+// the vhost, falls through to passthrough, and the GAMMA header mutation is never
+// applied (the X-Header-Set assertion fails).
+func TestCaptureVhosts_SABackedRouteTargetShortNames(t *testing.T) {
+	c := newTestCache("node-1")
+
+	// echo-v2 is BOTH an SA-backed mesh authority (it has its own pods/Service)
+	// AND the route target the HTTPRoute attaches to. The reconciler projects its
+	// cluster.local FQDN into captureAuthorities.
+	c.SetCaptureAuthorities(map[string]string{
+		"gateway-conformance-mesh/echo-v2": "echo-v2.gateway-conformance-mesh.svc.cluster.local",
+	})
+	// The GAMMA rule on the echo-v2 route target (a single self-backend rule with a
+	// header mutation — the ResponseHeaderModifier in MeshFrontend).
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"gateway-conformance-mesh/echo-v2": {
+			{
+				Backends: []proxy.GammaBackend{{
+					Service: "gateway-conformance-mesh/echo-v2",
+					Cluster: "echo-v2.gateway-conformance-mesh.aether.internal",
+					Weight:  1,
+				}},
+			},
+		},
+	})
+	// The route target is addressed on its real Service port 80 (echo Service :80).
+	c.SetRouteTargetPorts(map[string][]uint32{"gateway-conformance-mesh/echo-v2": {80}})
+
+	vhosts := c.captureVhosts()
+
+	// The client dials the bare short name (same-namespace) with no port -> :authority
+	// "echo-v2". With a single owner the bare spelling must be emitted, AND the
+	// real-port spelling for clients that present "echo-v2:80".
+	require.NotNil(t, findVHost(vhosts, "echo-v2"),
+		"SA-backed route target must host-match its bare short name; got vhosts=%v", domainsOf(vhosts))
+
+	vh := findVHost(vhosts, "echo-v2.gateway-conformance-mesh.svc.cluster.local")
+	require.NotNil(t, vh)
+	domains := vh.GetDomains()
+	assert.Contains(t, domains, "echo-v2")
+	assert.Contains(t, domains, "echo-v2.gateway-conformance-mesh")
+	assert.Contains(t, domains, "echo-v2.gateway-conformance-mesh.svc")
+	assert.Contains(t, domains, "echo-v2:80")
+	assert.Contains(t, domains, "echo-v2.gateway-conformance-mesh.svc.cluster.local:80")
+
+	// The GAMMA rule (header mutation) must be projected onto the vhost — the route
+	// carries a backend cluster (so the mutation lowers to ResponseHeadersToAdd on
+	// the matched route, not the passthrough default).
+	routes := vh.GetRoutes()
+	require.GreaterOrEqual(t, len(routes), 1)
+	var sawBackend bool
+	for _, rt := range routes {
+		if rt.GetRoute().GetCluster() == "echo-v2.gateway-conformance-mesh.aether.internal" {
+			sawBackend = true
+		}
+	}
+	assert.True(t, sawBackend, "the route target's GAMMA rule routes to its backend cluster")
+}
+
 // TestCaptureVhosts_RouteTargetNoPort verifies a route target whose parentRef
 // declares no port falls back to the M1 behavior (portless + :18081 only) — no
 // spurious :0 domain.


### PR DESCRIPTION
## Summary

MESH-HTTP conformance **MeshFrontend** failed in CI (passed in the agent's minimal local repro). Root-caused to a real cap_http host-matching gap, fixed minimally.

### The bug (with evidence)

`MeshFrontend` ([upstream test](https://github.com/kubernetes-sigs/gateway-api/blob/v1.5.1/conformance/tests/mesh/mesh-frontend.go)) is **not** cross-namespace (the task's initial hypothesis): both client (`echo-v1`) and target (`echo-v2`) live in `gateway-conformance-mesh`. Its HTTPRoute `mesh-split-v1` has `parentRef: Service echo-v2` with a **ResponseHeaderModifier** filter (`X-Header-Set: set`), backendRef `echo-v2:80`. Case 1 ("Send to service"): `echo-v1` execs `client http://echo-v2/` → expects 200 + `X-Header-Set: set`.

The client dials the **bare** name `echo-v2` (port 80 implied), so the captured request's `:authority` is `echo-v2`. But `echo-v2` is an SA-backed mesh Service that is **also** its own GAMMA route target → it was handled by `captureVhosts`' first loop, which only emitted:

```
echo-v2.<ns>.svc.cluster.local        echo-v2.<ns>.svc.cluster.local:18081
echo-v2.<ns>.aether.internal          echo-v2.<ns>.aether.internal:18081
```

`echo-v2` / `echo-v2:80` / `echo-v2.<ns>` / `echo-v2.<ns>.svc` were **never emitted** → the dial missed the route-target vhost → fell through to `passthrough_original_dst` → the GAMMA ResponseHeaderModifier was never applied → no `X-Header-Set` → MeshFrontend case 1 fails. (Case 2, "Send to pod IP", expects the header to be *absent* and passes regardless.)

The versioned-fanout shape (a route target with **no** own SA, e.g. an `echo` target → `echo-v1`/`echo-v2`) goes through the **second** loop, which already emits every short-name + real-port spelling — which is exactly why the agent's minimal repro (that shape) passed while CI (`echo-v2`, its own backend) failed. **Not** an env/timing artifact.

### The fix

Extract the route-target domain-spelling logic (short names + guarded bare name + real Service ports, proposal 023 M2) into `routeTargetDomains`, and apply it in the first loop too — **only when the authority carries GAMMA rules**. Plain mesh Services (no rules) keep their minimal cluster.local + mesh spellings (passthrough reaches the same backend; emitting bare short names for every service would risk cross-namespace bare-name NACK collisions). Strictly additive, production-safe; the second loop's behavior is byte-for-byte preserved.

### Proof

`TestCaptureVhosts_SABackedRouteTargetShortNames` reproduces the exact MeshFrontend shape. On the old code it fails with the observed missing-domain set; with the fix the vhost carries `echo-v2`, `echo-v2:80`, `echo-v2.<ns>`, `echo-v2.<ns>.svc`, and the GAMMA rule routes to the backend cluster. Full `//agent/internal/xds/cache`, `proxy`, `capture`, and `gamma` test targets pass. (A full kind MESH e2e was not run here — ~3 image builds + CNI/agent; the unit test reproduces the exact host-match gap with the exact MeshFrontend domains.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)