### PR TITLE
feat(registry): ConfigExporter interface + etcd config channel (026 EM1b)

### DIFF
--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -14,6 +14,7 @@ package etcd
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -450,6 +451,79 @@ func (r *EtcdRegistry) ListExports(ctx context.Context) ([]export.ServiceExport,
 
 	r.log.DebugContext(ctx, "listed service exports", "count", len(exports))
 	return exports, nil
+}
+
+// configMarker delimits the config-projection segment within a key, after the origin
+// (region/cluster) prefix: <ownPrefix>/config/<service> = marshaled
+// ServiceConfigProjection. The service ("<ns>/<svc>" route-target key) is base64url-
+// encoded so its embedded "/" does not split the etcd key path.
+const configMarker = "/config/"
+
+// configKey builds the key for one of THIS instance's own config projections.
+func (r *EtcdRegistry) configKey(service string) string {
+	return r.ownPrefix + configMarker + base64.RawURLEncoding.EncodeToString([]byte(service))
+}
+
+// SetConfig records this cluster's projected GAMMA config for a service under its own
+// authoritative partition (proposal 026). origin_cluster is stamped to this instance's
+// cluster so the stored value matches the key path. Satisfies registry.ConfigExporter.
+func (r *EtcdRegistry) SetConfig(ctx context.Context, projection *registryv1.ServiceConfigProjection) error {
+	if projection == nil || projection.GetService() == "" {
+		return fmt.Errorf("config projection requires a service")
+	}
+	projection.OriginCluster = r.config.Cluster
+	data, err := proto.Marshal(projection)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config projection for %s: %w", projection.GetService(), err)
+	}
+	key := r.configKey(projection.GetService())
+	if _, err := r.client.Put(ctx, key, string(data)); err != nil {
+		r.log.ErrorContext(ctx, "failed to set config projection", "error", err, "service", projection.GetService(), "key", key)
+		return fmt.Errorf("failed to set config for service %s: %w", projection.GetService(), err)
+	}
+	r.log.InfoContext(ctx, "config projection set", "service", projection.GetService(), "version", projection.GetVersion())
+	return nil
+}
+
+// UnsetConfig removes the local cluster's config projection for the named service.
+// Idempotent. Satisfies registry.ConfigExporter.
+func (r *EtcdRegistry) UnsetConfig(ctx context.Context, service string) error {
+	key := r.configKey(service)
+	if _, err := r.client.Delete(ctx, key); err != nil {
+		r.log.ErrorContext(ctx, "failed to unset config projection", "error", err, "service", service, "key", key)
+		return fmt.Errorf("failed to unset config for service %s: %w", service, err)
+	}
+	r.log.InfoContext(ctx, "config projection unset", "service", service)
+	return nil
+}
+
+// ListConfig returns every config projection across all origins (clusterset-wide). It
+// ranges the whole root and unmarshals each /config/ value, setting origin_cluster
+// authoritatively from the key path (defending against a forged origin in the value).
+// Satisfies registry.ConfigExporter.
+func (r *EtcdRegistry) ListConfig(ctx context.Context) ([]*registryv1.ServiceConfigProjection, error) {
+	resp, err := r.client.Get(ctx, r.keyPrefix, clientv3.WithPrefix())
+	if err != nil {
+		r.log.ErrorContext(ctx, "failed to list config projections", "error", err)
+		return nil, fmt.Errorf("failed to list config projections: %w", err)
+	}
+	projections := make([]*registryv1.ServiceConfigProjection, 0)
+	for _, kv := range resp.Kvs {
+		key := string(kv.Key)
+		if !strings.Contains(key, configMarker) {
+			continue
+		}
+		p := &registryv1.ServiceConfigProjection{}
+		if err := proto.Unmarshal(kv.Value, p); err != nil {
+			r.log.WarnContext(ctx, "skipping unparseable config projection", "key", key, "error", err)
+			continue
+		}
+		// The key path is the authority for the origin, not the stored value.
+		p.OriginCluster = extractCluster(key)
+		projections = append(projections, p)
+	}
+	r.log.DebugContext(ctx, "listed config projections", "count", len(projections))
+	return projections, nil
 }
 
 // extractCluster pulls the origin cluster name from a full key path. Keys are

--- a/registry/internal/etcd/etcd_test.go
+++ b/registry/internal/etcd/etcd_test.go
@@ -555,3 +555,39 @@ func TestEtcdRegistry_ServiceExportsCrossOrigin(t *testing.T) {
 	assert.Contains(t, remaining, "cluster-b/svc")
 	assert.Contains(t, remaining, "cluster-b/other")
 }
+
+// TestEtcdRegistry_ConfigProjection_RoundTrip verifies SetConfig/ListConfig/UnsetConfig
+// (proposal 026 EM1b): a projected GAMMA config round-trips through the registry,
+// origin_cluster is stamped from the writing instance, and ListConfig ranges all origins.
+func TestEtcdRegistry_ConfigProjection_RoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	ctx := context.Background()
+	registry := setupRegistry(ctx, t)
+
+	proj := &registryv1.ServiceConfigProjection{
+		Service: "team-a/echo",
+		Version: "v7",
+		Routes: []*registryv1.GammaRoute{{
+			Matches:  []*registryv1.GammaMatch{{Prefix: "/v2"}},
+			Backends: []*registryv1.GammaBackend{{Service: "team-a/echo-v2", Cluster: "echo-v2.team-a.aether.internal", Weight: 1}},
+		}},
+	}
+	require.NoError(t, registry.SetConfig(ctx, proj))
+
+	got, err := registry.ListConfig(ctx)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "team-a/echo", got[0].GetService())
+	assert.Equal(t, "v7", got[0].GetVersion())
+	assert.NotEmpty(t, got[0].GetOriginCluster(), "origin stamped from the key path")
+	require.Len(t, got[0].GetRoutes(), 1)
+	assert.Equal(t, "/v2", got[0].GetRoutes()[0].GetMatches()[0].GetPrefix())
+	assert.Equal(t, "echo-v2.team-a.aether.internal", got[0].GetRoutes()[0].GetBackends()[0].GetCluster())
+
+	require.NoError(t, registry.UnsetConfig(ctx, "team-a/echo"))
+	after, err := registry.ListConfig(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, after)
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -123,3 +123,26 @@ type ServiceExporter interface {
 type AuthoritativeLister interface {
 	ListAllEndpointsAuthoritative(ctx context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error)
 }
+
+// ConfigExporter is an optional capability for cross-cluster Registry backends:
+// multi-cluster CONFIG propagation (proposal 026, Option E/C). It rides the same
+// origin-partitioned plane as ServiceExporter — the authoritative (exporting) cluster
+// writes a service's projected GAMMA config under THIS instance's own partition
+// (writes), while ListConfig ranges every origin (reads), so each cluster sees the
+// clusterset-wide config view and can materialize imported routes read-only. Backends
+// without a cross-cluster plane (kubernetes, dynamodb) do not implement it; the
+// config export/import controllers no-op when it is absent.
+type ConfigExporter interface {
+	// SetConfig records this cluster's projected config for a service under its own
+	// authoritative partition. Idempotent (last-writer per origin); the stored
+	// projection's origin_cluster is stamped to this instance's cluster.
+	SetConfig(ctx context.Context, projection *registryv1.ServiceConfigProjection) error
+	// UnsetConfig removes this cluster's projection for the named service ("<ns>/<svc>"
+	// route-target key). Idempotent.
+	UnsetConfig(ctx context.Context, service string) error
+	// ListConfig returns every projection across all origins (the clusterset-wide
+	// config view). Each projection's origin_cluster is set authoritatively from its
+	// key path (not the stored value), so a forged origin cannot impersonate a peer.
+	// The same service may appear once per exporting cluster.
+	ListConfig(ctx context.Context) ([]*registryv1.ServiceConfigProjection, error)
+}


### PR DESCRIPTION
The cross-cluster config channel for proposal 026 (Option E/C), riding the same origin-partitioned etcd plane as MCS `ServiceExporter` — **no new bus**.

- **`registry.ConfigExporter`**: `SetConfig`/`UnsetConfig` (write under THIS cluster's own partition) + `ListConfig` (range every origin = clusterset-wide view). Optional capability — etcd implements it; kubernetes/dynamodb don't.
- **etcd backend**: keys `<ownPrefix>/config/<base64url(<ns>/<svc>)>` = marshaled `ServiceConfigProjection`. `SetConfig` stamps `origin_cluster` from the instance; `ListConfig` sets it **authoritatively from the key path** (a forged origin in the value can't impersonate a peer — the EM3 authority floor, cheap now). The existing prefix Watch already signals config-key changes (shared CDC; consumer reacts via `Changes()`).
- Integration roundtrip test (testcontainers; skipped in `-test.short`, runs in CI).

Next: **EM2** (consumer materializer reads `ListConfig` + `Changes()`) and **EM1c** (hub export wiring calls `SetConfig` from the GAMMA reconciler). `bazel build //...` + registry unit tests + format-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)