### PR TITLE
feat(registrar): drop + count malformed streamed service keys (wire ingress guard)

### DIFF
--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//api/aether/registrar/v1:registrar",
         "//api/aether/registry/v1:registry",
         "//common/log",
+        "//common/serviceref",
         "//common/telemetry",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_metric//:metric",

--- a/registry/internal/registrar/metrics.go
+++ b/registry/internal/registrar/metrics.go
@@ -18,9 +18,10 @@ const meterName = "aether/registry-registrar"
 // query: compare against aether.registrar.snapshot.version — a persistent gap
 // means this agent is consuming a stale endpoint view.
 type clientMetrics struct {
-	reconnects  metric.Int64Counter
-	watchErrors metric.Int64Counter
-	lastVersion metric.Int64Gauge
+	reconnects    metric.Int64Counter
+	watchErrors   metric.Int64Counter
+	lastVersion   metric.Int64Gauge
+	malformedKeys metric.Int64Counter
 }
 
 // newClientMetrics registers the watch-stream instruments on the given meter.
@@ -40,6 +41,10 @@ func newClientMetrics(meter metric.Meter) (*clientMetrics, error) {
 		metric.WithDescription("Last registrar snapshot version applied by this agent (compare with aether.registrar.snapshot.version for skew)")); err != nil {
 		return nil, fmt.Errorf("last version: %w", err)
 	}
+	if m.malformedKeys, err = meter.Int64Counter("aether.agent.registry.malformed_keys",
+		metric.WithDescription("Streamed endpoint events dropped because the service key was not a namespace-qualified <ns>/<sa> (a backend keying bug; otherwise 0)")); err != nil {
+		return nil, fmt.Errorf("malformed keys: %w", err)
+	}
 
 	return m, nil
 }
@@ -56,6 +61,13 @@ func (m *clientMetrics) streamFailed(ctx context.Context) {
 		return
 	}
 	m.watchErrors.Add(ctx, 1)
+}
+
+func (m *clientMetrics) malformedKey(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.malformedKeys.Add(ctx, 1)
 }
 
 func (m *clientMetrics) versionApplied(ctx context.Context, version string) {

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -16,6 +16,7 @@ import (
 	registrarv1 "github.com/bpalermo/aether/api/aether/registrar/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	commonlog "github.com/bpalermo/aether/common/log"
+	"github.com/bpalermo/aether/common/serviceref"
 	"github.com/bpalermo/aether/common/telemetry"
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
@@ -539,7 +540,7 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 			r.readyOnce.Do(func() { close(r.ready) })
 		}
 
-		r.applyEvent(event)
+		r.applyEvent(ctx, event)
 
 		if event.GetVersion() != "" {
 			lastVersion = event.GetVersion()
@@ -549,13 +550,26 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 }
 
 // applyEvent updates the local cache based on an endpoint event.
-func (r *RegistrarRegistry) applyEvent(event *registrarv1.WatchEndpointsResponse) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
+func (r *RegistrarRegistry) applyEvent(ctx context.Context, event *registrarv1.WatchEndpointsResponse) {
 	svcName := event.GetServiceName()
 	protocol := event.GetProtocol()
 	ep := event.GetEndpoint()
+
+	// Ingress validation: a mutating event must carry a namespace-qualified
+	// "<ns>/<sa>" key (proposal 020). A bare/malformed key means a backend keying
+	// bug (e.g. the kubernetes backend before #427); drop it with a metric +
+	// rate-aware warn rather than caching a key every downstream consumer would
+	// silently skip. SNAPSHOT_COMPLETE is a marker with no service name.
+	if event.GetType() != registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE {
+		if _, ok := serviceref.ParseKey(svcName); !ok {
+			r.metrics.malformedKey(ctx)
+			r.log.WarnContext(ctx, "dropping endpoint event with a non-namespace-qualified service key (backend keying bug)", "service", svcName)
+			return
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	switch event.GetType() {
 	case registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT:

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -42,10 +42,10 @@ func TestApplyEvent_FullSnapshot_AddsToCache(t *testing.T) {
 	}{
 		{
 			name:        "full snapshot adds endpoint to empty cache",
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    ep,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep},
+				"default/svc-a": {ep},
 			},
 		},
 	}
@@ -53,7 +53,7 @@ func TestApplyEvent_FullSnapshot_AddsToCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
-			r.applyEvent(&registrarv1.WatchEndpointsResponse{
+			r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
@@ -61,6 +61,22 @@ func TestApplyEvent_FullSnapshot_AddsToCache(t *testing.T) {
 			assert.Equal(t, tt.expected, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 		})
 	}
+}
+
+// TestApplyEvent_DropsMalformedKey is the ingress-validation guard (the wire
+// boundary): a streamed event whose service key is not a namespace-qualified
+// "<ns>/<sa>" (a backend keying bug, e.g. the kubernetes backend before #427) is
+// dropped, not cached — so the agent never derives config from a key every
+// downstream consumer would skip, and the drop is counted (aether.agent.registry.
+// malformed_keys) instead of being silent.
+func TestApplyEvent_DropsMalformedKey(t *testing.T) {
+	r := newTestRegistry()
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
+		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT,
+		ServiceName: "svc-a", // BARE — not the namespace-qualified "<ns>/<sa>"
+		Endpoint:    makeEndpoint("10.0.0.1", 8080),
+	})
+	assert.Empty(t, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED], "a bare-keyed event must be dropped, not cached")
 }
 
 func TestApplyEvent_EndpointAdded(t *testing.T) {
@@ -77,31 +93,31 @@ func TestApplyEvent_EndpointAdded(t *testing.T) {
 		{
 			name:         "adds endpoint to empty service",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{},
-			serviceName:  "svc-a",
+			serviceName:  "default/svc-a",
 			endpoint:     ep1,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
+				"default/svc-a": {ep1},
 			},
 		},
 		{
 			name: "adds second endpoint to existing service",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
+				"default/svc-a": {ep1},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    ep2,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1, ep2},
+				"default/svc-a": {ep1, ep2},
 			},
 		},
 		{
 			name:         "adds endpoint to new service alongside existing service",
-			initialCache: map[string][]*registryv1.ServiceEndpoint{"svc-a": {ep1}},
-			serviceName:  "svc-b",
+			initialCache: map[string][]*registryv1.ServiceEndpoint{"default/svc-a": {ep1}},
+			serviceName:  "default/svc-b",
 			endpoint:     ep2,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
-				"svc-b": {ep2},
+				"default/svc-a": {ep1},
+				"default/svc-b": {ep2},
 			},
 		},
 	}
@@ -110,7 +126,7 @@ func TestApplyEvent_EndpointAdded(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
 			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
-			r.applyEvent(&registrarv1.WatchEndpointsResponse{
+			r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
@@ -138,34 +154,34 @@ func TestApplyEvent_EndpointUpdated(t *testing.T) {
 		{
 			name: "updates existing endpoint by IP",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {original},
+				"default/svc-a": {original},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    updated,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {updated},
+				"default/svc-a": {updated},
 			},
 		},
 		{
 			name: "updates correct endpoint when multiple exist",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {original, other},
+				"default/svc-a": {original, other},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    updated,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {updated, other},
+				"default/svc-a": {updated, other},
 			},
 		},
 		{
 			name: "adds endpoint if IP not found during update",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {other},
+				"default/svc-a": {other},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    updated,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {other, updated},
+				"default/svc-a": {other, updated},
 			},
 		},
 	}
@@ -174,7 +190,7 @@ func TestApplyEvent_EndpointUpdated(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
 			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
-			r.applyEvent(&registrarv1.WatchEndpointsResponse{
+			r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
@@ -198,38 +214,38 @@ func TestApplyEvent_EndpointRemoved(t *testing.T) {
 		{
 			name: "removes the only endpoint and deletes service key",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
+				"default/svc-a": {ep1},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    ep1,
 			expected:    map[string][]*registryv1.ServiceEndpoint{},
 		},
 		{
 			name: "removes one of multiple endpoints",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1, ep2},
+				"default/svc-a": {ep1, ep2},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    ep1,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep2},
+				"default/svc-a": {ep2},
 			},
 		},
 		{
 			name: "remove on non-existent IP is a no-op",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep2},
+				"default/svc-a": {ep2},
 			},
-			serviceName: "svc-a",
+			serviceName: "default/svc-a",
 			endpoint:    ep1,
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep2},
+				"default/svc-a": {ep2},
 			},
 		},
 		{
 			name:         "remove on non-existent service is a no-op",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{},
-			serviceName:  "svc-missing",
+			serviceName:  "default/svc-missing",
 			endpoint:     ep1,
 			expected:     map[string][]*registryv1.ServiceEndpoint{},
 		},
@@ -239,7 +255,7 @@ func TestApplyEvent_EndpointRemoved(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := newTestRegistry()
 			r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED] = tt.initialCache
-			r.applyEvent(&registrarv1.WatchEndpointsResponse{
+			r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED,
 				ServiceName: tt.serviceName,
 				Endpoint:    tt.endpoint,
@@ -253,14 +269,14 @@ func TestRemoveLocked_CleansUpEmptyServiceKey(t *testing.T) {
 	ep := makeEndpoint("10.0.0.1", 8080)
 	r := newTestRegistry()
 	r.cache[registryv1.Service_PROTOCOL_HTTP] = map[string][]*registryv1.ServiceEndpoint{
-		"svc-a": {ep},
+		"default/svc-a": {ep},
 	}
 
 	r.mu.Lock()
-	r.removeLocked(registryv1.Service_PROTOCOL_HTTP, "svc-a", "10.0.0.1")
+	r.removeLocked(registryv1.Service_PROTOCOL_HTTP, "default/svc-a", "10.0.0.1")
 	r.mu.Unlock()
 
-	_, exists := r.cache[registryv1.Service_PROTOCOL_HTTP]["svc-a"]
+	_, exists := r.cache[registryv1.Service_PROTOCOL_HTTP]["default/svc-a"]
 	assert.False(t, exists, "service key should be removed from cache when no endpoints remain")
 	assert.Empty(t, r.cache[registryv1.Service_PROTOCOL_HTTP])
 }
@@ -277,21 +293,21 @@ func TestListAllEndpoints_ReadsFromCache(t *testing.T) {
 		{
 			name: "returns all services from populated cache",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
-				"svc-b": {ep2},
+				"default/svc-a": {ep1},
+				"default/svc-b": {ep2},
 			},
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
-				"svc-b": {ep2},
+				"default/svc-a": {ep1},
+				"default/svc-b": {ep2},
 			},
 		},
 		{
 			name: "returns single service from cache",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1, ep2},
+				"default/svc-a": {ep1, ep2},
 			},
 			expected: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1, ep2},
+				"default/svc-a": {ep1, ep2},
 			},
 		},
 	}
@@ -321,18 +337,18 @@ func TestListEndpoints_ReadsFromCache(t *testing.T) {
 		{
 			name: "returns endpoints for matching service",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1, ep2},
-				"svc-b": {ep2},
+				"default/svc-a": {ep1, ep2},
+				"default/svc-b": {ep2},
 			},
-			service:  "svc-a",
+			service:  "default/svc-a",
 			expected: []*registryv1.ServiceEndpoint{ep1, ep2},
 		},
 		{
 			name: "returns single endpoint for service",
 			initialCache: map[string][]*registryv1.ServiceEndpoint{
-				"svc-a": {ep1},
+				"default/svc-a": {ep1},
 			},
-			service:  "svc-a",
+			service:  "default/svc-a",
 			expected: []*registryv1.ServiceEndpoint{ep1},
 		},
 	}
@@ -356,53 +372,53 @@ func TestCache_MultipleServices(t *testing.T) {
 	ep3 := makeEndpoint("10.0.0.3", 9090)
 
 	// Add endpoints across two services.
-	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-		ServiceName: "svc-a",
+		ServiceName: "default/svc-a",
 		Endpoint:    ep1,
 	})
-	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-		ServiceName: "svc-b",
+		ServiceName: "default/svc-b",
 		Endpoint:    ep2,
 	})
-	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-		ServiceName: "svc-a",
+		ServiceName: "default/svc-a",
 		Endpoint:    ep3,
 	})
 
 	assert.Equal(t, map[string][]*registryv1.ServiceEndpoint{
-		"svc-a": {ep1, ep3},
-		"svc-b": {ep2},
+		"default/svc-a": {ep1, ep3},
+		"default/svc-b": {ep2},
 	}, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 
 	// Remove svc-a entirely.
-	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED,
-		ServiceName: "svc-a",
+		ServiceName: "default/svc-a",
 		Endpoint:    ep1,
 	})
-	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED,
-		ServiceName: "svc-a",
+		ServiceName: "default/svc-a",
 		Endpoint:    ep3,
 	})
 
 	assert.Equal(t, map[string][]*registryv1.ServiceEndpoint{
-		"svc-b": {ep2},
+		"default/svc-b": {ep2},
 	}, r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED])
 
-	_, exists := r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED]["svc-a"]
+	_, exists := r.cache[registryv1.Service_PROTOCOL_UNSPECIFIED]["default/svc-a"]
 	assert.False(t, exists, "svc-a key should be absent after all endpoints removed")
 }
 
 func TestApplyEvent_SignalsChange(t *testing.T) {
 	r := newTestRegistry()
 
-	r.applyEvent(&registrarv1.WatchEndpointsResponse{
+	r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-		ServiceName: "svc-a",
+		ServiceName: "default/svc-a",
 		Endpoint:    makeEndpoint("10.0.0.1", 8080),
 	})
 
@@ -419,9 +435,9 @@ func TestSignalChange_Coalesces(t *testing.T) {
 	// A burst of events must collapse into a single pending signal (the notify
 	// channel is buffered with capacity 1 and written non-blocking).
 	for range 5 {
-		r.applyEvent(&registrarv1.WatchEndpointsResponse{
+		r.applyEvent(context.Background(), &registrarv1.WatchEndpointsResponse{
 			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-			ServiceName: "svc-a",
+			ServiceName: "default/svc-a",
 			Endpoint:    makeEndpoint("10.0.0.1", 8080),
 		})
 	}
@@ -458,7 +474,7 @@ func TestProcessStream_TracksLastVersion(t *testing.T) {
 		events: []*registrarv1.WatchEndpointsResponse{
 			{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-				ServiceName: "svc-a",
+				ServiceName: "default/svc-a",
 				Endpoint:    makeEndpoint("10.0.0.1", 8080),
 				Version:     "7",
 			},
@@ -482,7 +498,7 @@ func TestProcessStream_DataLossClearsResumeToken(t *testing.T) {
 		events: []*registrarv1.WatchEndpointsResponse{
 			{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED,
-				ServiceName: "svc-a",
+				ServiceName: "default/svc-a",
 				Endpoint:    makeEndpoint("10.0.0.1", 8080),
 				Version:     "7",
 			},
@@ -520,7 +536,7 @@ func TestSnapshotCompleteClosesReady(t *testing.T) {
 		events: []*registrarv1.WatchEndpointsResponse{
 			{
 				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT,
-				ServiceName: "svc-a",
+				ServiceName: "default/svc-a",
 				Protocol:    registryv1.Service_PROTOCOL_HTTP,
 				Endpoint:    makeEndpoint("10.0.0.1", 8080),
 				Version:     "7",
@@ -577,15 +593,15 @@ func TestSetServiceFilter_ReassertsOnChangeOnly(t *testing.T) {
 	r.streamCancel = func() { cancels++ }
 	r.filterMu.Unlock()
 
-	r.SetServiceFilter([]string{"svc-a", "svc-b"})
+	r.SetServiceFilter([]string{"default/svc-a", "default/svc-b"})
 	assert.Equal(t, 1, cancels, "first filter must cancel the stream")
 
 	// Same set, different order: no re-assert.
-	r.SetServiceFilter([]string{"svc-b", "svc-a"})
+	r.SetServiceFilter([]string{"default/svc-b", "default/svc-a"})
 	assert.Equal(t, 1, cancels, "unchanged filter must not cancel")
 
 	// Shrink: re-assert.
-	r.SetServiceFilter([]string{"svc-a"})
+	r.SetServiceFilter([]string{"default/svc-a"})
 	assert.Equal(t, 2, cancels)
 
 	// Empty non-nil (watch nothing) differs from nil (full watch).
@@ -612,17 +628,17 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 
 	// First connection: replay svc-a, svc-b; complete at version 5.
 	stream := &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
-		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-a", "5"),
-		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-b", "5"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "default/svc-a", "5"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "default/svc-b", "5"),
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "5"),
 		// Post-marker incremental transitions.
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-c", "6"),
-		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, "svc-b", "7"),
+		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, "default/svc-b", "7"),
 	}, err: io.EOF}
 	last := r.processStream(context.Background(), stream, "")
 	assert.Equal(t, "7", last)
-	assert.True(t, r.HasService("svc-a"))
-	assert.False(t, r.HasService("svc-b"), "incremental removal applies")
+	assert.True(t, r.HasService("default/svc-a"))
+	assert.False(t, r.HasService("default/svc-b"), "incremental removal applies")
 	assert.True(t, r.HasService("svc-c"))
 	assert.False(t, r.HasService("ghost"))
 
@@ -634,7 +650,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 	}, err: io.EOF}
 	_ = r.processStream(context.Background(), stream, "7")
 	assert.True(t, r.HasService("svc-z"))
-	assert.False(t, r.HasService("svc-a"), "swap drops stale catalog entries")
+	assert.False(t, r.HasService("default/svc-a"), "swap drops stale catalog entries")
 	assert.False(t, r.HasService("svc-c"))
 
 	// Reconnect where the client is CURRENT (marker version == resume token):
@@ -654,18 +670,18 @@ func TestSetServiceFilter_PurgesOutOfScopeCache(t *testing.T) {
 	r := NewRegistrarRegistry(slog.New(slog.DiscardHandler), Config{Address: "test"})
 	r.mu.Lock()
 	r.cache[registryv1.Service_PROTOCOL_HTTP] = map[string][]*registryv1.ServiceEndpoint{
-		"svc-a": {{Ip: "10.0.0.1"}},
+		"default/svc-a": {{Ip: "10.0.0.1"}},
 	}
 	r.cache[registryv1.Service_PROTOCOL_TCP] = map[string][]*registryv1.ServiceEndpoint{
-		"svc-b": {{Ip: "10.0.0.2"}}, // a TCP service must purge with the filter too
+		"default/svc-b": {{Ip: "10.0.0.2"}}, // a TCP service must purge with the filter too
 	}
 	r.mu.Unlock()
 
-	r.SetServiceFilter([]string{"svc-a", "svc-b"})
-	r.SetServiceFilter([]string{"svc-a"}) // svc-b leaves the filter
+	r.SetServiceFilter([]string{"default/svc-a", "default/svc-b"})
+	r.SetServiceFilter([]string{"default/svc-a"}) // svc-b leaves the filter
 
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	assert.Contains(t, r.cache[registryv1.Service_PROTOCOL_HTTP], "svc-a")
-	assert.NotContains(t, r.cache[registryv1.Service_PROTOCOL_TCP], "svc-b", "out-of-scope entries must purge with the filter, across protocols")
+	assert.Contains(t, r.cache[registryv1.Service_PROTOCOL_HTTP], "default/svc-a")
+	assert.NotContains(t, r.cache[registryv1.Service_PROTOCOL_TCP], "default/svc-b", "out-of-scope entries must purge with the filter, across protocols")
 }


### PR DESCRIPTION
Closes the wire-side gap from the keying discussion. The registrar stream is `map<string, ServiceEndpoints>` (proto map keys are string-only), so a backend keying bug could put a bare key on the wire. Consumers already `ParseKey`-skip it, but silently — `applyEvent` now drops a non-`<ns>/<sa>` key at ingress with a metric (`aether.agent.registry.malformed_keys`) + warn, so a regression shows on a dashboard instead of as missing clusters. The cheap alternative to typing the interface key (which the proto map boundary defeats). 🤖 Generated with [Claude Code](https://claude.com/claude-code)