### PR TITLE
feat(registrar): ListAllConfig RPC — surface imported config to agents (026)

### DIFF
--- a/api/aether/registrar/v1/registrar.proto
+++ b/api/aether/registrar/v1/registrar.proto
@@ -2,6 +2,7 @@ edition = "2023";
 
 package aether.registrar.v1;
 
+import "api/aether/registry/v1/config.proto";
 import "api/aether/registry/v1/endpoint.proto";
 import "api/aether/registry/v1/service.proto";
 
@@ -22,6 +23,13 @@ service RegistrarService {
 
   // ListAllEndpoints returns all endpoints from the registrar's snapshot.
   rpc ListAllEndpoints(ListAllEndpointsRequest) returns (ListAllEndpointsResponse);
+
+  // ListAllConfig returns the clusterset-wide config projections (multi-cluster
+  // config propagation, proposal 026 Option E/C). Agents do NOT read the registry
+  // directly; the spoke registrar surfaces imported projections through this pull.
+  // A push stream (WatchConfig) is a later optimization; the pull is correct and
+  // eventually-consistent (AP), matching the import posture.
+  rpc ListAllConfig(ListAllConfigRequest) returns (ListAllConfigResponse);
 }
 
 message RegisterEndpointRequest {
@@ -101,4 +109,12 @@ message ListAllEndpointsResponse {
 
 message ServiceEndpoints {
   repeated aether.registry.v1.ServiceEndpoint endpoints = 1;
+}
+
+message ListAllConfigRequest {}
+
+message ListAllConfigResponse {
+  // projections is the clusterset-wide set of service config projections, one per
+  // (service, origin cluster). origin_cluster is set authoritatively by the registry.
+  repeated aether.registry.v1.ServiceConfigProjection projections = 1;
 }

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -298,3 +298,23 @@ func (s *RegistrarServer) ListAllEndpoints(ctx context.Context, req *registrarv1
 		Version:  version,
 	}, nil
 }
+
+// ListAllConfig returns the clusterset-wide config projections (proposal 026,
+// multi-cluster config propagation). Agents pull this from the spoke registrar rather
+// than reading the registry directly (the standing directive: agents don't talk to the
+// store). When the backend has no cross-cluster config plane (kubernetes/dynamodb), the
+// registry does not implement ConfigExporter and this returns an empty set — config
+// stays cluster-local, which is the correct degenerate behaviour.
+func (s *RegistrarServer) ListAllConfig(ctx context.Context, _ *registrarv1.ListAllConfigRequest) (*registrarv1.ListAllConfigResponse, error) {
+	exporter, ok := s.registry.(registry.ConfigExporter)
+	if !ok {
+		return &registrarv1.ListAllConfigResponse{}, nil
+	}
+	projections, err := exporter.ListConfig(ctx)
+	if err != nil {
+		s.log.ErrorContext(ctx, "ListAllConfig failed", "error", err)
+		return nil, status.Error(codes.Internal, "failed to list config projections")
+	}
+	s.log.DebugContext(ctx, "ListAllConfig", "count", len(projections))
+	return &registrarv1.ListAllConfigResponse{Projections: projections}, nil
+}

--- a/registrar/internal/server/server_test.go
+++ b/registrar/internal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 
 	registrarv1 "github.com/bpalermo/aether/api/aether/registrar/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/bpalermo/aether/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -203,4 +204,47 @@ func TestWatchEndpointsFilteredSnapshot(t *testing.T) {
 	// No filter: full snapshot (both services) + catalog + marker.
 	sent = run(&registrarv1.WatchEndpointsRequest{})
 	require.Len(t, sent, 5)
+}
+
+// fakeConfigRegistry embeds the (nil) registry.Registry interface to satisfy the type
+// and implements registry.ConfigExporter; only ListConfig is exercised here.
+type fakeConfigRegistry struct {
+	registry.Registry
+	projections []*registryv1.ServiceConfigProjection
+}
+
+func (f *fakeConfigRegistry) SetConfig(context.Context, *registryv1.ServiceConfigProjection) error {
+	return nil
+}
+func (f *fakeConfigRegistry) UnsetConfig(context.Context, string) error { return nil }
+func (f *fakeConfigRegistry) ListConfig(context.Context) ([]*registryv1.ServiceConfigProjection, error) {
+	return f.projections, nil
+}
+
+// TestListAllConfig verifies the registrar surfaces config projections from a
+// ConfigExporter backend (proposal 026) and degrades to empty when the backend has no
+// cross-cluster config plane.
+func TestListAllConfig(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no config plane -> empty", func(t *testing.T) {
+		snap := NewSnapshot()
+		s := NewRegistrarServer(nil, snap, NewBroadcaster(slog.New(slog.DiscardHandler), nil), "127.0.0.1:0", slog.New(slog.DiscardHandler), nil)
+		resp, err := s.ListAllConfig(ctx, &registrarv1.ListAllConfigRequest{})
+		require.NoError(t, err)
+		assert.Empty(t, resp.GetProjections())
+	})
+
+	t.Run("ConfigExporter backend -> projections", func(t *testing.T) {
+		reg := &fakeConfigRegistry{projections: []*registryv1.ServiceConfigProjection{
+			{Service: "team-a/echo", OriginCluster: "cluster-a", Version: "v3"},
+		}}
+		snap := NewSnapshot()
+		s := NewRegistrarServer(reg, snap, NewBroadcaster(slog.New(slog.DiscardHandler), nil), "127.0.0.1:0", slog.New(slog.DiscardHandler), nil)
+		resp, err := s.ListAllConfig(ctx, &registrarv1.ListAllConfigRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.GetProjections(), 1)
+		assert.Equal(t, "team-a/echo", resp.GetProjections()[0].GetService())
+		assert.Equal(t, "cluster-a", resp.GetProjections()[0].GetOriginCluster())
+	})
 }


### PR DESCRIPTION
The registrar's config-import surface (proposal 026 registrar streaming). Agents do **not** read the registry directly (standing directive) — the spoke registrar pulls the clusterset-wide config projections and serves them.

- `registrar.proto`: `ListAllConfig` RPC returning `{projections[]}` (imports registry/v1 `config.proto`). A push stream (`WatchConfig`) is a later optimization; the pull is correct + eventually-consistent (AP), matching the import posture.
- `RegistrarServer.ListAllConfig`: type-asserts `registry.ConfigExporter` → `ListConfig()`; returns empty when the backend has no cross-cluster config plane (kubernetes/dynamodb) — config stays cluster-local (correct degenerate behaviour).
- Test: empty (no config plane) + projections (ConfigExporter backend).

Next: **agent consumer** (poll `ListAllConfig` → `proxy.FromConfigProjection` → merge into `SetServiceRoutes`, demand-scoped) + **hub export** (`SetConfig`). `bazel build //...` + registrar tests + format-check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)