### PR TITLE
feat(026): config authority (EM3) + propagation observability (EM4)

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -94,6 +94,11 @@ type AgentConfig struct {
 	// no-op when the registry backend has no cross-cluster config plane (etcd only).
 	ImportConfig bool
 
+	// ControlCluster, when set, names the single authorized config-exporting cluster
+	// (proposal 026 EM3, Option E): the importer then trusts ONLY config originating
+	// there and ignores all other origins. Empty = federated (trust any peer origin).
+	ControlCluster string
+
 	// L4Routes enables L4 route types (TCPRoute/TLSRoute/UDPRoute parentRef=Service,
 	// proposal 018, Phase 3b): the agent watches these route types and projects
 	// weighted TCP floor chains and SNI-routed TLS chains onto the capture listener.

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -122,6 +122,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
 	rootCmd.Flags().BoolVar(&cfg.Gamma, "gamma", false, "Enable GAMMA east-west L7 routing: watch HTTPRoutes parented to a Service and enrich the node proxy's outbound routes (proposal 018, Phase 2)")
 	rootCmd.Flags().BoolVar(&cfg.ImportConfig, "import-config", false, "Enable cross-cluster config import: poll the registrar for GAMMA config projections peer clusters exported and materialize them into the node proxy's routes (proposal 026). No-op unless the registry backend has a cross-cluster config plane (etcd)")
+	rootCmd.Flags().StringVar(&cfg.ControlCluster, "control-cluster", "", "Name of the single authorized config-exporting cluster (proposal 026 EM3, Option E). When set, imported config is trusted ONLY from this origin; empty = federated (trust any peer)")
 	rootCmd.Flags().BoolVar(&cfg.L4Routes, "l4-routes", false, "Enable L4 route types (TCPRoute/TLSRoute/UDPRoute) parented to a Service: weighted TCP floor chains and SNI-routed TLS chains on the capture listener (proposal 018, Phase 3b). NOTE: UDPRoute is control-plane only until the CNI UDP redirect lands.")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCapture, "transparent-capture", false, "Enable transparent capture: per-pod capture listeners + cap_http route table from the generated mesh Services (proposal 018, Phase 3a)")
 	rootCmd.Flags().BoolVar(&cfg.CaptureRedirectAll, "capture-redirect-all", false, "Add the dormant ORIGINAL_DST passthrough DefaultFilterChain to capture listeners (proposal 022 M2a spike). Harmless unless a pod is redirect-all'd via the capture.aether.io/redirect-all annotation; only then does non-mesh egress reach the passthrough.")
@@ -387,7 +388,7 @@ func runAgent(ctx context.Context) (retErr error) {
 	// plane (kubernetes/dynamodb don't implement registry.ConfigImporter).
 	if cfg.ImportConfig {
 		if imp, ok := reg.(registry.ConfigImporter); ok {
-			importer := configimport.NewImporter(imp, snapshotCache, cfg.ClusterName, 0, l)
+			importer := configimport.NewImporter(imp, snapshotCache, cfg.ClusterName, cfg.ControlCluster, 0, l)
 			if err = m.Add(importer); err != nil {
 				return fmt.Errorf("failed to add config importer: %w", err)
 			}

--- a/agent/internal/configimport/BUILD.bazel
+++ b/agent/internal/configimport/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "configimport",
-    srcs = ["importer.go"],
+    srcs = [
+        "importer.go",
+        "metrics.go",
+    ],
     importpath = "github.com/bpalermo/aether/agent/internal/configimport",
     visibility = ["//agent:__subpackages__"],
     deps = [
@@ -10,6 +13,8 @@ go_library(
         "//api/aether/registry/v1:registry",
         "//common/log",
         "//registry",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel_metric//:metric",
     ],
 )
 

--- a/agent/internal/configimport/importer.go
+++ b/agent/internal/configimport/importer.go
@@ -28,23 +28,32 @@ type Importer struct {
 	importer   registry.ConfigImporter
 	sink       Sink
 	ownCluster string
-	interval   time.Duration
-	log        *slog.Logger
+	// controlCluster, when non-empty, is the single authorized config exporter
+	// (proposal 026 EM3, Option E control-cluster authority): the importer then trusts
+	// ONLY projections originating there and ignores all other origins. Empty =
+	// federated (any peer origin is trusted, highest-version wins).
+	controlCluster string
+	interval       time.Duration
+	log            *slog.Logger
+	metrics        *metrics
 }
 
 // NewImporter builds the config-import poller. ownCluster is this cluster's name; the
 // importer SKIPS projections that originate here (a cluster's own export is redundant
-// with its local routes). interval defaults to 10s when non-positive.
-func NewImporter(imp registry.ConfigImporter, sink Sink, ownCluster string, interval time.Duration, log *slog.Logger) *Importer {
+// with its local routes). controlCluster (optional) restricts trust to a single hub
+// origin (EM3). interval defaults to 10s when non-positive.
+func NewImporter(imp registry.ConfigImporter, sink Sink, ownCluster, controlCluster string, interval time.Duration, log *slog.Logger) *Importer {
 	if interval <= 0 {
 		interval = 10 * time.Second
 	}
 	return &Importer{
-		importer:   imp,
-		sink:       sink,
-		ownCluster: ownCluster,
-		interval:   interval,
-		log:        commonlog.Named(log, "configimport"),
+		importer:       imp,
+		sink:           sink,
+		ownCluster:     ownCluster,
+		controlCluster: controlCluster,
+		interval:       interval,
+		log:            commonlog.Named(log, "configimport"),
+		metrics:        newMetrics(),
 	}
 }
 
@@ -69,16 +78,27 @@ func (i *Importer) Start(ctx context.Context) error {
 func (i *Importer) poll(ctx context.Context) {
 	projections, err := i.importer.ListConfig(ctx)
 	if err != nil {
+		i.metrics.fetchError(ctx)
 		i.log.WarnContext(ctx, "config import fetch failed; keeping last-known imported routes", "error", err)
 		return
 	}
-	i.sink.SetImportedServiceRoutes(i.materialize(projections))
+	routes, oldest := i.materialize(projections)
+	i.sink.SetImportedServiceRoutes(routes)
+	// EM4: surface propagation lag — the age of the OLDEST imported projection. Negative
+	// when nothing carried a parseable export timestamp.
+	age := -1.0
+	if !oldest.IsZero() {
+		age = time.Since(oldest).Seconds()
+	}
+	i.metrics.observe(ctx, len(routes), age)
 }
 
 // materialize converts peer-origin projections into a service→routes map, skipping
 // this cluster's own exports. On a same-service conflict across peers the
-// higher-version projection wins (deterministic, last-writer-by-version).
-func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection) map[string][]proxy.GammaRoute {
+// higher-version projection wins (deterministic, last-writer-by-version). It also
+// returns the oldest materialized projection's export time (zero when none parseable)
+// for the EM4 propagation-lag metric.
+func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection) (map[string][]proxy.GammaRoute, time.Time) {
 	type chosen struct {
 		version string
 		routes  []proxy.GammaRoute
@@ -87,6 +107,10 @@ func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection
 	for _, p := range projections {
 		if p.GetOriginCluster() == i.ownCluster {
 			continue // own export — local routes already cover it
+		}
+		// EM3 control-cluster authority: when a hub is designated, trust only its config.
+		if i.controlCluster != "" && p.GetOriginCluster() != i.controlCluster {
+			continue
 		}
 		svc := p.GetService()
 		if svc == "" {
@@ -98,11 +122,19 @@ func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection
 		picked[svc] = chosen{version: p.GetVersion(), routes: proxy.FromConfigProjection(p)}
 	}
 	if len(picked) == 0 {
-		return nil
+		return nil, time.Time{}
 	}
 	out := make(map[string][]proxy.GammaRoute, len(picked))
+	var oldest time.Time
 	for svc, c := range picked {
 		out[svc] = c.routes
+		// version is the exporter's RFC3339Nano timestamp (proposal 026 EM1c); track the
+		// oldest for the propagation-lag metric. Unparseable (e.g. a test stamp) → ignored.
+		if ts, err := time.Parse(time.RFC3339Nano, c.version); err == nil {
+			if oldest.IsZero() || ts.Before(oldest) {
+				oldest = ts
+			}
+		}
 	}
-	return out
+	return out, oldest
 }

--- a/agent/internal/configimport/importer_test.go
+++ b/agent/internal/configimport/importer_test.go
@@ -26,7 +26,7 @@ func (s *fakeSink) SetImportedServiceRoutes(r map[string][]proxy.GammaRoute) { s
 
 func newImporter(t *testing.T, imp *fakeImporter, sink *fakeSink, own string) *Importer {
 	t.Helper()
-	return NewImporter(imp, sink, own, 0, slog.New(slog.DiscardHandler))
+	return NewImporter(imp, sink, own, "", 0, slog.New(slog.DiscardHandler)) // "" = federated
 }
 
 func proj(svc, origin, version, prefix string) *registryv1.ServiceConfigProjection {
@@ -52,6 +52,23 @@ func TestImporter_Materialize_SkipsOwnAndPicksHighestVersion(t *testing.T) {
 	require.Contains(t, sink.routes, "team-a/echo")
 	assert.Equal(t, "/new", sink.routes["team-a/echo"][0].Matches[0].Prefix, "highest version wins; own export skipped")
 	require.Contains(t, sink.routes, "team-b/svc")
+}
+
+// TestImporter_Materialize_ControlClusterAuthority verifies EM3: with a control cluster
+// designated, only its origin is trusted — other peers' projections are ignored even if
+// higher-version.
+func TestImporter_Materialize_ControlClusterAuthority(t *testing.T) {
+	imp := &fakeImporter{projections: []*registryv1.ServiceConfigProjection{
+		proj("team-a/echo", "hub", "v1", "/hub"),     // control cluster → trusted
+		proj("team-a/echo", "rogue", "v9", "/rogue"), // higher version but NOT the hub → ignored
+		proj("team-b/svc", "rogue", "v5", "/rogue"),  // untrusted origin → dropped entirely
+	}}
+	sink := &fakeSink{}
+	NewImporter(imp, sink, "self", "hub", 0, slog.New(slog.DiscardHandler)).poll(context.Background())
+
+	require.Len(t, sink.routes, 1)
+	assert.Equal(t, "/hub", sink.routes["team-a/echo"][0].Matches[0].Prefix, "only the control cluster's config is trusted")
+	assert.NotContains(t, sink.routes, "team-b/svc", "a non-hub origin is ignored entirely")
 }
 
 // TestImporter_Poll_KeepsLastKnownOnError verifies a fetch error does not clobber the

--- a/agent/internal/configimport/metrics.go
+++ b/agent/internal/configimport/metrics.go
@@ -1,0 +1,59 @@
+package configimport
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// metrics holds the config-import OTel instruments (proposal 026 EM4: make
+// cross-cluster propagation lag + drift observable). All methods are nil-receiver-safe
+// so the importer runs unchanged when telemetry is disabled.
+type metrics struct {
+	services metric.Int64Gauge
+	ageMax   metric.Float64Gauge
+	errors   metric.Int64Counter
+}
+
+// newMetrics builds the instruments on the global MeterProvider (a no-op meter until a
+// provider is installed). Returns nil on registration error (the importer stays
+// functional; methods are nil-safe).
+func newMetrics() *metrics {
+	meter := otel.Meter("aether/config-import")
+	m := &metrics{}
+	var err error
+	if m.services, err = meter.Int64Gauge("aether.config.import.services",
+		metric.WithDescription("Cross-cluster config projections currently materialized into the proxy (proposal 026)")); err != nil {
+		return nil
+	}
+	if m.ageMax, err = meter.Float64Gauge("aether.config.import.age_max",
+		metric.WithUnit("s"),
+		metric.WithDescription("Staleness of the OLDEST imported projection = now - its export timestamp; the cross-cluster propagation-lag/skew signal")); err != nil {
+		return nil
+	}
+	if m.errors, err = meter.Int64Counter("aether.config.import.errors",
+		metric.WithDescription("Config-import fetch failures (last-known imported routes retained; AP)")); err != nil {
+		return nil
+	}
+	return m
+}
+
+// observe records the imported-service count and the oldest-projection age after a
+// successful poll. A negative ageMax means no projection carried a parseable timestamp.
+func (m *metrics) observe(ctx context.Context, services int, ageMaxSeconds float64) {
+	if m == nil {
+		return
+	}
+	m.services.Record(ctx, int64(services))
+	if ageMaxSeconds >= 0 {
+		m.ageMax.Record(ctx, ageMaxSeconds)
+	}
+}
+
+func (m *metrics) fetchError(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.errors.Add(ctx, 1)
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.61.0-{GIT_COMMIT}"
+version: "0.62.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -87,6 +87,9 @@ spec:
             {{- if .Values.agent.importConfig }}
             - "--import-config"
             {{- end }}
+            {{- if .Values.controlCluster }}
+            - "--control-cluster={{ .Values.controlCluster }}"
+            {{- end }}
             {{- if .Values.agent.l4Routes }}
             - "--l4-routes"
             {{- end }}

--- a/charts/aether/templates/registrar-deployment.yaml
+++ b/charts/aether/templates/registrar-deployment.yaml
@@ -57,6 +57,9 @@ spec:
             {{- if .Values.registrar.enableMCS }}
             - "--enable-mcs"
             {{- end }}
+            {{- if .Values.controlCluster }}
+            - "--control-cluster={{ .Values.controlCluster }}"
+            {{- end }}
             - "--spire-enabled={{ .Values.spire.enabled }}"
             {{- if .Values.spire.enabled }}
             {{- with .Values.spire.trustDomain }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -31,6 +31,13 @@ namespace:
 # Cluster name passed to the agent and registrar (`--cluster-name`).
 clusterName: talos-main
 
+# Cross-cluster config authority (proposal 026 EM3, Option E). When set to a cluster
+# name, ONLY that cluster's registrar exports GAMMA config and every cluster imports
+# config ONLY from that origin (single source of truth, no drift). Empty = federated
+# (every cluster may export; consumers trust any peer origin, highest-version wins).
+# Passed to both the agent and registrar (`--control-cluster`).
+controlCluster: ""
+
 # Enable verbose logging on all components (`--debug`).
 debug: true
 

--- a/registrar/internal/cmd/config.go
+++ b/registrar/internal/cmd/config.go
@@ -31,6 +31,13 @@ type RegistrarConfig struct {
 	// controller (proposal 026) to resolve backend cluster names <svc>.<meshDomain>.
 	MeshDomain string
 
+	// ControlCluster, when set, names the single authorized config-exporting cluster
+	// (proposal 026 EM3, Option E control-cluster authority). The config-export
+	// controller runs ONLY when this is empty (federated) or equals ClusterName (this
+	// IS the hub); spokes in control-cluster mode do not export. Endpoint export (MCS)
+	// is unaffected — it stays per-cluster.
+	ControlCluster string
+
 	// Region is this registrar's region — the etcd backend's authoritative
 	// partition root (proposal 006). Shared by every registrar on the same
 	// regional etcd; empty falls back to the etcd backend's default.

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -67,6 +67,7 @@ func init() {
 
 	rootCmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", "", "Kubernetes cluster name (required)")
 	rootCmd.Flags().StringVar(&cfg.MeshDomain, "mesh-domain", constants.DefaultMeshDomain, "DNS-style mesh domain (proposal 026 config export resolves backend clusters <svc>.<mesh-domain>)")
+	rootCmd.Flags().StringVar(&cfg.ControlCluster, "control-cluster", "", "Name of the single authorized config-exporting cluster (proposal 026 EM3, Option E). When set, the config-export controller runs only on this cluster; empty = federated (every cluster may export)")
 	rootCmd.Flags().StringVar(&cfg.Region, "region", cfg.Region, "Region owning this registrar's etcd partition (etcd backend; proposal 006). MUST be unique per regional etcd cluster: one region = one etcd. Pointing two etcds at the same region splits the registry; pointing two regions at one etcd collides their writes.")
 	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", cfg.RegistryBackend, "Registry backend (kubernetes, dynamodb, or etcd)")
 	rootCmd.Flags().StringSliceVar(&cfg.EtcdEndpoints, "etcd-endpoints", cfg.EtcdEndpoints, "Comma-separated etcd endpoints")
@@ -223,7 +224,16 @@ func runRegistrar(ctx context.Context) (retErr error) {
 		// Cross-cluster config export (proposal 026 EM1c): project exported services'
 		// GAMMA config and write it to the registry for peers to import. Rides the same
 		// ConfigExporter plane as MCS (etcd); leader-elected via the manager.
-		if configExporter, ok := reg.(registry.ConfigExporter); ok {
+		//
+		// EM3 authority (Option E): when a control cluster is designated, only IT exports
+		// config (single writer = no drift); spokes skip the export controller. Empty =
+		// federated (every cluster may export). Endpoint export (MCS, above) is unaffected.
+		exportAuthorized := cfg.ControlCluster == "" || cfg.ControlCluster == cfg.ClusterName
+		configExporter, isConfigExporter := reg.(registry.ConfigExporter)
+		if isConfigExporter && !exportAuthorized {
+			l.InfoContext(ctx, "cross-cluster config export disabled on this spoke (control-cluster authority)", "controlCluster", cfg.ControlCluster)
+		}
+		if isConfigExporter && exportAuthorized {
 			ctl := &configexport.Controller{
 				Client:     m.GetClient(),
 				Exporter:   configExporter,

--- a/registrar/internal/configexport/BUILD.bazel
+++ b/registrar/internal/configexport/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "configexport",
-    srcs = ["controller.go"],
+    srcs = [
+        "controller.go",
+        "metrics.go",
+    ],
     importpath = "github.com/bpalermo/aether/registrar/internal/configexport",
     visibility = ["//registrar:__subpackages__"],
     deps = [
@@ -20,6 +23,8 @@ go_library(
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@io_k8s_sigs_mcs_api//pkg/apis/v1alpha1",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel_metric//:metric",
         "@org_golang_google_protobuf//proto",
     ],
 )

--- a/registrar/internal/configexport/controller.go
+++ b/registrar/internal/configexport/controller.go
@@ -40,6 +40,7 @@ type Controller struct {
 	Log     *slog.Logger
 
 	httpFilterEnabled bool
+	metrics           *metrics
 }
 
 // SetupWithManager registers the controller. It watches HTTPRoutes/GRPCRoutes (the
@@ -47,6 +48,7 @@ type Controller struct {
 // resolution); the optional HTTPFilter watch is gated on the CRD being present.
 func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 	c.Log = commonlog.Named(c.Log, "config-export-controller")
+	c.metrics = newMetrics()
 	enqueueAll := handler.EnqueueRequestsFromMapFunc(func(context.Context, client.Object) []reconcile.Request {
 		return []reconcile.Request{{}}
 	})
@@ -141,6 +143,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			continue
 		}
 		if err := c.Exporter.SetConfig(ctx, &registryv1.ServiceConfigProjection{Service: svc, Version: version, Routes: routes}); err != nil {
+			c.metrics.writeError(ctx)
 			c.Log.ErrorContext(ctx, "failed to export config projection", "service", svc, "error", err)
 			return reconcile.Result{}, err
 		}
@@ -152,11 +155,13 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			continue
 		}
 		if err := c.Exporter.UnsetConfig(ctx, svc); err != nil {
+			c.metrics.writeError(ctx)
 			c.Log.ErrorContext(ctx, "failed to unexport config projection", "service", svc, "error", err)
 			return reconcile.Result{}, err
 		}
 		c.Log.InfoContext(ctx, "unexported config projection", "service", svc)
 	}
+	c.metrics.observe(ctx, len(desired))
 	return reconcile.Result{}, nil
 }
 

--- a/registrar/internal/configexport/metrics.go
+++ b/registrar/internal/configexport/metrics.go
@@ -1,0 +1,46 @@
+package configexport
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// metrics holds the config-export OTel instruments (proposal 026 EM4). All methods are
+// nil-receiver-safe so the controller runs unchanged when telemetry is disabled.
+type metrics struct {
+	services metric.Int64Gauge
+	errors   metric.Int64Counter
+}
+
+// newMetrics builds the instruments on the global MeterProvider (a no-op meter until a
+// provider is installed). Returns nil on registration error (methods are nil-safe).
+func newMetrics() *metrics {
+	meter := otel.Meter("aether/config-export")
+	m := &metrics{}
+	var err error
+	if m.services, err = meter.Int64Gauge("aether.config.export.services",
+		metric.WithDescription("Services whose GAMMA config this cluster currently exports for peers to import (proposal 026)")); err != nil {
+		return nil
+	}
+	if m.errors, err = meter.Int64Counter("aether.config.export.errors",
+		metric.WithDescription("Config export/unexport write failures against the registry")); err != nil {
+		return nil
+	}
+	return m
+}
+
+func (m *metrics) observe(ctx context.Context, services int) {
+	if m == nil {
+		return
+	}
+	m.services.Record(ctx, int64(services))
+}
+
+func (m *metrics) writeError(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.errors.Add(ctx, 1)
+}


### PR DESCRIPTION
Closes the last two 026 slices.

**EM3 — control-cluster authority (Option E).** One `controlCluster` setting = single config source of truth: empty = federated (any cluster exports, consumers trust any peer, highest-version wins); set = only the named hub's registrar runs the export controller AND every importer trusts ONLY that origin (a rogue cluster's higher-version projection is ignored). Gated on the registrar (`controlCluster=="" || ==self`) and in the agent importer's `materialize()`. `--control-cluster` on both binaries + a top-level chart value. MCS endpoint export unaffected.

**EM4 — observability** (OTel, nil-safe):
- `aether.config.export.services` / `.errors`
- `aether.config.import.services` / `.errors` + **`aether.config.import.age_max`** = the propagation-lag signal (now − the oldest imported projection's export timestamp).

Tests: control-cluster trust filter + existing suites green. `bazel build //...` + format-check green. aether chart 0.62.0.