### PR TITLE
feat(025): M3 — Service-targetRef policy attachment for HTTPFilter

### DIFF
--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//agent/internal/gatewaystatus",
         "//agent/internal/xds/proxy",
         "//api/aether/config/v1:config",
+        "//api/aether/registry/v1:registry",
         "//common/apis/config/v1:config",
         "//common/gammaproject",
         "//common/log",

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
+	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
 	"github.com/bpalermo/aether/common/gammaproject"
 	commonlog "github.com/bpalermo/aether/common/log"
@@ -150,12 +151,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 		portSets[key][port] = struct{}{}
 	}
+	// serviceFilters caches the M3 targetRef-attached HTTPFilters per route-target Service
+	// (they apply to every route of that service).
+	specs := httpFilterSpecs(httpFilters)
+	serviceFiltersFor := func(key string) []*registryv1.ExtensionFilter {
+		return gammaproject.ServiceFilters(key, specs)
+	}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
 		for _, p := range gammaproject.ServiceParents(hr.Spec.ParentRefs, hr.Namespace) {
 			collectPort(p.Key, p.Port)
+			svcFilters := serviceFiltersFor(p.Key)
 			for _, rule := range hr.Spec.Rules {
-				routes[p.Key] = append(routes[p.Key], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants, httpFilters))
+				routes[p.Key] = append(routes[p.Key], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants, httpFilters, svcFilters))
 			}
 		}
 	}
@@ -163,8 +171,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		gr := &grpcList.Items[i]
 		for _, p := range gammaproject.ServiceParents(gr.Spec.ParentRefs, gr.Namespace) {
 			collectPort(p.Key, p.Port)
+			svcFilters := serviceFiltersFor(p.Key)
 			for _, rule := range gr.Spec.Rules {
-				routes[p.Key] = append(routes[p.Key], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants, httpFilters))
+				routes[p.Key] = append(routes[p.Key], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants, httpFilters, svcFilters))
 			}
 		}
 	}
@@ -335,13 +344,13 @@ func grpcBackendRefs(rules []gatewayv1.GRPCRouteRule) []gatewayv1.BackendObjectR
 // converts it to the agent's in-memory GammaRoute. The projector is shared with the
 // registrar's cross-cluster export controller (proposal 026 EM1c) so a cluster's local
 // routing and the config it exports for peers never drift.
-func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configapisv1.HTTPFilter) proxy.GammaRoute {
-	return proxy.GammaRouteFromProto(gammaproject.ProjectHTTPRule(rule, routeNamespace, routeKind, r.MeshDomain, grants, httpFilterSpecs(httpFilters)))
+func (r *Reconciler) buildGammaRoute(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configapisv1.HTTPFilter, serviceFilters []*registryv1.ExtensionFilter) proxy.GammaRoute {
+	return proxy.GammaRouteFromProto(gammaproject.ProjectHTTPRule(rule, routeNamespace, routeKind, r.MeshDomain, grants, httpFilterSpecs(httpFilters), serviceFilters))
 }
 
 // buildGammaRouteFromGRPC projects a GRPCRoute rule via the shared projector.
-func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configapisv1.HTTPFilter) proxy.GammaRoute {
-	return proxy.GammaRouteFromProto(gammaproject.ProjectGRPCRule(rule, routeNamespace, routeKind, r.MeshDomain, grants, httpFilterSpecs(httpFilters)))
+func (r *Reconciler) buildGammaRouteFromGRPC(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configapisv1.HTTPFilter, serviceFilters []*registryv1.ExtensionFilter) proxy.GammaRoute {
+	return proxy.GammaRouteFromProto(gammaproject.ProjectGRPCRule(rule, routeNamespace, routeKind, r.MeshDomain, grants, httpFilterSpecs(httpFilters), serviceFilters))
 }
 
 // httpFilterSpecs extracts each K8s HTTPFilter's proto spec for the shared projector

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -93,7 +93,7 @@ func TestBuildGammaRoute_ExtensionRef(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gr := r.buildGammaRoute(gatewayv1.HTTPRouteRule{Filters: tc.filters}, "ns", "HTTPRoute", nil, httpFilters)
+			gr := r.buildGammaRoute(gatewayv1.HTTPRouteRule{Filters: tc.filters}, "ns", "HTTPRoute", nil, httpFilters, nil)
 			require.Len(t, gr.ExtensionFilters, tc.wantLen)
 			if tc.wantLen == 1 {
 				assert.Equal(t, "envoy.filters.http.header_to_metadata", gr.ExtensionFilters[0].Name)
@@ -286,7 +286,7 @@ func TestBuildGammaRoute_DropsUngrantedCrossNamespaceBackend(t *testing.T) {
 		},
 	}
 	// No grants: the cross-ns "remote" backend is dropped.
-	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 	require.Len(t, gr.Backends, 1)
 	assert.Equal(t, "ns/local", gr.Backends[0].Service)
 
@@ -298,7 +298,7 @@ func TestBuildGammaRoute_DropsUngrantedCrossNamespaceBackend(t *testing.T) {
 			To:   []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service", Name: ptr(gatewayv1.ObjectName("remote"))}},
 		},
 	}}
-	gr = r.buildGammaRoute(rule, "ns", "HTTPRoute", grants, nil)
+	gr = r.buildGammaRoute(rule, "ns", "HTTPRoute", grants, nil, nil)
 	require.Len(t, gr.Backends, 2)
 }
 
@@ -317,7 +317,7 @@ func TestBuildGammaRoute(t *testing.T) {
 		},
 		Timeouts: &gatewayv1.HTTPRouteTimeouts{Request: ptr(gatewayv1.Duration("5s"))},
 	}
-	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 
 	require.Len(t, gr.Matches, 1)
 	assert.Equal(t, "/admin", gr.Matches[0].Exact)
@@ -345,7 +345,7 @@ func TestBuildGammaRouteFromGRPC(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-2"}, Weight: w}},
 		},
 	}
-	gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil, nil)
+	gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil, nil, nil)
 	require.Len(t, gr.Matches, 2)
 	assert.Equal(t, "/foo.Bar/Baz", gr.Matches[0].Exact, "service+method -> exact path")
 	assert.Equal(t, "/foo.Bar/", gr.Matches[1].Prefix, "service-only -> prefix path")
@@ -395,7 +395,7 @@ func TestBuildGammaRouteFromGRPC_RegularExpression(t *testing.T) {
 					{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc"}}},
 				},
 			}
-			gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil, nil)
+			gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil, nil, nil)
 			require.Len(t, gr.Matches, 1)
 			assert.Equal(t, tc.wantRegex, gr.Matches[0].Regex, "Regex field")
 			assert.Empty(t, gr.Matches[0].Exact, "Exact must be empty for regex match")
@@ -423,7 +423,7 @@ func TestBuildGammaRoute_RequestHeaderModifier(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 
 	require.NotNil(t, gr.HeaderMutation)
 	require.Len(t, gr.HeaderMutation.SetRequest, 1)
@@ -453,7 +453,7 @@ func TestBuildGammaRoute_ResponseHeaderModifier(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 
 	require.NotNil(t, gr.HeaderMutation)
 	assert.Empty(t, gr.HeaderMutation.SetRequest, "no request headers")
@@ -476,7 +476,7 @@ func TestBuildGammaRoute_UnknownFilterSkipped(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 	assert.Nil(t, gr.HeaderMutation, "redirect filter type must not produce a HeaderMutation")
 }
 
@@ -540,7 +540,7 @@ func TestBuildGammaRoute_RequestRedirect(t *testing.T) {
 					{Type: gatewayv1.HTTPRouteFilterRequestRedirect, RequestRedirect: &f},
 				},
 			}
-			gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+			gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 			require.NotNil(t, gr.Redirect, "RequestRedirect filter must produce GammaRoute.Redirect")
 			assert.Nil(t, gr.URLRewrite, "RequestRedirect must not produce URLRewrite")
 			assert.Equal(t, tc.wantScheme, gr.Redirect.Scheme)
@@ -603,7 +603,7 @@ func TestBuildGammaRoute_URLRewrite(t *testing.T) {
 					{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 				},
 			}
-			gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+			gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 			require.NotNil(t, gr.URLRewrite, "URLRewrite filter must produce GammaRoute.URLRewrite")
 			assert.Nil(t, gr.Redirect, "URLRewrite must not produce Redirect")
 			assert.Equal(t, tc.wantHost, gr.URLRewrite.Hostname)
@@ -622,7 +622,7 @@ func TestBuildGammaRoute_NilRedirectWhenNoFilter(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-1"}}},
 		},
 	}
-	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil)
+	gr := r.buildGammaRoute(rule, "ns", "HTTPRoute", nil, nil, nil)
 	assert.Nil(t, gr.Redirect, "no filter must produce nil Redirect")
 	assert.Nil(t, gr.URLRewrite, "no filter must produce nil URLRewrite")
 }
@@ -650,7 +650,7 @@ func TestBuildGammaRouteFromGRPC_HeaderModifier(t *testing.T) {
 			{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-2"}}},
 		},
 	}
-	gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil, nil)
+	gr := r.buildGammaRouteFromGRPC(rule, "ns", "GRPCRoute", nil, nil, nil)
 
 	require.NotNil(t, gr.HeaderMutation)
 	require.Len(t, gr.HeaderMutation.SetRequest, 1)

--- a/api/aether/config/v1/http_filter.proto
+++ b/api/aether/config/v1/http_filter.proto
@@ -38,4 +38,20 @@ message HTTPFilterSpec {
     SCOPE_ROUTE = 1;
     SCOPE_CHAIN = 2;
   }
+
+  // target_refs attaches this filter to Gateway API objects (policy attachment,
+  // GEP-713/-2648 direct) — proposal 025 M3. The supported kind is Service (core
+  // group): the filter then applies to EVERY route targeting that Service, for all its
+  // callers (object-wide), in addition to any per-route ExtensionRef. Targets are
+  // same-namespace as this HTTPFilter. A Service-attached filter is a class-1 payload
+  // that rides proposal 026's config channel to peer clusters.
+  repeated PolicyTargetRef target_refs = 4;
+}
+
+// PolicyTargetRef is a Gateway API policy-attachment target: a namespace-local
+// group/kind/name. For M3, group = "" (core) and kind = "Service".
+message PolicyTargetRef {
+  string group = 1;
+  string kind = 2 [(buf.validate.field).string.min_len = 1];
+  string name = 3 [(buf.validate.field).string.min_len = 1];
 }

--- a/common/gammaproject/project.go
+++ b/common/gammaproject/project.go
@@ -9,6 +9,7 @@ package gammaproject
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
@@ -58,8 +59,10 @@ func ServiceParents(refs []gatewayv1.ParentReference, routeNamespace string) []S
 // resolved to namespace-qualified "<ns>/<svc>" keys + data-plane cluster names
 // (<svc>.<meshDomain>); ungranted cross-namespace backends are dropped. httpFilters
 // resolves a route's ExtensionRef escape-hatch filters (proposal 025), keyed by
-// "<ns>/<name>"; nil/empty when none.
-func ProjectHTTPRule(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.GammaRoute {
+// "<ns>/<name>"; nil/empty when none. serviceFilters are policy-attached (M3
+// targetRef) filters that apply to every route of the target Service (see
+// ServiceFilters); they are appended after any per-route ExtensionRef.
+func ProjectHTTPRule(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec, serviceFilters []*registryv1.ExtensionFilter) *registryv1.GammaRoute {
 	gr := &registryv1.GammaRoute{}
 	if rule.Timeouts != nil && rule.Timeouts.Request != nil {
 		if d, err := time.ParseDuration(string(*rule.Timeouts.Request)); err == nil && d > 0 {
@@ -91,13 +94,14 @@ func ProjectHTTPRule(rule gatewayv1.HTTPRouteRule, routeNamespace, routeKind, me
 			}
 		}
 	}
+	gr.ExtensionFilters = append(gr.ExtensionFilters, serviceFilters...)
 	return gr
 }
 
 // ProjectGRPCRule projects one GRPCRoute rule. gRPC rides HTTP/2 as POST
 // /<service>/<method>, so a method match becomes a path match (svc+method = exact
 // /svc/method; svc-only = prefix /svc/; regex for RegularExpression). No per-rule timeout.
-func ProjectGRPCRule(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.GammaRoute {
+func ProjectGRPCRule(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind, meshDomain string, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec, serviceFilters []*registryv1.ExtensionFilter) *registryv1.GammaRoute {
 	gr := &registryv1.GammaRoute{}
 	gr.Backends = projectGRPCBackends(rule.BackendRefs, routeNamespace, routeKind, meshDomain, grants)
 	for _, m := range rule.Matches {
@@ -146,6 +150,7 @@ func ProjectGRPCRule(rule gatewayv1.GRPCRouteRule, routeNamespace, routeKind, me
 			}
 		}
 	}
+	gr.ExtensionFilters = append(gr.ExtensionFilters, serviceFilters...)
 	return gr
 }
 
@@ -233,18 +238,66 @@ func resolveExtensionFilter(ref *gatewayv1.LocalObjectReference, routeNamespace 
 		string(ref.Kind) != configapisv1.HTTPFilterKind {
 		return nil, false
 	}
-	spec, ok := httpFilters[routeNamespace+"/"+string(ref.Name)]
-	if !ok || spec == nil {
+	return allowedExtensionFilter(httpFilters[routeNamespace+"/"+string(ref.Name)])
+}
+
+// allowedExtensionFilter validates an HTTPFilter spec and converts it to an
+// ExtensionFilter, or (nil,false) when it is nil, CHAIN-scoped (admin-owned, deferred),
+// not allow-listed, or missing typed_config.
+func allowedExtensionFilter(spec *configprotov1.HTTPFilterSpec) (*registryv1.ExtensionFilter, bool) {
+	if spec == nil || spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
 		return nil, false
-	}
-	if spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
-		return nil, false // chain scope deferred to a later milestone
 	}
 	name := spec.GetFilter()
 	if !extensionfilter.Allowed(name) || spec.GetTypedConfig() == nil {
 		return nil, false
 	}
 	return &registryv1.ExtensionFilter{Name: name, Config: spec.GetTypedConfig()}, true
+}
+
+// ServiceFilters resolves the HTTPFilters (proposal 025 M3) that policy-attach to the
+// Service identified by serviceKey ("<ns>/<svc>") via a targetRef, returning their
+// allow-listed ExtensionFilters. Policy attachment is same-namespace: only HTTPFilters
+// in the service's namespace whose target_refs name it (kind=Service, core group)
+// apply. Sorted by HTTPFilter key for deterministic order (stable
+// typed_per_filter_config across reconciles). These attach to EVERY route of the
+// service, additive to per-route ExtensionRefs.
+func ServiceFilters(serviceKey string, httpFilters map[string]*configprotov1.HTTPFilterSpec) []*registryv1.ExtensionFilter {
+	sref, ok := serviceref.ParseKey(serviceKey)
+	if !ok || len(httpFilters) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(httpFilters))
+	for k := range httpFilters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var out []*registryv1.ExtensionFilter
+	for _, k := range keys {
+		fref, ok := serviceref.ParseKey(k)
+		if !ok || fref.Namespace != sref.Namespace { // same-namespace policy attachment
+			continue
+		}
+		if !targetsService(httpFilters[k], sref.Name) {
+			continue
+		}
+		if ef, ok := allowedExtensionFilter(httpFilters[k]); ok {
+			out = append(out, ef)
+		}
+	}
+	return out
+}
+
+func targetsService(spec *configprotov1.HTTPFilterSpec, serviceName string) bool {
+	if spec == nil {
+		return false
+	}
+	for _, t := range spec.GetTargetRefs() {
+		if (t.GetGroup() == "" || t.GetGroup() == "core") && t.GetKind() == "Service" && t.GetName() == serviceName {
+			return true
+		}
+	}
+	return false
 }
 
 func httpHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *registryv1.GammaHeaderMutation {

--- a/common/gammaproject/project_test.go
+++ b/common/gammaproject/project_test.go
@@ -59,7 +59,7 @@ func TestProjectHTTPRule(t *testing.T) {
 		},
 	}
 
-	gr := ProjectHTTPRule(rule, "team-a", "HTTPRoute", "aether.internal", nil, httpFilters)
+	gr := ProjectHTTPRule(rule, "team-a", "HTTPRoute", "aether.internal", nil, httpFilters, nil)
 
 	require.Len(t, gr.GetBackends(), 1)
 	assert.Equal(t, "team-a/echo-v2", gr.GetBackends()[0].GetService())
@@ -77,6 +77,39 @@ func TestProjectHTTPRule(t *testing.T) {
 
 	require.Len(t, gr.GetExtensionFilters(), 1)
 	assert.Equal(t, "envoy.filters.http.header_mutation", gr.GetExtensionFilters()[0].GetName())
+}
+
+// TestServiceFilters covers M3 policy attachment: an HTTPFilter with a targetRef to a
+// Service resolves for that service (same-namespace, allow-listed), and does not leak
+// to other services or namespaces.
+func TestServiceFilters(t *testing.T) {
+	cfg, err := anypb.New(&configprotov1.HTTPFilterSpec{})
+	require.NoError(t, err)
+	withTarget := func(filter, svc string) *configprotov1.HTTPFilterSpec {
+		return configprotov1.HTTPFilterSpec_builder{
+			Filter: filter, TypedConfig: cfg,
+			TargetRefs: []*configprotov1.PolicyTargetRef{
+				configprotov1.PolicyTargetRef_builder{Kind: "Service", Name: svc}.Build(),
+			},
+		}.Build()
+	}
+	httpFilters := map[string]*configprotov1.HTTPFilterSpec{
+		"team-a/h2m": withTarget("envoy.filters.http.header_mutation", "echo"),     // attaches to team-a/echo
+		"team-a/h2t": withTarget("envoy.filters.http.header_to_metadata", "other"), // different svc
+		"team-b/dup": withTarget("envoy.filters.http.header_mutation", "echo"),     // different ns, same svc name
+		"team-a/lua": withTarget("envoy.filters.http.lua", "echo"),                 // targets echo but NOT allow-listed
+	}
+
+	got := ServiceFilters("team-a/echo", httpFilters)
+	require.Len(t, got, 1, "only the same-namespace, allow-listed filter targeting echo applies")
+	assert.Equal(t, "envoy.filters.http.header_mutation", got[0].GetName())
+
+	assert.Empty(t, ServiceFilters("team-a/none", httpFilters), "a service with no targeting filter gets none")
+
+	// The resolved service filters attach to every projected route of the service.
+	route := ProjectHTTPRule(gatewayv1.HTTPRouteRule{}, "team-a", "HTTPRoute", "aether.internal", nil, nil, got)
+	require.Len(t, route.GetExtensionFilters(), 1)
+	assert.Equal(t, "envoy.filters.http.header_mutation", route.GetExtensionFilters()[0].GetName())
 }
 
 // TestProjectHTTPRule_RedirectAndExtensionRefSkips covers a RequestRedirect → no
@@ -98,7 +131,7 @@ func TestProjectHTTPRule_RedirectAndExtensionRefSkips(t *testing.T) {
 			}},
 		},
 	}
-	gr := ProjectHTTPRule(rule, "ns", "HTTPRoute", "aether.internal", nil, httpFilters)
+	gr := ProjectHTTPRule(rule, "ns", "HTTPRoute", "aether.internal", nil, httpFilters, nil)
 	require.NotNil(t, gr.GetRedirect())
 	assert.Equal(t, "example.org", gr.GetRedirect().GetHostname())
 	assert.Equal(t, int32(301), gr.GetRedirect().GetStatusCode())

--- a/registrar/internal/configexport/controller.go
+++ b/registrar/internal/configexport/controller.go
@@ -107,8 +107,9 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			if _, ok := exported[p.Key]; !ok {
 				continue
 			}
+			svcFilters := gammaproject.ServiceFilters(p.Key, httpFilters) // M3 targetRef-attached
 			for _, rule := range hr.Spec.Rules {
-				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectHTTPRule(rule, hr.Namespace, "HTTPRoute", c.MeshDomain, grantList.Items, httpFilters))
+				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectHTTPRule(rule, hr.Namespace, "HTTPRoute", c.MeshDomain, grantList.Items, httpFilters, svcFilters))
 			}
 		}
 	}
@@ -118,8 +119,9 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			if _, ok := exported[p.Key]; !ok {
 				continue
 			}
+			svcFilters := gammaproject.ServiceFilters(p.Key, httpFilters) // M3 targetRef-attached
 			for _, rule := range gr.Spec.Rules {
-				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectGRPCRule(rule, gr.Namespace, "GRPCRoute", c.MeshDomain, grantList.Items, httpFilters))
+				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectGRPCRule(rule, gr.Namespace, "GRPCRoute", c.MeshDomain, grantList.Items, httpFilters, svcFilters))
 			}
 		}
 	}


### PR DESCRIPTION
An HTTPFilter can now attach to a **Service via `targetRefs`** (Gateway API policy attachment), applying to every route of that Service for all callers — object-wide, additive to per-route ExtensionRef. Unblocked by 026: because the shared `gammaproject` projector runs on both the agent and the 026 export controller, a Service-attached filter rides 026's config channel to peer clusters automatically.

- `HTTPFilterSpec.target_refs` (`[]PolicyTargetRef`); CRD spec is opaque → no schema change.
- `gammaproject.ServiceFilters` resolves same-namespace, allow-listed HTTPFilters targeting the Service (deterministic order); `ProjectHTTPRule/GRPCRule` append them per route.
- agent reconciler + registrar export controller thread them through (local + exported config both carry them).
- Tests green; `bazel build //...` + format-check green. No chart change.