### PR TITLE
fix(registry): kubernetes backend must not serve managed pods as TCP endpoints

### DIFF
--- a/registry/internal/k8s/kubernetes.go
+++ b/registry/internal/k8s/kubernetes.go
@@ -74,8 +74,24 @@ func (r *KubernetesRegistry) UnregisterEndpoints(_ context.Context, _ string, _ 
 
 // ListEndpoints returns all endpoints for a service by listing managed pods whose ServiceAccount
 // matches the given service name. Node topology labels are used for locality information.
-func (r *KubernetesRegistry) ListEndpoints(ctx context.Context, service string, _ registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
+//
+// The Kubernetes registry derives endpoints from managed pods, every one of which is a
+// mesh-inbound (HTTP/h2 over :15008) endpoint by construction — it has no notion of a
+// per-pod TCP-only service. A TCP query must therefore return NOTHING, not the same
+// HTTP endpoint set: the agent's LoadClustersFromRegistry builds a service's HTTP
+// cluster (with its outbound/cap_http vhost) from the HTTP listing, then in a second
+// pass OVERWRITES the same map key with a vhost-less tcp:true entry from the TCP
+// listing ("a service is HTTP or TCP, never both" — true for etcd/ddb, which key by
+// protocol). Returning the pods for TCP too violated that invariant: every mesh
+// service collapsed to a TCP-only entry, its CDS cluster + GAMMA cap_http vhost
+// vanished, and captured requests routing to it 503'd (no_healthy_upstream). Treat
+// HTTP/UNSPECIFIED as the served protocol; TCP yields no endpoints.
+func (r *KubernetesRegistry) ListEndpoints(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
 	r.log.DebugContext(ctx, "listing endpoints", "service", service)
+
+	if protocol == registryv1.Service_PROTOCOL_TCP {
+		return nil, nil
+	}
 
 	pods, err := r.listManagedPods(ctx)
 	if err != nil {
@@ -114,8 +130,17 @@ func (r *KubernetesRegistry) ListEndpoints(ctx context.Context, service string, 
 
 // ListAllEndpoints returns all endpoints for all services, grouped by service name (ServiceAccount).
 // It lists all managed pods, resolves node localities, and converts each pod to a ServiceEndpoint.
-func (r *KubernetesRegistry) ListAllEndpoints(ctx context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+//
+// Every managed-pod endpoint is a mesh-inbound HTTP/h2 endpoint (see ListEndpoints).
+// A TCP query returns an empty map so the agent's TCP cluster pass does not clobber
+// the HTTP cluster/vhost entries built from the HTTP listing (HTTP/UNSPECIFIED is the
+// served protocol).
+func (r *KubernetesRegistry) ListAllEndpoints(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 	r.log.DebugContext(ctx, "listing all endpoints")
+
+	if protocol == registryv1.Service_PROTOCOL_TCP {
+		return map[string][]*registryv1.ServiceEndpoint{}, nil
+	}
 
 	pods, err := r.listManagedPods(ctx)
 	if err != nil {

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -894,6 +894,47 @@ func TestListAllEndpoints_SameSANamespaceIsolation(t *testing.T) {
 	assert.Equal(t, "10.0.0.1", epsA[0].GetIp())
 }
 
+// TestKubernetesRegistry_TCPProtocolReturnsEmpty is the regression guard for the
+// MESH-HTTP RequestHeaderModifier/MeshFrontend 503 bug: the Kubernetes registry
+// derives every endpoint from a managed pod's mesh-inbound (HTTP/h2) listener and
+// has no per-pod TCP service. Returning the same pods for a PROTOCOL_TCP query made
+// the agent's LoadClustersFromRegistry overwrite each service's HTTP cluster+vhost
+// with a vhost-less tcp:true entry, so the CDS cluster and GAMMA cap_http vhost
+// disappeared and captured requests 503'd. A TCP query must yield no endpoints;
+// HTTP and UNSPECIFIED return the managed-pod endpoints.
+func TestKubernetesRegistry_TCPProtocolReturnsEmpty(t *testing.T) {
+	r := newTestRegistry("c",
+		managedPod("echo-a", "team-a", "echo-v1", "10.0.0.1", "node-1"),
+		topologyNode("node-1", "us-east-1", "us-east-1a"),
+	)
+
+	// HTTP sees the managed pod.
+	httpAll, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, httpAll, 1)
+
+	// UNSPECIFIED is treated as the served (HTTP) protocol too.
+	unspecAll, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_UNSPECIFIED)
+	require.NoError(t, err)
+	require.Len(t, unspecAll, 1)
+
+	// TCP returns an empty (non-nil) map so the agent's TCP cluster pass does not
+	// clobber the HTTP cluster/vhost entries.
+	tcpAll, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_TCP)
+	require.NoError(t, err)
+	require.NotNil(t, tcpAll)
+	require.Empty(t, tcpAll)
+
+	// Single-service TCP read is empty as well.
+	tcpOne, err := r.ListEndpoints(context.Background(), "team-a/echo-v1", registryv1.Service_PROTOCOL_TCP)
+	require.NoError(t, err)
+	require.Empty(t, tcpOne)
+
+	httpOne, err := r.ListEndpoints(context.Background(), "team-a/echo-v1", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, httpOne, 1)
+}
+
 // ─── Annotation parsing helpers (unit-level) ─────────────────────────────────
 
 func TestGetPortFromAnnotations(t *testing.T) {


### PR DESCRIPTION
## Problem

The MESH-HTTP conformance score was stuck at **5 PASS / 3 FAIL** (`MeshHTTPRouteRedirectHostAndStatus`, `MeshHTTPRouteRequestHeaderModifier`, `MeshFrontend`). Prior investigation attributed the fails to registrar-replica churn; live `config_dump` on a kind mesh proxy disproves that and pins the real cause.

## Root cause (config_dump evidence)

On a local kind mesh (aether + SPIRE off + redirect-all + the conformance echo shapes), `curl` from a meshed pod gave deterministic, non-churn results:

| shape | before |
| --- | --- |
| `echo/set` (RequestHeaderModifier, backendRef `echo-v1:8080`) | **503** 5/5 |
| `echo-v2/` (MeshFrontend, backendRef `echo-v2:80`) | **503** 5/5 |
| `echo/host-and-status` (Redirect, no backend) | 301 5/5 |

The `cap_http` RouteConfiguration was **correct** — the `/set` route carried `request_headers_to_add: X-Header-Set`, the redirect routes emitted `Route_Redirect`, the catch-all forwarded to the backend cluster. But the referenced outbound clusters (`echo-v1.<ns>.aether.internal`, `echo-v2.<ns>.aether.internal`) were **absent from CDS** — only the inbound `app_*`/`health_*` static clusters + `passthrough_original_dst` were present. Agent snapshot logs showed `clusters:7, vhosts:0, tcpCount:3` in steady state. Redirect "worked" because it needs no backend cluster; every backendRef-forwarding route 503'd with `no_healthy_upstream`.

The Kubernetes registry backend (the conformance/CI registry) derives every endpoint from a managed pod's mesh-inbound (HTTP/h2) listener and **ignored the protocol argument**, returning the same pod set for a `PROTOCOL_TCP` query as for HTTP. The agent's `LoadClustersFromRegistry` builds each service's HTTP cluster + GAMMA `cap_http` vhost from the HTTP listing, then in a second pass **overwrites the same map key** with a vhost-less `tcp:true` entry from the TCP listing — relying on the invariant "a service is HTTP or TCP, never both" (true for etcd/ddb, which key endpoints by protocol). The kubernetes backend violated it: every mesh service collapsed to a TCP-only entry, dropping its CDS cluster and GAMMA vhost.

## Fix

The kubernetes backend treats HTTP/UNSPECIFIED as the served protocol and returns no endpoints for `PROTOCOL_TCP` (`ListAllEndpoints` → empty map, `ListEndpoints` → nil). HTTP/UNSPECIFIED behaviour is unchanged; etcd/ddb backends are unaffected. Production posture (SPIRE on, real TCP services via etcd/ddb) is untouched.

## Validation (live kind, SPIRE off, redirect-all)

After the fix the agent snapshot goes **clusters 7→10 / vhosts 0→3 / tcpCount 3→0**, the three outbound service clusters appear in CDS, and `curl` from a meshed pod:

| shape | after |
| --- | --- |
| `echo/set` → backend sees `RequestHeader=X-Header-Set:set-overwrites-values` | **200** ✓ |
| `echo-v2/` response header `x-header-set: set` | **200** ✓ |
| `echo/hostname-redirect` → `302 Found` + `location: http://example.org/hostname-redirect` | ✓ |
| `echo/host-and-status` → `301 Moved Permanently` + `location: http://example.org/host-and-status` | ✓ |

Added `TestKubernetesRegistry_TCPProtocolReturnsEmpty` as a regression guard. All registry/cache/registrar tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)