### PR TITLE
fix(capture): TCP hardening — no dead connections, no fake 400s

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -197,6 +197,15 @@ type SnapshotCache struct {
 	// for a route target whose parentRefs declare no port (then only the portless +
 	// mesh :18081 spellings are emitted, as before). Guarded by depMu.
 	routeTargetPorts map[string][]uint32
+	// captureTCPDeps mirrors captureTCPServices' service names into dependency
+	// state (guarded by depMu; the entries themselves stay under captureMu).
+	// Every TCP mesh service is ALWAYS in the node dependency set: the capture
+	// listener emits a per-VIP floor chain for each one unconditionally, and
+	// tcp_proxy has no ODCDS cold path — a chain whose tcp: cluster is demand-
+	// gated out means every connection dies silently (chain matches, cluster
+	// missing). TCP mesh services are explicit, cluster-wide, and few (like
+	// GAMMA route targets), so global scope is the right trade.
+	captureTCPDeps []string
 	// tcpServiceRoutes holds the TCPRoute L4 rules (parentRef=Service, proposal 018
 	// Phase 3b), keyed by the parent service. Empty unless --l4-routes is enabled.
 	// Guarded by depMu (same lock as serviceRoutes: dependency state).

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -169,6 +169,19 @@ func (c *SnapshotCache) SetCaptureTCPServices(services []capture.CaptureTCPServi
 		return
 	}
 
+	// Mirror the service names into dependency state (depMu): every TCP mesh
+	// service joins the node dependency set so its endpoints + tcp: cluster are
+	// always delivered alongside its (unconditional) capture floor chain — a
+	// chain without its cluster kills every connection silently, and tcp_proxy
+	// has no ODCDS cold path to recover.
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.serviceName)
+	}
+	c.depMu.Lock()
+	c.captureTCPDeps = names
+	c.depMu.Unlock()
+
 	// Per-pod capture listeners embed TCP floor chains; regenerate all of them.
 	if c.captureEnabled {
 		c.listenerMu.Lock()

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -143,6 +143,13 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 	for svc := range c.staticDeps {
 		set[svc] = struct{}{}
 	}
+	// TCP mesh services (capture floor): always in scope — their per-VIP floor
+	// chains are emitted unconditionally on every capture listener, and a chain
+	// whose tcp: cluster is missing dead-ends every connection (no ODCDS for
+	// tcp_proxy). Explicit + cluster-wide + few, like GAMMA route targets.
+	for _, svc := range c.captureTCPDeps {
+		set[svc] = struct{}{}
+	}
 	for _, deps := range c.podDeps {
 		if deps.service != "" {
 			set[deps.service] = struct{}{}

--- a/agent/internal/xds/cache/tcp_service_test.go
+++ b/agent/internal/xds/cache/tcp_service_test.go
@@ -119,3 +119,29 @@ func TestLoadClustersFromRegistry_TCPCluster(t *testing.T) {
 	addr := cla.GetEndpoints()[0].GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
 	assert.Equal(t, "10.0.0.9", addr.GetAddress())
 }
+
+// TestCaptureTCPServices_JoinDependencySet verifies every TCP mesh service joins the
+// node dependency set on its own — WITHOUT any local pod declaring it as an upstream.
+// The capture listener emits a per-VIP floor chain for each TCP service
+// unconditionally, and tcp_proxy has no ODCDS cold path: if the tcp: cluster were
+// demand-gated out, the chain would match and every connection would die silently
+// (the #460 e2e trap). Chain and cluster must always ship together.
+func TestCaptureTCPServices_JoinDependencySet(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetCaptureEnabled(true)
+
+	c.SetCaptureTCPServices([]capture.CaptureTCPService{
+		{ServiceName: "aether-test/tcp-echo", ClusterIP: "10.96.0.50"},
+		{ServiceName: "team-b/redis", ClusterIP: "10.96.0.51"},
+	})
+
+	deps := c.DependencySet()
+	assert.Contains(t, deps, "aether-test/tcp-echo", "TCP mesh service must be in scope without a declaring pod")
+	assert.Contains(t, deps, "team-b/redis")
+
+	// Removal drops them again (level-based replace).
+	c.SetCaptureTCPServices(nil)
+	deps = c.DependencySet()
+	assert.NotContains(t, deps, "aether-test/tcp-echo")
+	assert.NotContains(t, deps, "team-b/redis")
+}

--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -204,15 +204,23 @@ func buildCaptureTCPFloorFilterChain(svc CaptureTCPService) *listenerv3.FilterCh
 // stats filters and per-source mTLS egress path.
 //
 // scopeToCleartext (redirect-all / withPassthrough, proposal 022 M2a): match the
-// chain on transport_protocol="raw_buffer" so it catches ONLY cleartext traffic —
-// mesh egress is cleartext to this listener (the proxy adds mTLS upstream). TLS
-// egress (external HTTPS, kube-apiserver) is detected by tls_inspector as
-// transport_protocol="tls", does NOT match here, and falls to the DefaultFilterChain
-// ORIGINAL_DST passthrough. Without this the no-match HCM chain catches the TLS
-// stream and the handshake fails (it tries to parse TLS as HTTP). Scoping by
-// application_protocol does NOT work — a TLS ClientHello's ALPN (h2/http/1.1) looks
-// like HTTP. In scoped (non-redirect-all) mode the chain stays a catch-all: only
-// mesh ClusterIPs are captured (all cleartext) and there is no passthrough fallback.
+// chain on transport_protocol="raw_buffer" AND the http_inspector-detected HTTP
+// application protocols, so it catches ONLY cleartext HTTP —
+//   - TLS egress (external HTTPS, kube-apiserver): tls_inspector marks it
+//     transport_protocol="tls" → no match → DefaultFilterChain ORIGINAL_DST
+//     passthrough. (Matching application_protocol ALONE would not exclude TLS —
+//     a TLS ClientHello's ALPN h2/http/1.1 looks like HTTP — hence the combined
+//     match; on a raw_buffer stream the application protocol comes from
+//     http_inspector, not ALPN.)
+//   - Cleartext NON-HTTP (raw TCP to a non-mesh destination): http_inspector
+//     detects no HTTP → no match → passthrough to the original destination.
+//     Without the application_protocols constraint this chain swallowed such
+//     streams and answered a fake "HTTP/1.1 400 Bad Request" (#460 e2e finding).
+//     Raw TCP to a TCP MESH service is unaffected: its per-VIP floor chain
+//     matches on destination IP, which beats any protocol match.
+//
+// In scoped (non-redirect-all) mode the chain stays a catch-all: only mesh
+// ClusterIPs are captured (all cleartext HTTP) and there is no passthrough fallback.
 func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool, scopeToCleartext bool, extensionFilters []*http_connection_managerv3.HttpFilter) *listenerv3.FilterChain {
 	hcm := buildHTTPConnectionManager("capture_http", ReporterSource, cniPod.GetName(), cniPod.GetNamespace(), nil)
 
@@ -244,9 +252,13 @@ func buildCaptureHTTPFilterChain(cniPod *cniv1.CNIPod, meshDomain string, emitSt
 		},
 	}
 	if scopeToCleartext {
-		// raw_buffer = cleartext (tls_inspector marks TLS streams "tls"). TLS egress
-		// then misses this chain and falls to the passthrough DefaultFilterChain.
-		fc.FilterChainMatch = &listenerv3.FilterChainMatch{TransportProtocol: "raw_buffer"}
+		// raw_buffer = cleartext (tls_inspector marks TLS "tls") + detected HTTP
+		// (http_inspector). TLS egress AND cleartext non-HTTP both miss this chain
+		// and fall to the passthrough DefaultFilterChain (see the func comment).
+		fc.FilterChainMatch = &listenerv3.FilterChainMatch{
+			TransportProtocol:    "raw_buffer",
+			ApplicationProtocols: []string{"http/1.0", "http/1.1", "h2c"},
+		}
 	}
 	return fc
 }

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -126,6 +126,12 @@ func TestGenerateCaptureListener_WithPassthrough(t *testing.T) {
 	// DefaultFilterChain passthrough instead of failing in the HTTP codec.
 	assert.Equal(t, "raw_buffer", l.GetFilterChains()[0].GetFilterChainMatch().GetTransportProtocol(),
 		"HCM chain must match raw_buffer so TLS egress falls through to the passthrough")
+	// ... AND detected-HTTP application protocols, so cleartext NON-HTTP (raw TCP to
+	// a non-mesh destination) also falls to the passthrough instead of being parsed
+	// as HTTP and answered with a fake 400 (#460 e2e finding).
+	assert.Equal(t, []string{"http/1.0", "http/1.1", "h2c"},
+		l.GetFilterChains()[0].GetFilterChainMatch().GetApplicationProtocols(),
+		"HCM chain must also require http_inspector-detected HTTP so raw TCP passes through")
 
 	// DefaultFilterChain must be set.
 	require.NotNil(t, l.GetDefaultFilterChain(), "DefaultFilterChain must be set when withPassthrough=true")


### PR DESCRIPTION
Two silent-failure modes from the #460 TCP floor e2e:

1. **Chain-without-cluster dead connections**: per-VIP floor chains are emitted for every TCP mesh service, but the `tcp:` cluster was demand-gated → undeclared TCP upstream = chain matches, connection dies silently (no ODCDS for tcp_proxy). Fix: **every TCP mesh service joins the node dependency set** (explicit + cluster-wide + few — same trade as GAMMA route targets), so chain/cluster/endpoints always ship together.
2. **cap_http swallowed cleartext non-HTTP** (fake `HTTP/1.1 400`): the redirect-all HCM chain now requires `raw_buffer` **and** http_inspector-detected HTTP (`http/1.0`, `http/1.1`, `h2c`) — undetected cleartext falls to the ORIGINAL_DST passthrough. TLS exclusion unchanged; TCP mesh VIPs unaffected (/32 dest-IP match wins).

Tests + `envoy --mode validate` green.