### PR TITLE
fix(registrar): enable leader election so mesh-Service generators run on one replica (MESH-HTTP GAMMA features)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.55.3-{GIT_COMMIT}"
+version: "0.55.4-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/registrar-rbac.yaml
+++ b/charts/aether/templates/registrar-rbac.yaml
@@ -51,3 +51,38 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "aether.registrar.serviceAccountName" . }}
     namespace: {{ include "aether.namespace" . }}
+---
+# Leader election: the registrar runs multiple replicas, but its leader-only
+# runnables (mesh-Service VIP generator, MCS ServiceImport generator) must run on
+# exactly one replica. controller-runtime coordinates this with a Lease in the
+# registrar's own namespace, so grant namespaced lease + event access.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "aether.registrar.fullname" . }}
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.registrar.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "aether.registrar.fullname" . }}
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.registrar.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "aether.registrar.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "aether.registrar.serviceAccountName" . }}
+    namespace: {{ include "aether.namespace" . }}

--- a/registrar/internal/cmd/config.go
+++ b/registrar/internal/cmd/config.go
@@ -79,6 +79,22 @@ func NewRegistrarConfig() *RegistrarConfig {
 		Config: manager.Config{
 			HealthProbeBindAddress: ":8082",
 			MetricsBindAddress:     ":8081",
+			// Leader election: the registrar runs multiple replicas (HA endpoint
+			// stream), but the leader-only runnables — the mesh-Service VIP
+			// generator and the MCS ServiceImport generator (both
+			// NeedLeaderElection()=true) — must run on exactly ONE replica. Without
+			// leader election controller-runtime ignores NeedLeaderElection and runs
+			// every runnable on every replica, so two replicas' transiently-divergent
+			// registry snapshots fight create-vs-prune on the selectorless mesh
+			// Services every sync interval. That flap forces a full agent xDS snapshot
+			// rebuild each cycle; a captured request landing in the rebuild window
+			// misses the cap_http GAMMA vhost and falls through to the ORIGINAL_DST
+			// passthrough (kube-proxy round-robin), dropping the HTTPRoute feature
+			// (header mutation / redirect / weight). The per-replica
+			// syncer/broadcaster/write-behind stay NeedLeaderElection()=false, so the
+			// endpoint stream remains served by every replica.
+			LeaderElection:   true,
+			LeaderElectionID: "aether-registrar.registry.aether.io",
 		},
 		RegistryBackend:         "kubernetes",
 		EtcdEndpoints:           []string{"localhost:2379"},

--- a/registrar/internal/cmd/config_test.go
+++ b/registrar/internal/cmd/config_test.go
@@ -47,6 +47,19 @@ func TestRegistrarConfig_DefaultValues(t *testing.T) {
 			got:      c.Debug,
 			expected: false,
 		},
+		{
+			// Leader election must be on so the leader-only mesh-Service / MCS
+			// generators run on exactly one replica (two replicas otherwise fight
+			// create-vs-prune on the selectorless mesh Services).
+			name:     "leader election is enabled by default",
+			got:      c.LeaderElection,
+			expected: true,
+		},
+		{
+			name:     "leader election ID is set",
+			got:      c.LeaderElectionID,
+			expected: "aether-registrar.registry.aether.io",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What

Enable controller-runtime **leader election** in the registrar manager so the leader-only mesh-Service VIP generator and MCS ServiceImport generator (both `NeedLeaderElection()=true`) run on **exactly one** replica, and grant the namespaced Lease/event RBAC the Lease needs.

## Why — the MESH-HTTP GAMMA-feature runtime failure, root-caused with live config_dump

The MESH-HTTP conformance fails (`MeshHTTPRouteRequestHeaderModifier`, `MeshHTTPRouteRedirectHostAndStatus`, `MeshHTTPRouteWeight`) were stuck failing **at runtime** despite the generated config being provably correct.

**Live config_dump on a kind mesh proxy** (the `echo` route-target cap_http vhost):

```
VHOST echo.gateway-conformance-mesh.aether.internal
  domains = [... 'echo', 'echo:18081', ... 'echo:80']
  match=/set act=route cluster=echo-v1.gateway-conformance-mesh.aether.internal req_hdrs_add=['X-Header-Set']
  match=/   act=route cluster=echo.gateway-conformance-mesh.aether.internal
```

The conformance client dials bare `Host: echo` (port 80). The vhost host-matches `echo`, the `/set` route carries `request_headers_to_add:[X-Header-Set]` and routes to `echo-v1`. Yet CI saw **missing `X-Header-Set`** and a **50/50** (kube-proxy round-robin) weight split — the signature of requests hitting the **ORIGINAL_DST passthrough** instead of the GAMMA vhost.

**Root cause (registrar logs on the live cluster):** the registrar runs 2 replicas but leader election was never enabled (no `--leader-election` flag, no `LeaderElection:true` default). controller-runtime only honors `NeedLeaderElection()` when leader election is on, so the mesh-Service generators ran on **both** replicas, fighting create-vs-prune on the selectorless mesh Services every 5s. That flap forced a full agent xDS snapshot rebuild each cycle; a captured request landing in the rebuild window missed the cap_http GAMMA vhost and fell through to the redirect-all passthrough → kube-proxy → feature dropped.

## Fix

- `registrar/internal/cmd/config.go`: `LeaderElection: true` + `LeaderElectionID` (mirrors the controller).
- `charts/aether/templates/registrar-rbac.yaml`: namespaced `Role`/`RoleBinding` for `coordination.k8s.io/leases` + events.
- The per-replica syncer/broadcaster/write-behind stay `NeedLeaderElection()=false` — the endpoint stream is still served by every replica; only the single-writer generators are gated to the leader.

## Proof (live kind mesh, SPIRE off, redirect-all, conformance echo shape)

After the fix the lease is held by one pod, only the leader runs the generator, and from the echo pod:

- **Header**: `X-Header-Set:set-overwrites-values` applied, 30/30.
- **Redirect**: `StatusCode=301`, `Location: http://example.org/host-and-status`.
- **Weight**: 70/30 split confirmed (31/9 of 40).

`cluster.passthrough_original_dst` traffic stays at 0.

## Scope / honesty

GATEWAY-HTTP and production mTLS untouched. A residual **consumer-namespace** registry-snapshot flap (single leader still create-vs-prunes `gateway-conformance-mesh-consumer/echo-v1`) remains — the `MeshFrontend` shape, a separate follow-up not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)