### PR TITLE
feat(api): HTTPFilter CRD (025 M1)

### DIFF
--- a/api/aether/config/v1/BUILD.bazel
+++ b/api/aether/config/v1/BUILD.bazel
@@ -12,11 +12,15 @@ load("//bazel/lint:linters.bzl", "buf_test")
 proto_library(
     name = "configv1_proto",
     srcs = [
+        "http_filter.proto",
         "mesh_config.proto",
         "secret.proto",
     ],
     visibility = ["//visibility:public"],
-    deps = ["@protovalidate//proto/protovalidate/buf/validate:validate_proto"],
+    deps = [
+        "@protobuf//:any_proto",
+        "@protovalidate//proto/protovalidate/buf/validate:validate_proto",
+    ],
 )
 
 go_proto_library(

--- a/api/aether/config/v1/http_filter.proto
+++ b/api/aether/config/v1/http_filter.proto
@@ -1,0 +1,41 @@
+edition = "2024";
+
+package aether.config.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/any.proto";
+
+option features.field_presence = IMPLICIT;
+option go_package = "github.com/bpalermo/aether/api/aether/config/v1;configv1";
+
+// HTTPFilterSpec is the `.spec` of the HTTPFilter custom resource — the
+// proxy-extension escape hatch (proposal 025). An HTTPRoute/GRPCRoute rule references
+// it through a standard Gateway API `ExtensionRef` filter; aether attaches the named
+// Envoy HTTP filter to the route's typed_per_filter_config (and adds it to the HCM
+// chain default-disabled). The body is opaque Envoy config, validated fail-closed by
+// the aether-controller admission webhook (in-process proto-validate: @type resolve +
+// protoc-gen-validate), NOT by the CRD's OpenAPI schema. See docs/proposals/025.
+message HTTPFilterSpec {
+  // filter is the Envoy HTTP filter name (e.g. "envoy.filters.http.header_to_metadata").
+  // It MUST be in aether's allow-list of filters the proxy build compiles in; the
+  // webhook rejects others.
+  string filter = 1 [(buf.validate.field).string.min_len = 1];
+
+  // typed_config is the opaque Envoy filter config (the filter's `typed_config` Any).
+  // Carried verbatim into the route's typed_per_filter_config. The `@type` must
+  // resolve to a known Envoy message and pass its protoc-gen-validate constraints —
+  // enforced by the webhook, not here.
+  google.protobuf.Any typed_config = 2;
+
+  // scope selects where the filter applies. ROUTE (default, incl. UNSPECIFIED) emits
+  // the config into the referencing route's typed_per_filter_config — the v1 escape
+  // hatch. CHAIN (arbitrary HCM http_filters placement) is admin-owned and deferred
+  // to a later milestone; the webhook rejects it until then.
+  Scope scope = 3 [(buf.validate.field).enum.defined_only = true];
+
+  enum Scope {
+    SCOPE_UNSPECIFIED = 0;
+    SCOPE_ROUTE = 1;
+    SCOPE_CHAIN = 2;
+  }
+}

--- a/charts/crds/Chart.yaml
+++ b/charts/crds/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   channel); the VirtualHost CRD was retired (proposal 018).
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.5.0-{GIT_COMMIT}"
+version: "0.6.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/crds/templates/httpfilter.yaml
+++ b/charts/crds/templates/httpfilter.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: httpfilters.config.aether.io
+  annotations:
+    # Keep the CRD (and the CRs it owns) if this chart is uninstalled.
+    helm.sh/resource-policy: keep
+spec:
+  group: config.aether.io
+  # Namespaced: an HTTPFilter lives beside the HTTPRoute/Service that references it.
+  scope: Namespaced
+  names:
+    kind: HTTPFilter
+    listKind: HTTPFilterList
+    plural: httpfilters
+    singular: httpfilter
+    shortNames:
+      - htf
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            HTTPFilter is the proxy-extension escape hatch (aether.config.v1.HTTPFilter,
+            proposal 025): a named Envoy HTTP filter, configured opaquely, that an
+            HTTPRoute/GRPCRoute rule references via a Gateway API ExtensionRef. The spec
+            is intentionally a permissive structural object: the authoritative
+            validation is the aether-controller webhook (in-process proto-validate of
+            spec.typedConfig — @type resolution + protoc-gen-validate — plus the
+            filter allow-list), which OpenAPI cannot express. spec.typedConfig is an
+            opaque Envoy Any and is preserved unknown.
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Filter
+          type: string
+          jsonPath: .spec.filter
+        - name: Accepted
+          type: string
+          jsonPath: .status.conditions[?(@.type=="Accepted")].status
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/common/apis/config/v1/BUILD.bazel
+++ b/common/apis/config/v1/BUILD.bazel
@@ -1,8 +1,11 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "config",
     srcs = [
+        "httpfilter_deepcopy.go",
+        "httpfilter_jsonshim.go",
+        "httpfilter_types.go",
         "meshconfig_deepcopy.go",
         "meshconfig_jsonshim.go",
         "meshconfig_types.go",
@@ -16,5 +19,18 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/schema",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
+    ],
+)
+
+go_test(
+    name = "config_test",
+    srcs = ["httpfilter_test.go"],
+    embed = [":config"],
+    deps = [
+        "//api/aether/config/v1:config",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//types/known/anypb",
     ],
 )

--- a/common/apis/config/v1/httpfilter_deepcopy.go
+++ b/common/apis/config/v1/httpfilter_deepcopy.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DeepCopyInto copies the receiver into out. The proto spec is cloned via proto.Clone
+// (never shallow-copied — proto messages, and the opaque typedConfig Any, hold
+// internal state).
+func (in *HTTPFilter) DeepCopyInto(out *HTTPFilter) {
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Spec != nil {
+		out.Spec = proto.Clone(in.Spec).(*configv1.HTTPFilterSpec)
+	} else {
+		out.Spec = nil
+	}
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+// DeepCopy returns a deep copy of the HTTPFilter.
+func (in *HTTPFilter) DeepCopy() *HTTPFilter {
+	if in == nil {
+		return nil
+	}
+	out := new(HTTPFilter)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyObject implements runtime.Object.
+func (in *HTTPFilter) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+// DeepCopyInto copies the status into out.
+func (in *HTTPFilterStatus) DeepCopyInto(out *HTTPFilterStatus) {
+	*out = *in
+	if in.Conditions != nil {
+		out.Conditions = make([]metav1.Condition, len(in.Conditions))
+		for i := range in.Conditions {
+			in.Conditions[i].DeepCopyInto(&out.Conditions[i])
+		}
+	}
+}
+
+// DeepCopyInto copies the list into out.
+func (in *HTTPFilterList) DeepCopyInto(out *HTTPFilterList) {
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]HTTPFilter, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+// DeepCopy returns a deep copy of the HTTPFilterList.
+func (in *HTTPFilterList) DeepCopy() *HTTPFilterList {
+	if in == nil {
+		return nil
+	}
+	out := new(HTTPFilterList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyObject implements runtime.Object.
+func (in *HTTPFilterList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}

--- a/common/apis/config/v1/httpfilter_jsonshim.go
+++ b/common/apis/config/v1/httpfilter_jsonshim.go
@@ -1,0 +1,63 @@
+package v1
+
+import (
+	"encoding/json"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// httpFilterShim is the wire shape of an HTTPFilter: standard Kubernetes
+// TypeMeta/ObjectMeta/Status with the spec held as raw JSON so it is (un)marshalled
+// through protojson (which honours proto JSON names, the google.protobuf.Any
+// `@type` envelope of spec.typedConfig, and well-known types) rather than
+// encoding/json.
+type httpFilterShim struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              json.RawMessage  `json:"spec,omitempty"`
+	Status            HTTPFilterStatus `json:"status,omitempty"`
+}
+
+// MarshalJSON serializes the HTTPFilter, encoding `.spec` with protojson.
+func (in *HTTPFilter) MarshalJSON() ([]byte, error) {
+	shim := httpFilterShim{
+		TypeMeta:   in.TypeMeta,
+		ObjectMeta: in.ObjectMeta,
+		Status:     in.Status,
+	}
+	if in.Spec != nil {
+		raw, err := protojson.Marshal(in.Spec)
+		if err != nil {
+			return nil, err
+		}
+		shim.Spec = raw
+	}
+	return json.Marshal(shim)
+}
+
+// UnmarshalJSON parses an HTTPFilter, decoding `.spec` with protojson.
+//
+// Decoding is LENIENT (DiscardUnknown) for forward-compatibility across rolling
+// upgrades — same contract as MeshConfig. The opaque spec.typedConfig Any decodes by
+// its `@type`; an unknown/garbage `@type` surfaces here (and is rejected cleanly by
+// the admission webhook). Semantic validation of the payload is proto-validate's job.
+func (in *HTTPFilter) UnmarshalJSON(data []byte) error {
+	var shim httpFilterShim
+	if err := json.Unmarshal(data, &shim); err != nil {
+		return err
+	}
+	in.TypeMeta = shim.TypeMeta
+	in.ObjectMeta = shim.ObjectMeta
+	in.Status = shim.Status
+	in.Spec = nil
+	if len(shim.Spec) > 0 && string(shim.Spec) != "null" {
+		spec := &configv1.HTTPFilterSpec{}
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(shim.Spec, spec); err != nil {
+			return err
+		}
+		in.Spec = spec
+	}
+	return nil
+}

--- a/common/apis/config/v1/httpfilter_test.go
+++ b/common/apis/config/v1/httpfilter_test.go
@@ -1,0 +1,66 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	header_to_metadatav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// TestHTTPFilter_JSONRoundtrip verifies the jsonshim (un)marshals an HTTPFilter
+// through protojson, preserving the opaque spec.typedConfig Any by its @type — the
+// reconciler depends on getting a usable *anypb.Any back out.
+func TestHTTPFilter_JSONRoundtrip(t *testing.T) {
+	cfg, err := anypb.New(&header_to_metadatav3.Config{
+		RequestRules: []*header_to_metadatav3.Config_Rule{{
+			Header:          "x-tenant",
+			OnHeaderPresent: &header_to_metadatav3.Config_KeyValuePair{MetadataNamespace: "aether", Key: "tenant"},
+		}},
+	})
+	require.NoError(t, err)
+
+	in := &HTTPFilter{
+		Spec: configv1.HTTPFilterSpec_builder{
+			Filter:      "envoy.filters.http.header_to_metadata",
+			TypedConfig: cfg,
+			Scope:       configv1.HTTPFilterSpec_SCOPE_ROUTE,
+		}.Build(),
+	}
+	in.Name = "h2m"
+	in.Namespace = "team-a"
+
+	data, err := json.Marshal(in)
+	require.NoError(t, err)
+	// The opaque Any is serialized with its @type envelope.
+	assert.Contains(t, string(data), "header_to_metadata.v3.Config")
+
+	var out HTTPFilter
+	require.NoError(t, json.Unmarshal(data, &out))
+	assert.Equal(t, "h2m", out.Name)
+	require.NotNil(t, out.Spec)
+	assert.Equal(t, "envoy.filters.http.header_to_metadata", out.Spec.GetFilter())
+	assert.Equal(t, configv1.HTTPFilterSpec_SCOPE_ROUTE, out.Spec.GetScope())
+
+	// The typedConfig Any survives the roundtrip and unmarshals back to its message.
+	require.NotNil(t, out.Spec.GetTypedConfig())
+	got := &header_to_metadatav3.Config{}
+	require.NoError(t, out.Spec.GetTypedConfig().UnmarshalTo(got))
+	require.Len(t, got.GetRequestRules(), 1)
+	assert.Equal(t, "x-tenant", got.GetRequestRules()[0].GetHeader())
+}
+
+// TestHTTPFilter_DeepCopy verifies DeepCopy clones the proto spec (incl. the opaque
+// Any) rather than sharing it.
+func TestHTTPFilter_DeepCopy(t *testing.T) {
+	cfg, err := anypb.New(&header_to_metadatav3.Config{})
+	require.NoError(t, err)
+	in := &HTTPFilter{Spec: configv1.HTTPFilterSpec_builder{Filter: "f", TypedConfig: cfg}.Build()}
+	out := in.DeepCopy()
+	require.NotNil(t, out.Spec)
+	assert.NotSame(t, in.Spec, out.Spec, "spec is cloned, not shared")
+	assert.Equal(t, "f", out.Spec.GetFilter())
+}

--- a/common/apis/config/v1/httpfilter_types.go
+++ b/common/apis/config/v1/httpfilter_types.go
@@ -1,0 +1,38 @@
+package v1
+
+import (
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// HTTPFilterKind is the CRD kind.
+const HTTPFilterKind = "HTTPFilter"
+
+// HTTPFilter is a namespaced custom resource carrying a proxy-extension escape-hatch
+// filter (proposal 025): a named Envoy HTTP filter, configured opaquely, that an
+// HTTPRoute/GRPCRoute rule references via a Gateway API `ExtensionRef`. Its `.spec`
+// is the protobuf HTTPFilterSpec (opaque `typedConfig` Any). The aether-controller
+// validates the body fail-closed (in-process proto-validate) before admission.
+type HTTPFilter struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec is the protobuf HTTPFilterSpec, serialized via protojson (see the jsonshim).
+	Spec *configv1.HTTPFilterSpec `json:"spec,omitempty"`
+
+	Status HTTPFilterStatus `json:"status,omitempty"`
+}
+
+// HTTPFilterStatus reports the last admission/validation result.
+type HTTPFilterStatus struct {
+	// Conditions follows metav1.Condition; the controller sets an "Accepted" condition
+	// (false with a reason when proto-validate or the allow-list rejects the filter).
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// HTTPFilterList is the list type for HTTPFilter.
+type HTTPFilterList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []HTTPFilter `json:"items"`
+}

--- a/common/apis/config/v1/meshconfig_types.go
+++ b/common/apis/config/v1/meshconfig_types.go
@@ -29,6 +29,7 @@ func AddToScheme(s *runtime.Scheme) error {
 
 func addKnownTypes(s *runtime.Scheme) error {
 	s.AddKnownTypes(GroupVersion, &MeshConfig{}, &MeshConfigList{})
+	s.AddKnownTypes(GroupVersion, &HTTPFilter{}, &HTTPFilterList{})
 	metav1.AddToGroupVersion(s, GroupVersion)
 	return nil
 }


### PR DESCRIPTION
Second **M1** slice: the `config.aether.io/v1` **HTTPFilter** CRD — the escape hatch's typed CRD with an opaque Envoy `typedConfig`, mirroring MeshConfig's proto-spec pattern.

- Proto `HTTPFilterSpec{ filter, typed_config (google.protobuf.Any), scope }` (edition 2024 opaque API).
- `common/apis/config/v1`: hand-written HTTPFilter types + protojson jsonshim (opaque Any survives roundtrip by `@type`, lenient decode) + DeepCopy; registered in the config.aether.io scheme.
- `charts/crds/templates/httpfilter.yaml`: namespaced CRD, permissive structural spec (webhook is the real validation). crds chart `0.5.0 → 0.6.0`.
- Roundtrip + deepcopy tests; `bazel build //...`, config + crds tests, format-check green.

Inert until the GAMMA reconciler resolves `ExtensionRef`s to it (next M1 slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)