### PR TITLE
fix(capture): don't close short-first-write TCP conns stalled in the inspectors

### DIFF
--- a/agent/internal/xds/proxy/capture.go
+++ b/agent/internal/xds/proxy/capture.go
@@ -3,6 +3,9 @@ package proxy
 import (
 	"fmt"
 	"net"
+	"time"
+
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
@@ -129,12 +132,24 @@ func GenerateCaptureListener(cniPod *cniv1.CNIPod, capturePort uint32, meshDomai
 		// http_inspector detects HTTP/1 vs HTTP/2; tls_inspector detects TLS on the
 		// captured stream for future downstreams that speak TLS at the app layer.
 		// use_original_dst keeps the recovered destination on the connection.
-		ListenerFilters:               buildCaptureListenerFilters(),
-		UseOriginalDst:                wrapperspb.Bool(true),
-		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
-		StatPrefix:                    fmt.Sprintf("capture_%s", cniPod.GetName()),
-		TrafficDirection:              corev3.TrafficDirection_OUTBOUND,
-		FilterChains:                  chains,
+		ListenerFilters: buildCaptureListenerFilters(),
+		// The inspectors stall INCONCLUSIVE first writes: a raw-TCP client whose first
+		// chunk is <6 bytes (e.g. a 4-byte "p9\r\n") — or a server-first protocol that
+		// writes nothing (MySQL-style greeting) — never satisfies http_inspector, so
+		// chain selection never runs and Envoy's default 15s listener_filters_timeout
+		// CLOSES the conn (continue_on defaults false). Cap the wait at 1s and CONTINUE:
+		// matching proceeds with whatever was sniffed — a TCP-service destination still
+		// wins on the /32 destination-IP tier (dest IP outranks every protocol tier), so
+		// short-first-write and server-first TCP work with at most +1s connect latency.
+		// Real HTTP/TLS clients send their preface immediately and never hit the timeout.
+		// Found via the tcp-echo probes: payloads p1..p99 (<6B) failed, p100+ worked.
+		ListenerFiltersTimeout:           durationpb.New(time.Second),
+		ContinueOnListenerFiltersTimeout: true,
+		UseOriginalDst:                   wrapperspb.Bool(true),
+		PerConnectionBufferLimitBytes:    wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		StatPrefix:                       fmt.Sprintf("capture_%s", cniPod.GetName()),
+		TrafficDirection:                 corev3.TrafficDirection_OUTBOUND,
+		FilterChains:                     chains,
 	}
 
 	// SPIKE/M2a passthrough: the DefaultFilterChain is Envoy's true "no named chain

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -28,6 +28,14 @@ func TestGenerateCaptureListener(t *testing.T) {
 	assert.Equal(t, "/var/run/netns/p1", sa.GetNetworkNamespaceFilepath())
 	assert.True(t, l.GetUseOriginalDst().GetValue(), "use_original_dst set")
 
+	// Inspector stall guard: inconclusive first writes (<6B raw TCP, server-first
+	// protocols) must CONTINUE to chain matching after 1s instead of being closed at
+	// Envoy's 15s default (found via tcp-echo probes: p1..p99 failed, p100+ worked).
+	assert.Equal(t, int64(1), l.GetListenerFiltersTimeout().GetSeconds(),
+		"listener_filters_timeout must be capped at 1s")
+	assert.True(t, l.GetContinueOnListenerFiltersTimeout(),
+		"inconclusive sniffs must continue to chain matching, not close")
+
 	// listener filters: original_dst, http_inspector, tls_inspector.
 	require.Len(t, l.GetListenerFilters(), 3)
 	assert.Equal(t, listenerFilterOriginalDstName, l.GetListenerFilters()[0].GetName())


### PR DESCRIPTION
The capture listener's inspectors stall on an inconclusive first write (<6 bytes raw TCP, or server-first protocols that write nothing) → chain selection never runs → Envoy's default 15s `listener_filters_timeout` **closes** the conn.

Found chasing a phantom "~4-min new-SA cold start": five probes all flipped at exactly request #100 — the payload `p$i` crosses to ≥6 bytes at `p100`. Reproduced live on a steady-state pod: 4-byte first write fails, 6-byte works, same second. SPIRE/SDS/LDS were innocent (<5s each).

Fix: `listener_filters_timeout: 1s` + `continue_on_listener_filters_timeout: true` — inconclusive conns proceed to matching, where TCP-service dests still win on the /32 dest-IP tier. At most +1s connect latency for short-first-write/server-first TCP; HTTP/TLS clients never wait. Tests + `envoy --mode validate` green.