### PR TITLE
test(xds): lock capture demand-scope invariant (022 M4)

### DIFF
--- a/agent/internal/xds/cache/capture_test.go
+++ b/agent/internal/xds/cache/capture_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"regexp"
 	"testing"
 
@@ -174,6 +175,41 @@ func matchesAuthority(targets []proxy.KnownTargetRoute, authority string) (strin
 		}
 	}
 	return "", false
+}
+
+// TestCaptureVhosts_DemandScoped locks the M4 invariant (proposal 022/004): the
+// cap_http table is bounded by the node dependency set, NOT the cluster-wide set of
+// mesh authorities. This is what keeps redirect-all (now the managed-pod default)
+// from exploding cap_http to every mesh Service on every node — Envoy only carries
+// routes/clusters for destinations this node actually depends on; everything else
+// rides the catch-all (ODCDS cold path / passthrough). The cold path then pulls a
+// newly-used service into scope on demand.
+func TestCaptureVhosts_DemandScoped(t *testing.T) {
+	c := newTestCache("node-1")
+	ctx := context.Background()
+
+	// Two real mesh authorities exist cluster-wide (the mesh-Service reconciler feeds
+	// the full set, independent of any one node's dependency set).
+	c.SetCaptureAuthorities(map[string]string{
+		"default/in-scope":  "in-scope.default.svc.cluster.local",
+		"default/off-scope": "off-scope.default.svc.cluster.local",
+	})
+	// A local pod declares only in-scope as an upstream, so only it enters this
+	// node's dependency set.
+	require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/in-scope"), "example.org"))
+
+	vhosts := c.captureVhosts()
+	require.NotNil(t, findVHost(vhosts, "in-scope.default.svc.cluster.local"),
+		"in-scope authority must build a cap_http vhost")
+	assert.Nil(t, findVHost(vhosts, "off-scope.default.svc.cluster.local"),
+		"off-scope authority must be excluded from cap_http (demand-scoped), even though it is a known mesh authority")
+
+	// Cold path: once off-scope is observed via ODCDS it joins the dependency set,
+	// so capture scope follows demand and its vhost now builds.
+	require.True(t, c.ObserveDependency(ctx, "default/off-scope"))
+	vhosts = c.captureVhosts()
+	assert.NotNil(t, findVHost(vhosts, "off-scope.default.svc.cluster.local"),
+		"observed (ODCDS) authority must now build a cap_http vhost — scope follows demand")
 }
 
 // TestCaptureKnownTargets_StableAcrossGAMMAChurn is the regression guard for the

--- a/docs/proposals/022_arbitrary-service-interception.md
+++ b/docs/proposals/022_arbitrary-service-interception.md
@@ -96,7 +96,15 @@ on 020 Part 1: the mesh Service becomes the real Service, captured by its Cluste
 
 - **Data-plane scope creep.** Capturing all in-mesh ports means the proxy sees far more
   traffic. Mitigate with **demand-scoping** (proposal 004): only capture/serve
-  destinations in the node's dependency set.
+  destinations in the node's dependency set. ✅ **ALREADY IN PLACE** — `captureVhosts`
+  filters every cap_http vhost (and the TCP/UDP floor clusters) through
+  `DependencySet()`, so the served set is bounded to the node's deps even though the
+  redirect-all listener sees all egress; off-scope mesh dests ride the catch-all
+  (ODCDS cold path pulls a newly-used service into scope on demand, TTL-expired out).
+  Invariant locked by `TestCaptureVhosts_DemandScoped`. **M4 remaining = soak +
+  re-run MESH conformance with redirect-all as the managed-pod DEFAULT** (the harness
+  no longer needs the per-pod redirect-all annotation patch, since namespace injection
+  → managed pods → redirect-all default).
 - **Non-mesh egress** must pass through cleanly (redirect-all, option ii) — an
   on-demand/passthrough path; the ODCDS catch-all is the starting point.
 - **Coexistence** with the `<svc>.<meshDomain>` / `:18081` path: keep it working (it's the


### PR DESCRIPTION
## What

M4's core — **bound capture to the node dependency set** (proposal 004) — turns out to be **already implemented**: `captureVhosts` filters every cap_http vhost through `DependencySet()`, and the TCP/UDP floor clusters are demand-scoped too. With redirect-all now the managed-pod default (#437, validated on talos), every pod captures all egress, so this bound is exactly what keeps the cap_http table from exploding to every mesh Service on every node. This PR **locks that invariant** with a regression test.

`TestCaptureVhosts_DemandScoped`:
- A known **cluster-wide** mesh authority (fed by the mesh-Service reconciler) is **excluded** from cap_http until it enters the node's dependency set.
- The **ODCDS cold path** (`ObserveDependency`) then pulls a newly-used service into scope on demand — scope follows demand.

## M4 status

Proposal 022 updated: demand-scoping of the capture path is in place + locked. **Remaining M4 = soak + re-run MESH conformance with redirect-all as the managed-pod DEFAULT** (the conformance harness no longer needs the per-pod redirect-all annotation patch, since namespace injection → managed pods → redirect-all default).

## Tests

- `TestCaptureVhosts_DemandScoped` (new), full `//agent/internal/xds/cache:cache_test`, `make format-check` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)