### PR TITLE
feat(cni): exclude link-local + multicast from redirect-all (022 P3a)

### DIFF
--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -19,6 +19,19 @@ const captureTableName = "aether_capture"
 // captureRedirectAllTableName is the nft table for the redirect-all mode (spike/M2a).
 const captureRedirectAllTableName = "aether_capture_all"
 
+// builtinRedirectAllExcludedRanges are destination ranges always carved out of the
+// broad redirect-all capture (proposal 022 M2-default), in addition to the /8
+// loopback mask baked into redirectAllTCPExprs:
+//   - 169.254.0.0/16 link-local — the cloud instance metadata service
+//     (169.254.169.254) and other link-local endpoints must be reached directly.
+//   - 224.0.0.0/4 multicast — never a unicast mesh destination.
+//
+// These do not apply to the scoped rule, which only captures ClusterIP:18081.
+var builtinRedirectAllExcludedRanges = []netip.Prefix{
+	netip.MustParsePrefix("169.254.0.0/16"),
+	netip.MustParsePrefix("224.0.0.0/4"),
+}
+
 // installCaptureRedirect programs, inside the pod's network namespace, an nftables
 // REDIRECT of outbound TCP destined for a mesh ClusterIP:<meshPort> to the pod-local
 // transparent-capture listener on <capturePort> (proposal 018, Phase 3a).
@@ -220,6 +233,17 @@ func programCaptureRedirectAll(excludePorts []uint16, excludeRanges []netip.Pref
 		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludePortAcceptExprs(port)})
 	}
 	for _, r := range excludeRanges {
+		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludeIPRangeAcceptExprs(r)})
+	}
+
+	// Rule 0c: built-in special-range exclusions (proposal 022 M2-default). The
+	// scoped rule only ever captured ClusterIP:18081, so these never mattered; the
+	// broad redirect-all captures EVERY non-loopback TCP dest, which the /8 loopback
+	// mask alone does not carve out. Link-local (169.254.0.0/16) carries the cloud
+	// instance metadata service (169.254.169.254) and must reach it directly, not via
+	// an Envoy passthrough hop; multicast (224.0.0.0/4) is never a unicast mesh
+	// destination. Always excluded, independent of the per-pod annotations.
+	for _, r := range builtinRedirectAllExcludedRanges {
 		c.AddRule(&nftables.Rule{Table: table, Chain: chain, Exprs: excludeIPRangeAcceptExprs(r)})
 	}
 

--- a/cni/internal/plugin/capture_test.go
+++ b/cni/internal/plugin/capture_test.go
@@ -304,6 +304,20 @@ func TestExcludeIPRangeAcceptExprs(t *testing.T) {
 	assert.Equal(t, expr.VerdictAccept, exprs[3].(*expr.Verdict).Kind)
 }
 
+// TestBuiltinRedirectAllExcludedRanges verifies the always-on redirect-all carve-outs
+// cover IPv4 link-local (the cloud metadata service) and multicast (proposal 022),
+// which the /8 loopback mask in redirectAllTCPExprs does not exclude.
+func TestBuiltinRedirectAllExcludedRanges(t *testing.T) {
+	got := make(map[netip.Prefix]bool)
+	for _, r := range builtinRedirectAllExcludedRanges {
+		got[r] = true
+	}
+	assert.True(t, got[netip.MustParsePrefix("169.254.0.0/16")], "link-local must be excluded (IMDS 169.254.169.254)")
+	assert.True(t, got[netip.MustParsePrefix("224.0.0.0/4")], "multicast must be excluded")
+	// Sanity: the metadata IP falls inside the excluded link-local prefix.
+	assert.True(t, netip.MustParsePrefix("169.254.0.0/16").Contains(netip.MustParseAddr("169.254.169.254")))
+}
+
 // TestPassthroughMarkAcceptExprs verifies the self-exclusion rule matches the
 // proxy's fwmark (little-endian u32) and accepts, so SO_MARK'd passthrough egress
 // bypasses the redirect (proposal 022 M2-default).

--- a/docs/proposals/022_arbitrary-service-interception.md
+++ b/docs/proposals/022_arbitrary-service-interception.md
@@ -196,3 +196,18 @@ The mark is unique to the proxy's passthrough — no UID collision, app-UID-agno
 
 This is the big architectural item; the CNI redirect change is the riskiest blast radius
 (every meshed pod's egress), which is why the default flip is last and gated on the spike.
+
+### Residual redirect-all correctness gaps
+
+The broad redirect captures every non-loopback TCP dest, so special ranges the scoped
+`:18081` rule never touched now need handling:
+
+- **Link-local `169.254.0.0/16` + multicast `224.0.0.0/4`.** ✅ **DONE** — always excluded
+  (`builtinRedirectAllExcludedRanges`) so the cloud instance-metadata service
+  (169.254.169.254) is reached directly, not via an Envoy passthrough hop.
+- **IPv6.** OPEN — the capture nft table is `TableFamilyIPv4` only, so IPv6 outbound is not
+  captured at all (bypasses the mesh, reaches its dest directly). Not a breakage, but IPv6
+  mesh traffic is unmeshed until an IPv6 table + listener path is added.
+- **UDP.** OPEN — redirect-all redirects only TCP; UDP egress is uncaptured in redirect-all
+  mode (the scoped rule does redirect UDP to :18081 when `--l4-routes`). No DTLS, so UDP
+  mesh remains plaintext/forwarded; revisit with the L4 floor.


### PR DESCRIPTION
## What

Hardens the redirect-all flip (#437). The broad redirect captures **every** non-loopback TCP destination, but the `/8` loopback mask baked into `redirectAllTCPExprs` does not carve out link-local or multicast — ranges the scoped `:18081` rule never touched. Adds always-on built-in exclusions:

- **`169.254.0.0/16` link-local** — the cloud instance metadata service (`169.254.169.254`, IMDS) and other link-local endpoints are reached **directly**, not via an Envoy passthrough hop.
- **`224.0.0.0/4` multicast** — never a unicast mesh destination.

## How

Reuses the `excludeIPRangeAcceptExprs` builder from P0 (#436), emitted ahead of the redirect via a package-level `builtinRedirectAllExcludedRanges`. Applied **only** in the redirect-all path; the scoped rule (dport==18081) never needed it.

## Residual gaps (documented, still OPEN)

Proposal 022 now tracks the remaining redirect-all correctness gaps:
- **IPv6** — the capture nft table is `TableFamilyIPv4` only, so IPv6 outbound bypasses the mesh (not a breakage; unmeshed until an IPv6 table + listener path is added).
- **UDP** — redirect-all redirects only TCP; UDP egress is uncaptured in redirect-all mode.

## Tests

- `TestBuiltinRedirectAllExcludedRanges` — asserts link-local + multicast are excluded and the IMDS IP falls inside the link-local prefix.
- `bazel build //...`, `//cni/...`, `make format-check` — green.

Backlog: P3a ✅. Remaining P3 = IPv6/UDP capture + **M4 demand-scoping** (the large item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)