### PR TITLE
chore(api): migrate aether protos off proto3 to edition 2023 (#17)

### DIFF
--- a/api/aether/cni/v1/cni.proto
+++ b/api/aether/cni/v1/cni.proto
@@ -1,10 +1,13 @@
-syntax = "proto3";
+edition = "2023";
 
 package aether.cni.v1;
 
 import "buf/validate/validate.proto";
 import "google/protobuf/wrappers.proto";
 
+// Preserve proto3 implicit field presence so the generated Go/C++ API is
+// unchanged by the edition migration (scalars stay value types, not pointers).
+option features.field_presence = IMPLICIT;
 option go_package = "github.com/bpalermo/aether/api/aether/cni/v1;cniv1";
 
 message CNIPod {

--- a/api/aether/cni/v1/service.proto
+++ b/api/aether/cni/v1/service.proto
@@ -1,10 +1,13 @@
-syntax = "proto3";
+edition = "2023";
 
 package aether.cni.v1;
 
 import "api/aether/cni/v1/cni.proto";
 import "buf/validate/validate.proto";
 
+// Preserve proto3 implicit field presence so the generated Go/C++ API is
+// unchanged by the edition migration (scalars stay value types, not pointers).
+option features.field_presence = IMPLICIT;
 option go_package = "github.com/bpalermo/aether/api/aether/cni/v1;cniv1";
 
 service CNIService {

--- a/api/aether/registrar/v1/registrar.proto
+++ b/api/aether/registrar/v1/registrar.proto
@@ -1,10 +1,13 @@
-syntax = "proto3";
+edition = "2023";
 
 package aether.registrar.v1;
 
 import "api/aether/registry/v1/endpoint.proto";
 import "api/aether/registry/v1/service.proto";
 
+// Preserve proto3 implicit field presence so the generated Go/C++ API is
+// unchanged by the edition migration (scalars stay value types, not pointers).
+option features.field_presence = IMPLICIT;
 option go_package = "github.com/bpalermo/aether/api/aether/registrar/v1;registrarv1";
 
 service RegistrarService {

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -1,9 +1,12 @@
-syntax = "proto3";
+edition = "2023";
 
 package aether.registry.v1;
 
 import "buf/validate/validate.proto";
 
+// Preserve proto3 implicit field presence so the generated Go/C++ API is
+// unchanged by the edition migration (scalars stay value types, not pointers).
+option features.field_presence = IMPLICIT;
 option go_package = "github.com/bpalermo/aether/api/aether/registry/v1;registryv1";
 
 message ServiceEndpoint {
@@ -46,7 +49,7 @@ message ServiceEndpoint {
     // 4 was node_ip (the node InternalIP, used as the HBONE tunnel target). The
     // plain mTLS transport routes to pod IPs directly, so it is no longer needed.
     reserved 4;
-    reserved "node_ip";
+    reserved node_ip;
   }
 
   KubernetesMetadata kubernetes_metadata = 8;

--- a/api/aether/registry/v1/service.proto
+++ b/api/aether/registry/v1/service.proto
@@ -1,4 +1,4 @@
-syntax = "proto3";
+edition = "2023";
 
 package aether.registry.v1;
 
@@ -6,6 +6,9 @@ import "api/aether/registry/v1/endpoint.proto";
 import "buf/validate/validate.proto";
 import "proto/dynamo/v1/dynamo.proto";
 
+// Preserve proto3 implicit field presence so the generated Go/C++ API is
+// unchanged by the edition migration (scalars stay value types, not pointers).
+option features.field_presence = IMPLICIT;
 option go_package = "github.com/bpalermo/aether/api/aether/registry/v1;registryv1";
 
 message Service {


### PR DESCRIPTION
## What

Migrates the 5 `api/aether/` protos from `syntax = "proto3"` to `edition = "2023"`.

| File | edition |
|------|---------|
| `api/aether/cni/v1/cni.proto` | 2023 |
| `api/aether/cni/v1/service.proto` | 2023 |
| `api/aether/registrar/v1/registrar.proto` | 2023 |
| `api/aether/registry/v1/endpoint.proto` | 2023 |
| `api/aether/registry/v1/service.proto` | 2023 |

The proxy-workspace `aether_stats.proto` is intentionally left on proto3.

## Why edition 2023 and not 2024

Edition 2024 codegen is rejected by the toolchain generators these files run through:
- **`protoc-gen-go-grpc`** (rules_go `go_grpc_v2`) → blocks the cni + registrar gRPC services.
- **`protoc-gen-dynamo` v0.12.0** (latest; no edition-2024 release) → blocks the registry pair.

Both emit "isn't supported … maximum of edition 2023." Edition 2023 — still an edition, not proto3 — builds cleanly through both.

## Non-breaking migration

- `option features.field_presence = IMPLICIT;` preserves proto3 implicit scalar presence (editions default to *explicit*, which would turn scalars into `*T` pointers and break every consumer). Result: generated Go/C++ API is unchanged — zero consumer edits.
- `reserved "node_ip"` → `reserved node_ip` (identifier form editions require).

## Verification

- `bazel build //...` — whole repo compiles.
- `bazel test //...` (unit) + 4 `buf_lint_test` targets — pass.
- `make format-check` — clean.

Closes #17 (proto edition portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)