### PR TITLE
feat(cni): exclude-outbound-ip-ranges capture carve-out (022 Step 1)

### DIFF
--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -3,6 +3,8 @@ package plugin
 import (
 	"encoding/binary"
 	"fmt"
+	"net"
+	"net/netip"
 
 	commonconstants "github.com/bpalermo/aether/common/constants"
 	"github.com/google/nftables"
@@ -31,8 +33,8 @@ const captureRedirectAllTableName = "aether_capture_all"
 // It enters the netns by setns on a locked OS thread (matching netnsDialContext): the
 // netlink socket nftables opens then lives in the pod netns. A failed restore leaves
 // the thread locked so the Go runtime destroys it rather than reusing a poisoned one.
-func installCaptureRedirect(netnsPath string, excludePorts []uint16, logger *zap.Logger) error {
-	return withPodNetns(netnsPath, func() error { return programCaptureRedirect(excludePorts, logger) })
+func installCaptureRedirect(netnsPath string, excludePorts []uint16, excludeRanges []netip.Prefix, logger *zap.Logger) error {
+	return withPodNetns(netnsPath, func() error { return programCaptureRedirect(excludePorts, excludeRanges, logger) })
 }
 
 // programCaptureRedirect adds the nat/output REDIRECT rules in the CURRENT netns:
@@ -50,7 +52,7 @@ func installCaptureRedirect(netnsPath string, excludePorts []uint16, logger *zap
 // dropped until the agent creates the listener, which is correct behaviour
 // (UDPRoute without --l4-routes = no listener = datagrams discarded rather than
 // sent to an unexpected destination).
-func programCaptureRedirect(excludePorts []uint16, logger *zap.Logger) error {
+func programCaptureRedirect(excludePorts []uint16, excludeRanges []netip.Prefix, logger *zap.Logger) error {
 	meshPort := uint16(commonconstants.ProxyOutboundPort)
 	capturePort := uint16(commonconstants.ProxyCapturePort)
 
@@ -67,10 +69,14 @@ func programCaptureRedirect(excludePorts []uint16, logger *zap.Logger) error {
 		Hooknum:  nftables.ChainHookOutput,
 		Priority: nftables.ChainPriorityNATDest,
 	})
-	// Excluded ports (proposal 022 M2-default): accept (RETURN) ahead of the
-	// redirect so connections to these dports bypass capture entirely.
+	// Excluded ports / IP ranges (proposal 022 M2-default): accept (RETURN) ahead of
+	// the redirect so connections to these dports / destination ranges bypass capture
+	// entirely. Ranges are destination-based, so they carve out both TCP and UDP.
 	for _, port := range excludePorts {
 		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludePortAcceptExprs(port)})
+	}
+	for _, r := range excludeRanges {
+		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludeIPRangeAcceptExprs(r)})
 	}
 	// TCP: outbound TCP to ClusterIP:meshPort → capturePort (Phase 3a).
 	c.AddRule(&nftables.Rule{
@@ -162,8 +168,8 @@ func beUint16(v uint16) []byte {
 // CaptureRedirectAllEnabled is true AND TransparentCaptureEnabled is false, only
 // the broad rule is installed. When both are true, both tables exist and the
 // redirect-all subsumes the scoped rule (all traffic is already captured).
-func installCaptureRedirectAll(netnsPath string, excludePorts []uint16, logger *zap.Logger) error {
-	return withPodNetns(netnsPath, func() error { return programCaptureRedirectAll(excludePorts, logger) })
+func installCaptureRedirectAll(netnsPath string, excludePorts []uint16, excludeRanges []netip.Prefix, logger *zap.Logger) error {
+	return withPodNetns(netnsPath, func() error { return programCaptureRedirectAll(excludePorts, excludeRanges, logger) })
 }
 
 // programCaptureRedirectAll adds the redirect-all nat/output rule in the CURRENT
@@ -177,7 +183,7 @@ func installCaptureRedirectAll(netnsPath string, excludePorts []uint16, logger *
 // it in a separate higher-priority "conntrack" chain to avoid coupling to
 // rule position, but for a single-table approach both rules go in "output" with
 // the conntrack rule first (lower rule index wins in nft).
-func programCaptureRedirectAll(excludePorts []uint16, logger *zap.Logger) error {
+func programCaptureRedirectAll(excludePorts []uint16, excludeRanges []netip.Prefix, logger *zap.Logger) error {
 	capturePort := uint16(commonconstants.ProxyCapturePort)
 
 	c, err := nftables.New()
@@ -206,11 +212,15 @@ func programCaptureRedirectAll(excludePorts []uint16, logger *zap.Logger) error 
 		Exprs: passthroughMarkAcceptExprs(commonconstants.CapturePassthroughFwMark),
 	})
 
-	// Rule 0b: excluded ports (proposal 022 M2-default) — accept ahead of the broad
-	// redirect so connections to these dports bypass the mesh. This is where
-	// exclusions matter most: redirect-all otherwise captures every port.
+	// Rule 0b: excluded ports / IP ranges (proposal 022 M2-default) — accept ahead of
+	// the broad redirect so connections to these dports / destination ranges bypass
+	// the mesh. This is where exclusions matter most: redirect-all otherwise captures
+	// every port. Ranges are destination-based (no L4 proto match).
 	for _, port := range excludePorts {
 		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludePortAcceptExprs(port)})
+	}
+	for _, r := range excludeRanges {
+		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludeIPRangeAcceptExprs(r)})
 	}
 
 	// Rule 1: skip established/related connections (conntrack).
@@ -312,6 +322,30 @@ func excludePortAcceptExprs(port uint16) []expr.Any {
 		// tcp dport == port
 		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseTransportHeader, Offset: 2, Len: 2},
 		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: beUint16(port)},
+		&expr.Verdict{Kind: expr.VerdictAccept},
+	}
+}
+
+// excludeIPRangeAcceptExprs builds the rule:
+//
+//	ip daddr & <netmask> == <network> · accept
+//
+// Placed ahead of the redirect, it carves an outbound destination IP range OUT of
+// capture (proposal 022 M2-default, the exclude-outbound-ip-ranges annotation):
+// connections to any address in the prefix bypass the mesh and reach their real
+// destination directly. Unlike excludePortAcceptExprs it matches no L4 protocol —
+// the carve-out is destination-based, so it applies to both the TCP and UDP
+// capture rules. The prefix is IPv4 (the capture table is TableFamilyIPv4).
+func excludeIPRangeAcceptExprs(prefix netip.Prefix) []expr.Any {
+	network := prefix.Masked().Addr().As4()
+	mask := net.CIDRMask(prefix.Bits(), 32)
+	return []expr.Any{
+		// ip daddr (IPv4 dest = offset 16, len 4)
+		&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 16, Len: 4},
+		// reg1 &= netmask
+		&expr.Bitwise{SourceRegister: 1, DestRegister: 1, Len: 4, Mask: mask, Xor: []byte{0x00, 0x00, 0x00, 0x00}},
+		// reg1 == network -> accept
+		&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: network[:]},
 		&expr.Verdict{Kind: expr.VerdictAccept},
 	}
 }

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/bpalermo/aether/cni/config"
@@ -254,6 +255,58 @@ func TestPodExcludedOutboundPorts(t *testing.T) {
 			assert.Equal(t, tc.want, podExcludedOutboundPorts(tc.conf))
 		})
 	}
+}
+
+// TestPodExcludedOutboundIPRanges verifies the exclude-outbound-ip-ranges
+// annotation (proposal 022 M2-default) parses into a deduplicated, network-masked,
+// IPv4-only prefix list and degrades gracefully on malformed/blank/non-IPv4 entries.
+func TestPodExcludedOutboundIPRanges(t *testing.T) {
+	anno := func(v string) config.AetherConf {
+		m := map[string]string{commonconstants.AnnotationCaptureExcludeOutboundIPRanges: v}
+		return config.AetherConf{RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &m}}
+	}
+	mk := func(s string) netip.Prefix { return netip.MustParsePrefix(s) }
+	tests := []struct {
+		name string
+		conf config.AetherConf
+		want []netip.Prefix
+	}{
+		{name: "single cidr", conf: anno("10.0.0.0/8"), want: []netip.Prefix{mk("10.0.0.0/8")}},
+		{name: "bare addr -> /32", conf: anno("192.168.1.5"), want: []netip.Prefix{mk("192.168.1.5/32")}},
+		{name: "list with whitespace", conf: anno("10.0.0.0/8, 192.168.1.0/24 ,172.16.0.0/12"), want: []netip.Prefix{mk("10.0.0.0/8"), mk("192.168.1.0/24"), mk("172.16.0.0/12")}},
+		{name: "host bits masked off", conf: anno("10.1.2.3/8"), want: []netip.Prefix{mk("10.0.0.0/8")}},
+		{name: "dedup after masking", conf: anno("10.1.2.3/8,10.4.5.6/8"), want: []netip.Prefix{mk("10.0.0.0/8")}},
+		{name: "skips blank/garbage/ipv6", conf: anno("10.0.0.0/8,,foo,fd00::/8,300.0.0.0/8,192.168.1.5"), want: []netip.Prefix{mk("10.0.0.0/8"), mk("192.168.1.5/32")}},
+		{name: "empty value", conf: anno(""), want: nil},
+		{name: "nil annotations", conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{}}, want: nil},
+		{name: "nil runtime config", conf: config.AetherConf{}, want: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, podExcludedOutboundIPRanges(tc.conf))
+		})
+	}
+}
+
+// TestExcludeIPRangeAcceptExprs verifies the exclusion rule masks the destination
+// IPv4 address to the prefix and accepts on a network match (so the redirect that
+// follows never sees it). It matches no L4 proto — the carve-out is destination-based.
+func TestExcludeIPRangeAcceptExprs(t *testing.T) {
+	exprs := excludeIPRangeAcceptExprs(netip.MustParsePrefix("10.0.0.0/8"))
+	require.Len(t, exprs, 4)
+	// ip daddr payload (network header offset 16, len 4).
+	require.IsType(t, &expr.Payload{}, exprs[0])
+	assert.Equal(t, uint32(16), exprs[0].(*expr.Payload).Offset)
+	assert.Equal(t, uint32(4), exprs[0].(*expr.Payload).Len)
+	// reg1 &= /8 netmask.
+	require.IsType(t, &expr.Bitwise{}, exprs[1])
+	assert.Equal(t, []byte{0xff, 0x00, 0x00, 0x00}, exprs[1].(*expr.Bitwise).Mask)
+	// reg1 == network (10.0.0.0).
+	require.IsType(t, &expr.Cmp{}, exprs[2])
+	assert.Equal(t, expr.CmpOpEq, exprs[2].(*expr.Cmp).Op)
+	assert.Equal(t, []byte{10, 0, 0, 0}, exprs[2].(*expr.Cmp).Data)
+	require.IsType(t, &expr.Verdict{}, exprs[3])
+	assert.Equal(t, expr.VerdictAccept, exprs[3].(*expr.Verdict).Kind)
 }
 
 // TestPassthroughMarkAcceptExprs verifies the self-exclusion rule matches the

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -21,6 +21,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -108,9 +109,10 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 	// connections to these dports bypass the mesh via an nft RETURN ahead of the
 	// redirect, in whichever capture path is active.
 	excludePorts := podExcludedOutboundPorts(netConf)
+	excludeRanges := podExcludedOutboundIPRanges(netConf)
 
 	if netConf.TransparentCaptureEnabled {
-		if err := installCaptureRedirect(args.Netns, excludePorts, p.logger); err != nil {
+		if err := installCaptureRedirect(args.Netns, excludePorts, excludeRanges, p.logger); err != nil {
 			p.logger.Warn("failed to install transparent-capture redirect; continuing without capture",
 				zap.String("netns", args.Netns), zap.Error(err))
 		}
@@ -128,7 +130,7 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 	// CaptureRedirectAllEnabled netconf flag is retained as an optional node-wide
 	// override (off by default).
 	if netConf.CaptureRedirectAllEnabled || podWantsRedirectAll(netConf) {
-		if err := installCaptureRedirectAll(args.Netns, excludePorts, p.logger); err != nil {
+		if err := installCaptureRedirectAll(args.Netns, excludePorts, excludeRanges, p.logger); err != nil {
 			p.logger.Warn("failed to install redirect-all capture (spike/M2a); continuing without redirect-all",
 				zap.String("netns", args.Netns), zap.Error(err))
 		}
@@ -661,4 +663,49 @@ func podExcludedOutboundPorts(conf config.AetherConf) []uint16 {
 		ports = append(ports, p)
 	}
 	return ports
+}
+
+// podExcludedOutboundIPRanges parses the capture.aether.io/exclude-outbound-ip-ranges
+// annotation (proposal 022, M2-default; Istio parity) into a deduplicated list of
+// IPv4 destination prefixes to carve OUT of capture. The value is comma-separated
+// CIDRs (e.g. "10.0.0.0/8, 192.168.1.5/32"); a bare address is treated as a /32.
+// Blanks, unparseable entries, and non-IPv4 prefixes (the capture table is IPv4) are
+// skipped so a malformed annotation degrades to "exclude what parses" rather than
+// failing the pod's networking. Each prefix is normalised to its network address so
+// the nft mask/cmp matches. Returns nil when unset.
+func podExcludedOutboundIPRanges(conf config.AetherConf) []netip.Prefix {
+	if conf.RuntimeConfig == nil || conf.RuntimeConfig.PodAnnotations == nil {
+		return nil
+	}
+	raw := (*conf.RuntimeConfig.PodAnnotations)[constants.AnnotationCaptureExcludeOutboundIPRanges]
+	if raw == "" {
+		return nil
+	}
+	seen := make(map[netip.Prefix]struct{})
+	var ranges []netip.Prefix
+	for _, f := range strings.Split(raw, ",") {
+		s := strings.TrimSpace(f)
+		if s == "" {
+			continue
+		}
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			// Accept a bare IPv4 address as a /32.
+			if addr, aerr := netip.ParseAddr(s); aerr == nil {
+				p = netip.PrefixFrom(addr, addr.BitLen())
+			} else {
+				continue
+			}
+		}
+		if !p.Addr().Is4() {
+			continue
+		}
+		p = p.Masked()
+		if _, dup := seen[p]; dup {
+			continue
+		}
+		seen[p] = struct{}{}
+		ranges = append(ranges, p)
+	}
+	return ranges
 }

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -36,6 +36,20 @@ const (
 	// the operator's escape hatch once redirect-all is the managed-pod default.
 	AnnotationCaptureExcludeOutboundPorts = annotationAetherCapturePrefix + "exclude-outbound-ports"
 
+	// AnnotationCaptureExcludeOutboundIPRanges carves outbound traffic to specific
+	// destination IP ranges OUT of transparent capture (proposal 022, M2-default,
+	// Istio parity with traffic.sidecar.istio.io/excludeOutboundIPRanges). The value
+	// is a comma-separated list of IPv4 CIDRs (e.g. "10.0.0.0/8,192.168.1.5/32"; a
+	// bare address is treated as /32); the CNI emits an nft RETURN matching the
+	// destination range, ahead of the redirect rule, so connections to those ranges
+	// bypass the mesh entirely (an external dependency, a metadata endpoint, a peer
+	// CIDR). The match is protocol-agnostic (destination-based), so it carves out
+	// both the TCP and UDP capture rules. Applies to both the scoped and redirect-all
+	// capture paths. Invalid/empty/non-IPv4 entries are ignored. Independent of the
+	// redirect mode — the operator's escape hatch once redirect-all is the
+	// managed-pod default.
+	AnnotationCaptureExcludeOutboundIPRanges = annotationAetherCapturePrefix + "exclude-outbound-ip-ranges"
+
 	// AnnotationConfigUpstreams is the pod annotation declaring the upstream
 	// services the pod calls, as a comma-separated list of service names
 	// (e.g. "svc-payments,svc-ledger"). The agent unions the annotations of

--- a/docs/proposals/022_arbitrary-service-interception.md
+++ b/docs/proposals/022_arbitrary-service-interception.md
@@ -165,7 +165,11 @@ The mark is unique to the proxy's passthrough — no UID collision, app-UID-agno
 ## Sequencing
 
 1. **Exclusion annotations** (`exclude-outbound-ports` / `-ip-ranges`) — safe, additive,
-   verification-independent. **Implement first.**
+   verification-independent. **Implement first.** ✅ **DONE** — `capture.aether.io/exclude-outbound-ports`
+   (comma-separated TCP dports) and `capture.aether.io/exclude-outbound-ip-ranges`
+   (comma-separated IPv4 CIDRs; bare addr = /32; destination-based, carves out both TCP
+   and UDP) emit nft RETURN rules ahead of the redirect in both the scoped and
+   redirect-all capture paths. Malformed/non-IPv4 entries degrade to "exclude what parses".
 2. **Passthrough-loop verification spike** — confirm whether the redirect-all `original_dst`
    passthrough upstream socket egresses from the pod netns (and thus self-matches the
    redirect). The gate for the default flip.


### PR DESCRIPTION
## What

Completes **proposal 022 M2-default Step 1** (exclusion annotations — the part the proposal flags as "safe, additive, verification-independent; implement first"). The port half (`capture.aether.io/exclude-outbound-ports`) already shipped; this PR adds the **IP-range** half.

New annotation: **`capture.aether.io/exclude-outbound-ip-ranges`** — comma-separated IPv4 CIDRs (e.g. `10.0.0.0/8,192.168.1.5/32`; a bare address = `/32`). Carves matching destinations OUT of transparent capture so connections reach their real destination directly — an external dependency, a metadata endpoint, a peer CIDR. This is the operator escape hatch needed before redirect-all becomes the managed-pod default (Step 4).

## How

- `podExcludedOutboundIPRanges` parses the annotation with the same graceful "exclude what parses" degradation as the port parser: blanks, garbage, and non-IPv4 prefixes are skipped; entries are deduped after network masking; nil when unset.
- `excludeIPRangeAcceptExprs` emits an nft `ip daddr & <netmask> == <network> accept` rule ahead of the redirect, in **both** the scoped (`aether_capture`) and redirect-all (`aether_capture_all`) paths.
- The match is **destination-based** (no L4 proto), so it carves out both the TCP and UDP capture rules — unlike the port carve-out, which is inherently per-protocol.

Istio parity with `traffic.sidecar.istio.io/excludeOutboundIPRanges`.

## Tests

- `TestPodExcludedOutboundIPRanges` — parsing: single CIDR, bare addr→/32, whitespace, host-bit masking, dedup-after-mask, skips blank/garbage/IPv6/out-of-range, nil cases.
- `TestExcludeIPRangeAcceptExprs` — nft rule shape (daddr payload, /8 mask, network cmp, accept verdict).
- `bazel build //...`, `bazel test //cni/internal/plugin:plugin_test`, `make format-check` — green.

Proposal 022 sequencing updated: Step 1 ✅ DONE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)