### PR TITLE
feat(025): M4 — typed headerToMetadata + service-wide CHAIN scope

### DIFF
--- a/agent/internal/configimport/importer.go
+++ b/agent/internal/configimport/importer.go
@@ -20,6 +20,9 @@ import (
 // Sink receives the materialized imported routes (the xDS SnapshotCache).
 type Sink interface {
 	SetImportedServiceRoutes(routes map[string][]proxy.GammaRoute)
+	// SetImportedServiceChainFilters receives the imported service-wide always-on
+	// extension filters (025 M4 CHAIN scope over the 026 channel); local wins.
+	SetImportedServiceChainFilters(filters map[string]proxy.ExtensionFilter)
 }
 
 // Importer polls the registrar for cross-cluster config projections and materializes
@@ -82,8 +85,9 @@ func (i *Importer) poll(ctx context.Context) {
 		i.log.WarnContext(ctx, "config import fetch failed; keeping last-known imported routes", "error", err)
 		return
 	}
-	routes, oldest := i.materialize(projections)
+	routes, chainFilters, oldest := i.materialize(projections)
 	i.sink.SetImportedServiceRoutes(routes)
+	i.sink.SetImportedServiceChainFilters(chainFilters)
 	// EM4: surface propagation lag — the age of the OLDEST imported projection. Negative
 	// when nothing carried a parseable export timestamp.
 	age := -1.0
@@ -98,10 +102,11 @@ func (i *Importer) poll(ctx context.Context) {
 // higher-version projection wins (deterministic, last-writer-by-version). It also
 // returns the oldest materialized projection's export time (zero when none parseable)
 // for the EM4 propagation-lag metric.
-func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection) (map[string][]proxy.GammaRoute, time.Time) {
+func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection) (map[string][]proxy.GammaRoute, map[string]proxy.ExtensionFilter, time.Time) {
 	type chosen struct {
 		version string
 		routes  []proxy.GammaRoute
+		filter  *registryv1.ExtensionFilter
 	}
 	picked := make(map[string]chosen, len(projections))
 	for _, p := range projections {
@@ -119,15 +124,22 @@ func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection
 		if cur, ok := picked[svc]; ok && cur.version >= p.GetVersion() {
 			continue
 		}
-		picked[svc] = chosen{version: p.GetVersion(), routes: proxy.FromConfigProjection(p)}
+		picked[svc] = chosen{version: p.GetVersion(), routes: proxy.FromConfigProjection(p), filter: p.GetServiceFilter()}
 	}
 	if len(picked) == 0 {
-		return nil, time.Time{}
+		return nil, nil, time.Time{}
 	}
 	out := make(map[string][]proxy.GammaRoute, len(picked))
+	var chainFilters map[string]proxy.ExtensionFilter
 	var oldest time.Time
 	for svc, c := range picked {
 		out[svc] = c.routes
+		if c.filter != nil {
+			if chainFilters == nil {
+				chainFilters = map[string]proxy.ExtensionFilter{}
+			}
+			chainFilters[svc] = proxy.ExtensionFilter{Name: c.filter.GetName(), Config: c.filter.GetConfig()}
+		}
 		// version is the exporter's RFC3339Nano timestamp (proposal 026 EM1c); track the
 		// oldest for the propagation-lag metric. Unparseable (e.g. a test stamp) → ignored.
 		if ts, err := time.Parse(time.RFC3339Nano, c.version); err == nil {
@@ -136,5 +148,5 @@ func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection
 			}
 		}
 	}
-	return out, oldest
+	return out, chainFilters, oldest
 }

--- a/agent/internal/configimport/importer_test.go
+++ b/agent/internal/configimport/importer_test.go
@@ -20,9 +20,15 @@ func (f *fakeImporter) ListConfig(context.Context) ([]*registryv1.ServiceConfigP
 	return f.projections, f.err
 }
 
-type fakeSink struct{ routes map[string][]proxy.GammaRoute }
+type fakeSink struct {
+	routes  map[string][]proxy.GammaRoute
+	filters map[string]proxy.ExtensionFilter
+}
 
 func (s *fakeSink) SetImportedServiceRoutes(r map[string][]proxy.GammaRoute) { s.routes = r }
+func (s *fakeSink) SetImportedServiceChainFilters(f map[string]proxy.ExtensionFilter) {
+	s.filters = f
+}
 
 func newImporter(t *testing.T, imp *fakeImporter, sink *fakeSink, own string) *Importer {
 	t.Helper()

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 
 	"github.com/bpalermo/aether/common/serviceref"
 
@@ -34,6 +35,11 @@ import (
 // RouteSink receives the projected per-service GAMMA rules (the snapshot cache).
 type RouteSink interface {
 	SetServiceRoutes(routes map[string][]proxy.GammaRoute)
+	// SetServiceChainFilters receives the service-wide ALWAYS-ON extension filters
+	// (proposal 025 M4 CHAIN scope), keyed by "<ns>/<svc>": at most one per service,
+	// from a CHAIN-scope HTTPFilter with a same-namespace Service targetRef. Enabled
+	// at the service's capture vhost.
+	SetServiceChainFilters(filters map[string]proxy.ExtensionFilter)
 	// SetRouteTargetPorts receives the real Service port(s) of each route target
 	// (proposal 023 M2), keyed by the same "<ns>/<svc>" route-target key as
 	// SetServiceRoutes. Sourced from the HTTPRoute/GRPCRoute parentRef port; lets the
@@ -157,6 +163,24 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	serviceFiltersFor := func(key string) []*registryv1.ExtensionFilter {
 		return gammaproject.ServiceFilters(key, specs)
 	}
+	// Service-wide always-on filters (M4 CHAIN scope): resolve per targeted service.
+	chainFilters := map[string]proxy.ExtensionFilter{}
+	for key, spec := range specs {
+		if spec.GetScope() != configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+			continue
+		}
+		ns, _, _ := strings.Cut(key, "/")
+		for _, t := range spec.GetTargetRefs() {
+			if (t.GetGroup() != "" && t.GetGroup() != "core") || t.GetKind() != "Service" {
+				continue
+			}
+			svcKey := ns + "/" + t.GetName()
+			// Deterministic pick delegated to the shared projector (name-sorted).
+			if ef := gammaproject.ServiceChainFilter(svcKey, specs); ef != nil {
+				chainFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
+			}
+		}
+	}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
 		for _, p := range gammaproject.ServiceParents(hr.Spec.ParentRefs, hr.Namespace) {
@@ -189,6 +213,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 
 	r.Sink.SetServiceRoutes(routes)
+	r.Sink.SetServiceChainFilters(chainFilters)
 	r.Sink.SetRouteTargetPorts(routeTargetPorts)
 	r.Log.DebugContext(ctx, "projected gamma service routes",
 		"httpRoutes", len(httpList.Items), "grpcRoutes", len(grpcList.Items), "services", len(routes))

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -104,12 +104,16 @@ func TestBuildGammaRoute_ExtensionRef(t *testing.T) {
 }
 
 type fakeSink struct {
-	routes map[string][]proxy.GammaRoute
-	ports  map[string][]uint32
+	routes       map[string][]proxy.GammaRoute
+	ports        map[string][]uint32
+	chainFilters map[string]proxy.ExtensionFilter
 }
 
 func (f *fakeSink) SetServiceRoutes(r map[string][]proxy.GammaRoute) { f.routes = r }
 func (f *fakeSink) SetRouteTargetPorts(p map[string][]uint32)        { f.ports = p }
+func (f *fakeSink) SetServiceChainFilters(c map[string]proxy.ExtensionFilter) {
+	f.chainFilters = c
+}
 
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "@io_opentelemetry_go_otel_metric//:metric",
         "@io_opentelemetry_go_otel_trace//:trace",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_uber_go_atomic//:atomic",
     ],

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -197,6 +197,14 @@ type SnapshotCache struct {
 	// for a route target whose parentRefs declare no port (then only the portless +
 	// mesh :18081 spellings are emitted, as before). Guarded by depMu.
 	routeTargetPorts map[string][]uint32
+	// serviceChainFilters holds the service-wide ALWAYS-ON extension filter per
+	// route-target service (proposal 025 M4 CHAIN scope), fed by the gamma
+	// reconciler; at most one per service (webhook-enforced). Enabled at the
+	// service's capture vhost. Guarded by depMu.
+	serviceChainFilters map[string]proxy.ExtensionFilter
+	// importedServiceChainFilters is the peer-cluster-imported variant (026);
+	// local wins on collision. Guarded by depMu.
+	importedServiceChainFilters map[string]proxy.ExtensionFilter
 	// captureTCPDeps mirrors captureTCPServices' service names into dependency
 	// state (guarded by depMu; the entries themselves stay under captureMu).
 	// Every TCP mesh service is ALWAYS in the node dependency set: the capture

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -80,7 +80,12 @@ func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Res
 	for _, rules := range c.serviceRoutesSnapshot() {
 		allRules = append(allRules, rules...)
 	}
-	extensionFilters := proxy.CollectExtensionFilters(allRules)
+	chainFilters := c.serviceChainFiltersSnapshot()
+	chainExtras := make([]proxy.ExtensionFilter, 0, len(chainFilters))
+	for _, ef := range chainFilters {
+		chainExtras = append(chainExtras, ef)
+	}
+	extensionFilters := proxy.CollectExtensionFilters(allRules, chainExtras...)
 
 	l, err := proxy.GenerateCaptureListener(cniPod, constants.ProxyCapturePort, c.meshDomain, c.emitStatsPod, tcpServices, c.captureRedirectAll, extensionFilters)
 	if err != nil {
@@ -423,6 +428,8 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 	// default client path (mesh-DNS), so the same L7 vocabulary the outbound listener
 	// applies must apply here; no rules = passthrough to the service cluster.
 	gammaRoutes := c.serviceRoutesSnapshot()
+	// Service-wide always-on extension filters (025 M4 CHAIN scope), vhost-enabled.
+	chainFilters := c.serviceChainFiltersSnapshot()
 	// Real Service port(s) of each route target (proposal 023 M2): a client dials the
 	// route target on its REAL port (e.g. echo:8080), and Envoy includes the port in
 	// vhost host-matching — so the vhost must carry a "<fqdn>:<realPort>" domain, not
@@ -481,7 +488,9 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 				mesh, fmt.Sprintf("%s:%d", mesh, constants.ProxyOutboundPort),
 			}
 		}
-		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, rules))
+		vh := proxy.BuildOutboundServiceVirtualHost(mesh, domains, rules)
+		applyChainFilter(vh, chainFilters, svc)
+		vhosts = append(vhosts, vh)
 	}
 	// Service-based routing (proposal 023): a GAMMA route TARGET with no SA-backed
 	// mesh Service of its own (the versioned-fanout shape — an "echo" target routed
@@ -503,7 +512,9 @@ func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
 		fqdn := ref.ClusterLocalFQDN()
 		mesh := proxy.ServiceClusterName(svc, c.meshDomain)
 		domains := c.routeTargetDomains(svc, fqdn, mesh, bareNameCount, routeTargetPorts[svc])
-		vhosts = append(vhosts, proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc]))
+		vh := proxy.BuildOutboundServiceVirtualHost(mesh, domains, gammaRoutes[svc])
+		applyChainFilter(vh, chainFilters, svc)
+		vhosts = append(vhosts, vh)
 	}
 	return vhosts
 }
@@ -687,4 +698,12 @@ func equalTCPEntries(a, b []captureTCPEntry) bool {
 		}
 	}
 	return true
+}
+
+// applyChainFilter enables svc's service-wide extension filter (025 M4 CHAIN scope)
+// on its capture vhost, when one is configured.
+func applyChainFilter(vh *routev3.VirtualHost, filters map[string]proxy.ExtensionFilter, svc string) {
+	if ef, ok := filters[svc]; ok {
+		proxy.ApplyServiceChainFilter(vh, &ef)
+	}
 }

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // SetServiceRoutes replaces the GAMMA east-west L7 rules (HTTPRoute parentRef=
@@ -253,4 +255,66 @@ func timeoutNanos(r proxy.GammaRoute) int64 {
 		return 0
 	}
 	return r.Timeout.AsDuration().Nanoseconds()
+}
+
+// SetServiceChainFilters replaces the service-wide ALWAYS-ON extension filters
+// (proposal 025 M4 CHAIN scope), keyed by "<ns>/<svc>". Fed by the gamma reconciler
+// from CHAIN-scope HTTPFilters with a Service targetRef; at most one per service.
+// Enabled at each service's capture vhost (vhost-level typed_per_filter_config).
+func (c *SnapshotCache) SetServiceChainFilters(filters map[string]proxy.ExtensionFilter) {
+	c.depMu.Lock()
+	changed := !equalServiceChainFilters(c.serviceChainFilters, filters)
+	c.serviceChainFilters = filters
+	c.depMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// SetImportedServiceChainFilters replaces the peer-cluster-imported service chain
+// filters (proposal 026). Local wins on a per-service collision, like routes.
+func (c *SnapshotCache) SetImportedServiceChainFilters(filters map[string]proxy.ExtensionFilter) {
+	c.depMu.Lock()
+	changed := !equalServiceChainFilters(c.importedServiceChainFilters, filters)
+	c.importedServiceChainFilters = filters
+	c.depMu.Unlock()
+	if changed {
+		c.signalDependencyChange()
+	}
+}
+
+// serviceChainFiltersSnapshot returns the effective (local ∪ imported, local wins)
+// per-service chain filters for a snapshot rebuild.
+func (c *SnapshotCache) serviceChainFiltersSnapshot() map[string]proxy.ExtensionFilter {
+	c.depMu.RLock()
+	defer c.depMu.RUnlock()
+	if len(c.serviceChainFilters) == 0 && len(c.importedServiceChainFilters) == 0 {
+		return nil
+	}
+	out := make(map[string]proxy.ExtensionFilter, len(c.serviceChainFilters)+len(c.importedServiceChainFilters))
+	for k, v := range c.importedServiceChainFilters {
+		out[k] = v
+	}
+	for k, v := range c.serviceChainFilters { // local overrides imported
+		out[k] = v
+	}
+	return out
+}
+
+func equalServiceChainFilters(a, b map[string]proxy.ExtensionFilter) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k, av := range a {
+		bv, ok := b[k]
+		if !ok || av.Name != bv.Name || !equalAny(av.Config, bv.Config) {
+			return false
+		}
+	}
+	return true
+}
+
+// equalAny compares two Any configs by proto semantics (nil-safe).
+func equalAny(a, b *anypb.Any) bool {
+	return proto.Equal(a, b)
 }

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//config/trace/v3:trace",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/open_telemetry/v3:open_telemetry",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/router/v3:router",

--- a/agent/internal/xds/proxy/extension_filter.go
+++ b/agent/internal/xds/proxy/extension_filter.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"github.com/bpalermo/aether/agent/internal/xds/config"
 	"github.com/bpalermo/aether/common/extensionfilter"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -34,12 +35,19 @@ func extensionHTTPFilter(name string, defaultConfig *anypb.Any) *http_connection
 // union of allow-listed extension filters referenced by the given rules (deduped,
 // stable order). Returns nil when none — the common case adds nothing to the chain.
 // Non-allow-listed names are skipped (the webhook rejects them at admission).
-func CollectExtensionFilters(rules []GammaRoute) []*http_connection_managerv3.HttpFilter {
+// extra carries filters not referenced by any rule — the service-wide CHAIN-scope
+// filters (025 M4), which are enabled at the vhost instead of a route but still need
+// their default-disabled chain entry.
+func CollectExtensionFilters(rules []GammaRoute, extra ...ExtensionFilter) []*http_connection_managerv3.HttpFilter {
 	var (
 		seen map[string]struct{}
 		out  []*http_connection_managerv3.HttpFilter
 	)
-	for _, r := range rules {
+	all := rules
+	if len(extra) > 0 {
+		all = append(append([]GammaRoute{}, rules...), GammaRoute{ExtensionFilters: extra})
+	}
+	for _, r := range all {
 		for _, ef := range r.ExtensionFilters {
 			defaultConfig, ok := extensionfilter.DefaultConfig(ef.Name)
 			if !ok {
@@ -75,4 +83,27 @@ func extensionPerFilterConfig(filters []ExtensionFilter) map[string]*anypb.Any {
 		m[ef.Name] = ef.Config
 	}
 	return m
+}
+
+// ApplyServiceChainFilter enables the service-wide ALWAYS-ON extension filter on a
+// service's capture vhost via vhost-level typed_per_filter_config (proposal 025 M4
+// CHAIN scope). It applies to every route in the vhost — including the default route
+// and routes added later — and a per-route ExtensionRef overrides it (Envoy resolves
+// route-level typed_per_filter_config over vhost-level; most-specific wins). No-op on
+// a nil filter or a non-allow-listed name.
+func ApplyServiceChainFilter(vh *routev3.VirtualHost, ef *ExtensionFilter) {
+	if vh == nil || ef == nil {
+		return
+	}
+	m := extensionPerFilterConfig([]ExtensionFilter{*ef})
+	if m == nil {
+		return
+	}
+	if vh.TypedPerFilterConfig == nil {
+		vh.TypedPerFilterConfig = m
+		return
+	}
+	for k, v := range m {
+		vh.TypedPerFilterConfig[k] = v
+	}
 }

--- a/agent/internal/xds/proxy/extension_filter_test.go
+++ b/agent/internal/xds/proxy/extension_filter_test.go
@@ -4,9 +4,12 @@ import (
 	"testing"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	header_to_metadatav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const h2mFilter = "envoy.filters.http.header_to_metadata"
@@ -88,4 +91,37 @@ func TestBuildOutboundServiceVirtualHost_EmitsExtensionConfig(t *testing.T) {
 	// First route is the rule's; the trailing catch-all carries no per-filter config.
 	assert.Same(t, cfg, vh.GetRoutes()[0].GetTypedPerFilterConfig()[h2mFilter])
 	assert.Nil(t, vh.GetRoutes()[len(vh.GetRoutes())-1].GetTypedPerFilterConfig(), "catch-all has no extension config")
+}
+
+// TestApplyServiceChainFilter covers the vhost-level enablement (025 M4 CHAIN):
+// the filter lands in vhost typed_per_filter_config; nil/non-allow-listed are no-ops.
+func TestApplyServiceChainFilter(t *testing.T) {
+	cfg, err := anypb.New(&header_mutationv3.HeaderMutationPerRoute{})
+	require.NoError(t, err)
+
+	vh := &routev3.VirtualHost{Name: "svc"}
+	ApplyServiceChainFilter(vh, &ExtensionFilter{Name: "envoy.filters.http.header_mutation", Config: cfg})
+	require.Contains(t, vh.GetTypedPerFilterConfig(), "envoy.filters.http.header_mutation")
+
+	// Non-allow-listed → no-op.
+	vh2 := &routev3.VirtualHost{Name: "svc2"}
+	ApplyServiceChainFilter(vh2, &ExtensionFilter{Name: "envoy.filters.http.lua", Config: cfg})
+	assert.Empty(t, vh2.GetTypedPerFilterConfig())
+	// Nil filter → no-op.
+	ApplyServiceChainFilter(vh2, nil)
+	assert.Empty(t, vh2.GetTypedPerFilterConfig())
+}
+
+// TestCollectExtensionFilters_Extra covers the chain-filter union: extras (not
+// referenced by any rule) still get their default-disabled HCM entries, deduped
+// against rule-referenced filters.
+func TestCollectExtensionFilters_Extra(t *testing.T) {
+	cfg, err := anypb.New(&header_mutationv3.HeaderMutationPerRoute{})
+	require.NoError(t, err)
+	rules := []GammaRoute{{ExtensionFilters: []ExtensionFilter{{Name: "envoy.filters.http.header_mutation", Config: cfg}}}}
+	out := CollectExtensionFilters(rules,
+		ExtensionFilter{Name: "envoy.filters.http.header_mutation", Config: cfg},    // dup of rule's
+		ExtensionFilter{Name: "envoy.filters.http.header_to_metadata", Config: cfg}, // new
+	)
+	require.Len(t, out, 2, "dedup across rules+extras; both allow-listed filters present")
 }

--- a/api/aether/config/v1/http_filter.proto
+++ b/api/aether/config/v1/http_filter.proto
@@ -27,10 +27,16 @@ message HTTPFilterSpec {
   // enforced by the webhook, not here.
   google.protobuf.Any typed_config = 2;
 
-  // scope selects where the filter applies. ROUTE (default, incl. UNSPECIFIED) emits
-  // the config into the referencing route's typed_per_filter_config — the v1 escape
-  // hatch. CHAIN (arbitrary HCM http_filters placement) is admin-owned and deferred
-  // to a later milestone; the webhook rejects it until then.
+  // scope selects where the filter applies (proposal 025 M4 semantics):
+  //   - ROUTE (default, incl. UNSPECIFIED): default-disabled in the HCM chain,
+  //     enabled per route via ExtensionRef / targetRef typed_per_filter_config.
+  //   - CHAIN: service-wide ALWAYS-ON — requires target_refs naming a Service; the
+  //     filter is enabled at the service's capture vhost (vhost-level
+  //     typed_per_filter_config), applying to ALL of that service's traffic. At most
+  //     ONE chain-scope filter per service (webhook-enforced; the projector
+  //     tie-breaks deterministically). Position in the chain is aether-owned (the
+  //     extension anchor); a per-route ExtensionRef overrides it (Envoy
+  //     most-specific-wins).
   Scope scope = 3 [(buf.validate.field).enum.defined_only = true];
 
   enum Scope {
@@ -46,6 +52,27 @@ message HTTPFilterSpec {
   // same-namespace as this HTTPFilter. A Service-attached filter is a class-1 payload
   // that rides proposal 026's config channel to peer clusters.
   repeated PolicyTargetRef target_refs = 4;
+
+  // header_to_metadata is the TYPED form of envoy.filters.http.header_to_metadata
+  // (proposal 025 M4 typed promotion): the one allow-listed filter Gateway API cannot
+  // express (it powers subset routing). Mutually exclusive with filter/typed_config —
+  // set exactly one authoring form; aether renders the Envoy proto internally.
+  HeaderToMetadata header_to_metadata = 5;
+}
+
+// HeaderToMetadata promotes the common header_to_metadata use to typed config: each
+// rule copies a request header's value into dynamic metadata when present.
+message HeaderToMetadata {
+  repeated Rule rules = 1 [(buf.validate.field).repeated.min_items = 1];
+
+  message Rule {
+    // header is the request header to read.
+    string header = 1 [(buf.validate.field).string.min_len = 1];
+    // metadata_key is the key written under the metadata namespace.
+    string metadata_key = 2 [(buf.validate.field).string.min_len = 1];
+    // metadata_namespace defaults to "envoy.lb" (the subset-routing namespace).
+    string metadata_namespace = 3;
+  }
 }
 
 // PolicyTargetRef is a Gateway API policy-attachment target: a namespace-local

--- a/api/aether/registry/v1/config.proto
+++ b/api/aether/registry/v1/config.proto
@@ -30,6 +30,10 @@ message ServiceConfigProjection {
   // routes is the projected, specificity-independent GAMMA rule set (the consumer
   // sorts/builds vhosts exactly as the local path does).
   repeated GammaRoute routes = 4;
+  // service_filter is the service-wide always-on extension filter (proposal 025 M4
+  // CHAIN scope): at most one per service, enabled at the service's capture vhost
+  // (vhost-level typed_per_filter_config). Rides the 026 channel like routes.
+  ExtensionFilter service_filter = 5;
 }
 
 // GammaRoute mirrors the in-memory proxy.GammaRoute: one HTTPRoute/GRPCRoute rule

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.62.0-{GIT_COMMIT}"
+version: "0.63.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-rbac.yaml
+++ b/charts/aether/templates/controller-rbac.yaml
@@ -12,6 +12,11 @@ rules:
   - apiGroups: ["config.aether.io"]
     resources: ["meshconfigs/status"]
     verbs: ["get", "update", "patch"]
+  # List HTTPFilters for the one-CHAIN-filter-per-service validating webhook
+  # (proposal 025 M4).
+  - apiGroups: ["config.aether.io"]
+    resources: ["httpfilters"]
+    verbs: ["get", "list"]
   # List HTTPRoutes cluster-wide for the hostname-conflict validating webhook
   # (proposal 018).
   - apiGroups: ["gateway.networking.k8s.io"]

--- a/common/extensionfilter/BUILD.bazel
+++ b/common/extensionfilter/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//types/known/anypb",
     ],
 )
 

--- a/common/extensionfilter/extensionfilter.go
+++ b/common/extensionfilter/extensionfilter.go
@@ -15,6 +15,7 @@ import (
 	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	header_to_metadatav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // allowed maps each allow-listed Envoy HTTP filter name to a builder for an EMPTY
@@ -45,12 +46,25 @@ func DefaultConfig(name string) (proto.Message, bool) {
 	return b(), true
 }
 
+// HeaderToMetadataFilterName is the Envoy filter the typed header_to_metadata
+// authoring form renders to.
+const HeaderToMetadataFilterName = "envoy.filters.http.header_to_metadata"
+
+// defaultMetadataNamespace is where header_to_metadata rules write when the rule
+// omits a namespace — "envoy.lb", the subset-routing namespace (aether's use case).
+const defaultMetadataNamespace = "envoy.lb"
+
 // ValidateSpec validates an HTTPFilterSpec fail-closed, IN-PROCESS (no Envoy binary):
-//   - spec.filter is non-empty and allow-listed (a filter the proxy build compiles in);
-//   - spec.scope is not CHAIN (deferred to a later milestone — route scope only);
-//   - spec.typedConfig resolves by its `@type` to a known Envoy message (else unknown/
-//     malformed → reject), and that message passes its protoc-gen-validate constraints
-//     (the same `(validate.rules)` Envoy enforces at config load).
+//   - exactly ONE authoring form is set: typed (headerToMetadata) XOR opaque
+//     (filter + typedConfig) — proposal 025 M4 typed promotion;
+//   - opaque form: spec.filter is allow-listed and spec.typedConfig resolves by its
+//     `@type` to a known Envoy message (else unknown/malformed → reject) passing its
+//     protoc-gen-validate constraints (the same `(validate.rules)` Envoy enforces);
+//   - typed form: rules are structurally valid (rendered internally, always
+//     allow-listed by construction);
+//   - scope CHAIN (M4: service-wide always-on) requires a Service targetRef — the
+//     "one CHAIN filter per service" invariant is enforced by the webhook (it needs
+//     the cluster view), not here.
 //
 // It does NOT prove the config composes with the live chain (ordering, filter
 // interactions) — that's the optional `envoy --mode validate` CI gate. Returns nil
@@ -59,15 +73,33 @@ func ValidateSpec(spec *configprotov1.HTTPFilterSpec) error {
 	if spec == nil {
 		return errors.New("spec is required")
 	}
+	typed := spec.GetHeaderToMetadata() != nil
+	opaque := spec.GetFilter() != "" || spec.GetTypedConfig() != nil
+	if typed && opaque {
+		return errors.New("set exactly one authoring form: headerToMetadata (typed) OR filter+typedConfig (opaque), not both")
+	}
+	if !typed && !opaque {
+		return errors.New("spec must set an authoring form: headerToMetadata (typed) or filter+typedConfig (opaque)")
+	}
+	if spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+		if !targetsAService(spec) {
+			return errors.New("spec.scope CHAIN (service-wide always-on) requires a targetRef of kind Service")
+		}
+	}
+	if typed {
+		for i, r := range spec.GetHeaderToMetadata().GetRules() {
+			if r.GetHeader() == "" || r.GetMetadataKey() == "" {
+				return fmt.Errorf("headerToMetadata.rules[%d]: header and metadataKey are required", i)
+			}
+		}
+		return nil
+	}
 	name := spec.GetFilter()
 	if name == "" {
 		return errors.New("spec.filter is required")
 	}
 	if !Allowed(name) {
 		return fmt.Errorf("spec.filter %q is not a supported extension filter (not in aether's allow-list / proxy build)", name)
-	}
-	if spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
-		return errors.New("spec.scope CHAIN is not yet supported; use route scope (ExtensionRef)")
 	}
 	tc := spec.GetTypedConfig()
 	if tc == nil {
@@ -86,4 +118,45 @@ func ValidateSpec(spec *configprotov1.HTTPFilterSpec) error {
 		}
 	}
 	return nil
+}
+
+// targetsAService reports whether the spec has a targetRef of kind Service (core group).
+func targetsAService(spec *configprotov1.HTTPFilterSpec) bool {
+	for _, t := range spec.GetTargetRefs() {
+		if (t.GetGroup() == "" || t.GetGroup() == "core") && t.GetKind() == "Service" {
+			return true
+		}
+	}
+	return false
+}
+
+// Render resolves an HTTPFilterSpec's authoring form to the concrete Envoy filter
+// name + typed config (proposal 025 M4): the typed headerToMetadata form is rendered
+// to envoy.filters.http.header_to_metadata config; the opaque form passes through
+// verbatim. Assumes ValidateSpec passed; callers on unvalidated input must check the
+// error.
+func Render(spec *configprotov1.HTTPFilterSpec) (string, *anypb.Any, error) {
+	if h2m := spec.GetHeaderToMetadata(); h2m != nil {
+		cfg := &header_to_metadatav3.Config{}
+		for _, r := range h2m.GetRules() {
+			ns := r.GetMetadataNamespace()
+			if ns == "" {
+				ns = defaultMetadataNamespace
+			}
+			cfg.RequestRules = append(cfg.RequestRules, &header_to_metadatav3.Config_Rule{
+				Header: r.GetHeader(),
+				OnHeaderPresent: &header_to_metadatav3.Config_KeyValuePair{
+					MetadataNamespace: ns,
+					Key:               r.GetMetadataKey(),
+					Type:              header_to_metadatav3.Config_STRING,
+				},
+			})
+		}
+		a, err := anypb.New(cfg)
+		if err != nil {
+			return "", nil, fmt.Errorf("render headerToMetadata: %w", err)
+		}
+		return HeaderToMetadataFilterName, a, nil
+	}
+	return spec.GetFilter(), spec.GetTypedConfig(), nil
 }

--- a/common/extensionfilter/extensionfilter_test.go
+++ b/common/extensionfilter/extensionfilter_test.go
@@ -44,7 +44,17 @@ func TestValidateSpec(t *testing.T) {
 		{"nil spec", nil, "spec is required"},
 		{"empty filter", spec("", configprotov1.HTTPFilterSpec_SCOPE_ROUTE, h2mCfg), "spec.filter is required"},
 		{"not allow-listed", spec("envoy.filters.http.lua", configprotov1.HTTPFilterSpec_SCOPE_ROUTE, h2mCfg), "not a supported extension filter"},
-		{"chain scope", spec("envoy.filters.http.header_mutation", configprotov1.HTTPFilterSpec_SCOPE_CHAIN, validPerRoute), "CHAIN is not yet supported"},
+		{"chain scope without targetRef", spec("envoy.filters.http.header_mutation", configprotov1.HTTPFilterSpec_SCOPE_CHAIN, validPerRoute), "CHAIN (service-wide always-on) requires a targetRef"},
+		{"chain scope with Service targetRef", withTarget(spec("envoy.filters.http.header_mutation", configprotov1.HTTPFilterSpec_SCOPE_CHAIN, validPerRoute), "echo"), ""},
+		{"both authoring forms", withTyped(spec("envoy.filters.http.header_mutation", configprotov1.HTTPFilterSpec_SCOPE_ROUTE, validPerRoute)), "exactly one authoring form"},
+		{"typed form valid", withTyped(&configprotov1.HTTPFilterSpec{}), ""},
+		{"typed form empty rule", func() *configprotov1.HTTPFilterSpec {
+			sp := &configprotov1.HTTPFilterSpec{}
+			sp.SetHeaderToMetadata(configprotov1.HeaderToMetadata_builder{Rules: []*configprotov1.HeaderToMetadata_Rule{
+				configprotov1.HeaderToMetadata_Rule_builder{Header: "x"}.Build(),
+			}}.Build())
+			return sp
+		}(), "header and metadataKey are required"},
 		{"nil typedConfig", spec("envoy.filters.http.header_mutation", configprotov1.HTTPFilterSpec_SCOPE_ROUTE, nil), "spec.typedConfig is required"},
 		{"unknown @type", spec("envoy.filters.http.header_mutation", configprotov1.HTTPFilterSpec_SCOPE_ROUTE, &anypb.Any{TypeUrl: "type.googleapis.com/does.not.Exist"}), "unknown or malformed"},
 	}
@@ -59,4 +69,47 @@ func TestValidateSpec(t *testing.T) {
 			assert.Contains(t, err.Error(), tc.wantErr)
 		})
 	}
+}
+
+// withTarget adds a Service targetRef to a spec (builder helpers for the M4 cases).
+func withTarget(sp *configprotov1.HTTPFilterSpec, svc string) *configprotov1.HTTPFilterSpec {
+	sp.SetTargetRefs([]*configprotov1.PolicyTargetRef{
+		configprotov1.PolicyTargetRef_builder{Kind: "Service", Name: svc}.Build(),
+	})
+	return sp
+}
+
+// withTyped sets the typed headerToMetadata authoring form.
+func withTyped(sp *configprotov1.HTTPFilterSpec) *configprotov1.HTTPFilterSpec {
+	sp.SetHeaderToMetadata(configprotov1.HeaderToMetadata_builder{Rules: []*configprotov1.HeaderToMetadata_Rule{
+		configprotov1.HeaderToMetadata_Rule_builder{Header: "x-canary", MetadataKey: "canary"}.Build(),
+	}}.Build())
+	return sp
+}
+
+// TestRender covers the typed→Envoy render and the opaque passthrough.
+func TestRender(t *testing.T) {
+	// Typed form renders to header_to_metadata with envoy.lb default namespace.
+	sp := withTyped(&configprotov1.HTTPFilterSpec{})
+	name, cfg, err := Render(sp)
+	require.NoError(t, err)
+	assert.Equal(t, HeaderToMetadataFilterName, name)
+	msg, err := cfg.UnmarshalNew()
+	require.NoError(t, err)
+	h2m, ok := msg.(*header_to_metadatav3.Config)
+	require.True(t, ok)
+	require.Len(t, h2m.GetRequestRules(), 1)
+	assert.Equal(t, "x-canary", h2m.GetRequestRules()[0].GetHeader())
+	assert.Equal(t, "canary", h2m.GetRequestRules()[0].GetOnHeaderPresent().GetKey())
+	assert.Equal(t, "envoy.lb", h2m.GetRequestRules()[0].GetOnHeaderPresent().GetMetadataNamespace())
+
+	// Opaque passthrough.
+	op := &configprotov1.HTTPFilterSpec{}
+	op.SetFilter("envoy.filters.http.header_mutation")
+	a, _ := anypb.New(&header_to_metadatav3.Config{})
+	op.SetTypedConfig(a)
+	name2, cfg2, err := Render(op)
+	require.NoError(t, err)
+	assert.Equal(t, "envoy.filters.http.header_mutation", name2)
+	assert.Same(t, a, cfg2)
 }

--- a/common/gammaproject/project.go
+++ b/common/gammaproject/project.go
@@ -246,13 +246,56 @@ func resolveExtensionFilter(ref *gatewayv1.LocalObjectReference, routeNamespace 
 // not allow-listed, or missing typed_config.
 func allowedExtensionFilter(spec *configprotov1.HTTPFilterSpec) (*registryv1.ExtensionFilter, bool) {
 	if spec == nil || spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+		return nil, false // CHAIN is vhost-level (ServiceChainFilter), never per-route
+	}
+	return renderedExtensionFilter(spec)
+}
+
+// renderedExtensionFilter resolves a spec's authoring form (typed headerToMetadata or
+// opaque filter+typedConfig — proposal 025 M4) to an allow-listed ExtensionFilter.
+func renderedExtensionFilter(spec *configprotov1.HTTPFilterSpec) (*registryv1.ExtensionFilter, bool) {
+	name, cfg, err := extensionfilter.Render(spec)
+	if err != nil || !extensionfilter.Allowed(name) || cfg == nil {
 		return nil, false
 	}
-	name := spec.GetFilter()
-	if !extensionfilter.Allowed(name) || spec.GetTypedConfig() == nil {
-		return nil, false
+	return &registryv1.ExtensionFilter{Name: name, Config: cfg}, true
+}
+
+// ServiceChainFilter resolves the service-wide ALWAYS-ON extension filter for
+// serviceKey ("<ns>/<svc>") — proposal 025 M4 CHAIN scope: an HTTPFilter with
+// scope CHAIN and a same-namespace targetRef naming the Service. At most one per
+// service (webhook-enforced); ties are broken deterministically by HTTPFilter key
+// order as belt-and-braces. Returns nil when none. The filter is enabled at the
+// service's capture vhost (vhost-level typed_per_filter_config), so it applies to
+// ALL of the service's traffic; a per-route ExtensionRef overrides it (Envoy
+// most-specific-wins).
+func ServiceChainFilter(serviceKey string, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.ExtensionFilter {
+	sref, ok := serviceref.ParseKey(serviceKey)
+	if !ok || len(httpFilters) == 0 {
+		return nil
 	}
-	return &registryv1.ExtensionFilter{Name: name, Config: spec.GetTypedConfig()}, true
+	keys := make([]string, 0, len(httpFilters))
+	for k := range httpFilters {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		spec := httpFilters[k]
+		if spec == nil || spec.GetScope() != configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+			continue
+		}
+		fref, ok := serviceref.ParseKey(k)
+		if !ok || fref.Namespace != sref.Namespace { // same-namespace policy attachment
+			continue
+		}
+		if !targetsService(spec, sref.Name) {
+			continue
+		}
+		if ef, ok := renderedExtensionFilter(spec); ok {
+			return ef
+		}
+	}
+	return nil
 }
 
 // ServiceFilters resolves the HTTPFilters (proposal 025 M3) that policy-attach to the

--- a/common/gammaproject/project_test.go
+++ b/common/gammaproject/project_test.go
@@ -137,3 +137,55 @@ func TestProjectHTTPRule_RedirectAndExtensionRefSkips(t *testing.T) {
 	assert.Equal(t, int32(301), gr.GetRedirect().GetStatusCode())
 	assert.Empty(t, gr.GetExtensionFilters(), "non-allow-listed ExtensionRef is skipped")
 }
+
+// TestServiceChainFilter covers M4 CHAIN scope: a CHAIN-scope HTTPFilter with a
+// Service targetRef resolves as the service-wide filter; ROUTE-scope filters and
+// other namespaces/services don't; ServiceFilters (route-level) skips CHAIN specs.
+func TestServiceChainFilter(t *testing.T) {
+	cfg, err := anypb.New(&configprotov1.HTTPFilterSpec{})
+	require.NoError(t, err)
+	chain := func(filter, svc string) *configprotov1.HTTPFilterSpec {
+		return configprotov1.HTTPFilterSpec_builder{
+			Filter: filter, TypedConfig: cfg,
+			Scope: configprotov1.HTTPFilterSpec_SCOPE_CHAIN,
+			TargetRefs: []*configprotov1.PolicyTargetRef{
+				configprotov1.PolicyTargetRef_builder{Kind: "Service", Name: svc}.Build(),
+			},
+		}.Build()
+	}
+	httpFilters := map[string]*configprotov1.HTTPFilterSpec{
+		"team-a/chain-hm": chain("envoy.filters.http.header_mutation", "echo"),
+		"team-b/other-ns": chain("envoy.filters.http.header_mutation", "echo"), // wrong ns
+	}
+
+	got := ServiceChainFilter("team-a/echo", httpFilters)
+	require.NotNil(t, got)
+	assert.Equal(t, "envoy.filters.http.header_mutation", got.GetName())
+	assert.Nil(t, ServiceChainFilter("team-a/none", httpFilters))
+
+	// ServiceFilters (route-level, M3) must SKIP chain-scope specs.
+	assert.Empty(t, ServiceFilters("team-a/echo", httpFilters), "CHAIN specs are vhost-level, never per-route")
+
+	// Deterministic tie-break: two chain filters (webhook-enforced not to happen) →
+	// key order picks team-a/aaa.
+	httpFilters["team-a/aaa"] = chain("envoy.filters.http.header_to_metadata", "echo")
+	tie := ServiceChainFilter("team-a/echo", httpFilters)
+	require.NotNil(t, tie)
+	assert.Equal(t, "envoy.filters.http.header_to_metadata", tie.GetName())
+
+	// Typed authoring form renders through the shared Render path.
+	typedSpec := configprotov1.HTTPFilterSpec_builder{
+		Scope: configprotov1.HTTPFilterSpec_SCOPE_CHAIN,
+		TargetRefs: []*configprotov1.PolicyTargetRef{
+			configprotov1.PolicyTargetRef_builder{Kind: "Service", Name: "typed"}.Build(),
+		},
+		HeaderToMetadata: configprotov1.HeaderToMetadata_builder{Rules: []*configprotov1.HeaderToMetadata_Rule{
+			configprotov1.HeaderToMetadata_Rule_builder{Header: "x-canary", MetadataKey: "canary"}.Build(),
+		}}.Build(),
+	}.Build()
+	httpFilters["team-a/typed"] = typedSpec
+	tf := ServiceChainFilter("team-a/typed", httpFilters)
+	require.NotNil(t, tf)
+	assert.Equal(t, "envoy.filters.http.header_to_metadata", tf.GetName())
+	assert.NotNil(t, tf.GetConfig())
+}

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -165,7 +165,7 @@ func runController(ctx context.Context) (retErr error) {
 	// list (uncached, correct regardless of the manager cache scope).
 	cwebhook.NewHandler(l, map[string]admission.Handler{
 		crdv1.MeshConfigKind:     &meshconfig.Validator{Log: l},
-		crdv1.HTTPFilterKind:     &httpfilter.Validator{Log: l},
+		crdv1.HTTPFilterKind:     &httpfilter.Validator{Reader: m.GetAPIReader(), Log: l},
 		gatewayapi.HTTPRouteKind: &gatewayapi.Validator{Reader: m.GetAPIReader(), Log: l},
 	}).SetupWithManager(m)
 

--- a/controller/internal/httpfilter/BUILD.bazel
+++ b/controller/internal/httpfilter/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/bpalermo/aether/controller/internal/httpfilter",
     visibility = ["//controller:__subpackages__"],
     deps = [
+        "//api/aether/config/v1:config",
         "//common/apis/config/v1:config",
         "//common/extensionfilter",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
     ],
 )

--- a/controller/internal/httpfilter/webhook.go
+++ b/controller/internal/httpfilter/webhook.go
@@ -12,15 +12,22 @@ import (
 	"fmt"
 	"log/slog"
 
+	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
 	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
 	"github.com/bpalermo/aether/common/extensionfilter"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 // Validator is served by the controller's shared /validate dispatcher, keyed by the
 // HTTPFilter Kind.
 type Validator struct {
-	Log *slog.Logger
+	// Reader lists existing HTTPFilters for the one-CHAIN-filter-per-service check
+	// (025 M4). Use the manager's APIReader (uncached — correct regardless of cache
+	// scope). Optional: when nil the dup check is skipped (the projector still
+	// tie-breaks deterministically).
+	Reader client.Reader
+	Log    *slog.Logger
 }
 
 // Handle validates the incoming HTTPFilter's spec.
@@ -35,5 +42,52 @@ func (v *Validator) Handle(ctx context.Context, req admission.Request) admission
 		v.Log.InfoContext(ctx, "rejected invalid HTTPFilter", "name", hf.GetName(), "error", err)
 		return admission.Denied(err.Error())
 	}
+	// One CHAIN-scope filter per service (025 M4): the service-wide always-on slot is
+	// singular by design — no merge/ordering semantics across filters. Reject a second
+	// CHAIN filter targeting a service another HTTPFilter (different name) already
+	// claims. The shared projector's deterministic tie-break is belt-and-braces for
+	// races the webhook can't see.
+	if hf.Spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN && v.Reader != nil {
+		if resp := v.checkChainConflict(ctx, hf); resp != nil {
+			return *resp
+		}
+	}
 	return admission.Allowed("")
+}
+
+// checkChainConflict returns a denial when another CHAIN-scope HTTPFilter in the
+// namespace targets one of hf's target services; nil when admissible.
+func (v *Validator) checkChainConflict(ctx context.Context, hf *crdv1.HTTPFilter) *admission.Response {
+	targets := map[string]struct{}{}
+	for _, t := range hf.Spec.GetTargetRefs() {
+		if (t.GetGroup() == "" || t.GetGroup() == "core") && t.GetKind() == "Service" {
+			targets[t.GetName()] = struct{}{}
+		}
+	}
+	list := &crdv1.HTTPFilterList{}
+	if err := v.Reader.List(ctx, list, client.InNamespace(hf.GetNamespace())); err != nil {
+		// Fail-closed would block all CHAIN applies on a transient list error; the
+		// projector tie-break keeps the data plane deterministic, so warn + allow.
+		v.Log.WarnContext(ctx, "chain-conflict check skipped: list failed", "error", err)
+		return nil
+	}
+	for i := range list.Items {
+		other := &list.Items[i]
+		if other.GetName() == hf.GetName() || other.Spec == nil ||
+			other.Spec.GetScope() != configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+			continue
+		}
+		for _, t := range other.Spec.GetTargetRefs() {
+			if (t.GetGroup() != "" && t.GetGroup() != "core") || t.GetKind() != "Service" {
+				continue
+			}
+			if _, clash := targets[t.GetName()]; clash {
+				resp := admission.Denied(fmt.Sprintf(
+					"service %q already has a CHAIN-scope HTTPFilter (%q); at most one service-wide filter per service",
+					t.GetName(), other.GetName()))
+				return &resp
+			}
+		}
+	}
+	return nil
 }

--- a/registrar/internal/configexport/controller.go
+++ b/registrar/internal/configexport/controller.go
@@ -99,8 +99,10 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 	httpFilters := c.httpFilterSpecs(ctx)
 
-	// Desired: per EXPORTED route-target, the projected GAMMA routes.
+	// Desired: per EXPORTED route-target, the projected GAMMA routes (+ the
+	// service-wide chain filter, 025 M4 — resolved after the route loops).
 	desired := map[string][]*registryv1.GammaRoute{}
+	desiredFilter := map[string]*registryv1.ExtensionFilter{}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
 		for _, p := range gammaproject.ServiceParents(hr.Spec.ParentRefs, hr.Namespace) {
@@ -126,6 +128,17 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 	}
 
+	// Service-wide chain filters (025 M4): for every exported service — including one
+	// with a chain filter but NO routes (the filter alone is exportable config).
+	for svc := range exported {
+		if ef := gammaproject.ServiceChainFilter(svc, httpFilters); ef != nil {
+			desiredFilter[svc] = ef
+			if _, ok := desired[svc]; !ok {
+				desired[svc] = nil // filter-only projection
+			}
+		}
+	}
+
 	// Current state this cluster authored (origin == self), to diff against.
 	current, err := c.Exporter.ListConfig(ctx)
 	if err != nil {
@@ -141,10 +154,10 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	version := time.Now().UTC().Format(time.RFC3339Nano)
 	for svc, routes := range desired {
 		// Skip when unchanged — avoid churning importers with a fresh version every reconcile.
-		if existing, ok := own[svc]; ok && routesEqual(existing.GetRoutes(), routes) {
+		if existing, ok := own[svc]; ok && routesEqual(existing.GetRoutes(), routes) && proto.Equal(existing.GetServiceFilter(), desiredFilter[svc]) {
 			continue
 		}
-		if err := c.Exporter.SetConfig(ctx, &registryv1.ServiceConfigProjection{Service: svc, Version: version, Routes: routes}); err != nil {
+		if err := c.Exporter.SetConfig(ctx, &registryv1.ServiceConfigProjection{Service: svc, Version: version, Routes: routes, ServiceFilter: desiredFilter[svc]}); err != nil {
 			c.metrics.writeError(ctx)
 			c.Log.ErrorContext(ctx, "failed to export config projection", "service", svc, "error", err)
 			return reconcile.Result{}, err


### PR DESCRIPTION
Closes 025's last milestone with the agreed opinionated design (no position vocabulary, no merging).

**Typed promotion:** `spec.headerToMetadata` typed authoring form (the one filter Gateway API can't express); exactly-one-of vs the opaque form; `extensionfilter.Render` resolves both.

**CHAIN scope, redefined:** service-wide ALWAYS-ON via **vhost-level typed_per_filter_config** — requires a same-namespace Service targetRef, at most **one per service** (webhook-enforced + deterministic projector tie-break), aether-owned position, per-route ExtensionRef overrides (most-specific-wins). Tenancy rides the M3 targetRef model — no admin gate. Rides 026 cross-cluster via `ServiceConfigProjection.service_filter`.

RBAC += controller httpfilters get/list; chart 0.63.0. 32/32 tests green incl. envoy --mode validate.