### PR TITLE
fix(xds): TCP-floor SAN pin must use the bare SA name (020 regression)

### DIFF
--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -239,9 +239,18 @@ func (c *SnapshotCache) captureTCPClusters() []types.Resource {
 			// Service not yet in scope; skip until cluster map has it.
 			continue
 		}
+		// The peer SVID's SA segment is the BARE service name — entry.service is the
+		// namespace-qualified "<ns>/<svc>" key (020 Part 1), so parse out the bare
+		// name (mirrors the HTTP cluster SAN pinning; using the raw key pins
+		// sa/<ns>/<svc>, which never matches an SVID → fail_verify_san on every
+		// TCP-floor handshake).
+		saName := httpEntry.service
+		if ref, ok := serviceref.ParseKey(httpEntry.service); ok {
+			saName = ref.Name
+		}
 		sanURIs := make([]string, 0, len(httpEntry.sanNamespaces))
 		for _, ns := range httpEntry.sanNamespaces {
-			sanURIs = append(sanURIs, fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ns, httpEntry.service))
+			sanURIs = append(sanURIs, fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ns, saName))
 		}
 		tcpName := proxy.TCPClusterName(e.serviceName, c.meshDomain)
 		cl := proxy.NewTCPServiceCluster(tcpName, e.serviceName, e.serviceName, c.perDownstreamConnectionPool())
@@ -318,9 +327,15 @@ func (c *SnapshotCache) edgeTCPClusters() []types.Resource {
 		if !ok {
 			continue // not yet in scope; will appear when registry delivers endpoints
 		}
+		// Bare SA name for the SAN pin (entry.service is the "<ns>/<svc>" key; see the
+		// node-proxy TCP variant above).
+		saName := entry.service
+		if ref, ok := serviceref.ParseKey(entry.service); ok {
+			saName = ref.Name
+		}
 		sanURIs := make([]string, 0, len(entry.sanNamespaces))
 		for _, ns := range entry.sanNamespaces {
-			sanURIs = append(sanURIs, fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ns, entry.service))
+			sanURIs = append(sanURIs, fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, ns, saName))
 		}
 		tcpName := proxy.TCPClusterName(svc, c.meshDomain)
 		cl := proxy.NewTCPServiceCluster(tcpName, svc, svc, false /* edge = single identity, no per-downstream pool */)

--- a/agent/internal/xds/cache/tcp_service_test.go
+++ b/agent/internal/xds/cache/tcp_service_test.go
@@ -9,6 +9,7 @@ import (
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,25 @@ func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
 	inputName := tcpCluster.GetTransportSocketMatcher().GetMatcherTree().GetInput().GetName()
 	assert.Equal(t, tcpTransportSocketFilterStateExtName, inputName,
 		"TCP floor cluster transport_socket_matcher must use envoy.matching.inputs.transport_socket_filter_state")
+
+	// SAN pinning regression (020 Part 1): every per-source transport socket must
+	// pin the peer identity with the BARE ServiceAccount name in the sa/ segment —
+	// "spiffe://<td>/ns/<endpoint-ns>/sa/echo-tcp" — NOT the namespace-qualified
+	// key ("sa/aether-test/echo-tcp"), which never matches an SVID and fails every
+	// TCP-floor handshake with fail_verify_san (observed on talos, 2026-07-02).
+	require.NotEmpty(t, tcpCluster.GetTransportSocketMatches())
+	for _, m := range tcpCluster.GetTransportSocketMatches() {
+		utc := &tlsv3.UpstreamTlsContext{}
+		require.NoError(t, m.GetTransportSocket().GetTypedConfig().UnmarshalTo(utc))
+		combined := utc.GetCommonTlsContext().GetCombinedValidationContext()
+		require.NotNil(t, combined, "per-source socket pins the server identity (match %s)", m.GetName())
+		var got []string
+		for _, sm := range combined.GetDefaultValidationContext().GetMatchTypedSubjectAltNames() {
+			got = append(got, sm.GetMatcher().GetExact())
+		}
+		assert.Equal(t, []string{"spiffe://aether.internal/ns/default/sa/echo-tcp"}, got,
+			"SAN pin uses the bare SA name (match %s)", m.GetName())
+	}
 
 	// No HTTP cluster/vhost for a TCP-only service.
 	_, hasHTTP := clusters["echo-tcp.aether-test.aether.internal"]


### PR DESCRIPTION
The TCP-floor egress clusters pinned `sa/<entry.service>` — but `entry.service` is the namespace-qualified `<ns>/<svc>` key since 020, producing `sa/aether-test/tcp-echo`, which never matches an SVID → **every TCP-floor mTLS handshake failed `fail_verify_san`** (proven on talos: 3/3 attempts, `envoy_cluster_ssl_fail_verify_san_total` = attempts, inbound ssl errors matched). The 020 cutover fixed the HTTP cluster SAN path but missed capture.go's two TCP spots; the floor was never TCP-exercised post-020 (no TCP fixture until the #460 e2e).

Fix mirrors cluster.go (`serviceref.ParseKey` → bare SA name), both node-proxy + edge TCP variants. Regression test asserts the exact pinned SAN. Found validating #460.