### PR TITLE
test(registry): shared namespace-qualified-key contract for keying backends

### DIFF
--- a/registry/internal/k8s/BUILD.bazel
+++ b/registry/internal/k8s/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     deps = [
         "//api/aether/registry/v1:registry",
         "//common/constants",
+        "//registry/registrytest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_k8s_api//core/v1:core",

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -13,6 +13,7 @@ import (
 
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
+	"github.com/bpalermo/aether/registry/registrytest"
 )
 
 // newTestRegistry constructs a KubernetesRegistry wired to a fake client built
@@ -859,6 +860,8 @@ func TestListAllEndpoints(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, got)
+			// Shared cross-backend contract: keys must be namespace-qualified.
+			registrytest.RequireNamespaceQualifiedKeys(t, got)
 		})
 	}
 }

--- a/registry/registrytest/BUILD.bazel
+++ b/registry/registrytest/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "registrytest",
+    srcs = ["contract.go"],
+    importpath = "github.com/bpalermo/aether/registry/registrytest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//api/aether/registry/v1:registry",
+        "//common/serviceref",
+    ],
+)

--- a/registry/registrytest/contract.go
+++ b/registry/registrytest/contract.go
@@ -1,0 +1,43 @@
+// Package registrytest provides shared assertions every Registry backend must
+// satisfy, so the implementations (kubernetes, etcd, dynamodb, registrar) stay
+// consistent. The keying format is centralized in common/serviceref and the write
+// path qualifies once in registry/cni.go; this contract guards against a backend
+// (especially a read-only one that DERIVES keys, like the kubernetes backend)
+// silently diverging to a bare or cross-namespace key.
+package registrytest
+
+import (
+	"testing"
+
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/common/serviceref"
+)
+
+// RequireNamespaceQualifiedKeys asserts the contract that ListAllEndpoints output
+// must satisfy regardless of backend:
+//
+//  1. every service key is a namespace-qualified "<ns>/<sa>" (serviceref.ParseKey
+//     accepts it) — a bare ServiceAccount key is rejected by every downstream
+//     consumer (the VIP generator, the agent dependency set), so it is a bug;
+//  2. every endpoint listed under a key whose KubernetesMetadata carries a
+//     namespace agrees with the key's namespace — catches the collision where
+//     same-named ServiceAccounts in different namespaces merge under one key.
+//
+// Call it from each backend's ListAllEndpoints test (the kubernetes unit test and
+// the etcd/dynamodb integration tests) so the keying can't drift.
+func RequireNamespaceQualifiedKeys(t testing.TB, services map[string][]*registryv1.ServiceEndpoint) {
+	t.Helper()
+	for key, eps := range services {
+		ref, ok := serviceref.ParseKey(key)
+		if !ok {
+			t.Errorf("service key %q is not namespace-qualified <ns>/<sa> (a backend must key like serviceref/cni.go)", key)
+			continue
+		}
+		for _, ep := range eps {
+			epNS := ep.GetKubernetesMetadata().GetNamespace()
+			if epNS != "" && epNS != ref.Namespace {
+				t.Errorf("service key %q has an endpoint in namespace %q — same-named ServiceAccounts must not merge across namespaces", key, epNS)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Follow-up to #427. Adds `registrytest.RequireNamespaceQualifiedKeys` — a shared contract the key-deriving backends run on their ListAllEndpoints output: every key must be a serviceref-parseable `<ns>/<sa>`, and no endpoint's namespace may disagree with its key's namespace (the collision). Wired into the kubernetes backend test so the keying can't silently drift again.

Scope note: the keying format is centralized in `serviceref` and qualified once on the write path (`cni.go`); etcd/dynamodb are key-agnostic storage passthroughs, so the contract targets backends that *derive* keys (kubernetes). 🤖 Generated with [Claude Code](https://claude.com/claude-code)