### PR TITLE
fix(conformance): apply MESH-HTTP per-test manifests (overlay FS) → MESH-HTTP Core 7/7

### DIFF
--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -66,8 +66,68 @@ import (
 // capture.aether.io/redirect-all=true pod annotation (so real Service ports are
 // captured). Vanilla upstream manifests would not exercise aether's mesh path.
 //
+// It deliberately contains ONLY mesh/manifests.yaml — the base mesh apply the
+// suite does once in Setup. The per-test manifests (tests/mesh/*.yaml, applied by
+// each MeshConformanceTest's Manifests field — e.g. the mesh-frontend HTTPRoute that
+// carries the ResponseHeaderModifier) live ONLY in the upstream gwconformance.Manifests
+// embed and MUST still be reachable. See meshManifestFS / overlayFS below.
+//
 //go:embed mesh/manifests.yaml
 var meshManifests embed.FS
+
+// overlayFS composes the aether mesh overlay over the upstream gateway-api manifest
+// embed: a read for overridePath ("mesh/manifests.yaml") is served from the aether
+// overlay (its managed-namespace label / per-version SAs / redirect-all annotation),
+// and every OTHER path (the per-test tests/mesh/*.yaml the conformance tests apply,
+// plus base/*) falls through to the upstream embed.
+//
+// This MUST be a single composed fs.FS rather than passing both embeds in the suite's
+// ManifestFS slice: the suite's manifest loader (getContentsFromPathOrURL) iterates
+// every fs.FS and CONCATENATES the bytes from each that has the path. With both embeds
+// present, a read of mesh/manifests.yaml would return the aether overlay AND the
+// upstream base mesh manifests glued together — duplicate/conflicting Namespaces,
+// Deployments and Services that fail to apply. The overlay returns exactly one file per
+// path: the aether version for the overridden base, the upstream version for everything
+// else.
+//
+// Without this, ManifestFS = {meshManifests} alone makes every per-test manifest read
+// (tests/mesh/mesh-frontend.yaml, …) hit fs.ErrNotExist, which the loader swallows
+// silently (it `continue`s on not-found) — so the test's HTTPRoute is NEVER applied, no
+// GAMMA rule is projected, the captured request falls to the kube-proxy passthrough, and
+// the assertion (X-Header-Set present, a redirect, a request-header set) "fails" against
+// a route that was never installed. That is precisely why MeshFrontend,
+// MeshHTTPRouteRedirectHostAndStatus and MeshHTTPRouteRequestHeaderModifier failed (the
+// last two in ~0.01s: the first request returns a plain passthrough 200 immediately).
+type overlayFS struct {
+	overridePath string
+	override     fs.FS
+	base         fs.FS
+}
+
+func (o overlayFS) Open(name string) (fs.File, error) {
+	if name == o.overridePath {
+		return o.override.Open(name)
+	}
+	return o.base.Open(name)
+}
+
+func (o overlayFS) ReadFile(name string) ([]byte, error) {
+	if name == o.overridePath {
+		return fs.ReadFile(o.override, name)
+	}
+	return fs.ReadFile(o.base, name)
+}
+
+// meshManifestFS returns the composed manifest filesystem for the MESH-HTTP profile:
+// the aether overlay for mesh/manifests.yaml, the upstream embed for the per-test
+// tests/mesh/*.yaml (and base/*) manifests.
+func meshManifestFS() fs.FS {
+	return overlayFS{
+		overridePath: "mesh/manifests.yaml",
+		override:     meshManifests,
+		base:         &gwconformance.Manifests,
+	}
+}
 
 const (
 	aetherGatewayClassName = "aether"
@@ -302,8 +362,11 @@ func TestAetherMeshHTTP(t *testing.T) {
 		CleanupBaseResources:       cleanup(),
 		EnableAllSupportedFeatures: false,
 		SupportedFeatures:          meshFeats,
-		// Use aether's mesh overlay instead of the suite's base mesh manifests.
-		ManifestFS:          []fs.FS{meshManifests},
+		// Use aether's mesh overlay for the base mesh manifests (mesh/manifests.yaml)
+		// while still serving the per-test tests/mesh/*.yaml manifests from the upstream
+		// embed (see meshManifestFS / overlayFS). A bare {meshManifests} would silently
+		// drop every per-test HTTPRoute manifest — the route would never apply.
+		ManifestFS:          []fs.FS{meshManifestFS()},
 		TimeoutConfig:       aetherMeshTimeouts(),
 		ConformanceProfiles: sets.New(suite.MeshHTTPConformanceProfileName),
 		Implementation:      aetherImpl(),


### PR DESCRIPTION
## What

The committed MESH-HTTP conformance runner (`test/conformance/conformance_test.go`) set `ManifestFS` to **only** the aether overlay embed (`[]fs.FS{meshManifests}`, which embeds just `mesh/manifests.yaml`). The Gateway API conformance suite loads **both** the base mesh manifests **and** each test's per-test manifests (`tests/mesh/*.yaml`) through that same `ManifestFS`. The suite's loader (`getContentsFromPathOrURL`) swallows `fs.ErrNotExist` silently (`continue`), so every per-test HTTPRoute read returned **empty** — the test's route was **never applied**. The captured request then fell to the kube-proxy `ORIGINAL_DST` passthrough, and the assertion failed against a route that never existed.

## Root cause — proven in-suite (not via curl)

Standing up a local kind mesh (aether, SPIRE off, redirect-all) and running the **actual** `go test` MESH-HTTP suite:

- While `TestAetherMeshHTTP/MeshFrontend` was retrying `expected header X-Header-Set=set, got ` (the request reached echo-v2 but with **no** GAMMA header), the node proxy's `cap_http` RouteConfiguration (`127.0.0.1:9901/config_dump`) had **no `echo-v2` route-target vhost** — only `echo-v1.…-consumer` + the `on_demand_catch_all`. The catch-all's known-target net didn't match `echo-v2`, so the request fell to `passthrough_original_dst` → kube-proxy → echo-v2 pod (right backend, no header).
- The agent's GAMMA reconciler logged **zero** reconciles for `mesh-split-v1`; the HTTPRoute was **absent** from the API server (`kubectl get httproute -A` → none), even though the suite logged `Applying tests/mesh/mesh-frontend.yaml`. There was **no** `Creating … HTTPRoute` line, and the apply returned in 0.06ms — it applied **zero** resources.
- Manually applying the same route made the `echo-v2` vhost (with the `X-Header-Set` ResponseHeaderModifier `response_headers_to_add`) appear and the test PASS — confirming the **data plane was correct** and the gap was the un-applied manifest.

This is exactly the deterministic, ~0.01s fast-fail signature of `MeshHTTPRouteRedirectHostAndStatus` and `MeshHTTPRouteRequestHeaderModifier` (a plain passthrough 200 returns immediately, never the configured redirect / header).

## Fix

Compose a single `overlayFS` that serves `mesh/manifests.yaml` from the aether overlay and falls through to the upstream `gwconformance.Manifests` embed for the per-test `tests/mesh/*.yaml` (and `base/*`). A **single composed FS** (not two entries in the `ManifestFS` slice) is required: the suite loader **concatenates** bytes across all FSes, so two embeds would glue the aether overlay and the upstream base mesh manifests into duplicate/conflicting resources for `mesh/manifests.yaml`.

## Suite re-run (kind, SPIRE off, redirect-all) — official ConformanceReport

```
profiles:
- core:
    result: success
      Failed: 0
      Passed: 7
      Skipped: 0
  name: MESH-HTTP
  summary: Core tests succeeded.
```

Per-test (all PASS): `MeshBasic`, `MeshFrontend` (Send_to_service + Send_to_pod_IP), `MeshHTTPRouteMatching` (9/9), `MeshHTTPRouteRedirectHostAndStatus`, `MeshHTTPRouteRequestHeaderModifier` (7/7), `MeshHTTPRouteSimpleSameNamespace`, `MeshHTTPRouteWeight`, `MeshTrafficSplit`. The 3 previously-failing tests flipped to PASS; the formerly coincidental passes (split/weight) now pass for the right reason (real routes applied). Suite completes in ~20s (no false 300s timeouts).

## Scope

Only `test/conformance/conformance_test.go` changes (the `//go:build conformance` runner, not in the aether module build). **No** production code, charts, or the GATEWAY-HTTP runner path (`ManifestFS: []fs.FS{&gwconformance.Manifests}`, already correct) are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)