### PR TITLE
test(registry): shared protocol-disjoint contract (the #430 invariant)

### DIFF
--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -925,6 +925,9 @@ func TestKubernetesRegistry_TCPProtocolReturnsEmpty(t *testing.T) {
 	require.NotNil(t, tcpAll)
 	require.Empty(t, tcpAll)
 
+	// Shared cross-backend contract: a service serves HTTP xor TCP, never both.
+	registrytest.RequireProtocolDisjoint(t, httpAll, tcpAll)
+
 	// Single-service TCP read is empty as well.
 	tcpOne, err := r.ListEndpoints(context.Background(), "team-a/echo-v1", registryv1.Service_PROTOCOL_TCP)
 	require.NoError(t, err)

--- a/registry/registrytest/contract.go
+++ b/registry/registrytest/contract.go
@@ -41,3 +41,21 @@ func RequireNamespaceQualifiedKeys(t testing.TB, services map[string][]*registry
 		}
 	}
 }
+
+// RequireProtocolDisjoint asserts the second cross-backend invariant: a service
+// serves exactly ONE protocol, so the HTTP and TCP ListAllEndpoints maps must not
+// share a service key. The agent's LoadClustersFromRegistry relies on this — it
+// builds a service's HTTP cluster + GAMMA cap_http vhost from the HTTP listing,
+// then OVERWRITES the same map key with a vhost-less tcp:true entry from the TCP
+// listing (cluster.go: "HTTP or TCP, never both"). A backend that returns a service
+// under both protocols (the kubernetes backend before #430, which ignored the
+// protocol arg) makes every such service collapse to TCP-only — its cluster + vhost
+// vanish. Call it with both protocols' ListAllEndpoints output.
+func RequireProtocolDisjoint(t testing.TB, httpServices, tcpServices map[string][]*registryv1.ServiceEndpoint) {
+	t.Helper()
+	for key := range tcpServices {
+		if _, both := httpServices[key]; both {
+			t.Errorf("service %q appears under BOTH HTTP and TCP — a backend must honor the protocol arg (a service is HTTP xor TCP)", key)
+		}
+	}
+}


### PR DESCRIPTION
You asked whether to apply the same consistency treatment to the protocol arg as the keying issue — yes. Adds `registrytest.RequireProtocolDisjoint` mirroring `RequireNamespaceQualifiedKeys`: a service serves HTTP xor TCP, never both (the invariant `LoadClustersFromRegistry` relies on, which the kubernetes backend silently broke in #430). Wired into the k8s backend protocol test so a backend ignoring the protocol arg fails CI. 🤖 Generated with [Claude Code](https://claude.com/claude-code)