### PR TITLE
test(mesh): lock in GAMMA-on-capture feature application + diagnose the runtime gap

### DIFF
--- a/agent/internal/xds/cache/capture_test.go
+++ b/agent/internal/xds/cache/capture_test.go
@@ -171,3 +171,104 @@ func domainsOf(vhosts []*routev3.VirtualHost) []string {
 	}
 	return out
 }
+
+// routeForPrefix returns the first route in the vhost whose match is the given
+// segment-boundary prefix (path_separated_prefix) or plain prefix.
+func routeForPrefix(vh *routev3.VirtualHost, prefix string) *routev3.Route {
+	for _, r := range vh.GetRoutes() {
+		m := r.GetMatch()
+		if m.GetPathSeparatedPrefix() == prefix || m.GetPrefix() == prefix {
+			return r
+		}
+	}
+	return nil
+}
+
+// TestCaptureVhosts_RouteTargetGAMMAFeatures verifies that the capture (cap_http)
+// path applies the SAME full GAMMA feature set as the outbound path for a route
+// TARGET (proposal 023 shape: an "echo" target fanned out to echo-v1/echo-v2).
+// This is the MESH-HTTP conformance gap: the capture vhost must emit
+// request/response header modification, a request redirect, AND a weighted split —
+// not a reduced action. It mirrors the exact conformance HTTPRoute shapes
+// (MeshHTTPRouteRequestHeaderModifier / RedirectHostAndStatus / Weight).
+func TestCaptureVhosts_RouteTargetGAMMAFeatures(t *testing.T) {
+	const (
+		v1Cluster = "echo-v1.gateway-conformance-mesh.aether.internal"
+		v2Cluster = "echo-v2.gateway-conformance-mesh.aether.internal"
+	)
+	c := newTestCache("node-1")
+	// A single route target "gateway-conformance-mesh/echo" carrying all three
+	// conformance feature shapes as separate rules.
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"gateway-conformance-mesh/echo": {
+			{
+				// RequestHeaderModifier: set + add + remove on request, set + remove on response.
+				Matches:  []proxy.GammaMatch{{Prefix: "/set"}},
+				Backends: []proxy.GammaBackend{{Service: "gateway-conformance-mesh/echo-v1", Cluster: v1Cluster, Weight: 1}},
+				HeaderMutation: &proxy.GammaHeaderMutation{
+					SetRequest:     []proxy.GammaHeaderKV{{Name: "X-Header-Set", Value: "set-overwrites-values"}},
+					AddRequest:     []proxy.GammaHeaderKV{{Name: "X-Header-Add", Value: "add-appends-values"}},
+					RemoveRequest:  []string{"X-Header-Remove"},
+					SetResponse:    []proxy.GammaHeaderKV{{Name: "X-Resp-Set", Value: "v"}},
+					RemoveResponse: []string{"X-Resp-Remove"},
+				},
+			},
+			{
+				// RequestRedirect: host + 301, NO backend cluster.
+				Matches:  []proxy.GammaMatch{{Prefix: "/hostname-redirect"}},
+				Redirect: &proxy.GammaRedirect{Hostname: "example.org", StatusCode: 301},
+			},
+			{
+				// 70/30 weighted split on the default path.
+				Matches: []proxy.GammaMatch{{Prefix: "/"}},
+				Backends: []proxy.GammaBackend{
+					{Service: "gateway-conformance-mesh/echo-v1", Cluster: v1Cluster, Weight: 70},
+					{Service: "gateway-conformance-mesh/echo-v2", Cluster: v2Cluster, Weight: 30},
+				},
+			},
+		},
+	})
+	c.SetRouteTargetPorts(map[string][]uint32{"gateway-conformance-mesh/echo": {80}})
+
+	vhosts := c.captureVhosts()
+
+	// The route target must host-match the bare same-namespace dial "echo" (the
+	// authority the conformance client presents) — else the request falls to the
+	// redirect-all passthrough (kube-proxy bypass) and no GAMMA feature applies.
+	vh := findVHost(vhosts, "echo")
+	require.NotNil(t, vh, "route target must carry the bare 'echo' domain; got %v", domainsOf(vhosts))
+	assert.Contains(t, vh.GetDomains(), "echo:80", "real Service port spelling (M2) must host-match too")
+
+	// 1. Header modification: the /set route carries request + response header maps.
+	setRoute := routeForPrefix(vh, "/set")
+	require.NotNil(t, setRoute, "the /set rule must produce a capture route")
+	assert.Equal(t, v1Cluster, setRoute.GetRoute().GetCluster(), "/set forwards to echo-v1")
+	require.Len(t, setRoute.GetRequestHeadersToAdd(), 2, "set + add request headers emitted on the capture path")
+	assert.Equal(t, "X-Header-Set", setRoute.GetRequestHeadersToAdd()[0].GetHeader().GetKey())
+	assert.Equal(t, "X-Header-Add", setRoute.GetRequestHeadersToAdd()[1].GetHeader().GetKey())
+	assert.Equal(t, []string{"X-Header-Remove"}, setRoute.GetRequestHeadersToRemove())
+	require.Len(t, setRoute.GetResponseHeadersToAdd(), 1, "response set header emitted on the capture path")
+	assert.Equal(t, "X-Resp-Set", setRoute.GetResponseHeadersToAdd()[0].GetHeader().GetKey())
+	assert.Equal(t, []string{"X-Resp-Remove"}, setRoute.GetResponseHeadersToRemove())
+
+	// 2. Redirect: the /hostname-redirect route emits a RedirectAction (NOT a forward).
+	redirectRoute := routeForPrefix(vh, "/hostname-redirect")
+	require.NotNil(t, redirectRoute, "the redirect rule must produce a capture route")
+	rd := redirectRoute.GetRedirect()
+	require.NotNil(t, rd, "redirect rule emits a Route_Redirect on the capture path, not a cluster forward")
+	assert.Equal(t, "example.org", rd.GetHostRedirect())
+	assert.Equal(t, routev3.RedirectAction_MOVED_PERMANENTLY, rd.GetResponseCode())
+	assert.Nil(t, redirectRoute.GetRoute(), "a redirect route must not carry a RouteAction")
+
+	// 3. Weight: the default "/" route emits a 70/30 weighted_clusters split.
+	weightRoute := routeForPrefix(vh, "/")
+	require.NotNil(t, weightRoute, "the weighted '/' rule must produce a capture route")
+	wc := weightRoute.GetRoute().GetWeightedClusters().GetClusters()
+	require.Len(t, wc, 2, "two weighted backends on the capture path")
+	got := map[string]uint32{}
+	for _, w := range wc {
+		got[w.GetName()] = w.GetWeight().GetValue()
+	}
+	assert.Equal(t, uint32(70), got[v1Cluster], "echo-v1 weight 70 preserved on the capture path")
+	assert.Equal(t, uint32(30), got[v2Cluster], "echo-v2 weight 30 preserved on the capture path")
+}

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -197,17 +197,48 @@ func buildCaptureRouteTargetBootstrap() (*bootstrapv3.Bootstrap, error) {
 		realPort   = 8080
 	)
 
-	// The route target's GAMMA rules: /v2 -> echo-v2, / -> echo-v1, plus a header
-	// modifier on the fallback (mirrors the conformance shape).
+	// The route target's GAMMA rules mirror the exact MESH-HTTP conformance feature
+	// shapes (MeshHTTPRouteWeight / RequestHeaderModifier / RedirectHostAndStatus) so
+	// the offline `envoy --mode validate` gate proves Envoy ACCEPTS the capture-path
+	// route action for each — a NACK here would break the whole cap_http table at
+	// runtime (every request then falls to the redirect-all passthrough, i.e. the
+	// kube-proxy bypass that manifested as the conformance timeouts / wrong split):
+	//   - /v2 -> echo-v2 (single backend, segment-prefix match)
+	//   - /redirect -> RequestRedirect (host + 301, NO backend cluster)
+	//   - /headers -> echo-v1 with a request header set+add+remove + response mutation
+	//   - / (default) -> 70/30 WEIGHTED split across echo-v1/echo-v2
 	rules := []proxy.GammaRoute{
 		{
 			Matches:  []proxy.GammaMatch{{Prefix: "/v2"}},
 			Backends: []proxy.GammaBackend{{Service: "team-a/echo-v2", Cluster: v2Cluster, Weight: 1}},
 		},
 		{
-			Matches:        []proxy.GammaMatch{{Prefix: "/"}},
-			Backends:       []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: v1Cluster, Weight: 1}},
-			HeaderMutation: &proxy.GammaHeaderMutation{SetRequest: []proxy.GammaHeaderKV{{Name: "x-aether-route", Value: "echo-v1"}}},
+			// RequestRedirect: replaces the route action with a RedirectAction and
+			// carries NO backend cluster (Gateway API redirect-takes-precedence shape).
+			Matches:  []proxy.GammaMatch{{Prefix: "/redirect"}},
+			Redirect: &proxy.GammaRedirect{Hostname: "example.org", StatusCode: 301},
+		},
+		{
+			// Full header mutation: set/add/remove on the request, set/remove on the
+			// response — exactly the RequestHeaderModifier conformance vocabulary.
+			Matches:  []proxy.GammaMatch{{Prefix: "/headers"}},
+			Backends: []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: v1Cluster, Weight: 1}},
+			HeaderMutation: &proxy.GammaHeaderMutation{
+				SetRequest:     []proxy.GammaHeaderKV{{Name: "X-Header-Set", Value: "set-overwrites-values"}},
+				AddRequest:     []proxy.GammaHeaderKV{{Name: "X-Header-Add", Value: "add-appends-values"}},
+				RemoveRequest:  []string{"X-Header-Remove"},
+				SetResponse:    []proxy.GammaHeaderKV{{Name: "X-Resp-Set", Value: "resp"}},
+				RemoveResponse: []string{"X-Resp-Remove"},
+			},
+		},
+		{
+			// 70/30 WEIGHTED split (two backends) on the default "/" — the
+			// MeshHTTPRouteWeight shape (no match → default prefix).
+			Matches: []proxy.GammaMatch{{Prefix: "/"}},
+			Backends: []proxy.GammaBackend{
+				{Service: "team-a/echo-v1", Cluster: v1Cluster, Weight: 70},
+				{Service: "team-a/echo-v2", Cluster: v2Cluster, Weight: 30},
+			},
 		},
 	}
 	// Real-port domains (M2) + portless + mesh-name spellings, the exact set


### PR DESCRIPTION
## Summary

Investigation + test hardening for the **MESH-HTTP GAMMA-feature-on-capture gap** (`MeshHTTPRouteRequestHeaderModifier`, `MeshHTTPRouteRedirectHostAndStatus`, `MeshHTTPRouteWeight` failing; `MeshTrafficSplit`/`MeshHTTPRouteMatching`/`MeshBasic` passing).

**Key finding: the brief's hypothesis is incorrect against current `origin/main`.** The capture path is **not** a reduced/parallel action — `captureVhosts` already calls the same `proxy.BuildOutboundServiceVirtualHost` builder as the outbound path, so it emits the full GAMMA feature set (header mutation, redirect, weighted split). This PR proves that and guards it; the actual residual is a **runtime** capture-path issue, not a config-generation bug.

## What this PR adds (both pass against unmodified capture code)

- **`agent/internal/xds/cache` — `TestCaptureVhosts_RouteTargetGAMMAFeatures`**: builds a route TARGET (the proposal-023 `echo` → `echo-v1`/`echo-v2` fanout) carrying the exact conformance shapes and asserts the generated cap_http Envoy routes emit:
  - request set+add+remove **and** response set+remove header maps,
  - a `Route_Redirect` (host + 301, no cluster forward),
  - a 70/30 `weighted_clusters` split.
- **`test/envoy_validate`**: the route-target capture bootstrap now exercises a redirect route (no backend), a full request+response header mutation, and a 2-backend 70/30 weighted split, so `envoy --mode validate` proves **stock Envoy ACCEPTS** the capture-path config for all three features — ruling out a runtime NACK.

## Evidence the config is correct

1. Code: `captureVhosts` (both the captureAuthority loop and the route-target loop) → `BuildOutboundServiceVirtualHost`, the identical builder the outbound path uses. Header maps, `Route_Redirect`, and `weighted_clusters` are all emitted; the reconciler (`buildGammaRoute`) already parses all three filters.
2. Unit test dumps the generated `/set` route → `requestHeadersToAdd: X-Header-Set=set-overwrites-values`, the redirect route → `RedirectAction{host_redirect=example.org, 301}`, and the weighted route → `{echo-v1:70, echo-v2:30}`. Domains include bare `echo` and `echo:80`, so the conformance authority `echo` host-matches.
3. `envoy --mode validate` accepts all three shapes (no NACK).
4. `WeightedCluster.total_weight` is deprecated; Envoy uses the sum of weights (70+30) — the construction is complete.

## The real runtime gap (needs the post-merge CI run to confirm)

The CI failures are NOT in config generation. The echo-reflected request for `/set` in the failing CI run carries Envoy-added headers (`X-Forwarded-Proto`, `X-Request-Id`, `X-Envoy-Expected-Rq-Timeout-Ms`) but is **missing `X-Header-Set`** — i.e. the request reaches a backend through *an* Envoy but bypasses the cap_http `/set` GAMMA route. Combined with the weight test's fast wrong-distribution (~50/50, the kube-proxy signature) and the passing tests barely converging (53–88s), this points to the route-target `echo` cap_http vhost not being active in the proxy snapshot when these requests run, so they fall to the redirect-all `passthrough_original_dst` → kube-proxy. This is a capture-path runtime convergence/scoping issue, not a "feature dropped in the builder."

This PR's value: it locks in that the config aether generates is correct and Envoy-accepted, so a still-failing post-merge `mesh-http` run is conclusively a runtime/scoping problem (config-dump introspection on a live kind proxy), and any future regression to a partial capture action is caught offline.

## Validation
- `bazel test //agent/internal/xds/cache:cache_test` ✅
- `bazel test //test/envoy_validate:envoy_validate_test` ✅ (`envoy --mode validate`, offline)
- `bazel test //agent/... --test_arg=-test.short` (cache/proxy/gamma) ✅
- Cannot `workflow_dispatch` the conformance suite from a non-default branch; the `mesh-http` (soft) job must run post-merge. GATEWAY-HTTP hard gate (43/0) untouched; no production mTLS path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)