### PR TITLE
fix(025): chain-filtered services join the dependency set + push observability

### DIFF
--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
 go_test(
     name = "gamma_test",
     srcs = ["reconciler_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":gamma"],
     deps = [
         "//agent/internal/gatewaystatus",

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -662,3 +662,29 @@ func TestBuildGammaRouteFromGRPC_HeaderModifier(t *testing.T) {
 	require.Len(t, gr.HeaderMutation.RemoveResponse, 1)
 	assert.Equal(t, "x-grpc-debug", gr.HeaderMutation.RemoveResponse[0])
 }
+
+// TestReconcile_ServiceChainFilterPush (M4 seam test): a CHAIN-scope HTTPFilter with
+// a Service targetRef must reach the sink as a service chain filter through a full
+// Reconcile.
+func TestReconcile_ServiceChainFilterPush(t *testing.T) {
+	cfg, err := anypb.New(&header_to_metadatav3.Config{})
+	require.NoError(t, err)
+	hf := &configapisv1.HTTPFilter{
+		ObjectMeta: metav1.ObjectMeta{Name: "echo-chain", Namespace: "aether-test"},
+		Spec: configprotov1.HTTPFilterSpec_builder{
+			Filter: "envoy.filters.http.header_mutation", TypedConfig: cfg,
+			Scope: configprotov1.HTTPFilterSpec_SCOPE_CHAIN,
+			TargetRefs: []*configprotov1.PolicyTargetRef{
+				configprotov1.PolicyTargetRef_builder{Kind: "Service", Name: "echo"}.Build(),
+			},
+		}.Build(),
+	}
+	s := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(hf).Build()
+	sink := &fakeSink{}
+	r := &Reconciler{Client: c, Sink: sink, MeshDomain: "aether.internal", Log: slog.New(slog.DiscardHandler), httpFilterEnabled: true}
+	_, err = r.Reconcile(context.Background(), reconcile.Request{})
+	require.NoError(t, err)
+	require.Contains(t, sink.chainFilters, "aether-test/echo", "the CHAIN filter must be pushed keyed by <ns>/<svc>")
+	assert.Equal(t, "envoy.filters.http.header_mutation", sink.chainFilters["aether-test/echo"].Name)
+}

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
     srcs = [
         "cache_test.go",
         "capture_test.go",
+        "chain_seam_test.go",
         "cluster_alias_test.go",
         "cluster_test.go",
         "dependencies_test.go",
@@ -83,12 +84,14 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",
         "@io_opentelemetry_go_otel_sdk_metric//metricdata",
+        "@org_golang_google_protobuf//types/known/anypb",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/agent/internal/xds/cache/chain_seam_test.go
+++ b/agent/internal/xds/cache/chain_seam_test.go
@@ -1,0 +1,42 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+// TestCaptureVhosts_ServiceChainFilter (M4 seam test): SetServiceChainFilters must
+// surface as vhost-level typed_per_filter_config on the service's capture vhost.
+func TestCaptureVhosts_ServiceChainFilter(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetCaptureEnabled(true)
+	// The service must have a capture authority (mesh Service) for a vhost to render.
+	// Deliberately NO declared dependency and NO GAMMA routes: the chain filter
+	// itself must put the service in scope (2026-07-05 kind repro: a route-less
+	// chain-filtered service never got its dedicated vhost, so the filter silently
+	// never applied — requests fell to the ODCDS catch-all).
+	c.SetCaptureAuthorities(map[string]string{"aether-test/echo": "echo.aether-test.svc.cluster.local"})
+
+	cfg, err := anypb.New(&header_mutationv3.HeaderMutationPerRoute{})
+	require.NoError(t, err)
+	c.SetServiceChainFilters(map[string]proxy.ExtensionFilter{
+		"aether-test/echo": {Name: "envoy.filters.http.header_mutation", Config: cfg},
+	})
+
+	vhosts := c.captureVhosts()
+	require.NotEmpty(t, vhosts, "echo authority must render a vhost")
+	found := false
+	for _, vh := range vhosts {
+		if vh.GetName() == "echo.aether-test.aether.internal" || len(vh.GetDomains()) > 0 {
+			if _, ok := vh.GetTypedPerFilterConfig()["envoy.filters.http.header_mutation"]; ok {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "the chain filter must be enabled at the service vhost (typed_per_filter_config)")
+}

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -150,6 +150,18 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 	for _, svc := range c.captureTCPDeps {
 		set[svc] = struct{}{}
 	}
+	// Services with a service-wide chain filter (025 M4): always in scope — the
+	// filter is enabled at the service's capture vhost, and vhost emission is
+	// dependency-gated. Without this, a chain-filtered service with NO GAMMA routes
+	// and no declaring pod never gets its dedicated vhost, so the filter silently
+	// never applies (requests fall to the ODCDS catch-all vhost, which carries no
+	// typed_per_filter_config). Explicit + few, like GAMMA route targets.
+	for svc := range c.serviceChainFilters {
+		set[svc] = struct{}{}
+	}
+	for svc := range c.importedServiceChainFilters {
+		set[svc] = struct{}{}
+	}
 	for _, deps := range c.podDeps {
 		if deps.service != "" {
 			set[deps.service] = struct{}{}

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -267,6 +267,9 @@ func (c *SnapshotCache) SetServiceChainFilters(filters map[string]proxy.Extensio
 	c.serviceChainFilters = filters
 	c.depMu.Unlock()
 	if changed {
+		// INFO on change: the in-vivo debugging signal for "the filter never
+		// applied" (2026-07-05: one agent silently held an empty map until restart).
+		c.log.Info("service chain filters updated", "count", len(filters))
 		c.signalDependencyChange()
 	}
 }
@@ -279,6 +282,7 @@ func (c *SnapshotCache) SetImportedServiceChainFilters(filters map[string]proxy.
 	c.importedServiceChainFilters = filters
 	c.depMu.Unlock()
 	if changed {
+		c.log.Info("imported service chain filters updated", "count", len(filters))
 		c.signalDependencyChange()
 	}
 }


### PR DESCRIPTION
M4 talos e2e findings: (1) **confirmed bug** — a route-less CHAIN-filtered service never joined the dependency set → no dedicated vhost → the filter silently never applied (requests hit the ODCDS catch-all; persistent kind repro). Fix: chain-filtered services (local + imported) always in scope, like GAMMA targets/TCP floor services; regression test with NO declared deps. (2) **observability** — one talos agent held an empty chain-filter map until restart, undiagnosable post-mortem (TRACE not exported); cache setters now log INFO on change. One-off root cause unreproducible (unit + kind e2e + exact-bytes pipeline all green).