### PR TITLE
feat(agent): cross-cluster config import consumer (026 EM2)

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//agent/constants",
         "//agent/internal/capture",
         "//agent/internal/cni/server",
+        "//agent/internal/configimport",
         "//agent/internal/edge/gatewayapi",
         "//agent/internal/edge/secret",
         "//agent/internal/gamma",

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -88,6 +88,12 @@ type AgentConfig struct {
 	// 018, Phase 2). Default off — a no-op until enabled.
 	Gamma bool
 
+	// ImportConfig enables cross-cluster config import (proposal 026): the agent polls
+	// the registrar for GAMMA config projections peer clusters exported and materializes
+	// the imported routes into the cache (merged with local; local wins). Default off;
+	// no-op when the registry backend has no cross-cluster config plane (etcd only).
+	ImportConfig bool
+
 	// L4Routes enables L4 route types (TCPRoute/TLSRoute/UDPRoute parentRef=Service,
 	// proposal 018, Phase 3b): the agent watches these route types and projects
 	// weighted TCP floor chains and SNI-routed TLS chains onto the capture listener.

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bpalermo/aether/agent/constants"
 	"github.com/bpalermo/aether/agent/internal/capture"
 	cniServer "github.com/bpalermo/aether/agent/internal/cni/server"
+	"github.com/bpalermo/aether/agent/internal/configimport"
 	"github.com/bpalermo/aether/agent/internal/gamma"
 	"github.com/bpalermo/aether/agent/internal/l4route"
 	"github.com/bpalermo/aether/agent/internal/meshdns"
@@ -120,6 +121,7 @@ func init() {
 	// startup taint from this node once the CNI server is serving.
 	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
 	rootCmd.Flags().BoolVar(&cfg.Gamma, "gamma", false, "Enable GAMMA east-west L7 routing: watch HTTPRoutes parented to a Service and enrich the node proxy's outbound routes (proposal 018, Phase 2)")
+	rootCmd.Flags().BoolVar(&cfg.ImportConfig, "import-config", false, "Enable cross-cluster config import: poll the registrar for GAMMA config projections peer clusters exported and materialize them into the node proxy's routes (proposal 026). No-op unless the registry backend has a cross-cluster config plane (etcd)")
 	rootCmd.Flags().BoolVar(&cfg.L4Routes, "l4-routes", false, "Enable L4 route types (TCPRoute/TLSRoute/UDPRoute) parented to a Service: weighted TCP floor chains and SNI-routed TLS chains on the capture listener (proposal 018, Phase 3b). NOTE: UDPRoute is control-plane only until the CNI UDP redirect lands.")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCapture, "transparent-capture", false, "Enable transparent capture: per-pod capture listeners + cap_http route table from the generated mesh Services (proposal 018, Phase 3a)")
 	rootCmd.Flags().BoolVar(&cfg.CaptureRedirectAll, "capture-redirect-all", false, "Add the dormant ORIGINAL_DST passthrough DefaultFilterChain to capture listeners (proposal 022 M2a spike). Harmless unless a pod is redirect-all'd via the capture.aether.io/redirect-all annotation; only then does non-mesh egress reach the passthrough.")
@@ -375,6 +377,22 @@ func runAgent(ctx context.Context) (retErr error) {
 		}
 		if err = gammaReconciler.SetupWithManager(m); err != nil {
 			return fmt.Errorf("failed to set up GAMMA reconciler: %w", err)
+		}
+	}
+
+	// Cross-cluster config import (proposal 026): poll the registrar for config
+	// projections peer clusters exported and materialize the imported GAMMA routes
+	// into the cache (merged with local routes; local wins). Default off
+	// (--import-config). No-op when the registry backend has no cross-cluster config
+	// plane (kubernetes/dynamodb don't implement registry.ConfigImporter).
+	if cfg.ImportConfig {
+		if imp, ok := reg.(registry.ConfigImporter); ok {
+			importer := configimport.NewImporter(imp, snapshotCache, cfg.ClusterName, 0, l)
+			if err = m.Add(importer); err != nil {
+				return fmt.Errorf("failed to add config importer: %w", err)
+			}
+		} else {
+			l.Warn("config import enabled but the registry backend has no cross-cluster config plane; skipping")
 		}
 	}
 

--- a/agent/internal/configimport/BUILD.bazel
+++ b/agent/internal/configimport/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "configimport",
+    srcs = ["importer.go"],
+    importpath = "github.com/bpalermo/aether/agent/internal/configimport",
+    visibility = ["//agent:__subpackages__"],
+    deps = [
+        "//agent/internal/xds/proxy",
+        "//api/aether/registry/v1:registry",
+        "//common/log",
+        "//registry",
+    ],
+)
+
+go_test(
+    name = "configimport_test",
+    srcs = ["importer_test.go"],
+    embed = [":configimport"],
+    deps = [
+        "//agent/internal/xds/proxy",
+        "//api/aether/registry/v1:registry",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/agent/internal/configimport/importer.go
+++ b/agent/internal/configimport/importer.go
@@ -1,0 +1,108 @@
+// Package configimport materializes cross-cluster GAMMA config on a spoke (proposal
+// 026, multi-cluster config propagation — the consumer side). It periodically pulls
+// the clusterset-wide config projections from the registrar (registry.ConfigImporter
+// — agents never read the store directly) and feeds the imported routes into the xDS
+// cache, where they merge with local routes (local wins). Eventually-consistent / AP:
+// a fetch failure keeps the last-known imported set in place.
+package configimport
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	commonlog "github.com/bpalermo/aether/common/log"
+	"github.com/bpalermo/aether/registry"
+)
+
+// Sink receives the materialized imported routes (the xDS SnapshotCache).
+type Sink interface {
+	SetImportedServiceRoutes(routes map[string][]proxy.GammaRoute)
+}
+
+// Importer polls the registrar for cross-cluster config projections and materializes
+// them into the cache. Implements controller-runtime's Runnable (Start).
+type Importer struct {
+	importer   registry.ConfigImporter
+	sink       Sink
+	ownCluster string
+	interval   time.Duration
+	log        *slog.Logger
+}
+
+// NewImporter builds the config-import poller. ownCluster is this cluster's name; the
+// importer SKIPS projections that originate here (a cluster's own export is redundant
+// with its local routes). interval defaults to 10s when non-positive.
+func NewImporter(imp registry.ConfigImporter, sink Sink, ownCluster string, interval time.Duration, log *slog.Logger) *Importer {
+	if interval <= 0 {
+		interval = 10 * time.Second
+	}
+	return &Importer{
+		importer:   imp,
+		sink:       sink,
+		ownCluster: ownCluster,
+		interval:   interval,
+		log:        commonlog.Named(log, "configimport"),
+	}
+}
+
+// Start runs the poll loop until ctx is cancelled (controller-runtime Runnable).
+func (i *Importer) Start(ctx context.Context) error {
+	i.log.InfoContext(ctx, "starting cross-cluster config import", "interval", i.interval, "own_cluster", i.ownCluster)
+	t := time.NewTicker(i.interval)
+	defer t.Stop()
+	i.poll(ctx) // initial pull so imported config is present before the first tick
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t.C:
+			i.poll(ctx)
+		}
+	}
+}
+
+// poll fetches the projections and materializes them. A failure is logged and the
+// last-known imported set is retained (AP).
+func (i *Importer) poll(ctx context.Context) {
+	projections, err := i.importer.ListConfig(ctx)
+	if err != nil {
+		i.log.WarnContext(ctx, "config import fetch failed; keeping last-known imported routes", "error", err)
+		return
+	}
+	i.sink.SetImportedServiceRoutes(i.materialize(projections))
+}
+
+// materialize converts peer-origin projections into a service→routes map, skipping
+// this cluster's own exports. On a same-service conflict across peers the
+// higher-version projection wins (deterministic, last-writer-by-version).
+func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection) map[string][]proxy.GammaRoute {
+	type chosen struct {
+		version string
+		routes  []proxy.GammaRoute
+	}
+	picked := make(map[string]chosen, len(projections))
+	for _, p := range projections {
+		if p.GetOriginCluster() == i.ownCluster {
+			continue // own export — local routes already cover it
+		}
+		svc := p.GetService()
+		if svc == "" {
+			continue
+		}
+		if cur, ok := picked[svc]; ok && cur.version >= p.GetVersion() {
+			continue
+		}
+		picked[svc] = chosen{version: p.GetVersion(), routes: proxy.FromConfigProjection(p)}
+	}
+	if len(picked) == 0 {
+		return nil
+	}
+	out := make(map[string][]proxy.GammaRoute, len(picked))
+	for svc, c := range picked {
+		out[svc] = c.routes
+	}
+	return out
+}

--- a/agent/internal/configimport/importer_test.go
+++ b/agent/internal/configimport/importer_test.go
@@ -1,0 +1,73 @@
+package configimport
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeImporter struct {
+	projections []*registryv1.ServiceConfigProjection
+	err         error
+}
+
+func (f *fakeImporter) ListConfig(context.Context) ([]*registryv1.ServiceConfigProjection, error) {
+	return f.projections, f.err
+}
+
+type fakeSink struct{ routes map[string][]proxy.GammaRoute }
+
+func (s *fakeSink) SetImportedServiceRoutes(r map[string][]proxy.GammaRoute) { s.routes = r }
+
+func newImporter(t *testing.T, imp *fakeImporter, sink *fakeSink, own string) *Importer {
+	t.Helper()
+	return NewImporter(imp, sink, own, 0, slog.New(slog.DiscardHandler))
+}
+
+func proj(svc, origin, version, prefix string) *registryv1.ServiceConfigProjection {
+	return &registryv1.ServiceConfigProjection{
+		Service: svc, OriginCluster: origin, Version: version,
+		Routes: []*registryv1.GammaRoute{{Matches: []*registryv1.GammaMatch{{Prefix: prefix}}}},
+	}
+}
+
+// TestImporter_Materialize_SkipsOwnAndPicksHighestVersion verifies the consumer skips
+// its own exports and, on a same-service peer conflict, keeps the highest version.
+func TestImporter_Materialize_SkipsOwnAndPicksHighestVersion(t *testing.T) {
+	imp := &fakeImporter{projections: []*registryv1.ServiceConfigProjection{
+		proj("team-a/echo", "self", "v9", "/own"),   // own cluster — skipped
+		proj("team-a/echo", "peer-a", "v1", "/old"), // peer, older
+		proj("team-a/echo", "peer-b", "v2", "/new"), // peer, newer → wins
+		proj("team-b/svc", "peer-a", "v1", "/svc"),
+	}}
+	sink := &fakeSink{}
+	newImporter(t, imp, sink, "self").poll(context.Background())
+
+	require.Len(t, sink.routes, 2)
+	require.Contains(t, sink.routes, "team-a/echo")
+	assert.Equal(t, "/new", sink.routes["team-a/echo"][0].Matches[0].Prefix, "highest version wins; own export skipped")
+	require.Contains(t, sink.routes, "team-b/svc")
+}
+
+// TestImporter_Poll_KeepsLastKnownOnError verifies a fetch error does not clobber the
+// cache (AP — last-known retained; the sink is simply not called).
+func TestImporter_Poll_KeepsLastKnownOnError(t *testing.T) {
+	sink := &fakeSink{routes: map[string][]proxy.GammaRoute{"x": nil}}
+	imp := &fakeImporter{err: assert.AnError}
+	newImporter(t, imp, sink, "self").poll(context.Background())
+	assert.Equal(t, map[string][]proxy.GammaRoute{"x": nil}, sink.routes, "error must not overwrite last-known imported routes")
+}
+
+// TestImporter_Materialize_Empty verifies an all-own / empty projection set yields nil
+// (no imported routes).
+func TestImporter_Materialize_Empty(t *testing.T) {
+	imp := &fakeImporter{projections: []*registryv1.ServiceConfigProjection{proj("a/b", "self", "v1", "/")}}
+	sink := &fakeSink{}
+	newImporter(t, imp, sink, "self").poll(context.Background())
+	assert.Nil(t, sink.routes)
+}

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -184,6 +184,11 @@ type SnapshotCache struct {
 	// dependency set so their EDS clusters generate; the per-service outbound vhost
 	// is enriched with the rules. Guarded by depMu (dependency state).
 	serviceRoutes map[string][]proxy.GammaRoute
+	// importedServiceRoutes holds GAMMA rules IMPORTED from peer clusters (proposal
+	// 026, multi-cluster config propagation), fetched from the registrar (ConfigImporter)
+	// and materialized read-only. Merged with serviceRoutes at read time; a LOCAL route
+	// for the same service wins. Guarded by depMu.
+	importedServiceRoutes map[string][]proxy.GammaRoute
 	// routeTargetPorts holds the real Service port(s) of each GAMMA route TARGET
 	// (proposal 023 M2), keyed by the same "<ns>/<svc>" route-target key as
 	// serviceRoutes. Sourced from the HTTPRoute/GRPCRoute parentRef port. captureVhosts

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -164,13 +164,16 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 	// pods of its own (the versioned-fanout shape: an "echo" target routed to
 	// echo-v1/echo-v2). Its backendRefs are unioned in by routeBackendsLocked below.
 	// GAMMA routes are explicit, cluster-wide config (few), so global scope is fine.
-	for svc := range c.serviceRoutes {
+	// Imported (peer-cluster) routes are in scope too (proposal 026): a route target
+	// whose config arrives cross-cluster still needs its cap_http vhost + backends.
+	eff := c.effectiveServiceRoutesLocked()
+	for svc := range eff {
 		set[svc] = struct{}{}
 	}
 	// GAMMA (proposal 018 Phase 2): a depended-on service's L7 rule backends must
 	// also be resolvable, so union them in (their EDS clusters then generate).
 	// L4 routes (proposal 018 Phase 3b): same principle for TCP/TLS/UDP backends.
-	hasL7 := len(c.serviceRoutes) > 0
+	hasL7 := len(eff) > 0
 	hasL4 := len(c.tcpServiceRoutes) > 0 || len(c.tlsServiceRoutes) > 0 || len(c.udpServiceRoutes) > 0
 	if hasL7 || hasL4 {
 		base := make([]string, 0, len(set))
@@ -179,7 +182,7 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 		}
 		for _, svc := range base {
 			if hasL7 {
-				c.routeBackendsLocked(svc, set)
+				routeBackendsFrom(eff, svc, set)
 			}
 			if hasL4 {
 				c.l4RouteBackendsLocked(svc, set)

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -18,13 +18,46 @@ func (c *SnapshotCache) SetServiceRoutes(routes map[string][]proxy.GammaRoute) {
 	}
 }
 
-// serviceRoutesSnapshot returns a shallow copy of the GAMMA rules for use during a
-// snapshot rebuild (read once, outside the cluster lock).
+// SetImportedServiceRoutes replaces the GAMMA rules IMPORTED from peer clusters
+// (proposal 026): config a remote cluster authored for a service, fetched from the
+// registrar (ConfigImporter) and materialized read-only. Merged with local routes at
+// read time — a LOCAL HTTPRoute for the same service wins (a cluster's own config is
+// authoritative for itself). Signals a scoped-snapshot rebuild on change.
+func (c *SnapshotCache) SetImportedServiceRoutes(routes map[string][]proxy.GammaRoute) {
+	c.depMu.Lock()
+	changed := !equalServiceRoutes(c.importedServiceRoutes, routes)
+	c.importedServiceRoutes = routes
+	c.depMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// effectiveServiceRoutesLocked returns the merged GAMMA rules: imported (peer-cluster)
+// routes overlaid by local routes (local wins on a per-service key collision). Caller
+// holds depMu. Returns the local map directly when nothing is imported (no allocation).
+func (c *SnapshotCache) effectiveServiceRoutesLocked() map[string][]proxy.GammaRoute {
+	if len(c.importedServiceRoutes) == 0 {
+		return c.serviceRoutes
+	}
+	out := make(map[string][]proxy.GammaRoute, len(c.serviceRoutes)+len(c.importedServiceRoutes))
+	for k, v := range c.importedServiceRoutes {
+		out[k] = v
+	}
+	for k, v := range c.serviceRoutes { // local overrides imported
+		out[k] = v
+	}
+	return out
+}
+
+// serviceRoutesSnapshot returns a shallow copy of the effective (local ∪ imported)
+// GAMMA rules for use during a snapshot rebuild (read once, outside the cluster lock).
 func (c *SnapshotCache) serviceRoutesSnapshot() map[string][]proxy.GammaRoute {
 	c.depMu.RLock()
 	defer c.depMu.RUnlock()
-	out := make(map[string][]proxy.GammaRoute, len(c.serviceRoutes))
-	for k, v := range c.serviceRoutes {
+	eff := c.effectiveServiceRoutesLocked()
+	out := make(map[string][]proxy.GammaRoute, len(eff))
+	for k, v := range eff {
 		out[k] = v
 	}
 	return out
@@ -79,10 +112,11 @@ func equalRouteTargetPorts(a, b map[string][]uint32) bool {
 	return true
 }
 
-// routeBackendsLocked appends the bare backend services of a service's GAMMA rules
-// to set. Caller holds depMu (it reads c.serviceRoutes).
-func (c *SnapshotCache) routeBackendsLocked(service string, set map[string]struct{}) {
-	for _, r := range c.serviceRoutes[service] {
+// routeBackendsFrom appends the bare backend services of a service's GAMMA rules
+// (from the given effective route map) to set. Used by dependencySetLocked over the
+// merged local ∪ imported routes (caller holds depMu).
+func routeBackendsFrom(routes map[string][]proxy.GammaRoute, service string, set map[string]struct{}) {
+	for _, r := range routes[service] {
 		for _, b := range r.Backends {
 			if b.Service != "" {
 				set[b.Service] = struct{}{}

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -372,6 +372,19 @@ func (r *RegistrarRegistry) ListAllEndpointsAuthoritative(ctx context.Context, p
 	return r.listAllEndpointsFromServer(ctx, protocol)
 }
 
+// ListConfig fetches the clusterset-wide config projections via the registrar's
+// ListAllConfig RPC (proposal 026). It satisfies registry.ConfigImporter: the agent
+// imports cross-cluster GAMMA config through the registrar, never reading the store
+// directly. An empty result (e.g. a backend with no cross-cluster config plane) is
+// not an error.
+func (r *RegistrarRegistry) ListConfig(ctx context.Context) ([]*registryv1.ServiceConfigProjection, error) {
+	resp, err := r.client.ListAllConfig(ctx, &registrarv1.ListAllConfigRequest{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list config projections from registrar: %w", err)
+	}
+	return resp.GetProjections(), nil
+}
+
 func (r *RegistrarRegistry) listEndpointsFromServer(ctx context.Context, service string, protocol registryv1.Service_Protocol) ([]*registryv1.ServiceEndpoint, error) {
 	resp, err := r.client.ListAllEndpoints(ctx, &registrarv1.ListAllEndpointsRequest{
 		Protocol: protocol,

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -146,3 +146,11 @@ type ConfigExporter interface {
 	// The same service may appear once per exporting cluster.
 	ListConfig(ctx context.Context) ([]*registryv1.ServiceConfigProjection, error)
 }
+
+// ConfigImporter is the read-only consumer half of cross-cluster config propagation
+// (proposal 026): the agent's registry (the registrar client) lists imported config
+// projections via the registrar's ListAllConfig RPC — agents never read the store
+// directly. ConfigExporter (the store-backed half) also satisfies it.
+type ConfigImporter interface {
+	ListConfig(ctx context.Context) ([]*registryv1.ServiceConfigProjection, error)
+}


### PR DESCRIPTION
Closes the 026 read loop — a spoke agent materializes GAMMA config peer clusters exported, so imported routes actually take effect.

- `registry.ConfigImporter` (read-only `ListConfig`) + `RegistrarRegistry.ListConfig` (calls the registrar `ListAllConfig` RPC — agents never read the store directly).
- **cache**: `importedServiceRoutes` source + `SetImportedServiceRoutes`; `serviceRoutesSnapshot` and the dependency set use the merged **local ∪ imported** view (local wins; imported route targets enter the dependency set so their cap_http vhost + backends build).
- `configimport.Importer`: a manager Runnable polling `ListConfig`, skipping own-cluster exports, picking highest version on a same-service peer conflict, `proxy.FromConfigProjection` → cache. AP: a fetch error keeps last-known.
- agent `--import-config` flag (default off; no-op unless the backend has a cross-cluster config plane, i.e. etcd).
- Importer + cache-merge tests; `bazel build //...` + agent/registry tests + format-check green.

Next: EM1c hub export + the talos e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)