### PR TITLE
feat(gammaproject): shared GAMMA projector (026 EM1c)

### DIFF
--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//agent/internal/xds/proxy",
         "//api/aether/config/v1:config",
         "//common/apis/config/v1:config",
+        "//common/gammaproject",
         "//common/log",
         "//common/referencegrant",
         "//common/serviceref",
@@ -21,7 +22,6 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
-        "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
 

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
-	"time"
 
 	"github.com/bpalermo/aether/common/serviceref"
 
@@ -18,9 +17,9 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
 	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"github.com/bpalermo/aether/common/gammaproject"
 	commonlog "github.com/bpalermo/aether/common/log"
 	"github.com/bpalermo/aether/common/referencegrant"
-	"google.golang.org/protobuf/types/known/durationpb"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -370,337 +369,28 @@ func serviceParents(refs []gatewayv1.ParentReference, routeNamespace string) []s
 	return parents
 }
 
+// buildGammaRoute projects an HTTPRoute rule via the shared gammaproject projector and
+// converts it to the agent's in-memory GammaRoute. The projector is shared with the
+// registrar's cross-cluster export controller (proposal 026 EM1c) so a cluster's local
+// routing and the config it exports for peers never drift.
 func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configapisv1.HTTPFilter) proxy.GammaRoute {
-	gr := proxy.GammaRoute{}
-	if rule.Timeouts != nil && rule.Timeouts.Request != nil {
-		// HTTPRoute timeouts are GEP-2257 duration strings (a subset of Go's).
-		if d, err := time.ParseDuration(string(*rule.Timeouts.Request)); err == nil && d > 0 {
-			gr.Timeout = durationpb.New(d)
-		}
-	}
-	for _, b := range rule.BackendRefs {
-		if b.Group != nil && string(*b.Group) != "" {
-			continue
-		}
-		if b.Kind != nil && string(*b.Kind) != "Service" {
-			continue
-		}
-		name := string(b.Name)
-		// Drop ungranted cross-namespace backends (RefNotPermitted): they are removed
-		// from the data plane, but the rest of the route still applies.
-		if !backendPermitted(b.Namespace, routeNamespace, routeKind, name, grants) {
-			continue
-		}
-		weight := uint32(1)
-		if b.Weight != nil {
-			weight = uint32(*b.Weight)
-		}
-		// 020 Part 1: the backend's data-plane cluster and dependency-set key are
-		// namespace-qualified "<ns>/<svc>". A canary/split to a different backend
-		// service therefore resolves the right registry cluster.
-		key := backendServiceKey(b.Namespace, routeNamespace, name)
-		gr.Backends = append(gr.Backends, proxy.GammaBackend{
-			Service: key,
-			Cluster: proxy.ServiceClusterName(key, r.MeshDomain),
-			Weight:  weight,
-		})
-	}
-	for _, m := range rule.Matches {
-		gm := proxy.GammaMatch{}
-		if m.Path != nil && m.Path.Value != nil {
-			if m.Path.Type != nil && *m.Path.Type == gatewayv1.PathMatchExact {
-				gm.Exact = *m.Path.Value
-			} else {
-				gm.Prefix = *m.Path.Value
-			}
-		}
-		for _, h := range m.Headers {
-			gm.Headers = append(gm.Headers, proxy.GammaHeaderMatch{Name: string(h.Name), Value: h.Value})
-		}
-		gr.Matches = append(gr.Matches, gm)
-	}
-	gr.HeaderMutation = buildHTTPHeaderMutation(rule.Filters)
-	gr.Redirect = buildHTTPRedirect(rule.Filters)
-	gr.URLRewrite = buildHTTPURLRewrite(rule.Filters)
-	for _, f := range rule.Filters {
-		if f.Type == gatewayv1.HTTPRouteFilterExtensionRef {
-			if ef, ok := resolveExtensionFilter(f.ExtensionRef, routeNamespace, httpFilters); ok {
-				gr.ExtensionFilters = append(gr.ExtensionFilters, ef)
-			}
-		}
-	}
-	return gr
+	return proxy.GammaRouteFromProto(gammaproject.ProjectHTTPRule(rule, routeNamespace, routeKind, r.MeshDomain, grants, httpFilterSpecs(httpFilters)))
 }
 
-// resolveExtensionFilter resolves a route's ExtensionRef filter (proposal 025) to an
-// allow-listed proxy ExtensionFilter, or (zero, false) when it does not reference an
-// in-namespace, allow-listed, ROUTE-scope HTTPFilter with a typed_config. ExtensionRef
-// is a same-namespace LocalObjectReference (no namespace field), so no ReferenceGrant
-// applies. CHAIN scope is deferred (admin-owned, a later milestone). Invalid/dangling
-// refs are skipped here; M2 (the webhook) makes them a clean ResolvedRefs=False reject.
-func resolveExtensionFilter(ref *gatewayv1.LocalObjectReference, routeNamespace string, httpFilters map[string]*configapisv1.HTTPFilter) (proxy.ExtensionFilter, bool) {
-	if ref == nil ||
-		string(ref.Group) != configapisv1.GroupVersion.Group ||
-		string(ref.Kind) != configapisv1.HTTPFilterKind {
-		return proxy.ExtensionFilter{}, false
-	}
-	hf, ok := httpFilters[routeNamespace+"/"+string(ref.Name)]
-	if !ok || hf.Spec == nil {
-		return proxy.ExtensionFilter{}, false
-	}
-	if hf.Spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
-		return proxy.ExtensionFilter{}, false // chain scope deferred to a later milestone
-	}
-	name := hf.Spec.GetFilter()
-	if !proxy.ExtensionFilterAllowed(name) || hf.Spec.GetTypedConfig() == nil {
-		return proxy.ExtensionFilter{}, false
-	}
-	return proxy.ExtensionFilter{Name: name, Config: hf.Spec.GetTypedConfig()}, true
-}
-
-// buildHTTPHeaderMutation merges all RequestHeaderModifier and
-// ResponseHeaderModifier filters in an HTTPRoute rule's filter list into a single
-// GammaHeaderMutation. Unknown filter types (redirect, rewrite, mirror) are silently
-// skipped. Returns nil when no modifier filter is present.
-func buildHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaHeaderMutation {
-	var m *proxy.GammaHeaderMutation
-	ensure := func() {
-		if m == nil {
-			m = &proxy.GammaHeaderMutation{}
-		}
-	}
-	for _, f := range filters {
-		switch f.Type {
-		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
-			if f.RequestHeaderModifier == nil {
-				continue
-			}
-			ensure()
-			for _, h := range f.RequestHeaderModifier.Set {
-				m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			for _, h := range f.RequestHeaderModifier.Add {
-				m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
-		case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
-			if f.ResponseHeaderModifier == nil {
-				continue
-			}
-			ensure()
-			for _, h := range f.ResponseHeaderModifier.Set {
-				m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			for _, h := range f.ResponseHeaderModifier.Add {
-				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
-			// Redirect, rewrite, mirror: handled by dedicated builders below; skip here.
-		}
-	}
-	return m
-}
-
-// buildHTTPRedirect extracts the first RequestRedirect filter from an HTTPRoute
-// rule's filter list and converts it to a GammaRedirect. Returns nil when no
-// redirect filter is present. A rule with a RequestRedirect filter yields a redirect
-// route (no backend cluster) per the Gateway API spec.
-func buildHTTPRedirect(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaRedirect {
-	for _, f := range filters {
-		if f.Type != gatewayv1.HTTPRouteFilterRequestRedirect || f.RequestRedirect == nil {
-			continue
-		}
-		rd := f.RequestRedirect
-		r := &proxy.GammaRedirect{}
-		if rd.Scheme != nil {
-			r.Scheme = *rd.Scheme
-		}
-		if rd.Hostname != nil {
-			r.Hostname = string(*rd.Hostname)
-		}
-		if rd.Port != nil {
-			r.Port = uint32(*rd.Port)
-		}
-		if rd.StatusCode != nil {
-			r.StatusCode = *rd.StatusCode
-		}
-		if rd.Path != nil {
-			switch rd.Path.Type {
-			case gatewayv1.FullPathHTTPPathModifier:
-				if rd.Path.ReplaceFullPath != nil {
-					r.PathType = "ReplaceFullPath"
-					r.PathValue = *rd.Path.ReplaceFullPath
-				}
-			case gatewayv1.PrefixMatchHTTPPathModifier:
-				if rd.Path.ReplacePrefixMatch != nil {
-					r.PathType = "ReplacePrefixMatch"
-					r.PathValue = *rd.Path.ReplacePrefixMatch
-				}
-			}
-		}
-		return r
-	}
-	return nil
-}
-
-// buildHTTPURLRewrite extracts the first URLRewrite filter from an HTTPRoute
-// rule's filter list and converts it to a GammaURLRewrite. Returns nil when no
-// URLRewrite filter is present. URLRewrite is applied on the RouteAction (the
-// request still proxies to the backend).
-func buildHTTPURLRewrite(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaURLRewrite {
-	for _, f := range filters {
-		if f.Type != gatewayv1.HTTPRouteFilterURLRewrite || f.URLRewrite == nil {
-			continue
-		}
-		rw := f.URLRewrite
-		r := &proxy.GammaURLRewrite{}
-		if rw.Hostname != nil {
-			r.Hostname = string(*rw.Hostname)
-		}
-		if rw.Path != nil {
-			switch rw.Path.Type {
-			case gatewayv1.FullPathHTTPPathModifier:
-				if rw.Path.ReplaceFullPath != nil {
-					r.PathType = "ReplaceFullPath"
-					r.PathValue = *rw.Path.ReplaceFullPath
-				}
-			case gatewayv1.PrefixMatchHTTPPathModifier:
-				if rw.Path.ReplacePrefixMatch != nil {
-					r.PathType = "ReplacePrefixMatch"
-					r.PathValue = *rw.Path.ReplacePrefixMatch
-				}
-			}
-		}
-		return r
-	}
-	return nil
-}
-
-// buildGRPCHeaderMutation merges all RequestHeaderModifier and
-// ResponseHeaderModifier filters in a GRPCRoute rule's filter list into a single
-// GammaHeaderMutation. The filter shape is identical to the HTTP variant
-// (HTTPHeaderFilter is shared); unknown types are silently skipped.
-// Returns nil when no modifier filter is present.
-func buildGRPCHeaderMutation(filters []gatewayv1.GRPCRouteFilter) *proxy.GammaHeaderMutation {
-	var m *proxy.GammaHeaderMutation
-	ensure := func() {
-		if m == nil {
-			m = &proxy.GammaHeaderMutation{}
-		}
-	}
-	for _, f := range filters {
-		switch f.Type {
-		case gatewayv1.GRPCRouteFilterRequestHeaderModifier:
-			if f.RequestHeaderModifier == nil {
-				continue
-			}
-			ensure()
-			for _, h := range f.RequestHeaderModifier.Set {
-				m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			for _, h := range f.RequestHeaderModifier.Add {
-				m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
-		case gatewayv1.GRPCRouteFilterResponseHeaderModifier:
-			if f.ResponseHeaderModifier == nil {
-				continue
-			}
-			ensure()
-			for _, h := range f.ResponseHeaderModifier.Set {
-				m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			for _, h := range f.ResponseHeaderModifier.Add {
-				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
-			// Mirror and extension filter types are future items; skip silently.
-		}
-	}
-	return m
-}
-
-// buildGammaRouteFromGRPC translates a GRPCRouteRule into the same GammaRoute
-// vocabulary the HTTP path uses: gRPC rides HTTP/2 as POST /<service>/<method>, so a
-// method match becomes a path match (service+method = exact /svc/method; service-only
-// = prefix /svc/), and gRPC header matches map to request-header matches. GRPCRoute
-// has no per-rule timeout. The backends are identical (weighted Service refs).
+// buildGammaRouteFromGRPC projects a GRPCRoute rule via the shared projector.
 func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configapisv1.HTTPFilter) proxy.GammaRoute {
-	gr := proxy.GammaRoute{}
-	for _, b := range rule.BackendRefs {
-		if b.Group != nil && string(*b.Group) != "" {
-			continue
-		}
-		if b.Kind != nil && string(*b.Kind) != "Service" {
-			continue
-		}
-		name := string(b.Name)
-		if !backendPermitted(b.Namespace, routeNamespace, routeKind, name, grants) {
-			continue
-		}
-		weight := uint32(1)
-		if b.Weight != nil {
-			weight = uint32(*b.Weight)
-		}
-		// 020 Part 1: the backend's data-plane cluster and dependency-set key are
-		// namespace-qualified "<ns>/<svc>". A canary/split to a different backend
-		// service therefore resolves the right registry cluster.
-		key := backendServiceKey(b.Namespace, routeNamespace, name)
-		gr.Backends = append(gr.Backends, proxy.GammaBackend{
-			Service: key,
-			Cluster: proxy.ServiceClusterName(key, r.MeshDomain),
-			Weight:  weight,
-		})
+	return proxy.GammaRouteFromProto(gammaproject.ProjectGRPCRule(rule, routeNamespace, routeKind, r.MeshDomain, grants, httpFilterSpecs(httpFilters)))
+}
+
+// httpFilterSpecs extracts each K8s HTTPFilter's proto spec for the shared projector
+// (which is K8s-type-agnostic). Returns nil when there are none.
+func httpFilterSpecs(in map[string]*configapisv1.HTTPFilter) map[string]*configprotov1.HTTPFilterSpec {
+	if len(in) == 0 {
+		return nil
 	}
-	for _, m := range rule.Matches {
-		gm := proxy.GammaMatch{}
-		if m.Method != nil {
-			svc, method := "", ""
-			if m.Method.Service != nil {
-				svc = *m.Method.Service
-			}
-			if m.Method.Method != nil {
-				method = *m.Method.Method
-			}
-			matchType := gatewayv1.GRPCMethodMatchExact
-			if m.Method.Type != nil {
-				matchType = *m.Method.Type
-			}
-			switch matchType {
-			case gatewayv1.GRPCMethodMatchExact:
-				// svc+method = exact /svc/method; svc-only = prefix /svc/.
-				if svc != "" && method != "" {
-					gm.Exact = fmt.Sprintf("/%s/%s", svc, method)
-				} else if svc != "" {
-					gm.Prefix = fmt.Sprintf("/%s/", svc)
-				}
-			case gatewayv1.GRPCMethodMatchRegularExpression:
-				// Build a /<serviceRegex>/<methodRegex> safe_regex path. When a
-				// component is unset, use ".*" to match any value in that segment,
-				// mirroring the Exact service-only → prefix semantics.
-				svcPart := svc
-				if svcPart == "" {
-					svcPart = "[^/]+"
-				}
-				methodPart := method
-				if methodPart == "" {
-					methodPart = "[^/]+"
-				}
-				gm.Regex = fmt.Sprintf("/%s/%s", svcPart, methodPart)
-			}
-		}
-		for _, h := range m.Headers {
-			gm.Headers = append(gm.Headers, proxy.GammaHeaderMatch{Name: string(h.Name), Value: h.Value})
-		}
-		gr.Matches = append(gr.Matches, gm)
+	out := make(map[string]*configprotov1.HTTPFilterSpec, len(in))
+	for k, hf := range in {
+		out[k] = hf.Spec
 	}
-	gr.HeaderMutation = buildGRPCHeaderMutation(rule.Filters)
-	for _, f := range rule.Filters {
-		if f.Type == gatewayv1.GRPCRouteFilterExtensionRef {
-			if ef, ok := resolveExtensionFilter(f.ExtensionRef, routeNamespace, httpFilters); ok {
-				gr.ExtensionFilters = append(gr.ExtensionFilters, ef)
-			}
-		}
-	}
-	return gr
+	return out
 }

--- a/agent/internal/xds/proxy/projection.go
+++ b/agent/internal/xds/proxy/projection.go
@@ -29,7 +29,7 @@ func FromConfigProjection(p *registryv1.ServiceConfigProjection) []GammaRoute {
 	}
 	rules := make([]GammaRoute, 0, len(p.GetRoutes()))
 	for _, r := range p.GetRoutes() {
-		rules = append(rules, gammaRouteFromProto(r))
+		rules = append(rules, GammaRouteFromProto(r))
 	}
 	return rules
 }
@@ -65,7 +65,10 @@ func gammaRouteToProto(r GammaRoute) *registryv1.GammaRoute {
 	return out
 }
 
-func gammaRouteFromProto(r *registryv1.GammaRoute) GammaRoute {
+// GammaRouteFromProto converts a registryv1.GammaRoute proto (produced by the shared
+// gammaproject projector, locally or imported from a peer) into the agent's in-memory
+// GammaRoute the cache consumes.
+func GammaRouteFromProto(r *registryv1.GammaRoute) GammaRoute {
 	out := GammaRoute{Timeout: r.GetTimeout()}
 	for _, m := range r.GetMatches() {
 		gm := GammaMatch{Prefix: m.GetPrefix(), Exact: m.GetExact(), Regex: m.GetRegex()}

--- a/common/gammaproject/BUILD.bazel
+++ b/common/gammaproject/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "gammaproject",
+    srcs = ["project.go"],
+    importpath = "github.com/bpalermo/aether/common/gammaproject",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//api/aether/config/v1:config",
+        "//api/aether/registry/v1:registry",
+        "//common/apis/config/v1:config",
+        "//common/extensionfilter",
+        "//common/referencegrant",
+        "//common/serviceref",
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@io_k8s_sigs_gateway_api//apis/v1beta1",
+        "@org_golang_google_protobuf//types/known/durationpb",
+    ],
+)
+
+go_test(
+    name = "gammaproject_test",
+    srcs = ["project_test.go"],
+    embed = [":gammaproject"],
+    deps = [
+        "//api/aether/config/v1:config",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_gateway_api//apis/v1:apis",
+        "@org_golang_google_protobuf//types/known/anypb",
+    ],
+)

--- a/common/gammaproject/project.go
+++ b/common/gammaproject/project.go
@@ -1,0 +1,342 @@
+// Package gammaproject projects Gateway API HTTPRoute/GRPCRoute rules attached to a
+// Service into the data-plane GAMMA route model (proposal 018), as the
+// registryv1.GammaRoute PROTO. It is the single source of truth shared by the agent's
+// GAMMA reconciler (which converts the proto to its in-memory form) AND the registrar's
+// cross-cluster export controller (proposal 026 EM1c, which writes the proto to the
+// registry). Keeping one projector avoids drift between what a cluster routes locally
+// and what it exports for peers to import. Pure: no agent/registrar internals.
+package gammaproject
+
+import (
+	"fmt"
+	"time"
+
+	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
+	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"github.com/bpalermo/aether/common/extensionfilter"
+	"github.com/bpalermo/aether/common/referencegrant"
+	"github.com/bpalermo/aether/common/serviceref"
+	"google.golang.org/protobuf/types/known/durationpb"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// ProjectHTTPRule projects one HTTPRoute rule into a GammaRoute proto. Backends are
+// resolved to namespace-qualified "<ns>/<svc>" keys + data-plane cluster names
+// (<svc>.<meshDomain>); ungranted cross-namespace backends are dropped. httpFilters
+// resolves a route's ExtensionRef escape-hatch filters (proposal 025), keyed by
+// "<ns>/<name>"; nil/empty when none.
+func ProjectHTTPRule(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.GammaRoute {
+	gr := &registryv1.GammaRoute{}
+	if rule.Timeouts != nil && rule.Timeouts.Request != nil {
+		if d, err := time.ParseDuration(string(*rule.Timeouts.Request)); err == nil && d > 0 {
+			gr.Timeout = durationpb.New(d)
+		}
+	}
+	gr.Backends = projectBackends(rule.BackendRefs, routeNamespace, routeKind, meshDomain, grants)
+	for _, m := range rule.Matches {
+		gm := &registryv1.GammaMatch{}
+		if m.Path != nil && m.Path.Value != nil {
+			if m.Path.Type != nil && *m.Path.Type == gatewayv1.PathMatchExact {
+				gm.Exact = *m.Path.Value
+			} else {
+				gm.Prefix = *m.Path.Value
+			}
+		}
+		for _, h := range m.Headers {
+			gm.Headers = append(gm.Headers, &registryv1.GammaHeaderMatch{Name: string(h.Name), Value: h.Value})
+		}
+		gr.Matches = append(gr.Matches, gm)
+	}
+	gr.HeaderMutation = httpHeaderMutation(rule.Filters)
+	gr.Redirect = httpRedirect(rule.Filters)
+	gr.UrlRewrite = httpURLRewrite(rule.Filters)
+	for _, f := range rule.Filters {
+		if f.Type == gatewayv1.HTTPRouteFilterExtensionRef {
+			if ef, ok := resolveExtensionFilter(f.ExtensionRef, routeNamespace, httpFilters); ok {
+				gr.ExtensionFilters = append(gr.ExtensionFilters, ef)
+			}
+		}
+	}
+	return gr
+}
+
+// ProjectGRPCRule projects one GRPCRoute rule. gRPC rides HTTP/2 as POST
+// /<service>/<method>, so a method match becomes a path match (svc+method = exact
+// /svc/method; svc-only = prefix /svc/; regex for RegularExpression). No per-rule timeout.
+func ProjectGRPCRule(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.GammaRoute {
+	gr := &registryv1.GammaRoute{}
+	gr.Backends = projectGRPCBackends(rule.BackendRefs, routeNamespace, routeKind, meshDomain, grants)
+	for _, m := range rule.Matches {
+		gm := &registryv1.GammaMatch{}
+		if m.Method != nil {
+			svc, method := "", ""
+			if m.Method.Service != nil {
+				svc = *m.Method.Service
+			}
+			if m.Method.Method != nil {
+				method = *m.Method.Method
+			}
+			matchType := gatewayv1.GRPCMethodMatchExact
+			if m.Method.Type != nil {
+				matchType = *m.Method.Type
+			}
+			switch matchType {
+			case gatewayv1.GRPCMethodMatchExact:
+				if svc != "" && method != "" {
+					gm.Exact = fmt.Sprintf("/%s/%s", svc, method)
+				} else if svc != "" {
+					gm.Prefix = fmt.Sprintf("/%s/", svc)
+				}
+			case gatewayv1.GRPCMethodMatchRegularExpression:
+				svcPart := svc
+				if svcPart == "" {
+					svcPart = "[^/]+"
+				}
+				methodPart := method
+				if methodPart == "" {
+					methodPart = "[^/]+"
+				}
+				gm.Regex = fmt.Sprintf("/%s/%s", svcPart, methodPart)
+			}
+		}
+		for _, h := range m.Headers {
+			gm.Headers = append(gm.Headers, &registryv1.GammaHeaderMatch{Name: string(h.Name), Value: h.Value})
+		}
+		gr.Matches = append(gr.Matches, gm)
+	}
+	gr.HeaderMutation = grpcHeaderMutation(rule.Filters)
+	for _, f := range rule.Filters {
+		if f.Type == gatewayv1.GRPCRouteFilterExtensionRef {
+			if ef, ok := resolveExtensionFilter(f.ExtensionRef, routeNamespace, httpFilters); ok {
+				gr.ExtensionFilters = append(gr.ExtensionFilters, ef)
+			}
+		}
+	}
+	return gr
+}
+
+func projectBackends(refs []gatewayv1.HTTPBackendRef, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant) []*registryv1.GammaBackend {
+	var out []*registryv1.GammaBackend
+	for _, b := range refs {
+		if be := projectBackend(b.BackendObjectReference, b.Weight, routeNamespace, routeKind, meshDomain, grants); be != nil {
+			out = append(out, be)
+		}
+	}
+	return out
+}
+
+func projectGRPCBackends(refs []gatewayv1.GRPCBackendRef, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant) []*registryv1.GammaBackend {
+	var out []*registryv1.GammaBackend
+	for _, b := range refs {
+		if be := projectBackend(b.BackendObjectReference, b.Weight, routeNamespace, routeKind, meshDomain, grants); be != nil {
+			out = append(out, be)
+		}
+	}
+	return out
+}
+
+func projectBackend(ref gatewayv1.BackendObjectReference, weight *int32, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant) *registryv1.GammaBackend {
+	if ref.Group != nil && string(*ref.Group) != "" {
+		return nil
+	}
+	if ref.Kind != nil && string(*ref.Kind) != "Service" {
+		return nil
+	}
+	name := string(ref.Name)
+	// Drop ungranted cross-namespace backends (RefNotPermitted): removed from the data
+	// plane, but the rest of the route still applies.
+	if !backendPermitted(ref.Namespace, routeNamespace, routeKind, name, grants) {
+		return nil
+	}
+	w := uint32(1)
+	if weight != nil {
+		w = uint32(*weight)
+	}
+	key := backendServiceKey(ref.Namespace, routeNamespace, name)
+	return &registryv1.GammaBackend{Service: key, Cluster: serviceClusterName(key, meshDomain), Weight: w}
+}
+
+// serviceClusterName builds a backend's data-plane cluster name "<svc>.<meshDomain>"
+// from its "<ns>/<svc>" key (= proxy.ServiceClusterName, kept in lockstep).
+func serviceClusterName(serviceKey, meshDomain string) string {
+	ref, ok := serviceref.ParseKey(serviceKey)
+	if !ok {
+		return ""
+	}
+	return ref.FQDN(meshDomain)
+}
+
+func backendServiceKey(backendNamespace *gatewayv1.Namespace, routeNamespace, name string) string {
+	ns := routeNamespace
+	if bn := derefBackendNamespace(backendNamespace); bn != "" {
+		ns = bn
+	}
+	return serviceref.New(ns, name).Key()
+}
+
+func backendPermitted(backendNamespace *gatewayv1.Namespace, routeNamespace, routeKind, name string, grants []gatewayv1beta1.ReferenceGrant) bool {
+	ns := derefBackendNamespace(backendNamespace)
+	if !referencegrant.CrossNamespace(ns, routeNamespace) {
+		return true
+	}
+	return referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, name)
+}
+
+func derefBackendNamespace(ns *gatewayv1.Namespace) string {
+	if ns == nil {
+		return ""
+	}
+	return string(*ns)
+}
+
+// resolveExtensionFilter resolves a route's ExtensionRef (proposal 025) to a proto
+// ExtensionFilter, or (nil, false) when it is not an in-namespace, allow-listed,
+// ROUTE-scope HTTPFilter with a typed_config. ExtensionRef is same-namespace (a
+// LocalObjectReference), so no ReferenceGrant applies.
+func resolveExtensionFilter(ref *gatewayv1.LocalObjectReference, routeNamespace string, httpFilters map[string]*configprotov1.HTTPFilterSpec) (*registryv1.ExtensionFilter, bool) {
+	if ref == nil ||
+		string(ref.Group) != configapisv1.GroupVersion.Group ||
+		string(ref.Kind) != configapisv1.HTTPFilterKind {
+		return nil, false
+	}
+	spec, ok := httpFilters[routeNamespace+"/"+string(ref.Name)]
+	if !ok || spec == nil {
+		return nil, false
+	}
+	if spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+		return nil, false // chain scope deferred to a later milestone
+	}
+	name := spec.GetFilter()
+	if !extensionfilter.Allowed(name) || spec.GetTypedConfig() == nil {
+		return nil, false
+	}
+	return &registryv1.ExtensionFilter{Name: name, Config: spec.GetTypedConfig()}, true
+}
+
+func httpHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *registryv1.GammaHeaderMutation {
+	var m *registryv1.GammaHeaderMutation
+	ensure := func() {
+		if m == nil {
+			m = &registryv1.GammaHeaderMutation{}
+		}
+	}
+	for _, f := range filters {
+		switch f.Type {
+		case gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+			if f.RequestHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			m.SetRequest = appendKV(m.SetRequest, f.RequestHeaderModifier.Set)
+			m.AddRequest = appendKV(m.AddRequest, f.RequestHeaderModifier.Add)
+			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
+		case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
+			if f.ResponseHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			m.SetResponse = appendKV(m.SetResponse, f.ResponseHeaderModifier.Set)
+			m.AddResponse = appendKV(m.AddResponse, f.ResponseHeaderModifier.Add)
+			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
+		}
+	}
+	return m
+}
+
+func grpcHeaderMutation(filters []gatewayv1.GRPCRouteFilter) *registryv1.GammaHeaderMutation {
+	var m *registryv1.GammaHeaderMutation
+	ensure := func() {
+		if m == nil {
+			m = &registryv1.GammaHeaderMutation{}
+		}
+	}
+	for _, f := range filters {
+		switch f.Type {
+		case gatewayv1.GRPCRouteFilterRequestHeaderModifier:
+			if f.RequestHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			m.SetRequest = appendKV(m.SetRequest, f.RequestHeaderModifier.Set)
+			m.AddRequest = appendKV(m.AddRequest, f.RequestHeaderModifier.Add)
+			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
+		case gatewayv1.GRPCRouteFilterResponseHeaderModifier:
+			if f.ResponseHeaderModifier == nil {
+				continue
+			}
+			ensure()
+			m.SetResponse = appendKV(m.SetResponse, f.ResponseHeaderModifier.Set)
+			m.AddResponse = appendKV(m.AddResponse, f.ResponseHeaderModifier.Add)
+			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
+		}
+	}
+	return m
+}
+
+func appendKV(dst []*registryv1.GammaHeaderKv, src []gatewayv1.HTTPHeader) []*registryv1.GammaHeaderKv {
+	for _, h := range src {
+		dst = append(dst, &registryv1.GammaHeaderKv{Name: string(h.Name), Value: h.Value})
+	}
+	return dst
+}
+
+func httpRedirect(filters []gatewayv1.HTTPRouteFilter) *registryv1.GammaRedirect {
+	for _, f := range filters {
+		if f.Type != gatewayv1.HTTPRouteFilterRequestRedirect || f.RequestRedirect == nil {
+			continue
+		}
+		rd := f.RequestRedirect
+		r := &registryv1.GammaRedirect{}
+		if rd.Scheme != nil {
+			r.Scheme = *rd.Scheme
+		}
+		if rd.Hostname != nil {
+			r.Hostname = string(*rd.Hostname)
+		}
+		if rd.Port != nil {
+			r.Port = uint32(*rd.Port)
+		}
+		if rd.StatusCode != nil {
+			r.StatusCode = int32(*rd.StatusCode)
+		}
+		if rd.Path != nil {
+			r.PathType, r.PathValue = pathModifier(rd.Path)
+		}
+		return r
+	}
+	return nil
+}
+
+func httpURLRewrite(filters []gatewayv1.HTTPRouteFilter) *registryv1.GammaUrlRewrite {
+	for _, f := range filters {
+		if f.Type != gatewayv1.HTTPRouteFilterURLRewrite || f.URLRewrite == nil {
+			continue
+		}
+		rw := f.URLRewrite
+		r := &registryv1.GammaUrlRewrite{}
+		if rw.Hostname != nil {
+			r.Hostname = string(*rw.Hostname)
+		}
+		if rw.Path != nil {
+			r.PathType, r.PathValue = pathModifier(rw.Path)
+		}
+		return r
+	}
+	return nil
+}
+
+func pathModifier(p *gatewayv1.HTTPPathModifier) (pathType, pathValue string) {
+	switch p.Type {
+	case gatewayv1.FullPathHTTPPathModifier:
+		if p.ReplaceFullPath != nil {
+			return "ReplaceFullPath", *p.ReplaceFullPath
+		}
+	case gatewayv1.PrefixMatchHTTPPathModifier:
+		if p.ReplacePrefixMatch != nil {
+			return "ReplacePrefixMatch", *p.ReplacePrefixMatch
+		}
+	}
+	return "", ""
+}

--- a/common/gammaproject/project_test.go
+++ b/common/gammaproject/project_test.go
@@ -1,0 +1,91 @@
+package gammaproject
+
+import (
+	"testing"
+
+	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+// TestProjectHTTPRule covers the shared projector's proto output: backends resolved to
+// <ns>/<svc> keys + cluster names, path/header matches, header mutation, redirect, and
+// an allow-listed ExtensionRef → ExtensionFilter.
+func TestProjectHTTPRule(t *testing.T) {
+	cfg, err := anypb.New(&configprotov1.HTTPFilterSpec{}) // any well-formed Any; allow-list+presence is what's checked
+	require.NoError(t, err)
+	httpFilters := map[string]*configprotov1.HTTPFilterSpec{
+		"team-a/h2m": configprotov1.HTTPFilterSpec_builder{
+			Filter: "envoy.filters.http.header_mutation", TypedConfig: cfg,
+		}.Build(),
+	}
+	rule := gatewayv1.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{{
+			Path:    &gatewayv1.HTTPPathMatch{Type: ptr(gatewayv1.PathMatchPathPrefix), Value: ptr("/v2")},
+			Headers: []gatewayv1.HTTPHeaderMatch{{Name: "x-canary", Value: "1"}},
+		}},
+		BackendRefs: []gatewayv1.HTTPBackendRef{{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{Name: "echo-v2"},
+				Weight:                 ptr(int32(70)),
+			},
+		}},
+		Filters: []gatewayv1.HTTPRouteFilter{
+			{Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier, RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+				Set: []gatewayv1.HTTPHeader{{Name: "X-Set", Value: "v"}},
+			}},
+			{Type: gatewayv1.HTTPRouteFilterExtensionRef, ExtensionRef: &gatewayv1.LocalObjectReference{
+				Group: "config.aether.io", Kind: "HTTPFilter", Name: "h2m",
+			}},
+		},
+	}
+
+	gr := ProjectHTTPRule(rule, "team-a", "HTTPRoute", "aether.internal", nil, httpFilters)
+
+	require.Len(t, gr.GetBackends(), 1)
+	assert.Equal(t, "team-a/echo-v2", gr.GetBackends()[0].GetService())
+	assert.Equal(t, "echo-v2.team-a.aether.internal", gr.GetBackends()[0].GetCluster())
+	assert.Equal(t, uint32(70), gr.GetBackends()[0].GetWeight())
+
+	require.Len(t, gr.GetMatches(), 1)
+	assert.Equal(t, "/v2", gr.GetMatches()[0].GetPrefix())
+	require.Len(t, gr.GetMatches()[0].GetHeaders(), 1)
+	assert.Equal(t, "x-canary", gr.GetMatches()[0].GetHeaders()[0].GetName())
+
+	require.NotNil(t, gr.GetHeaderMutation())
+	require.Len(t, gr.GetHeaderMutation().GetSetRequest(), 1)
+	assert.Equal(t, "X-Set", gr.GetHeaderMutation().GetSetRequest()[0].GetName())
+
+	require.Len(t, gr.GetExtensionFilters(), 1)
+	assert.Equal(t, "envoy.filters.http.header_mutation", gr.GetExtensionFilters()[0].GetName())
+}
+
+// TestProjectHTTPRule_RedirectAndExtensionRefSkips covers a RequestRedirect → no
+// backend, and that a non-allow-listed / wrong-group ExtensionRef is skipped.
+func TestProjectHTTPRule_RedirectAndExtensionRefSkips(t *testing.T) {
+	cfg, err := anypb.New(&configprotov1.HTTPFilterSpec{})
+	require.NoError(t, err)
+	httpFilters := map[string]*configprotov1.HTTPFilterSpec{
+		"ns/lua": configprotov1.HTTPFilterSpec_builder{Filter: "envoy.filters.http.lua", TypedConfig: cfg}.Build(),
+	}
+	rule := gatewayv1.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Value: ptr("/r")}}},
+		Filters: []gatewayv1.HTTPRouteFilter{
+			{Type: gatewayv1.HTTPRouteFilterRequestRedirect, RequestRedirect: &gatewayv1.HTTPRequestRedirectFilter{
+				Hostname: ptr(gatewayv1.PreciseHostname("example.org")), StatusCode: ptr(301),
+			}},
+			{Type: gatewayv1.HTTPRouteFilterExtensionRef, ExtensionRef: &gatewayv1.LocalObjectReference{
+				Group: "config.aether.io", Kind: "HTTPFilter", Name: "lua", // not allow-listed
+			}},
+		},
+	}
+	gr := ProjectHTTPRule(rule, "ns", "HTTPRoute", "aether.internal", nil, httpFilters)
+	require.NotNil(t, gr.GetRedirect())
+	assert.Equal(t, "example.org", gr.GetRedirect().GetHostname())
+	assert.Equal(t, int32(301), gr.GetRedirect().GetStatusCode())
+	assert.Empty(t, gr.GetExtensionFilters(), "non-allow-listed ExtensionRef is skipped")
+}


### PR DESCRIPTION
Single source of truth for projecting HTTPRoute/GRPCRoute rules into the GAMMA model as the **registryv1.GammaRoute proto** — so the agent (local routing) and the registrar export controller (026) never drift.

- **common/gammaproject**: `ProjectHTTPRule`/`ProjectGRPCRule` + helpers (backends w/ ReferenceGrant gating, matches, header mutation, redirect, urlrewrite, ExtensionRef) ported from the reconciler, emitting proto. Pure — common/ + api/ deps only.
- `proxy.GammaRouteFromProto` exported (proto→in-memory converter).
- agent gamma reconciler: `buildGammaRoute`/`buildGammaRouteFromGRPC` are now thin wrappers over the shared projector; duplicated helpers removed. **Reconciler tests (assert proxy.GammaRoute) are the equivalence guard — green**, so the proto round-trip preserves behaviour.
- gammaproject unit tests.

Next: the registrar export controller (`SetConfig`). `bazel build //...` + gamma/proxy/cache/gammaproject tests + format-check green.