### PR TITLE
feat(chart): flip redirect-all to chart default + simplify MESH conformance (022)

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -335,12 +335,15 @@ jobs:
       # Install aether with the MESH path on and SPIRE off. spire.enabled=false flips
       # the agent's cleartext-mesh mode (no SVID/SDS → cleartext inbound listener,
       # already-cleartext outbound). agent.gamma=true turns on the GAMMA reconciler
-      # (HTTPRoute parentRef=Service → cap_http route tables). agent.captureRedirectAll
-      # =true adds the ORIGINAL_DST passthrough so redirect-all'd pods (the overlay
-      # annotates the echo pods) capture their real Service ClusterIP:port — the route
-      # target's real port (proposal 023 M2). transparentCapture / generateMeshServices
-      # / namespaceInjection / injectPodNdots are chart defaults (on). The edge is not
-      # needed east-west, so leave it off.
+      # (HTTPRoute parentRef=Service → cap_http route tables). redirect-all is now the
+      # chart DEFAULT (agent.captureRedirectAllDefault=true, soak-validated on talos
+      # 2026-06-29), so the mesh path captures each managed pod's real Service
+      # ClusterIP:port with NO per-pod annotation — the overlay's managed-namespace
+      # label is enough (namespace injection labels the echo pods managed → default
+      # redirect-all). This exercises the real default config, not the old per-pod
+      # opt-in. transparentCapture / generateMeshServices / namespaceInjection /
+      # injectPodNdots are chart defaults (on). The edge is not needed east-west, so
+      # leave it off.
       - name: Install aether (mesh, no SPIRE)
         run: |
           sed -i -e 's/{GIT_COMMIT}/conformance/' -e 's/{STABLE_GIT_VERSION}/0.0.0-conformance/' charts/aether/Chart.yaml
@@ -350,7 +353,6 @@ jobs:
             --set namespace.create=false \
             --set spire.enabled=false \
             --set agent.gamma=true \
-            --set agent.captureRedirectAll=true \
             $(img agent agent) \
             $(img cniInstall cni-install) \
             $(img registrar registrar) \

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.56.0-{GIT_COMMIT}"
+version: "0.57.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -124,11 +124,13 @@ agent:
   # capture.aether.io/redirect-all="false" opt-out annotation (use it for infra /
   # hostNetwork / prober pods). Implies the Envoy passthrough filter chain, so it
   # enables the agent --capture-redirect-all flag too (no need to also set
-  # captureRedirectAll). Requires --transparent-capture. Default OFF until
-  # validated on talos — the CNI redirect change is the riskiest blast radius
-  # (every meshed pod's egress). Carve out destinations with
-  # capture.aether.io/exclude-outbound-ports / -ip-ranges.
-  captureRedirectAllDefault: false
+  # captureRedirectAll). Requires --transparent-capture. Carve out destinations
+  # with capture.aether.io/exclude-outbound-ports / -ip-ranges (link-local +
+  # multicast are always excluded). Default ON — validated HITLESS on talos
+  # (2026-06-29 churn soak: external prober 100%, k6 0.012%, egress intact, stable
+  # RSS through 6 proxy + 14 service rolls). This is the riskiest blast radius
+  # (every meshed pod's egress); set false to revert to per-pod opt-in.
+  captureRedirectAllDefault: true
   # Mesh DNS (proposal 018, mesh-global FQDN): the node agent runs an in-process
   # resolver answering <svc>.<meshDomain> from the generated mesh Services' ClusterIPs
   # (namespace-free, globally routable) and forwarding the rest to meshDnsUpstream;

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -64,10 +64,13 @@ the aether-specific adaptations the talos baseline runs applied by hand:
 
 - `aether.io/managed: "true"` on the `gateway-conformance-mesh` namespace (mesh injection),
 - **per-version ServiceAccounts** (`echo-v1`, `echo-v2`) on the echo Deployments —
-  aether's mesh identity is the ServiceAccount, so the two versions need distinct ones,
-- `capture.aether.io/redirect-all: "true"` pod annotation so real Service ports are
-  captured (the framework drives requests by `kubectl exec` into the echo pods, and
-  redirect-all routes those real ports through the mesh).
+  aether's mesh identity is the ServiceAccount, so the two versions need distinct ones.
+
+The managed-namespace label is enough to capture the echo pods' real Service ports:
+redirect-all is the chart default (`agent.captureRedirectAllDefault`, soak-validated),
+so namespace injection labels the pods managed and they get redirect-all with **no
+per-pod annotation** (the framework drives requests by `kubectl exec` into the echo
+pods, and redirect-all routes those real ports through the mesh).
 
 The Go test embeds this file (`//go:embed mesh/manifests.yaml`) and passes it as the
 suite's `ManifestFS` for the MESH run, overriding the suite's embedded base.

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -21,9 +21,11 @@
 //   - TestAetherMeshHTTP: the east-west GAMMA profile. Runs in CI (kind, no SPIRE)
 //     via the `mesh-http` job, SOFT (continue-on-error) while the score is driven up.
 //     Uses the committed mesh overlay (mesh/manifests.yaml) which adds the
-//     aether.io/managed namespace label, per-version ServiceAccounts, and the
-//     capture.aether.io/redirect-all annotation. With SPIRE off the mesh hop is
-//     cleartext (the inbound listener degrades to a no-mTLS HCM chain).
+//     aether.io/managed namespace label and per-version ServiceAccounts. Capture is
+//     the chart DEFAULT (agent.captureRedirectAllDefault), so the managed-namespace
+//     label alone meshes the echo pods (namespace injection → managed → redirect-all)
+//     — no per-pod annotation needed. With SPIRE off the mesh hop is cleartext (the
+//     inbound listener degrades to a no-mTLS HCM chain).
 //
 // Both tests require a live cluster reachable via the ambient kubeconfig and are
 // SKIPPED unless AETHER_CONFORMANCE=1.
@@ -61,10 +63,12 @@ import (
 )
 
 // meshManifests is aether's overlay of the suite's base mesh manifests: the
-// aether.io/managed=true namespace label, per-version ServiceAccounts for the
-// echo Deployments (aether identity = ServiceAccount), and the
-// capture.aether.io/redirect-all=true pod annotation (so real Service ports are
-// captured). Vanilla upstream manifests would not exercise aether's mesh path.
+// aether.io/managed=true namespace label and per-version ServiceAccounts for the
+// echo Deployments (aether identity = ServiceAccount). The managed-namespace label
+// is enough to mesh the echo pods and capture their real Service ports — redirect-all
+// is the chart default (agent.captureRedirectAllDefault), so namespace injection
+// labels the pods managed and they get redirect-all with no per-pod annotation.
+// Vanilla upstream manifests would not exercise aether's mesh path.
 //
 // It deliberately contains ONLY mesh/manifests.yaml — the base mesh apply the
 // suite does once in Setup. The per-test manifests (tests/mesh/*.yaml, applied by
@@ -77,7 +81,7 @@ var meshManifests embed.FS
 
 // overlayFS composes the aether mesh overlay over the upstream gateway-api manifest
 // embed: a read for overridePath ("mesh/manifests.yaml") is served from the aether
-// overlay (its managed-namespace label / per-version SAs / redirect-all annotation),
+// overlay (its managed-namespace label / per-version SAs),
 // and every OTHER path (the per-test tests/mesh/*.yaml the conformance tests apply,
 // plus base/*) falls through to the upstream embed.
 //
@@ -322,9 +326,10 @@ var meshNamespaces = []string{
 }
 
 // TestAetherMeshHTTP runs the MESH-HTTP (east-west GAMMA) conformance profile
-// against the committed mesh overlay (the aether.io/managed namespace label,
-// per-version ServiceAccounts, and the capture.aether.io/redirect-all annotation —
-// see mesh/manifests.yaml). It exercises the mesh data path: the CNI captures the
+// against the committed mesh overlay (the aether.io/managed namespace label and
+// per-version ServiceAccounts; redirect-all is the chart default so the managed
+// label alone meshes the echo pods — see mesh/manifests.yaml). It exercises the
+// mesh data path: the CNI captures the
 // echo client's egress, the agent routes it via the cap_http GAMMA tables to the
 // per-version backends. With SPIRE off the mesh hop is CLEARTEXT (the inbound
 // listener degrades to a no-mTLS HCM chain, symmetric with the cleartext outbound

--- a/test/conformance/mesh/manifests.yaml
+++ b/test/conformance/mesh/manifests.yaml
@@ -21,8 +21,6 @@ spec:
       version: v1
   template:
     metadata:
-      annotations:
-        capture.aether.io/redirect-all: "true"
       labels:
         app: echo
         version: v1
@@ -81,8 +79,6 @@ spec:
       version: v2
   template:
     metadata:
-      annotations:
-        capture.aether.io/redirect-all: "true"
       labels:
         app: echo
         version: v2
@@ -174,8 +170,6 @@ spec:
       version: v1
   template:
     metadata:
-      annotations:
-        capture.aether.io/redirect-all: "true"
       labels:
         app: echo
         version: v1


### PR DESCRIPTION
## What

The redirect-all default-on flip (`agent.captureRedirectAllDefault`) is **soak-validated HITLESS** on talos (2026-06-29: external prober 100%, k6 0.012%, egress intact, stable RSS through 6 proxy + 14 service rolls). This:

1. **Flips the chart default** `captureRedirectAllDefault: false → true` — every install now gets "capture what the app sends" with zero per-pod config (set `false` to revert to per-pod opt-in). Chart `0.56.0 → 0.57.0`.
2. **Simplifies MESH conformance to exercise the real default** (M4's last item):
   - Drops the 3 `capture.aether.io/redirect-all="true"` pod annotations from the mesh overlay — the `aether.io/managed` namespace label + the default flip mesh the echo pods via namespace injection.
   - mesh-http job drops `--set agent.captureRedirectAll=true` (chart default covers it).
   - Comment/README sync (conformance_test.go, README.md, workflow).

## Validation

Conformance runs on `workflow_dispatch`/nightly (not PR), so I'm triggering the workflow on this branch — **both GATEWAY-HTTP (43/0) and MESH-HTTP (Core 8/8) must stay green** with the new default before merge. The MESH job now proves conformance passes with redirect-all as the *default* (not the per-pod opt-in it used before). GATEWAY-HTTP confirms the default doesn't disturb the edge path.

## Backlog

Completes M4 (demand-scoping was already in place + locked in #439; this is the conformance-with-default + the chart-default flip). Remaining 022 follow-ups: IPv6/UDP capture gaps, `echo` test-fixture preStop drain, #425 escape-hatch review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)