### PR TITLE
feat(cni): redirect-all default-on for managed pods, opt-out (022 Step 4)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.55.4-{GIT_COMMIT}"
+version: "0.56.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -45,6 +45,9 @@ spec:
             {{- end }}
             {{- if .Values.agent.transparentCapture }}
             - "--transparent-capture"
+            {{- if .Values.agent.captureRedirectAllDefault }}
+            - "--capture-redirect-all-default"
+            {{- end }}
             {{- end }}
             {{- if .Values.agent.meshDns }}
             - "--mesh-dns"
@@ -86,7 +89,7 @@ spec:
             {{- end }}
             {{- if .Values.agent.transparentCapture }}
             - "--transparent-capture"
-            {{- if .Values.agent.captureRedirectAll }}
+            {{- if or .Values.agent.captureRedirectAll .Values.agent.captureRedirectAllDefault }}
             - "--capture-redirect-all"
             {{- end }}
             {{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -110,12 +110,25 @@ agent:
   # registrar.generateMeshServices (the VIPs) and the CNI dst-18081 redirect.
   # Default ON (validated hitless under churn); adds the services-read RBAC.
   transparentCapture: true
-  # SPIKE (proposal 022 M2a): redirect-ALL outbound TCP into the capture listener
-  # with an ORIGINAL_DST passthrough for non-mesh destinations, so GAMMA routing
-  # can apply to real Services on real ports. Requires --transparent-capture. This
-  # only adds the (dormant) passthrough filter chain; a pod is redirect-all'd ONLY
-  # when it carries the capture.aether.io/redirect-all="true" annotation. Default OFF.
+  # Redirect-ALL outbound TCP into the capture listener with an ORIGINAL_DST
+  # passthrough for non-mesh destinations, so GAMMA routing can apply to real
+  # Services on real ports (proposal 022). Requires --transparent-capture. This
+  # only adds the (dormant) passthrough filter chain on the Envoy side; a pod is
+  # redirect-all'd ONLY when it carries the capture.aether.io/redirect-all="true"
+  # annotation (per-pod opt-in). For node-wide default-on, use
+  # captureRedirectAllDefault below instead. Default OFF.
   captureRedirectAll: false
+  # M2-default flip (proposal 022, Step 4): make redirect-all the DEFAULT for
+  # managed pods (Istio-style "capture what the app sends", zero per-pod config).
+  # Every non-system pod on the node is redirect-all'd UNLESS it carries the
+  # capture.aether.io/redirect-all="false" opt-out annotation (use it for infra /
+  # hostNetwork / prober pods). Implies the Envoy passthrough filter chain, so it
+  # enables the agent --capture-redirect-all flag too (no need to also set
+  # captureRedirectAll). Requires --transparent-capture. Default OFF until
+  # validated on talos — the CNI redirect change is the riskiest blast radius
+  # (every meshed pod's egress). Carve out destinations with
+  # capture.aether.io/exclude-outbound-ports / -ip-ranges.
+  captureRedirectAllDefault: false
   # Mesh DNS (proposal 018, mesh-global FQDN): the node agent runs an in-process
   # resolver answering <svc>.<meshDomain> from the generated mesh Services' ClusterIPs
   # (namespace-free, globally routable) and forwarding the rest to meshDnsUpstream;

--- a/cni/config/config.go
+++ b/cni/config/config.go
@@ -88,6 +88,19 @@ type AetherConf struct {
 	//     or remains DNAT'd to the mesh-DNS resolver if MeshDNSEnabled=true
 	CaptureRedirectAllEnabled bool `json:"capture_redirect_all_enabled"`
 
+	// CaptureRedirectAllDefault makes redirect-all the DEFAULT for managed pods
+	// (proposal 022, M2-default Step 4 — the "flip"). When true, every non-ignored
+	// pod on the node gets the broad redirect-all capture UNLESS it carries the
+	// capture.aether.io/redirect-all="false" opt-out annotation. This is the
+	// Istio-style "capture what the app sends" posture, with zero per-pod config.
+	//
+	// Distinct from CaptureRedirectAllEnabled (the legacy node-wide spike override,
+	// which has no opt-out): the per-pod opt-out only applies to the default path.
+	// REQUIRES the agent --capture-redirect-all flag (the Envoy passthrough filter
+	// chain + ORIGINAL_DST cluster) — the chart enables both together. Default false
+	// until validated on talos.
+	CaptureRedirectAllDefault bool `json:"capture_redirect_all_default"`
+
 	// MeshDNSEnabled installs, inside each pod's netns, an nft DNAT of outbound DNS
 	// (UDP+TCP :53, non-loopback) -> the node agent's resolver at HostIP:18054
 	// (proposal 018, mesh-global FQDN). Off by default; pairs with the agent's

--- a/cni/internal/cmd/root.go
+++ b/cni/internal/cmd/root.go
@@ -38,6 +38,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.MountedCNINetDir, "mounted-cni-net-dir", constants.DefaultHostCNINetDir, "Directory where CNI network configuration files are located")
 	rootCmd.Flags().StringVar(&cfg.OTLPEndpoint, "otlp-endpoint", "", "OTLP gRPC collector endpoint written into the netconf so the CNI plugin pushes traces and metrics (e.g. collector:4317); empty disables plugin telemetry")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCaptureEnabled, "transparent-capture", false, "Write transparent_capture_enabled into the netconf so the CNI plugin installs the per-pod capture redirect (proposal 018, Phase 3a)")
+	rootCmd.Flags().BoolVar(&cfg.CaptureRedirectAllDefault, "capture-redirect-all-default", false, "Write capture_redirect_all_default into the netconf so redirect-all is the default for managed pods (proposal 022, M2-default), opt-out via capture.aether.io/redirect-all=false. Pairs with the agent --capture-redirect-all flag")
 	rootCmd.Flags().BoolVar(&cfg.MeshDNSEnabled, "mesh-dns", false, "Write mesh_dns_enabled into the netconf so the CNI plugin installs the per-pod :53 DNAT (proposal 018, mesh-global FQDN)")
 	rootCmd.Flags().StringVar(&cfg.HostIP, "host-ip", "", "Node IP written into the netconf as the mesh-DNS DNAT target (the agent's host-local resolver)")
 }

--- a/cni/internal/install/cniconfig.go
+++ b/cni/internal/install/cniconfig.go
@@ -52,6 +52,7 @@ func createCNIConfigFile(ctx context.Context, cfg *InstallerConfig) (string, err
 	pluginConfig.AgentCNIPath = constants.DefaultCNISocketPath
 	pluginConfig.OTLPEndpoint = cfg.OTLPEndpoint
 	pluginConfig.TransparentCaptureEnabled = cfg.TransparentCaptureEnabled
+	pluginConfig.CaptureRedirectAllDefault = cfg.CaptureRedirectAllDefault
 	pluginConfig.MeshDNSEnabled = cfg.MeshDNSEnabled
 	pluginConfig.HostIP = cfg.HostIP
 	// Declare the pod-annotations capability so containerd populates

--- a/cni/internal/install/config.go
+++ b/cni/internal/install/config.go
@@ -30,6 +30,11 @@ type InstallerConfig struct {
 	// so the CNI plugin installs the per-pod capture redirect (proposal 018, Phase
 	// 3a). Off by default.
 	TransparentCaptureEnabled bool
+	// CaptureRedirectAllDefault writes capture_redirect_all_default into the netconf
+	// so the CNI plugin makes redirect-all the default for managed pods (proposal
+	// 022, M2-default Step 4), opt-out via the capture.aether.io/redirect-all="false"
+	// annotation. Off by default; pairs with the agent --capture-redirect-all flag.
+	CaptureRedirectAllDefault bool
 	// MeshDNSEnabled writes mesh_dns_enabled into the netconf so the CNI plugin
 	// installs the per-pod :53 DNAT (proposal 018, mesh-global FQDN). Off by default.
 	MeshDNSEnabled bool

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -170,49 +170,44 @@ func TestRedirectAllTCPExprs(t *testing.T) {
 	require.IsType(t, &expr.Redir{}, exprs[6])
 }
 
-// TestPodWantsRedirectAll verifies that the per-pod redirect-all opt-in is driven
-// strictly by the capture.aether.io/redirect-all="true" annotation reaching the
-// plugin via the runtime config. This is the safety gate: without the annotation a
-// pod stays on the scoped redirect even when the spike build is rolled out.
-func TestPodWantsRedirectAll(t *testing.T) {
+// TestPodRedirectAll verifies the redirect-all decision precedence (proposal 022):
+// an explicit per-pod annotation ("true"=force on / "false"=force off) overrides
+// the node default; otherwise CaptureRedirectAllDefault (the M2-default flip) or the
+// legacy node-wide CaptureRedirectAllEnabled applies. This is the safety gate that
+// keeps infra/opt-out pods off redirect-all even when the node default is on.
+func TestPodRedirectAll(t *testing.T) {
 	annoTrue := map[string]string{commonconstants.AnnotationCaptureRedirectAll: "true"}
 	annoFalse := map[string]string{commonconstants.AnnotationCaptureRedirectAll: "false"}
 	annoOther := map[string]string{"some.other/annotation": "true"}
+	withAnno := func(m map[string]string) config.AetherConf {
+		return config.AetherConf{RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &m}}
+	}
 
 	tests := []struct {
 		name string
 		conf config.AetherConf
 		want bool
 	}{
+		{name: "annotation true forces on (default off)", conf: withAnno(annoTrue), want: true},
 		{
-			name: "annotation true opts in",
-			conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &annoTrue}},
-			want: true,
-		},
-		{
-			name: "annotation false does not opt in",
-			conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &annoFalse}},
+			name: "annotation false forces off even with default on",
+			conf: config.AetherConf{CaptureRedirectAllDefault: true, RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &annoFalse}},
 			want: false,
 		},
 		{
-			name: "unrelated annotation does not opt in",
-			conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &annoOther}},
+			name: "annotation false forces off even with node-wide override",
+			conf: config.AetherConf{CaptureRedirectAllEnabled: true, RuntimeConfig: &config.RuntimeConfig{PodAnnotations: &annoFalse}},
 			want: false,
 		},
-		{
-			name: "nil pod annotations does not opt in",
-			conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{}},
-			want: false,
-		},
-		{
-			name: "nil runtime config does not opt in",
-			conf: config.AetherConf{},
-			want: false,
-		},
+		{name: "no annotation, default on -> on", conf: config.AetherConf{CaptureRedirectAllDefault: true}, want: true},
+		{name: "no annotation, node-wide override on -> on", conf: config.AetherConf{CaptureRedirectAllEnabled: true}, want: true},
+		{name: "unrelated annotation, default off -> off", conf: withAnno(annoOther), want: false},
+		{name: "nil pod annotations, default off -> off", conf: config.AetherConf{RuntimeConfig: &config.RuntimeConfig{}}, want: false},
+		{name: "nil runtime config, default off -> off", conf: config.AetherConf{}, want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, podWantsRedirectAll(tc.conf))
+			assert.Equal(t, tc.want, podRedirectAll(tc.conf))
 		})
 	}
 }

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -118,18 +118,17 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	// SPIKE/EXPERIMENTAL (proposal 022, M2a): redirect ALL outbound non-local TCP
-	// into the capture listener; non-mesh egress passes through via ORIGINAL_DST.
+	// Redirect-all capture (proposal 022): redirect ALL outbound non-local TCP into
+	// the capture listener; non-mesh egress passes through via ORIGINAL_DST.
 	// Best-effort: failure leaves the scoped-redirect (or no capture) in place.
 	// Requires the agent --capture-redirect-all flag on the xDS side so the capture
 	// listener carries the passthrough fallback filter chain.
 	//
-	// Per-pod opt-in for safe scoping: redirect-all is applied for a pod ONLY when
-	// it carries the capture.aether.io/redirect-all="true" annotation (so a single
-	// pod can be tested without affecting other workloads on the node). The global
-	// CaptureRedirectAllEnabled netconf flag is retained as an optional node-wide
-	// override (off by default).
-	if netConf.CaptureRedirectAllEnabled || podWantsRedirectAll(netConf) {
+	// podRedirectAll resolves precedence: an explicit per-pod annotation (opt-in
+	// "true" / opt-out "false") wins, otherwise the node default applies
+	// (CaptureRedirectAllDefault — the M2-default flip for managed pods — or the
+	// legacy node-wide CaptureRedirectAllEnabled). All default false.
+	if podRedirectAll(netConf) {
 		if err := installCaptureRedirectAll(args.Netns, excludePorts, excludeRanges, p.logger); err != nil {
 			p.logger.Warn("failed to install redirect-all capture (spike/M2a); continuing without redirect-all",
 				zap.String("netns", args.Netns), zap.Error(err))
@@ -620,17 +619,37 @@ func ignorableNamespace(namespace string) bool {
 	return constants.IsIgnoredNamespace(namespace)
 }
 
-// podWantsRedirectAll reports whether the pod opted into redirect-all transparent
-// capture (proposal 022, M2a) via the capture.aether.io/redirect-all="true"
-// annotation. Pod annotations reach the CNI plugin through the runtime config
-// (io.kubernetes.cri.pod-annotations), populated by containerd when the aether
-// CNI conf declares that capability. The per-pod opt-in keeps the spike safe to
-// roll out node-wide while only redirecting the explicitly annotated pods.
-func podWantsRedirectAll(conf config.AetherConf) bool {
-	if conf.RuntimeConfig == nil || conf.RuntimeConfig.PodAnnotations == nil {
+// podRedirectAll decides whether the pod gets the broad redirect-all capture
+// (proposal 022). Precedence, highest first:
+//
+//   - capture.aether.io/redirect-all="true"  → force ON (explicit opt-in; lets a
+//     single pod be tested while the node default is off).
+//   - capture.aether.io/redirect-all="false" → force OFF (explicit opt-out; carves
+//     an infra/hostNetwork/prober pod out of the managed-pod default).
+//   - otherwise → the node default: CaptureRedirectAllDefault (the M2-default flip,
+//     redirect-all for managed pods) OR the legacy node-wide CaptureRedirectAllEnabled.
+//
+// Pod annotations reach the CNI plugin through the runtime config
+// (io.kubernetes.cri.pod-annotations), populated by containerd when the aether CNI
+// conf declares that capability.
+func podRedirectAll(conf config.AetherConf) bool {
+	switch podRedirectAllAnnotation(conf) {
+	case "true":
+		return true
+	case "false":
 		return false
 	}
-	return (*conf.RuntimeConfig.PodAnnotations)[constants.AnnotationCaptureRedirectAll] == "true"
+	return conf.CaptureRedirectAllDefault || conf.CaptureRedirectAllEnabled
+}
+
+// podRedirectAllAnnotation returns the raw capture.aether.io/redirect-all
+// annotation value ("" when unset), so podRedirectAll can distinguish an explicit
+// opt-out ("false") from "unset" (fall through to the node default).
+func podRedirectAllAnnotation(conf config.AetherConf) string {
+	if conf.RuntimeConfig == nil || conf.RuntimeConfig.PodAnnotations == nil {
+		return ""
+	}
+	return (*conf.RuntimeConfig.PodAnnotations)[constants.AnnotationCaptureRedirectAll]
 }
 
 // podExcludedOutboundPorts parses the capture.aether.io/exclude-outbound-ports
@@ -639,7 +658,7 @@ func podWantsRedirectAll(conf config.AetherConf) bool {
 // (e.g. "5432, 9000"); blanks and out-of-range/non-numeric entries are skipped so
 // a malformed annotation degrades to "exclude what parses" rather than failing the
 // pod's networking. Reaches the CNI via the same pod-annotations runtime config as
-// podWantsRedirectAll. Returns nil when unset.
+// podRedirectAll. Returns nil when unset.
 func podExcludedOutboundPorts(conf config.AetherConf) []uint16 {
 	if conf.RuntimeConfig == nil || conf.RuntimeConfig.PodAnnotations == nil {
 		return nil

--- a/common/constants/annotations.go
+++ b/common/constants/annotations.go
@@ -14,15 +14,18 @@ const (
 	// behaviour (what the CNI intercepts for the pod).
 	annotationAetherCapturePrefix = "capture." + annotationAetherPrefix
 
-	// AnnotationCaptureRedirectAll opts a single pod into the redirect-all
-	// transparent-capture mode (proposal 022, M2a spike): the CNI installs the
-	// broad nft rule that sends ALL outbound non-local TCP into the pod-local
-	// capture listener, where non-mesh egress is forwarded in plaintext via the
-	// Envoy passthrough_original_dst cluster. Per-pod opt-in (value "true") so a
-	// node-wide rollout can be tested on one annotated pod without affecting
-	// other workloads. REQUIRES the agent --capture-redirect-all flag so the
-	// capture listener carries the passthrough fallback filter chain. Absent or
-	// any value other than "true" leaves the pod on the scoped :18081 redirect.
+	// AnnotationCaptureRedirectAll controls per-pod redirect-all transparent-capture
+	// (proposal 022): the CNI installs the broad nft rule that sends ALL outbound
+	// non-local TCP into the pod-local capture listener, where non-mesh egress is
+	// forwarded in plaintext via the Envoy passthrough_original_dst cluster. The
+	// annotation overrides the node default both ways:
+	//   - "true"  → force ON (opt-in; test redirect-all on one pod while the node
+	//     default is off).
+	//   - "false" → force OFF (opt-out; carve an infra/hostNetwork/prober pod out of
+	//     the managed-pod default, agent.captureRedirectAllDefault).
+	// Absent (or any other value) falls through to the node default. REQUIRES the
+	// agent --capture-redirect-all flag so the capture listener carries the
+	// passthrough fallback filter chain.
 	AnnotationCaptureRedirectAll = annotationAetherCapturePrefix + "redirect-all"
 
 	// AnnotationCaptureExcludeOutboundPorts carves specific outbound TCP

--- a/docs/proposals/022_arbitrary-service-interception.md
+++ b/docs/proposals/022_arbitrary-service-interception.md
@@ -172,12 +172,27 @@ The mark is unique to the proxy's passthrough — no UID collision, app-UID-agno
    redirect-all capture paths. Malformed/non-IPv4 entries degrade to "exclude what parses".
 2. **Passthrough-loop verification spike** — confirm whether the redirect-all `original_dst`
    passthrough upstream socket egresses from the pod netns (and thus self-matches the
-   redirect). The gate for the default flip.
-3. **SO_MARK self-exclusion** (agent xDS `socket_options` + CNI `meta mark RETURN`) — only if
-   (2) shows a loop. Makes the default flip safe.
+   redirect). The gate for the default flip. ✅ **GATE CLEARED** — the loop failure mode is
+   prevented regardless of outcome (see step 3, SO_MARK, already wired both sides), and the
+   offline envoy-validate (`capture_bootstrap.json`, `withPassthrough=true`) accepts the
+   SO_MARK'd passthrough bootstrap. talos M2a (rev122) showed egress intact under redirect-all
+   (github:443=200, apiserver:443 TLS ok, mesh echo=200) — no observable loop. Final on-cluster
+   confirmation rides on the step-4 talos validation (where the flag is actually enabled).
+3. **SO_MARK self-exclusion** (agent xDS `socket_options` + CNI `meta mark RETURN`). ✅ **DONE** —
+   `NewPassthroughOriginalDstCluster` stamps `CapturePassthroughFwMark` (SO_MARK, STATE_PREBIND)
+   on the passthrough cluster's upstream sockets; `programCaptureRedirectAll` RETURNs that mark
+   ahead of the redirect. Defensive (harmless if the passthrough egresses proxy-side); unit-tested
+   both sides + covered by envoy-validate.
 4. **Flip redirect-all to default-on for managed pods** behind a chart value (default off
-   until validated on talos), annotation as opt-out. Validate egress volume on the
-   node-shared proxy + the non-mesh cleartext catch-all passthrough (the #288 failure mode).
+   until validated on talos), annotation as opt-out. ✅ **IMPLEMENTED (default off)** —
+   `agent.captureRedirectAllDefault` (chart, default false) → cni-install
+   `--capture-redirect-all-default` → netconf `capture_redirect_all_default` → the CNI
+   redirect-alls every non-system pod UNLESS `capture.aether.io/redirect-all="false"`; the
+   chart value also enables the agent `--capture-redirect-all` (Envoy passthrough chain).
+   Precedence resolved in `podRedirectAll` (annotation true/false overrides node default).
+   **REMAINING: enable on talos and validate** egress volume on the node-shared proxy + the
+   non-mesh cleartext catch-all passthrough (the #288 failure mode) before flipping the chart
+   default on.
 
 This is the big architectural item; the CNI redirect change is the riskiest blast radius
 (every meshed pod's egress), which is why the default flip is last and gated on the spike.


### PR DESCRIPTION
## What

Implements the **proposal 022 M2-default "flip"** (backlog **P2 / Step 4**). Redirect-all moves from a per-pod opt-in annotation to a **node-wide managed-pod default with an annotation opt-out** — the Istio-style "capture what the app sends" posture that lets GAMMA routing apply to real Service ports with zero per-pod config.

**Default OFF** until validated on talos (the CNI redirect change is the riskiest blast radius — every meshed pod's egress).

## How

- **Chart:** new `agent.captureRedirectAllDefault` (default `false`) → cni-install `--capture-redirect-all-default` → netconf `capture_redirect_all_default`. The same value also enables the agent `--capture-redirect-all` flag (the Envoy passthrough filter chain + ORIGINAL_DST cluster), so one switch turns on both halves.
- **CNI decision (`podRedirectAll`)** resolves precedence:
  - `capture.aether.io/redirect-all="true"` → force ON (opt-in)
  - `capture.aether.io/redirect-all="false"` → force OFF (opt-out — infra / hostNetwork / prober pods)
  - else → node default: `CaptureRedirectAllDefault` (the flip) or the legacy node-wide `CaptureRedirectAllEnabled`
- Carve out specific destinations with `capture.aether.io/exclude-outbound-ports` / `-ip-ranges` (P0, already shipped).
- Chart bumped `0.55.4` → `0.56.0`.

## P1 gate (Step 2 spike) — cleared

Recorded in the proposal: the passthrough-loop failure mode is **prevented regardless** by the SO_MARK self-exclusion already wired on **both** sides (`NewPassthroughOriginalDstCluster` stamps `CapturePassthroughFwMark`; `programCaptureRedirectAll` RETURNs it ahead of the redirect), and the offline envoy-validate (`capture_bootstrap.json`, `withPassthrough=true`) accepts the SO_MARK'd bootstrap. talos M2a (rev122) showed egress intact under redirect-all. Final on-cluster confirmation rides on the Step-4 talos enablement.

## Tests

- `TestPodRedirectAll` — full precedence matrix (opt-in/opt-out override default; default-on; legacy node-wide; opt-out beats both; nil cases).
- `bazel build //...`, `//cni/...`, `//common/constants/...`, chart template + lint tests, `make format-check` — all green.

Proposal 022 sequencing: Step 2 ✅ gate cleared · Step 3 ✅ done · Step 4 ✅ implemented (default off, **remaining: enable + validate on talos**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)