### PR TITLE
feat(027): M1 — authz sidecar system half

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -2,6 +2,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/bpalermo/aether/agent/constants"
 	cniServer "github.com/bpalermo/aether/agent/internal/cni/server"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -93,6 +95,16 @@ type AgentConfig struct {
 	// the imported routes into the cache (merged with local; local wins). Default off;
 	// no-op when the registry backend has no cross-cluster config plane (etcd only).
 	ImportConfig bool
+
+	// AuthzSidecar enables the node-local external-authorization sidecar entry
+	// (proposal 027): a disabled ext_authz HCM filter targeting the chart's static
+	// authz_sidecar UDS cluster; HTTPFilter (extAuthz) opts routes in.
+	AuthzSidecar bool
+	// AuthzSidecarTimeout is the per-check gRPC timeout.
+	AuthzSidecarTimeout time.Duration
+	// AuthzSidecarFailureModeAllow selects fail-open (true) vs fail-closed (false,
+	// requests on opted-in routes are denied when the sidecar is unreachable).
+	AuthzSidecarFailureModeAllow bool
 
 	// ControlCluster, when set, names the single authorized config-exporting cluster
 	// (proposal 026 EM3, Option E): the importer then trusts ONLY config originating

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/bpalermo/aether/agent/constants"
 	"github.com/bpalermo/aether/agent/internal/capture"
@@ -123,6 +124,9 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.RemoveStartupTaint, "remove-startup-taint", cfg.RemoveStartupTaint, "Remove the aether.io/agent-not-ready node taint once the CNI server is serving (needs nodes patch RBAC)")
 	rootCmd.Flags().BoolVar(&cfg.Gamma, "gamma", false, "Enable GAMMA east-west L7 routing: watch HTTPRoutes parented to a Service and enrich the node proxy's outbound routes (proposal 018, Phase 2)")
 	rootCmd.Flags().BoolVar(&cfg.ImportConfig, "import-config", false, "Enable cross-cluster config import: poll the registrar for GAMMA config projections peer clusters exported and materialize them into the node proxy's routes (proposal 026). No-op unless the registry backend has a cross-cluster config plane (etcd)")
+	rootCmd.Flags().BoolVar(&cfg.AuthzSidecar, "authz-sidecar", false, "Enable the node-local external-authorization sidecar entry (proposal 027): a disabled ext_authz HCM filter targeting the static authz_sidecar UDS cluster; HTTPFilter (extAuthz) opts routes in")
+	rootCmd.Flags().DurationVar(&cfg.AuthzSidecarTimeout, "authz-sidecar-timeout", 200*time.Millisecond, "Per-check gRPC timeout for the authz sidecar")
+	rootCmd.Flags().BoolVar(&cfg.AuthzSidecarFailureModeAllow, "authz-sidecar-failure-mode-allow", false, "Fail-open: allow requests when the authz sidecar is unreachable (default fail-closed: deny)")
 	rootCmd.Flags().StringVar(&cfg.ControlCluster, "control-cluster", "", "Name of the single authorized config-exporting cluster (proposal 026 EM3, Option E). When set, imported config is trusted ONLY from this origin; empty = federated (trust any peer)")
 	rootCmd.Flags().BoolVar(&cfg.L4Routes, "l4-routes", false, "Enable L4 route types (TCPRoute/TLSRoute/UDPRoute) parented to a Service: weighted TCP floor chains and SNI-routed TLS chains on the capture listener (proposal 018, Phase 3b). NOTE: UDPRoute is control-plane only until the CNI UDP redirect lands.")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCapture, "transparent-capture", false, "Enable transparent capture: per-pod capture listeners + cap_http route table from the generated mesh Services (proposal 018, Phase 3a)")
@@ -396,6 +400,9 @@ func runAgent(ctx context.Context) (retErr error) {
 	// into the cache (merged with local routes; local wins). Default off
 	// (--import-config). No-op when the registry backend has no cross-cluster config
 	// plane (kubernetes/dynamodb don't implement registry.ConfigImporter).
+	if cfg.AuthzSidecar {
+		snapshotCache.SetAuthzSidecar(cfg.AuthzSidecarTimeout, cfg.AuthzSidecarFailureModeAllow)
+	}
 	if cfg.ImportConfig {
 		if imp, ok := reg.(registry.ConfigImporter); ok {
 			importer := configimport.NewImporter(imp, snapshotCache, cfg.ClusterName, cfg.ControlCluster, 0, l)

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -205,6 +205,12 @@ type SnapshotCache struct {
 	// importedServiceChainFilters is the peer-cluster-imported variant (026);
 	// local wins on collision. Guarded by depMu.
 	importedServiceChainFilters map[string]proxy.ExtensionFilter
+	// authzSidecar enables the disabled ext_authz HCM entry for the node-local
+	// authorization sidecar (proposal 027). Boot-time (SetAuthzSidecar), so no
+	// locking/regeneration concerns.
+	authzSidecar          bool
+	authzTimeout          time.Duration
+	authzFailureModeAllow bool
 	// captureTCPDeps mirrors captureTCPServices' service names into dependency
 	// state (guarded by depMu; the entries themselves stay under captureMu).
 	// Every TCP mesh service is ALWAYS in the node dependency set: the capture

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bpalermo/aether/common/serviceref"
 
@@ -715,5 +716,20 @@ func (c *SnapshotCache) extensionHTTPFilters() []*http_connection_managerv3.Http
 	for _, ef := range chainFilters {
 		chainExtras = append(chainExtras, ef)
 	}
-	return proxy.CollectExtensionFilters(allRules, chainExtras...)
+	union := proxy.CollectExtensionFilters(allRules, chainExtras...)
+	// Node-local authz sidecar (proposal 027): the disabled ext_authz entry carries
+	// the full transport (the per-route type cannot); routes opt in via TPFC.
+	// Boot-time config — set before any listener generates.
+	if c.authzSidecar {
+		union = append(union, proxy.AuthzSidecarHTTPFilter(c.authzTimeout, c.authzFailureModeAllow))
+	}
+	return union
+}
+
+// SetAuthzSidecar configures the node-local authz sidecar ext_authz entry
+// (proposal 027). Called once at startup, before listener generation.
+func (c *SnapshotCache) SetAuthzSidecar(timeout time.Duration, failureModeAllow bool) {
+	c.authzSidecar = true
+	c.authzTimeout = timeout
+	c.authzFailureModeAllow = failureModeAllow
 }

--- a/agent/internal/xds/cache/chain_seam_test.go
+++ b/agent/internal/xds/cache/chain_seam_test.go
@@ -107,3 +107,15 @@ func TestOutboundVhost_ServiceChainFilter(t *testing.T) {
 	}
 	assert.True(t, foundChainEntry, "outbound HCM must carry the default-disabled extension entry")
 }
+
+// TestExtensionHTTPFilters_AuthzSidecar (027 M1): when the sidecar is enabled the
+// union carries the disabled ext_authz entry on top of any rule/chain filters.
+func TestExtensionHTTPFilters_AuthzSidecar(t *testing.T) {
+	c := newTestCache("node-1")
+	assert.Empty(t, c.extensionHTTPFilters(), "no entries by default")
+	c.SetAuthzSidecar(200*1000*1000, false) // 200ms
+	fs := c.extensionHTTPFilters()
+	require.Len(t, fs, 1)
+	assert.Equal(t, "envoy.filters.http.ext_authz", fs[0].GetName())
+	assert.True(t, fs[0].GetDisabled())
+}

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "proxy",
     srcs = [
         "accesslog.go",
+        "authz.go",
         "capture.go",
         "cluster.go",
         "edge.go",
@@ -51,6 +52,7 @@ go_library(
         "@com_github_envoyproxy_go_control_plane_envoy//config/trace/v3:trace",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/open_telemetry/v3:open_telemetry",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/ext_authz/v3:ext_authz",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/on_demand/v3:on_demand",
@@ -80,6 +82,7 @@ go_test(
     name = "proxy_test",
     srcs = [
         "accesslog_test.go",
+        "authz_test.go",
         "capture_test.go",
         "edge_test.go",
         "egress_test.go",
@@ -119,6 +122,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//config/trace/v3:trace",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/access_loggers/open_telemetry/v3:open_telemetry",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/common/set_filter_state/v3:set_filter_state",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/ext_authz/v3:ext_authz",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/health_check/v3:health_check",

--- a/agent/internal/xds/proxy/authz.go
+++ b/agent/internal/xds/proxy/authz.go
@@ -1,0 +1,43 @@
+package proxy
+
+import (
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// AuthzSidecarClusterName is the static bootstrap cluster the chart provisions for
+// the node-local authorization sidecar (proposal 027): a Unix-socket pipe to the
+// authz container in the aether-proxy pod. Always present/warm when the sidecar is
+// enabled — never demand-scoped.
+const AuthzSidecarClusterName = "authz_sidecar"
+
+// ExtAuthzFilterName is the Envoy HTTP filter this entry configures.
+const ExtAuthzFilterName = "envoy.filters.http.ext_authz"
+
+// AuthzSidecarHTTPFilter builds the ext_authz HCM entry for the node-local authz
+// sidecar (proposal 027 system half): FULL transport config — the per-route type
+// (ExtAuthzPerRoute) cannot carry it — but `disabled: true`, so it has ZERO effect
+// until a route/vhost opts in via typed_per_filter_config (the 025 enablement
+// machinery). failureModeAllow=false is fail-closed: requests on opted-in routes
+// are DENIED when the sidecar is unreachable.
+func AuthzSidecarHTTPFilter(timeout time.Duration, failureModeAllow bool) *http_connection_managerv3.HttpFilter {
+	cfg := &ext_authzv3.ExtAuthz{
+		Services: &ext_authzv3.ExtAuthz_GrpcService{
+			GrpcService: &corev3.GrpcService{
+				TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: AuthzSidecarClusterName},
+				},
+				Timeout: durationpb.New(timeout),
+			},
+		},
+		TransportApiVersion: corev3.ApiVersion_V3,
+		FailureModeAllow:    failureModeAllow,
+	}
+	f := httpFilter(ExtAuthzFilterName, cfg)
+	f.Disabled = true
+	return f
+}

--- a/agent/internal/xds/proxy/authz_test.go
+++ b/agent/internal/xds/proxy/authz_test.go
@@ -1,0 +1,33 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthzSidecarHTTPFilter (027 M1): the entry carries the FULL transport
+// (static UDS cluster, timeout, failure mode, V3) and is DISABLED — zero effect
+// until a route opts in via typed_per_filter_config.
+func TestAuthzSidecarHTTPFilter(t *testing.T) {
+	f := AuthzSidecarHTTPFilter(150*time.Millisecond, false)
+	require.Equal(t, ExtAuthzFilterName, f.GetName())
+	assert.True(t, f.GetDisabled(), "must be disabled: enablement is per-route (025 machinery)")
+
+	cfg := &ext_authzv3.ExtAuthz{}
+	require.NoError(t, f.GetTypedConfig().UnmarshalTo(cfg))
+	assert.Equal(t, AuthzSidecarClusterName, cfg.GetGrpcService().GetEnvoyGrpc().GetClusterName())
+	assert.Equal(t, 150*time.Millisecond, cfg.GetGrpcService().GetTimeout().AsDuration())
+	assert.Equal(t, corev3.ApiVersion_V3, cfg.GetTransportApiVersion())
+	assert.False(t, cfg.GetFailureModeAllow(), "fail-closed by default")
+
+	// Fail-open variant.
+	fo := AuthzSidecarHTTPFilter(time.Second, true)
+	cfg2 := &ext_authzv3.ExtAuthz{}
+	require.NoError(t, fo.GetTypedConfig().UnmarshalTo(cfg2))
+	assert.True(t, cfg2.GetFailureModeAllow())
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.63.0-{GIT_COMMIT}"
+version: "0.64.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -90,6 +90,13 @@ spec:
             {{- if .Values.controlCluster }}
             - "--control-cluster={{ .Values.controlCluster }}"
             {{- end }}
+            {{- if .Values.proxy.authzSidecar.enabled }}
+            - "--authz-sidecar"
+            - "--authz-sidecar-timeout={{ .Values.proxy.authzSidecar.timeout }}"
+            {{- if eq .Values.proxy.authzSidecar.failureMode "ALLOW" }}
+            - "--authz-sidecar-failure-mode-allow"
+            {{- end }}
+            {{- end }}
             {{- if .Values.agent.l4Routes }}
             - "--l4-routes"
             {{- end }}

--- a/charts/aether/templates/agent-proxy-configmap.yaml
+++ b/charts/aether/templates/agent-proxy-configmap.yaml
@@ -280,6 +280,27 @@ data:
 
     static_resources:
       clusters:
+{{- if .Values.proxy.authzSidecar.enabled }}
+      # External authorization sidecar (proposal 027): static UDS cluster — always
+      # present/warm, no demand-scoping. The agent emits a DISABLED ext_authz HCM
+      # entry targeting this cluster; HTTPFilter (extAuthz) opts routes in.
+      - name: authz_sidecar
+        type: STATIC
+        connect_timeout: 1s
+        load_assignment:
+          cluster_name: authz_sidecar
+          endpoints:
+            - lb_endpoints:
+                - endpoint:
+                    address:
+                      pipe:
+                        path: /run/aether/authz/authz.sock
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
+{{- end }}
       - name: agent_xds
         type: STATIC
         load_assignment:

--- a/charts/aether/templates/agent-proxy-daemonset.yaml
+++ b/charts/aether/templates/agent-proxy-daemonset.yaml
@@ -203,6 +203,46 @@ spec:
               mountPath: /dev/shm
             - name: ready-marker
               mountPath: /var/run/aether-proxy
+            {{- if .Values.proxy.authzSidecar.enabled }}
+            - name: authz-socket
+              mountPath: /run/aether/authz
+            {{- end }}
+        {{- if .Values.proxy.authzSidecar.enabled }}
+        # External authorization sidecar (proposal 027): serves
+        # envoy.service.auth.v3.Authorization on the shared Unix socket. The proxy's
+        # bootstrap carries a static `authz_sidecar` cluster pointing at it.
+        - name: authz
+          {{- if .Values.proxy.authzSidecar.opa.enabled }}
+          image: {{ .Values.proxy.authzSidecar.opa.image | quote }}
+          args:
+            - "run"
+            - "--server"
+            - "--disable-telemetry"
+            - "--addr=127.0.0.1:8181"
+            - "--set=plugins.envoy_ext_authz_grpc.addr=unix:///run/aether/authz/authz.sock"
+            - "--set=decision_logs.console=true"
+            - "/policy/policy.rego"
+          volumeMounts:
+            - name: authz-socket
+              mountPath: /run/aether/authz
+            - name: opa-policy
+              mountPath: /policy
+              readOnly: true
+          {{- else }}
+          image: "{{ .Values.proxy.authzSidecar.image.repository }}:{{ .Values.proxy.authzSidecar.image.tag }}"
+          {{- with .Values.proxy.authzSidecar.image.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: authz-socket
+              mountPath: /run/aether/authz
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+        {{- end }}
       volumes:
         - name: supervisor-bin
           emptyDir: {}
@@ -216,6 +256,15 @@ spec:
         # Pod-local readiness marker (not shared across pods).
         - name: ready-marker
           emptyDir: {}
+        {{- if .Values.proxy.authzSidecar.enabled }}
+        - name: authz-socket
+          emptyDir: {}
+        {{- if .Values.proxy.authzSidecar.opa.enabled }}
+        - name: opa-policy
+          configMap:
+            name: {{ include "aether.fullname" . }}-opa-policy
+        {{- end }}
+        {{- end }}
         - name: proxy-config
           configMap:
             name: {{ include "aether.proxy.configMapName" . }}

--- a/charts/aether/templates/agent-proxy-opa-policy.yaml
+++ b/charts/aether/templates/agent-proxy-opa-policy.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.proxy.authzSidecar.enabled .Values.proxy.authzSidecar.opa.enabled }}
+{{- if not .Values.proxy.authzSidecar.opa.policy }}
+{{- fail "proxy.authzSidecar.opa.policy is required when the OPA preset is enabled" }}
+{{- end }}
+# Rego policy for the OPA authz sidecar (proposal 027). Mounted read-only at
+# /policy/policy.rego in the sidecar container.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "aether.fullname" . }}-opa-policy
+  namespace: {{ include "aether.namespace" . }}
+  labels:
+    {{- include "aether.agent.labels" . | nindent 4 }}
+data:
+  policy.rego: |
+    {{- .Values.proxy.authzSidecar.opa.policy | nindent 4 }}
+{{- end }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -213,6 +213,30 @@ proxy:
       memory: 512Mi
     limits:
       memory: 512Mi
+  # External authorization sidecar (proposal 027): an authz gRPC service co-located
+  # in this DaemonSet pod, reached over a Unix socket. When enabled, the proxy
+  # bootstrap gains a static `authz_sidecar` cluster and the agent emits a
+  # DISABLED ext_authz entry on the HTTP filter chains — zero effect until an
+  # HTTPFilter (extAuthz) opts a route/service in.
+  authzSidecar:
+    enabled: false
+    # Built-in OPA preset (opt-in): runs the OPA envoy plugin with the policy below.
+    opa:
+      enabled: false
+      image: openpolicyagent/opa:1.9.0-envoy
+      # Rego policy mounted via ConfigMap; must define the decision the plugin
+      # queries (envoy/authz/allow by default). Required when opa.enabled.
+      policy: ""
+    # Bring-your-own authz container (used when opa.enabled is false). Must serve
+    # envoy.service.auth.v3.Authorization on unix:///run/aether/authz/authz.sock.
+    image:
+      repository: ""
+      tag: ""
+      args: []
+    # Check timeout and the REQUIRED failure mode: DENY (fail-closed, requests 403
+    # when the sidecar is unreachable) or ALLOW (fail-open).
+    timeout: 200ms
+    failureMode: DENY
   # Envoy overload manager graceful-degradation ladder; engages before the OOM
   # kill. Keep maxHeapSizeBytes at ~75% of resources.limits.memory.
   overload:

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -20,6 +20,7 @@ package envoy_validate
 
 import (
 	"fmt"
+	"time"
 
 	bootstrapv3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -104,11 +105,15 @@ func EdgeBootstrapJSON() ([]byte, error) {
 	return marshalBootstrap(bs)
 }
 
-// buildNodeBootstrap builds the core node-proxy bootstrap config.
+// buildNodeBootstrap builds the core node-proxy bootstrap config. The outbound
+// listener carries the node-local authz-sidecar ext_authz entry (proposal 027,
+// disabled — the real transport config, validated by stock Envoy) alongside a
+// static authz_sidecar UDS cluster mirroring the chart's bootstrap cluster.
 func buildNodeBootstrap() (*bootstrapv3.Bootstrap, error) {
 	pod := testPod()
 
-	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false, false, nil)
+	authzEntry := proxy.AuthzSidecarHTTPFilter(200*time.Millisecond, false)
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false, false, []*http_connection_managerv3.HttpFilter{authzEntry})
 	if err != nil {
 		return nil, fmt.Errorf("GenerateListenersFromRegistryPod: %w", err)
 	}
@@ -116,11 +121,26 @@ func buildNodeBootstrap() (*bootstrapv3.Bootstrap, error) {
 	passthrough := proxy.NewPassthroughOriginalDstCluster()
 	svcCluster := newServiceCluster("echo."+meshDomain, trustDomain, "default", "echo")
 
-	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster}
+	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster, authzSidecarCluster()}
 	staticClusters = append(staticClusters, appClusters...)
 	staticClusters = append(staticClusters, healthCluster)
 
 	return newBootstrap(staticClusters, []*listenerv3.Listener{inbound, outbound}), nil
+}
+
+// authzSidecarCluster mirrors the chart's static UDS cluster for the authz sidecar.
+func authzSidecarCluster() *clusterv3.Cluster {
+	return &clusterv3.Cluster{
+		Name:                 proxy.AuthzSidecarClusterName,
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STATIC},
+		ConnectTimeout:       durationpb.New(time.Second),
+		LoadAssignment:       pipeEndpoint(proxy.AuthzSidecarClusterName, "/run/aether/authz/authz.sock"),
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustAny(
+				config.Http2ProtocolOptions(),
+			),
+		},
+	}
 }
 
 // buildNodeCleartextBootstrap builds the node-proxy bootstrap with SPIRE off: the


### PR DESCRIPTION
System half of ext_authz (proposal 027, #471): opt-in authz sidecar in the aether-proxy pod (OPA preset default-false or bring-your-own image), static `authz_sidecar` UDS bootstrap cluster, and a **disabled** ext_authz HCM entry carrying the full transport (cluster/timeout/**explicit** failure mode) at the 025 extension anchor on capture+outbound. Zero effect until M2's typed `extAuthz` opts routes in. Everything defaults off; `envoy --mode validate` accepts the real config; chart renders verified both ways. Chart 0.64.0.