### PR TITLE
fix(build): missing gazelle BUILD dep from #461 (publish broken)

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//agent/storage",
         "//api/aether/cni/v1:cni",
         "//api/aether/config/v1:config",
+        "//common/apis/config/v1:config",
         "//common/config",
         "//common/constants",
         "//common/manager",


### PR DESCRIPTION
#461 committed root.go without the gazelle-updated BUILD.bazel — publish failed to compile `//agent/internal/cmd`. This adds the missing `common/apis/config/v1` dep. Built locally.