### PR TITLE
feat(chart): agent.importConfig value (026)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.59.0-{GIT_COMMIT}"
+version: "0.60.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -84,6 +84,9 @@ spec:
             {{- if .Values.agent.gamma }}
             - "--gamma"
             {{- end }}
+            {{- if .Values.agent.importConfig }}
+            - "--import-config"
+            {{- end }}
             {{- if .Values.agent.l4Routes }}
             - "--l4-routes"
             {{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -100,6 +100,11 @@ agent:
   # header / timeout). Requires the Gateway API CRDs. Default off — a no-op, and
   # adds the cluster-wide httproutes RBAC only when enabled.
   gamma: false
+  # Cross-cluster config import (proposal 026): poll the registrar for GAMMA config
+  # projections peer clusters exported and materialize them into the node proxy's
+  # routes (merged with local; local wins). Default off; no-op unless the registry
+  # backend has a cross-cluster config plane (etcd). Pairs with registrar.registryBackend=etcd.
+  importConfig: false
   # L4 route types (proposal 018, Phase 3b): watch TCPRoutes/TLSRoutes/UDPRoutes
   # parented to a Service and project weighted TCP floor chains + per-SNI TLS chains
   # onto the capture listener. Requires --transparent-capture. Default off.


### PR DESCRIPTION
Wires the `--import-config` agent flag (026 EM2) to a chart value (`agent.importConfig`, default off; no-op unless the etcd backend). Needed to enable the config-import consumer on a deployment. aether chart 0.60.0.