### PR TITLE
fix(build): stale testdata glob from #468 (build broken)

### DIFF
--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
 go_test(
     name = "gamma_test",
     srcs = ["reconciler_test.go"],
-    data = glob(["testdata/**"]),
     embed = [":gamma"],
     deps = [
         "//agent/internal/gatewaystatus",


### PR DESCRIPTION
The temp debug test's testdata/ was removed but the gazelle data glob remained; empty globs error. One-line removal; `bazel build //...` green.