### PR TITLE
fix(agent): redirect-all passthrough must never shadow a known mesh target (MESH-HTTP RDS-reload race)

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/bpalermo/aether/common/serviceref"
 
@@ -465,6 +467,113 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc]))
 	}
 	return vhosts
+}
+
+// captureKnownTargets builds the redirect-all catch-all's known-target safety net
+// (proposal 022 hardening): one route-target per in-scope mesh authority, pinning
+// all of that authority's non-mesh cluster.local dial spellings (on any port) to
+// its mesh cluster. The catch-all consults these BEFORE the ORIGINAL_DST
+// passthrough, so a captured request to a service the mesh knows about can never
+// leak to kube-proxy — including the window where the service's dedicated cap_http
+// vhost is mid-rebuild across a GAMMA HTTPRoute add/delete (serviceRoutes churns,
+// but captureAuthorities — fed by the generated mesh Services, independent of
+// HTTPRoute lifecycle — does not).
+//
+// Returns nil unless redirect-all capture is on (without a passthrough cluster
+// there is nothing to shadow, and the catch-all keeps its hard 404).
+//
+// Gating: the safety net is keyed on the STABLE known-mesh-service signals —
+// every captureAuthorities entry (a generated mesh Service exists ⇒ the service
+// is real and meshed; this map is fed by the mesh-Service reconciler and is
+// untouched by HTTPRoute churn) plus every current GAMMA route target. It is
+// deliberately NOT gated on the demand-scoped dependency set: a route target's
+// dependency-set membership comes from its (churning) GAMMA rule, so gating on
+// deps would re-introduce the very race this fixes — the entry would vanish the
+// instant the route is deleted. Routing a known service's captured traffic to its
+// mesh cluster fails CLOSED into the mesh (a brief 503 if the demand-scoped cluster
+// is momentarily absent — which the conformance harness cleanly retries) rather
+// than OPEN to kube-proxy (a silent 200 that drops the GAMMA feature and resets the
+// consecutive-success counter). The regex is built once per service over its
+// short-name spellings with an optional ":port" suffix, so it matches a dial on the
+// real Service port without the control plane tracking it.
+func (c *SnapshotCache) captureKnownTargets() []proxy.KnownTargetRoute {
+	if !c.captureEnabled || !c.captureRedirectAll {
+		return nil
+	}
+	gammaRoutes := c.serviceRoutesSnapshot()
+
+	c.captureMu.RLock()
+	defer c.captureMu.RUnlock()
+
+	seen := make(map[string]struct{}, len(c.captureAuthorities)+len(gammaRoutes))
+	targets := make([]proxy.KnownTargetRoute, 0, len(c.captureAuthorities)+len(gammaRoutes))
+	add := func(svc, fqdn string) {
+		if _, ok := seen[svc]; ok {
+			return
+		}
+		ref, ok := serviceref.ParseKey(svc)
+		if !ok {
+			return
+		}
+		seen[svc] = struct{}{}
+		targets = append(targets, proxy.KnownTargetRoute{
+			AuthorityRegex: knownTargetAuthorityRegex(ref.Name, ref.Namespace, fqdn),
+			Cluster:        proxy.ServiceClusterName(svc, c.meshDomain),
+		})
+	}
+	// Every SA-backed mesh authority (covers plain services AND the MeshFrontend
+	// shape where a Service is its own GAMMA backend). Stable across HTTPRoute churn.
+	for svc, fqdn := range c.captureAuthorities {
+		add(svc, fqdn)
+	}
+	// Route-only GAMMA targets (no SA-backed mesh Service of their own — the
+	// versioned-fanout shape): derive the cluster.local authority from the
+	// namespace-qualified key. Present only while the route is, but the dedicated
+	// vhost is too, so there is no extra window to cover here.
+	for svc := range gammaRoutes {
+		if _, ok := c.captureAuthorities[svc]; ok {
+			continue
+		}
+		ref, ok := serviceref.ParseKey(svc)
+		if !ok {
+			continue
+		}
+		add(svc, ref.ClusterLocalFQDN())
+	}
+	return targets
+}
+
+// knownTargetAuthorityRegex builds the RE2 :authority pattern covering all of a
+// service's non-mesh dial spellings with an optional ":port" suffix: the bare
+// same-namespace name, <name>.<ns>, <name>.<ns>.svc, and the cluster.local FQDN.
+// The mesh spelling (<svc>.<meshDomain>) is intentionally omitted — the catch-all
+// already routes mesh-shaped authorities via the ODCDS regex. The bare name is
+// always included here (unlike routeTargetDomains' bareNameCount guard) because a
+// safe_regex header match cannot collide the way duplicate vhost domains NACK; a
+// bare name shared across namespaces simply means both services' regexes match it,
+// and either resolves to a real in-scope cluster (never the passthrough), which is
+// strictly better than the kube-proxy leak. Port-agnostic so any real Service port
+// matches.
+func knownTargetAuthorityRegex(name, namespace, fqdn string) string {
+	spellings := []string{
+		name,
+		name + "." + namespace,
+		name + "." + namespace + ".svc",
+		fqdn,
+	}
+	quoted := make([]string, 0, len(spellings))
+	seen := make(map[string]struct{}, len(spellings))
+	for _, s := range spellings {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		quoted = append(quoted, regexp.QuoteMeta(s))
+	}
+	return "^(" + strings.Join(quoted, "|") + ")(:[0-9]+)?$"
 }
 
 // routeTargetDomains builds the cap_http host-match domains for a GAMMA route

--- a/agent/internal/xds/cache/capture_test.go
+++ b/agent/internal/xds/cache/capture_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -162,6 +163,118 @@ func TestCaptureVhosts_RouteTargetNoPort(t *testing.T) {
 	for _, d := range vh.GetDomains() {
 		assert.NotContains(t, d, ":0", "no spurious :0 domain when the parentRef omits a port")
 	}
+}
+
+// matchesAuthority reports whether any known-target route's authority regex matches
+// the given dialed authority and, if so, the cluster it pins to.
+func matchesAuthority(targets []proxy.KnownTargetRoute, authority string) (string, bool) {
+	for _, kt := range targets {
+		if regexp.MustCompile(kt.AuthorityRegex).MatchString(authority) {
+			return kt.Cluster, true
+		}
+	}
+	return "", false
+}
+
+// TestCaptureKnownTargets_StableAcrossGAMMAChurn is the regression guard for the
+// MESH-HTTP RDS-reload convergence race. The known-target safety net is derived
+// from captureAuthorities (fed by the generated mesh Services, INDEPENDENT of
+// HTTPRoute lifecycle), so an in-scope mesh authority remains pinned to its cluster
+// even after its GAMMA rules are cleared (the delete half of a suite's apply/delete
+// churn). A captured request to that authority therefore never falls to the
+// ORIGINAL_DST passthrough → kube-proxy while the dedicated vhost is mid-rebuild.
+func TestCaptureKnownTargets_StableAcrossGAMMAChurn(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetCaptureEnabled(true)
+	c.SetCaptureRedirectAll(true)
+
+	const (
+		svc     = "gateway-conformance-mesh/echo-v2"
+		cluster = "echo-v2.gateway-conformance-mesh.aether.internal"
+	)
+	// The mesh-Service reconciler projects the SA-backed authority. This is stable
+	// across HTTPRoute churn.
+	c.SetCaptureAuthorities(map[string]string{
+		svc: "echo-v2.gateway-conformance-mesh.svc.cluster.local",
+	})
+	// A GAMMA rule is applied (the route exists).
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		svc: {{Backends: []proxy.GammaBackend{{Service: svc, Cluster: cluster, Weight: 1}}}},
+	})
+
+	dialSpellings := []string{
+		"echo-v2",
+		"echo-v2:80",
+		"echo-v2.gateway-conformance-mesh",
+		"echo-v2.gateway-conformance-mesh.svc",
+		"echo-v2.gateway-conformance-mesh.svc.cluster.local",
+		"echo-v2.gateway-conformance-mesh.svc.cluster.local:8080",
+	}
+
+	// With the route applied, every spelling pins to the cluster.
+	withRules := c.captureKnownTargets()
+	for _, a := range dialSpellings {
+		got, ok := matchesAuthority(withRules, a)
+		require.Truef(t, ok, "with rules: %q must be a known target", a)
+		assert.Equalf(t, cluster, got, "with rules: %q -> %s", a, cluster)
+	}
+
+	// Now SIMULATE THE CHURN: the suite deletes the HTTPRoute, the gamma reconciler
+	// reconciles with the route gone -> serviceRoutes for echo-v2 is cleared. The
+	// dedicated cap_http vhost vanishes (this is the race window). The mesh Service
+	// is untouched, so captureAuthorities still carries echo-v2.
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{})
+
+	// The dedicated vhost is indeed gone (proving the window is real)...
+	assert.Nil(t, findVHost(c.captureVhosts(), "echo-v2"),
+		"the dedicated cap_http vhost is absent while rules are cleared (the race window)")
+
+	// ...but the known-target safety net STILL pins every spelling to the cluster,
+	// so a captured request reaches the backend in-mesh, never the passthrough.
+	afterChurn := c.captureKnownTargets()
+	for _, a := range dialSpellings {
+		got, ok := matchesAuthority(afterChurn, a)
+		require.Truef(t, ok, "after churn: %q must remain a known target (no passthrough leak)", a)
+		assert.Equalf(t, cluster, got, "after churn: %q -> %s", a, cluster)
+	}
+}
+
+// TestCaptureKnownTargets_RouteOnlyTarget covers the versioned-fanout shape: a GAMMA
+// route TARGET with no SA-backed mesh Service of its own (only in serviceRoutes).
+// Its cluster.local authority is derived from the namespace-qualified key and it is
+// pinned to its mesh cluster so the passthrough never shadows it.
+func TestCaptureKnownTargets_RouteOnlyTarget(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetCaptureEnabled(true)
+	c.SetCaptureRedirectAll(true)
+
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"team-a/echo": {{Backends: []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: "echo-v1.team-a.aether.internal", Weight: 1}}}},
+	})
+
+	targets := c.captureKnownTargets()
+	cluster, ok := matchesAuthority(targets, "echo.team-a.svc.cluster.local:8080")
+	require.True(t, ok, "route-only target must be pinned")
+	assert.Equal(t, "echo.team-a.aether.internal", cluster)
+	cluster, ok = matchesAuthority(targets, "echo")
+	require.True(t, ok, "bare same-namespace dial must be pinned")
+	assert.Equal(t, "echo.team-a.aether.internal", cluster)
+}
+
+// TestCaptureKnownTargets_DisabledWithoutRedirectAll: with scoped capture (no
+// redirect-all) there is no passthrough cluster to shadow a target, so the
+// known-target set is empty and the catch-all keeps its hard 404.
+func TestCaptureKnownTargets_DisabledWithoutRedirectAll(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetCaptureEnabled(true)
+	// redirect-all NOT enabled.
+	c.SetCaptureAuthorities(map[string]string{
+		"team-a/echo": "echo.team-a.svc.cluster.local",
+	})
+	c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+		"team-a/echo": {{Backends: []proxy.GammaBackend{{Service: "team-a/echo", Cluster: "echo.team-a.aether.internal", Weight: 1}}}},
+	})
+	assert.Nil(t, c.captureKnownTargets(), "no passthrough -> no known-target safety net")
 }
 
 func domainsOf(vhosts []*routev3.VirtualHost) []string {

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -130,7 +130,12 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 		// carries the on-demand catch-all) so the listeners' RDS resolves even with no
 		// in-scope authorities yet, and cold/off-node services recover via ODCDS.
 		if c.captureEnabled {
-			routes = append(routes, proxy.BuildCaptureRouteConfiguration(c.captureVhosts(), c.meshDomain, c.captureRedirectAll))
+			// captureKnownTargets pins every in-scope mesh authority to its cluster on
+			// the redirect-all catch-all (no-op when redirect-all is off), so a captured
+			// request to a known service never leaks to the ORIGINAL_DST passthrough
+			// while its dedicated cap_http vhost is mid-rebuild across a GAMMA churn.
+			routes = append(routes, proxy.BuildCaptureRouteConfiguration(
+				c.captureVhosts(), c.meshDomain, c.captureRedirectAll, c.captureKnownTargets()...))
 		}
 		if len(routes) > 0 {
 			resources[resourcev3.RouteType] = routes

--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -293,9 +293,14 @@ func BuildCapturePassthroughFilterChain() *listenerv3.FilterChain {
 // reachability is preserved (the passthrough_original_dst cluster is only emitted in
 // this mode). With scoped capture (redirectAll false) the catch-all keeps its hard
 // 404: only mesh VIPs are captured, so a non-mesh authority is genuinely foreign.
-func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost, meshDomain string, redirectAll bool) *routev3.RouteConfiguration {
+// knownTargets pins each known in-scope mesh authority's non-mesh dial spellings
+// to its cluster on the redirect-all catch-all, so a captured request to a known
+// service never leaks to the ORIGINAL_DST passthrough (kube-proxy) while its
+// dedicated cap_http vhost is mid-rebuild. Ignored when redirectAll is false (no
+// passthrough to shadow a target).
+func BuildCaptureRouteConfiguration(vhosts []*routev3.VirtualHost, meshDomain string, redirectAll bool, knownTargets ...KnownTargetRoute) *routev3.RouteConfiguration {
 	return &routev3.RouteConfiguration{
 		Name:         CaptureHTTPRouteName,
-		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain, redirectAll)),
+		VirtualHosts: append(vhosts, buildOnDemandCatchAllVirtualHost(meshDomain, redirectAll, knownTargets...)),
 	}
 }

--- a/agent/internal/xds/proxy/route.go
+++ b/agent/internal/xds/proxy/route.go
@@ -60,6 +60,33 @@ func outboundRetryPolicy() *routev3.RetryPolicy {
 // name translation anywhere.
 const onDemandClusterHeader = ":authority"
 
+// KnownTargetRoute pins a known in-scope mesh service's non-mesh dial spellings
+// (its cluster.local short names and FQDN, optionally with a port) to the
+// service's data-plane cluster. The redirect-all capture catch-all emits one
+// such route per in-scope mesh authority BEFORE the passthrough fallthrough so a
+// captured request to a service the mesh KNOWS ABOUT can never be shadowed by the
+// ORIGINAL_DST passthrough — even during the brief window where the service's
+// dedicated cap_http vhost is being rebuilt (a GAMMA HTTPRoute add/delete clears
+// and re-populates serviceRoutes between two reconciles; an in-flight captured
+// request landing in that window used to miss the dedicated vhost and fall to the
+// passthrough → kube-proxy → GAMMA features silently dropped). Because the
+// catch-all routes are derived from the STABLE mesh-authority set
+// (captureAuthorities ∩ dependency set, independent of HTTPRoute lifecycle), the
+// request still reaches the correct backend cluster (mTLS, in-mesh) rather than
+// leaking to kube-proxy. The dedicated vhost remains the precedence path when
+// present (it carries the GAMMA filters); this is the safety net that fails into
+// the mesh, never out of it.
+type KnownTargetRoute struct {
+	// AuthorityRegex is an RE2 pattern over all of the service's non-mesh dial
+	// spellings (bare name, <name>.<ns>, <name>.<ns>.svc, cluster.local FQDN) with
+	// an optional ":port" suffix. Port-agnostic by construction so it matches a
+	// dial on any real Service port without the control plane needing to track it.
+	AuthorityRegex string
+	// Cluster is the service's data-plane cluster (<svc>.<meshDomain>) the matched
+	// authority routes to.
+	Cluster string
+}
+
 // buildOnDemandCatchAllVirtualHost builds the lowest-priority outbound virtual
 // host (domain "*"). With the authority port retained (strip_any_host_port
 // off, for FQDN:port routing), a scoped catch-all "*.<meshDomain>" can't match
@@ -70,7 +97,11 @@ const onDemandClusterHeader = ":authority"
 // 404s immediately. This keeps instant foreign-404 determinism (spike-verified,
 // Envoy 1.38) while supporting FQDN:port (proposal 005). Nonexistent in-domain
 // services/ports fail when the ODCDS timeout expires.
-func buildOnDemandCatchAllVirtualHost(meshDomain string, passthrough bool) *routev3.VirtualHost {
+//
+// knownTargets is consulted only in redirect-all (passthrough) mode: each pins a
+// known in-scope service's non-mesh authority spellings to its cluster so the
+// passthrough never shadows a service the mesh knows about (see KnownTargetRoute).
+func buildOnDemandCatchAllVirtualHost(meshDomain string, passthrough bool, knownTargets ...KnownTargetRoute) *routev3.VirtualHost {
 	// 020 Part 1: mesh authorities are <svc>.<ns>.<meshDomain> (two labels before the
 	// mesh domain), with an optional :port. Cold/off-node services that miss the
 	// scoped vhost fall here and resolve via ODCDS (ClusterHeader=:authority).
@@ -103,51 +134,91 @@ func buildOnDemandCatchAllVirtualHost(meshDomain string, passthrough bool) *rout
 			},
 		}
 	}
-	return &routev3.VirtualHost{
-		Name:    "on_demand_catch_all",
-		Domains: []string{"*"},
-		Routes: []*routev3.Route{
-			// Egress liveness: a local-reply 200 on MeshLivePath, answered without
-			// leaving the proxy (no upstream, no app), for the synthetic mesh
-			// availability prober (proposal 013). First so it wins for this exact
-			// path regardless of authority; the prober uses a reserved non-service
-			// authority so it lands on this catch-all vhost. A 200 proves this
-			// node's egress listener is serving + config loaded; a connection error
-			// proves it is not — the signal aether_stats (proxy-emitted) is
-			// structurally blind to during hot restarts.
-			{
-				Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Path{Path: MeshLivePath}},
-				Action: &routev3.Route_DirectResponse{
-					DirectResponse: &routev3.DirectResponseAction{Status: 200},
-				},
+	routes := []*routev3.Route{
+		// Egress liveness: a local-reply 200 on MeshLivePath, answered without
+		// leaving the proxy (no upstream, no app), for the synthetic mesh
+		// availability prober (proposal 013). First so it wins for this exact
+		// path regardless of authority; the prober uses a reserved non-service
+		// authority so it lands on this catch-all vhost. A 200 proves this
+		// node's egress listener is serving + config loaded; a connection error
+		// proves it is not — the signal aether_stats (proxy-emitted) is
+		// structurally blind to during hot restarts.
+		{
+			Match: &routev3.RouteMatch{PathSpecifier: &routev3.RouteMatch_Path{Path: MeshLivePath}},
+			Action: &routev3.Route_DirectResponse{
+				DirectResponse: &routev3.DirectResponseAction{Status: 200},
 			},
-			{
-				Match: &routev3.RouteMatch{
-					PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"},
-					Headers: []*routev3.HeaderMatcher{
-						{
-							Name: ":authority",
-							HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
-								StringMatch: &matcherv3.StringMatcher{
-									MatchPattern: &matcherv3.StringMatcher_SafeRegex{
-										SafeRegex: &matcherv3.RegexMatcher{Regex: meshAuthorityRegex},
-									},
+		},
+		{
+			Match: &routev3.RouteMatch{
+				PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"},
+				Headers: []*routev3.HeaderMatcher{
+					{
+						Name: ":authority",
+						HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+							StringMatch: &matcherv3.StringMatcher{
+								MatchPattern: &matcherv3.StringMatcher_SafeRegex{
+									SafeRegex: &matcherv3.RegexMatcher{Regex: meshAuthorityRegex},
 								},
 							},
 						},
 					},
 				},
-				Action: &routev3.Route_Route{
-					Route: &routev3.RouteAction{
-						ClusterSpecifier: &routev3.RouteAction_ClusterHeader{
-							ClusterHeader: onDemandClusterHeader,
+			},
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_ClusterHeader{
+						ClusterHeader: onDemandClusterHeader,
+					},
+					RetryPolicy: outboundRetryPolicy(),
+				},
+			},
+		},
+	}
+	// Known-target safety net (redirect-all only): a captured request whose
+	// authority is a known in-scope mesh service — under any of its non-mesh
+	// cluster.local spellings, on any port — routes to that service's cluster
+	// rather than falling to the passthrough. This holds even while the service's
+	// dedicated cap_http vhost is being rebuilt across a GAMMA HTTPRoute add/delete
+	// (the dedicated vhost, when present, wins on host-match precedence and carries
+	// the GAMMA filters; this catch-all entry is the floor that keeps a known
+	// target in the mesh instead of leaking to kube-proxy). Disjoint authorities,
+	// so route order among them is irrelevant; all precede the passthrough. Only
+	// meaningful in redirect-all mode — without a passthrough there is nothing to
+	// shadow and the catch-all keeps its hard 404.
+	for _, kt := range knownTargets {
+		if !passthrough || kt.AuthorityRegex == "" || kt.Cluster == "" {
+			continue
+		}
+		routes = append(routes, &routev3.Route{
+			Match: &routev3.RouteMatch{
+				PathSpecifier: &routev3.RouteMatch_Prefix{Prefix: "/"},
+				Headers: []*routev3.HeaderMatcher{
+					{
+						Name: ":authority",
+						HeaderMatchSpecifier: &routev3.HeaderMatcher_StringMatch{
+							StringMatch: &matcherv3.StringMatcher{
+								MatchPattern: &matcherv3.StringMatcher_SafeRegex{
+									SafeRegex: &matcherv3.RegexMatcher{Regex: kt.AuthorityRegex},
+								},
+							},
 						},
-						RetryPolicy: outboundRetryPolicy(),
 					},
 				},
 			},
-			fallthrough_,
-		},
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: kt.Cluster},
+					RetryPolicy:      outboundRetryPolicy(),
+				},
+			},
+		})
+	}
+	routes = append(routes, fallthrough_)
+	return &routev3.VirtualHost{
+		Name:    "on_demand_catch_all",
+		Domains: []string{"*"},
+		Routes:  routes,
 	}
 }
 

--- a/agent/internal/xds/proxy/route_test.go
+++ b/agent/internal/xds/proxy/route_test.go
@@ -1,12 +1,119 @@
 package proxy
 
 import (
+	"regexp"
 	"testing"
 
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// resolveCatchAll mimics Envoy's first-match route selection over the catch-all
+// vhost for a given :authority and path: it walks the routes in order and returns
+// the cluster of the first whose path prefix and (if present) :authority safe_regex
+// header matcher both match. A direct_response (404/200) route returns "" for the
+// cluster and its status. This lets a unit test assert "a known target never
+// resolves to the passthrough cluster" without standing up Envoy.
+func resolveCatchAll(vh *routev3.VirtualHost, authority, path string) (cluster string, directStatus uint32) {
+	for _, rt := range vh.GetRoutes() {
+		m := rt.GetMatch()
+		switch {
+		case m.GetPath() != "":
+			if m.GetPath() != path {
+				continue
+			}
+		case m.GetPrefix() != "":
+			if len(path) < len(m.GetPrefix()) || path[:len(m.GetPrefix())] != m.GetPrefix() {
+				continue
+			}
+		}
+		ok := true
+		for _, h := range m.GetHeaders() {
+			if h.GetName() != ":authority" {
+				continue
+			}
+			re := h.GetStringMatch().GetSafeRegex().GetRegex()
+			if re == "" || !regexp.MustCompile(re).MatchString(authority) {
+				ok = false
+				break
+			}
+		}
+		if !ok {
+			continue
+		}
+		if dr := rt.GetDirectResponse(); dr != nil {
+			return "", dr.GetStatus()
+		}
+		if ch := rt.GetRoute().GetClusterHeader(); ch != "" {
+			// cluster_header(:authority) resolves to the authority itself.
+			return authority, 0
+		}
+		return rt.GetRoute().GetCluster(), 0
+	}
+	return "", 0
+}
+
+// TestCatchAll_KnownTargetNeverShadowedByPassthrough is the regression guard for the
+// MESH-HTTP RDS-reload convergence race: a captured request whose :authority is a
+// known in-scope mesh service must resolve to that service's cluster — under EVERY
+// dial spelling and on ANY port — never to the ORIGINAL_DST passthrough (which
+// leaks to kube-proxy and silently drops the GAMMA features). The known-target
+// routes are derived from the STABLE mesh-authority set, so this holds even while
+// the service's dedicated cap_http vhost is absent mid-rebuild.
+func TestCatchAll_KnownTargetNeverShadowedByPassthrough(t *testing.T) {
+	// echo-v2 in gateway-conformance-mesh, all spellings, optional port.
+	known := KnownTargetRoute{
+		AuthorityRegex: "^(echo-v2|echo-v2\\.gateway-conformance-mesh|echo-v2\\.gateway-conformance-mesh\\.svc|echo-v2\\.gateway-conformance-mesh\\.svc\\.cluster\\.local)(:[0-9]+)?$",
+		Cluster:        "echo-v2.gateway-conformance-mesh.aether.internal",
+	}
+	vh := buildOnDemandCatchAllVirtualHost("aether.internal", true, known)
+
+	// Every spelling a client might dial, with and without a real Service port.
+	for _, authority := range []string{
+		"echo-v2",
+		"echo-v2:80",
+		"echo-v2.gateway-conformance-mesh",
+		"echo-v2.gateway-conformance-mesh:80",
+		"echo-v2.gateway-conformance-mesh.svc",
+		"echo-v2.gateway-conformance-mesh.svc.cluster.local",
+		"echo-v2.gateway-conformance-mesh.svc.cluster.local:8080",
+	} {
+		cluster, _ := resolveCatchAll(vh, authority, "/set")
+		assert.Equalf(t, known.Cluster, cluster,
+			"known target %q must route to its cluster, not the passthrough", authority)
+		assert.NotEqualf(t, PassthroughClusterName, cluster,
+			"known target %q must never resolve to the passthrough", authority)
+	}
+
+	// A genuinely foreign authority still falls to the passthrough (redirect-all).
+	cluster, _ := resolveCatchAll(vh, "example.com", "/")
+	assert.Equal(t, PassthroughClusterName, cluster,
+		"a non-mesh, unknown authority still passes through (plain egress)")
+
+	// A mesh-shaped authority still resolves via ODCDS cluster_header(:authority).
+	cluster, _ = resolveCatchAll(vh, "other.team-a.aether.internal", "/")
+	assert.Equal(t, "other.team-a.aether.internal", cluster,
+		"a mesh-shaped authority still resolves via ODCDS, not the passthrough")
+}
+
+// TestCatchAll_KnownTargetsOnlyInRedirectAll: without redirect-all there is no
+// passthrough to shadow, so known-target routes must NOT be emitted (the catch-all
+// keeps its hard-404 fallthrough and the minimal mesh-authority/liveness routes).
+func TestCatchAll_KnownTargetsOnlyInRedirectAll(t *testing.T) {
+	known := KnownTargetRoute{AuthorityRegex: "^echo$", Cluster: "echo.ns.aether.internal"}
+
+	withPT := buildOnDemandCatchAllVirtualHost("aether.internal", true, known)
+	require.Len(t, withPT.GetRoutes(), 4, "liveness + mesh-regex + 1 known-target + passthrough")
+	assert.Equal(t, PassthroughClusterName,
+		withPT.GetRoutes()[len(withPT.GetRoutes())-1].GetRoute().GetCluster())
+
+	// redirectAll=false: knownTargets are ignored and the fallthrough is a 404.
+	noPT := buildOnDemandCatchAllVirtualHost("aether.internal", false, known)
+	require.Len(t, noPT.GetRoutes(), 3, "liveness + mesh-regex + 404 (no known-target, no passthrough)")
+	assert.Equal(t, uint32(404),
+		noPT.GetRoutes()[len(noPT.GetRoutes())-1].GetDirectResponse().GetStatus())
+}
 
 func TestBuildOutboundRouteConfiguration(t *testing.T) {
 	tests := []struct {

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -250,7 +250,15 @@ func buildCaptureRouteTargetBootstrap() (*bootstrapv3.Bootstrap, error) {
 		fmt.Sprintf("%s:%d", targetMesh, realPort),
 	}
 	vhost := proxy.BuildOutboundServiceVirtualHost(targetMesh, domains, rules)
-	routeCfg := proxy.BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vhost}, meshDomain, true)
+	// Known-target safety net (the RDS-reload-race fix): the redirect-all catch-all
+	// pins the route target's non-mesh dial spellings (any port) to its mesh cluster
+	// so a captured request never leaks to the passthrough while this vhost rebuilds.
+	// Validating it here proves Envoy ACCEPTS the extra :authority safe_regex route.
+	knownTargets := []proxy.KnownTargetRoute{{
+		AuthorityRegex: `^(echo|echo\.team-a|echo\.team-a\.svc|echo\.team-a\.svc\.cluster\.local)(:[0-9]+)?$`,
+		Cluster:        targetMesh,
+	}}
+	routeCfg := proxy.BuildCaptureRouteConfiguration([]*routev3.VirtualHost{vhost}, meshDomain, true, knownTargets...)
 
 	hcm := &http_connection_managerv3.HttpConnectionManager{
 		StatPrefix: "cap_http_validate",


### PR DESCRIPTION
## The race

The MESH-HTTP feature tests (`MeshHTTPRouteRequestHeaderModifier` / `MeshFrontend` / `RedirectHostAndStatus` / `Weight`) flake: the modifier applies hundreds of times in-suite but never hits `RequiredConsecutiveSuccesses=3` consecutively. This is **not** config generation (proven correct by #423/#424/#430 and stable-config curl). It is an **RDS-reload convergence race under the conformance suite's own cross-test apply/delete churn**.

**Mechanism.** A GAMMA HTTPRoute add/delete makes the gamma reconciler re-list and re-`SetServiceRoutes` between two reconciles. In the delete→create gap, a route target's `serviceRoutes` entry is momentarily empty → its dedicated `cap_http` vhost is absent from the rebuilt RouteConfiguration. Envoy's per-RouteConfiguration RDS apply is atomic, so the leak means the **pushed** table was itself missing the vhost: an in-flight captured request to that **known** target then lands on the redirect-all catch-all (domain `*`) and falls to `passthrough_original_dst` → kube-proxy → the GAMMA filters are silently skipped (`got some-other-value`), resetting the consecutive-success counter. Not reproducible manually (the stable-config curl always runs *between* rebuilds); only under the suite's rapid churn.

## The fix (direction 2 — the robust invariant)

**The passthrough must never shadow a service the mesh knows about.** The redirect-all catch-all now carries a *known-target safety net*: one `:authority` `safe_regex` route per in-scope mesh authority (every non-mesh cluster.local spelling — bare name, `<name>.<ns>`, `<name>.<ns>.svc`, FQDN — with an optional `:port`), pinning it to its mesh cluster **before** the passthrough fallthrough.

Crucially, the set is derived from the **stable** signals — `captureAuthorities` (fed by the generated mesh Services, untouched by HTTPRoute churn) plus current route targets — and **not** the demand-scoped dependency set, whose route-target membership churns with the rule and would re-introduce the race. So a known service's captured traffic fails **closed into the mesh** (a brief 503 if the demand-scoped cluster is momentarily absent — which the harness cleanly retries) instead of **open to kube-proxy** (a silent 200 that drops the GAMMA feature). The dedicated vhost still wins on host-match precedence when present and carries the GAMMA filters; this is the floor under it.

**Scope:** redirect-all capture only (no passthrough ⇒ nothing to shadow ⇒ catch-all keeps its hard 404). GATEWAY-HTTP (edge, 43/0 hard gate) and production mTLS paths are untouched. SPIRE-off / redirect-all guards on the new behavior.

## Validation

- `//agent/internal/xds/proxy:proxy_test` — a known target resolves to its cluster under every spelling + port, never the passthrough; foreign and mesh-shaped authorities unaffected; known-target routes only emitted in redirect-all.
- `//agent/internal/xds/cache:cache_test` — `captureKnownTargets` survives a **simulated GAMMA-rule-clear churn** even as the dedicated vhost vanishes (the race window), covering the SA-backed MeshFrontend shape and the versioned-fanout route-only shape.
- `//test/envoy_validate` — `envoy --mode validate` accepts the new `:authority` safe_regex route shape in the cap_http RouteConfiguration.
- Full `//agent/...` unit suite green.

## Honesty on the kind proof

The full MESH-HTTP suite is the CI `mesh-http` job (soft / continue-on-error). It cannot be `workflow_dispatch`-ed from a non-default branch, and the local kind path is a heavyweight multi-image build + cloud-provider-kind stand-up. This PR ships the offline proof (unit tests that *reproduce the race window* and assert the invariant + `envoy --mode validate`). Run the `mesh-http` job once this is on `main` to confirm the per-test score moves; the data path was already proven correct by curl, so this targets exactly the convergence artifact that gated the consecutive-success counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)