### PR TITLE
feat(027): M2+M3 — typed extAuthz + INBOUND enforcement

### DIFF
--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -40,6 +40,10 @@ type RouteSink interface {
 	// from a CHAIN-scope HTTPFilter with a same-namespace Service targetRef. Enabled
 	// at the service's capture vhost.
 	SetServiceChainFilters(filters map[string]proxy.ExtensionFilter)
+	// SetServiceInboundFilters receives the destination-side (INBOUND scope, 027 M3)
+	// filters, keyed by "<ns>/<svc>": enabled on the target service's own pods'
+	// inbound listeners. At most one per service.
+	SetServiceInboundFilters(filters map[string]proxy.ExtensionFilter)
 	// SetRouteTargetPorts receives the real Service port(s) of each route target
 	// (proposal 023 M2), keyed by the same "<ns>/<svc>" route-target key as
 	// SetServiceRoutes. Sourced from the HTTPRoute/GRPCRoute parentRef port; lets the
@@ -163,10 +167,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	serviceFiltersFor := func(key string) []*registryv1.ExtensionFilter {
 		return gammaproject.ServiceFilters(key, specs)
 	}
-	// Service-wide always-on filters (M4 CHAIN scope): resolve per targeted service.
+	// Service-wide always-on filters (M4 CHAIN scope) + destination-side INBOUND
+	// filters (027 M3): resolve per targeted service.
 	chainFilters := map[string]proxy.ExtensionFilter{}
+	inboundFilters := map[string]proxy.ExtensionFilter{}
 	for key, spec := range specs {
-		if spec.GetScope() != configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+		scope := spec.GetScope()
+		if scope != configprotov1.HTTPFilterSpec_SCOPE_CHAIN && scope != configprotov1.HTTPFilterSpec_SCOPE_INBOUND {
 			continue
 		}
 		ns, _, _ := strings.Cut(key, "/")
@@ -176,8 +183,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			}
 			svcKey := ns + "/" + t.GetName()
 			// Deterministic pick delegated to the shared projector (name-sorted).
-			if ef := gammaproject.ServiceChainFilter(svcKey, specs); ef != nil {
-				chainFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
+			if scope == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+				if ef := gammaproject.ServiceChainFilter(svcKey, specs); ef != nil {
+					chainFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
+				}
+			} else {
+				if ef := gammaproject.ServiceInboundFilter(svcKey, specs); ef != nil {
+					inboundFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
+				}
 			}
 		}
 	}
@@ -214,6 +227,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 	r.Sink.SetServiceRoutes(routes)
 	r.Sink.SetServiceChainFilters(chainFilters)
+	r.Sink.SetServiceInboundFilters(inboundFilters)
 	r.Sink.SetRouteTargetPorts(routeTargetPorts)
 	r.Log.DebugContext(ctx, "projected gamma service routes",
 		"httpRoutes", len(httpList.Items), "grpcRoutes", len(grpcList.Items), "services", len(routes))

--- a/agent/internal/gamma/reconciler_test.go
+++ b/agent/internal/gamma/reconciler_test.go
@@ -104,15 +104,20 @@ func TestBuildGammaRoute_ExtensionRef(t *testing.T) {
 }
 
 type fakeSink struct {
-	routes       map[string][]proxy.GammaRoute
-	ports        map[string][]uint32
-	chainFilters map[string]proxy.ExtensionFilter
+	routes         map[string][]proxy.GammaRoute
+	ports          map[string][]uint32
+	chainFilters   map[string]proxy.ExtensionFilter
+	inboundFilters map[string]proxy.ExtensionFilter
 }
 
 func (f *fakeSink) SetServiceRoutes(r map[string][]proxy.GammaRoute) { f.routes = r }
 func (f *fakeSink) SetRouteTargetPorts(p map[string][]uint32)        { f.ports = p }
 func (f *fakeSink) SetServiceChainFilters(c map[string]proxy.ExtensionFilter) {
 	f.chainFilters = c
+}
+
+func (f *fakeSink) SetServiceInboundFilters(c map[string]proxy.ExtensionFilter) {
+	f.inboundFilters = c
 }
 
 func newScheme(t *testing.T) *runtime.Scheme {

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -85,6 +85,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/listener/v3:listener",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/ext_authz/v3:ext_authz",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/http_connection_manager/v3:http_connection_manager",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -205,6 +205,11 @@ type SnapshotCache struct {
 	// importedServiceChainFilters is the peer-cluster-imported variant (026);
 	// local wins on collision. Guarded by depMu.
 	importedServiceChainFilters map[string]proxy.ExtensionFilter
+	// serviceInboundFilters holds the destination-side (INBOUND scope, 027 M3)
+	// filters keyed by "<ns>/<svc>": enabled on the target service's own pods'
+	// inbound listeners. NOT imported cross-cluster (enforcement is co-located
+	// with the pods). Guarded by depMu.
+	serviceInboundFilters map[string]proxy.ExtensionFilter
 	// authzSidecar enables the disabled ext_authz HCM entry for the node-local
 	// authorization sidecar (proposal 027). Boot-time (SetAuthzSidecar), so no
 	// locking/regeneration concerns.

--- a/agent/internal/xds/cache/chain_seam_test.go
+++ b/agent/internal/xds/cache/chain_seam_test.go
@@ -10,6 +10,7 @@ import (
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"github.com/stretchr/testify/assert"
@@ -118,4 +119,66 @@ func TestExtensionHTTPFilters_AuthzSidecar(t *testing.T) {
 	require.Len(t, fs, 1)
 	assert.Equal(t, "envoy.filters.http.ext_authz", fs[0].GetName())
 	assert.True(t, fs[0].GetDisabled())
+}
+
+// TestInboundFilter_Seam (027 M3): an INBOUND-scope filter for the pod's own service
+// lands on the pod's inbound listener — chain entry (via the authz-sidecar union) +
+// route-vhost TPFC — through the full snapshot path; with the sidecar disabled it is
+// dropped entirely (no TPFC referencing an absent chain filter = no NACK).
+func TestInboundFilter_Seam(t *testing.T) {
+	mk := func(sidecar bool) (*SnapshotCache, error) {
+		c := newTestCache("node-1")
+		if sidecar {
+			c.SetAuthzSidecar(200_000_000, false)
+		}
+		ctx := context.Background()
+		pod := &cniv1.CNIPod{
+			Name: "echo-1", Namespace: "aether-test", ServiceAccount: "echo",
+			NetworkNamespace: "/var/run/netns/cni-in",
+		}
+		if err := c.AddPod(ctx, pod, "aether.internal"); err != nil {
+			return nil, err
+		}
+		cfg, err := anypb.New(&ext_authzv3.ExtAuthzPerRoute{Override: &ext_authzv3.ExtAuthzPerRoute_CheckSettings{
+			CheckSettings: &ext_authzv3.CheckSettings{ContextExtensions: map[string]string{"policy": "x"}},
+		}})
+		if err != nil {
+			return nil, err
+		}
+		c.SetServiceInboundFilters(map[string]proxy.ExtensionFilter{
+			"aether-test/echo": {Name: "envoy.filters.http.ext_authz", Config: cfg},
+		})
+		return c, nil
+	}
+
+	// Sidecar ON: inbound listener carries the ext_authz chain entry + the TPFC.
+	c, err := mk(true)
+	require.NoError(t, err)
+	snap, err := c.GetSnapshot("node-1")
+	require.NoError(t, err)
+	entryCount, tpfcCount := 0, 0
+	for name, res := range snap.GetResources(resourcev3.ListenerType) {
+		if !strings.HasPrefix(name, "inbound_") {
+			continue
+		}
+		b, _ := protojson.Marshal(res.(*listenerv3.Listener))
+		js := string(b)
+		entryCount += strings.Count(js, `"envoy.filters.http.ext_authz"`)
+		tpfcCount += strings.Count(js, "typedPerFilterConfig")
+	}
+	assert.Greater(t, entryCount, 0, "inbound HCM must carry the ext_authz chain entry")
+	assert.Greater(t, tpfcCount, 0, "inbound route vhost must carry the TPFC")
+
+	// Sidecar OFF: the filter is dropped — no ext_authz anywhere on the inbound.
+	c2, err := mk(false)
+	require.NoError(t, err)
+	snap2, err := c2.GetSnapshot("node-1")
+	require.NoError(t, err)
+	for name, res := range snap2.GetResources(resourcev3.ListenerType) {
+		if !strings.HasPrefix(name, "inbound_") {
+			continue
+		}
+		b, _ := protojson.Marshal(res.(*listenerv3.Listener))
+		assert.NotContains(t, string(b), "ext_authz", "sidecar off: filter must be dropped, not emitted")
+	}
 }

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -1,7 +1,11 @@
 package cache
 
 import (
+	"context"
+
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	"github.com/bpalermo/aether/common/serviceref"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -64,7 +68,42 @@ func (c *SnapshotCache) serviceRoutesSnapshot() map[string][]proxy.GammaRoute {
 	eff := c.effectiveServiceRoutesLocked()
 	out := make(map[string][]proxy.GammaRoute, len(eff))
 	for k, v := range eff {
-		out[k] = v
+		out[k] = c.stripUnavailableExtensions(v)
+	}
+	return out
+}
+
+// stripUnavailableExtensions drops extension filters whose chain entry is not
+// present on this node — today only ext_authz when the authz sidecar is disabled
+// (proposal 027): a typed_per_filter_config naming an absent chain filter rejects
+// the whole route config, so a stray policy must degrade to a no-op, not a NACK.
+func (c *SnapshotCache) stripUnavailableExtensions(rules []proxy.GammaRoute) []proxy.GammaRoute {
+	if c.authzSidecar {
+		return rules
+	}
+	needsStrip := false
+	for _, r := range rules {
+		for _, ef := range r.ExtensionFilters {
+			if ef.Name == proxy.ExtAuthzFilterName {
+				needsStrip = true
+			}
+		}
+	}
+	if !needsStrip {
+		return rules
+	}
+	out := make([]proxy.GammaRoute, len(rules))
+	copy(out, rules)
+	for i := range out {
+		var kept []proxy.ExtensionFilter
+		for _, ef := range out[i].ExtensionFilters {
+			if ef.Name == proxy.ExtAuthzFilterName {
+				c.log.Warn("dropping extAuthz filter: the authz sidecar is not enabled on this cluster (proxy.authzSidecar.enabled)", "filter", ef.Name)
+				continue
+			}
+			kept = append(kept, ef)
+		}
+		out[i].ExtensionFilters = kept
 	}
 	return out
 }
@@ -308,6 +347,14 @@ func (c *SnapshotCache) serviceChainFiltersSnapshot() map[string]proxy.Extension
 	for k, v := range c.serviceChainFilters { // local overrides imported
 		out[k] = v
 	}
+	if !c.authzSidecar {
+		for k, v := range out {
+			if v.Name == proxy.ExtAuthzFilterName {
+				c.log.Warn("dropping extAuthz service filter: the authz sidecar is not enabled on this cluster", "service", k)
+				delete(out, k)
+			}
+		}
+	}
 	return out
 }
 
@@ -354,9 +401,55 @@ func (c *SnapshotCache) regenerateAllHTTPListeners() {
 				"netns", netns, "pod", entry.cniPod.GetName(), "error", err)
 			continue
 		}
+		newInbound, err := proxy.NewInboundListener(entry.cniPod, c.trustDomain, c.emitStatsPod, !c.spireEnabled, extensionFilters, c.inboundFilterForPod(entry.cniPod))
+		if err != nil {
+			c.log.Error("failed to regenerate inbound listener on extension-union change",
+				"netns", netns, "pod", entry.cniPod.GetName(), "error", err)
+			continue
+		}
 		entry.capture = newCapture
 		entry.outbound = newOutbound
+		entry.inbound = newInbound
 		c.listeners[netns] = entry
 	}
 	c.listenerMu.Unlock()
+	// Push the rebuilt listeners immediately (the dependency signal ALSO triggers a
+	// registry reload, but that path only runs when the refresher is up — and prompt
+	// convergence beats waiting a debounce for a pure listener change).
+	if err := c.generateListenerSnapshot(context.Background()); err != nil {
+		c.log.Error("failed to regenerate snapshot after extension-union change", "error", err)
+	}
+}
+
+// SetServiceInboundFilters replaces the destination-side (INBOUND scope, 027 M3)
+// filters, keyed by "<ns>/<svc>". Enabled on the target service's own pods'
+// inbound listeners; requires the authz sidecar (dropped with a warning otherwise).
+func (c *SnapshotCache) SetServiceInboundFilters(filters map[string]proxy.ExtensionFilter) {
+	c.depMu.Lock()
+	changed := !equalServiceChainFilters(c.serviceInboundFilters, filters)
+	c.serviceInboundFilters = filters
+	c.depMu.Unlock()
+	if changed {
+		c.log.Info("service inbound filters updated", "count", len(filters))
+		c.regenerateAllHTTPListeners()
+		c.signalDependencyChange()
+	}
+}
+
+// inboundFilterForPod returns the INBOUND-scope filter for the pod's own service,
+// nil when none (or when the authz sidecar is disabled — a TPFC naming an absent
+// chain filter rejects the listener).
+func (c *SnapshotCache) inboundFilterForPod(cniPod *cniv1.CNIPod) *proxy.ExtensionFilter {
+	key := serviceref.New(cniPod.GetNamespace(), cniPod.GetServiceAccount()).Key()
+	c.depMu.RLock()
+	ef, ok := c.serviceInboundFilters[key]
+	c.depMu.RUnlock()
+	if !ok {
+		return nil
+	}
+	if ef.Name == proxy.ExtAuthzFilterName && !c.authzSidecar {
+		c.log.Warn("dropping INBOUND extAuthz filter: the authz sidecar is not enabled on this cluster", "service", key)
+		return nil
+	}
+	return &ef
 }

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -31,7 +31,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	netns := cniPod.GetNetworkNamespace()
 	c.log.DebugContext(ctx, "adding listeners for pod", "pod", cniPod.GetName(), "namespace", cniPod.GetNamespace(), "netns", netns)
 
-	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, c.extensionHTTPFilters())
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, c.extensionHTTPFilters(), c.inboundFilterForPod(cniPod))
 	if err != nil {
 		return err
 	}
@@ -277,7 +277,7 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 		}
 		c.log.DebugContext(ctx, "generating listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace(), "netns", netns)
 
-		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, c.extensionHTTPFilters())
+		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, c.extensionHTTPFilters(), c.inboundFilterForPod(pod))
 		if listenerErr != nil {
 			c.log.ErrorContext(ctx, "failed to generate listeners for pod", "error", listenerErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())
 			errs = append(errs, listenerErr)

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -62,7 +62,7 @@ func InboundListenerName(cniPod *cniv1.CNIPod) string {
 // h2c and HTTP/1 are both detected, no ALPN/SNI demux, no XFCC since there is no
 // verified peer). This is for SPIRE-off testing/conformance (the suite asserts
 // routing correctness, not mTLS); the production posture keeps per-pod mTLS.
-func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod bool, cleartext bool) (*listenerv3.Listener, error) {
+func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod bool, cleartext bool, extensionFilters []*http_connection_managerv3.HttpFilter, inboundFilter *ExtensionFilter) (*listenerv3.Listener, error) {
 	if cniPod == nil {
 		return nil, fmt.Errorf("pod is required")
 	}
@@ -78,10 +78,10 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod b
 	if cleartext {
 		// No tls_inspector listener filter: there is no TLS to inspect, and a single
 		// default HCM chain serves every request.
-		chains = []*listenerv3.FilterChain{buildInboundCleartextFilterChain(cniPod, emitStatsPod)}
+		chains = []*listenerv3.FilterChain{buildInboundCleartextFilterChain(cniPod, emitStatsPod, extensionFilters, inboundFilter)}
 	} else {
 		listenerFilters = buildInboundListenerFilters()
-		chains = buildInboundFilterChains(cniPod, tlsCertificateSecretName, validationContextName, emitStatsPod)
+		chains = buildInboundFilterChains(cniPod, tlsCertificateSecretName, validationContextName, emitStatsPod, extensionFilters, inboundFilter)
 	}
 
 	return &listenerv3.Listener{
@@ -115,15 +115,18 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod b
 // SPIRE is disabled: no transport socket (plain TCP), AUTO codec (so cleartext h2c
 // from the source proxy and HTTP/1 are both handled), routing every request to the
 // pod's primary application cluster. XFCC is not set (no verified peer identity).
-func buildInboundCleartextFilterChain(cniPod *cniv1.CNIPod, emitStatsPod bool) *listenerv3.FilterChain {
+func buildInboundCleartextFilterChain(cniPod *cniv1.CNIPod, emitStatsPod bool, extensionFilters []*http_connection_managerv3.HttpFilter, inboundFilter *ExtensionFilter) *listenerv3.FilterChain {
 	defaultPort := AppPortFromPod(cniPod)
-	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, cniPod.GetName(), cniPod.GetNamespace(), buildInboundRouteConfiguration(AppClusterName(cniPod, defaultPort)))
-	hcm.HttpFilters = []*http_connection_managerv3.HttpFilter{
+	rc := buildInboundRouteConfiguration(AppClusterName(cniPod, defaultPort))
+	applyInboundFilter(rc, inboundFilter)
+	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, cniPod.GetName(), cniPod.GetNamespace(), rc)
+	filters := []*http_connection_managerv3.HttpFilter{
 		buildLivenessHealthCheckFilter(),
 		buildReadinessHealthCheckFilter(HealthProbeClusterName(cniPod)),
 		inboundStatsFilter(cniPod, emitStatsPod),
-		routerHttpFilter(),
 	}
+	filters = append(filters, extensionFilters...)
+	hcm.HttpFilters = append(filters, routerHttpFilter())
 	return &listenerv3.FilterChain{
 		Name:             fmt.Sprintf("in_%s", cniPod.GetName()),
 		FilterChainMatch: nil, // default chain: cleartext has no ALPN/SNI to demux on
@@ -144,7 +147,7 @@ func buildInboundCleartextFilterChain(cniPod *cniv1.CNIPod, emitStatsPod bool) *
 //     Demux is the standard "h2" ALPN for HTTP vs no-ALPN for TCP — no bespoke token.
 //
 // SNI is port routing only — identity stays the terminated mTLS SVID.
-func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) []*listenerv3.FilterChain {
+func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, validationContextName string, emitStatsPod bool, extensionFilters []*http_connection_managerv3.HttpFilter, inboundFilter *ExtensionFilter) []*listenerv3.FilterChain {
 	defaultPort := AppPortFromPod(cniPod)
 	ports := AppPortsFromPod(cniPod)
 
@@ -156,10 +159,10 @@ func buildInboundFilterChains(cniPod *cniv1.CNIPod, tlsCertificateSecretName, va
 
 	// No-SNI HCM chain: matches application_protocols ["h2"] (the mesh HTTP/2
 	// transport) on the primary port. Per-port SNI chains follow.
-	chains = append(chains, buildInboundFilterChain(cniPod, "", defaultPort, tlsCertificateSecretName, validationContextName, emitStatsPod))
+	chains = append(chains, buildInboundFilterChain(cniPod, "", defaultPort, tlsCertificateSecretName, validationContextName, emitStatsPod, extensionFilters, inboundFilter))
 	// One chain per served port, SNI-matched on the port number.
 	for _, port := range ports {
-		chains = append(chains, buildInboundFilterChain(cniPod, strconv.Itoa(int(port)), port, tlsCertificateSecretName, validationContextName, emitStatsPod))
+		chains = append(chains, buildInboundFilterChain(cniPod, strconv.Itoa(int(port)), port, tlsCertificateSecretName, validationContextName, emitStatsPod, extensionFilters, inboundFilter))
 	}
 	return chains
 }
@@ -188,19 +191,24 @@ func buildInboundTCPFloorFilterChain(cniPod *cniv1.CNIPod, defaultPort uint16, t
 // sni is non-empty the chain is SNI-matched (server_names); the empty-sni chain
 // is the default (no match criteria). chainPort selects both the app cluster
 // and the chain name suffix.
-func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string, emitStatsPod bool) *listenerv3.FilterChain {
-	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, cniPod.GetName(), cniPod.GetNamespace(), buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort)))
+func buildInboundFilterChain(cniPod *cniv1.CNIPod, sni string, chainPort uint16, tlsCertificateSecretName, validationContextName string, emitStatsPod bool, extensionFilters []*http_connection_managerv3.HttpFilter, inboundFilter *ExtensionFilter) *listenerv3.FilterChain {
+	rc := buildInboundRouteConfiguration(AppClusterName(cniPod, chainPort))
+	applyInboundFilter(rc, inboundFilter)
+	hcm := buildHTTPConnectionManager("inbound", ReporterDestination, cniPod.GetName(), cniPod.GetNamespace(), rc)
 	// Liveness/readiness are answered locally before the router; everything else
 	// passes through to the pod's application. The stats filter sits after the
 	// health-check filters (so locally-answered probe requests are not counted)
 	// and before the router, recording the destination-reported edge at the log
 	// phase (proposal 007 Phase 2).
-	hcm.HttpFilters = []*http_connection_managerv3.HttpFilter{
+	filters := []*http_connection_managerv3.HttpFilter{
 		buildLivenessHealthCheckFilter(),
 		buildReadinessHealthCheckFilter(HealthProbeClusterName(cniPod)),
 		inboundStatsFilter(cniPod, emitStatsPod),
-		routerHttpFilter(),
 	}
+	// Escape-hatch extension entries (default-disabled; 027 M3): probes above stay
+	// exempt, the INBOUND filter's TPFC (below) opts the app traffic in.
+	filters = append(filters, extensionFilters...)
+	hcm.HttpFilters = append(filters, routerHttpFilter())
 	// SANITIZE_SET replaces any client-supplied XFCC with details derived from the
 	// verified peer certificate, exposing the caller's SPIFFE ID (URI SAN) to the app.
 	hcm.ForwardClientCertDetails = http_connection_managerv3.HttpConnectionManager_SANITIZE_SET
@@ -295,5 +303,18 @@ func buildInboundRouteConfiguration(appClusterName string) *routev3.RouteConfigu
 				},
 			},
 		},
+	}
+}
+
+// applyInboundFilter enables the pod's destination-side (INBOUND scope, 027 M3)
+// filter on the inbound route config's vhost — every app-bound request on this
+// pod is checked; the health/readiness filters run BEFORE the extension anchor so
+// probes stay exempt.
+func applyInboundFilter(rc *routev3.RouteConfiguration, inboundFilter *ExtensionFilter) {
+	if rc == nil || inboundFilter == nil {
+		return
+	}
+	for _, vh := range rc.GetVirtualHosts() {
+		ApplyServiceChainFilter(vh, inboundFilter)
 	}
 }

--- a/agent/internal/xds/proxy/ingress_test.go
+++ b/agent/internal/xds/proxy/ingress_test.go
@@ -25,7 +25,7 @@ func TestNewInboundListener(t *testing.T) {
 		Ips:              []string{"10.0.0.1"},
 	}
 
-	l, err := NewInboundListener(pod, "example.org", false, false)
+	l, err := NewInboundListener(pod, "example.org", false, false, nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, InboundListenerName(pod), l.GetName())
 
@@ -92,7 +92,7 @@ func TestNewInboundListenerCleartext(t *testing.T) {
 		Ips:              []string{"10.0.0.1"},
 	}
 
-	l, err := NewInboundListener(pod, "example.org", false, true)
+	l, err := NewInboundListener(pod, "example.org", false, true, nil, nil)
 	require.NoError(t, err)
 
 	// No tls_inspector: there is no TLS to inspect in cleartext mode.
@@ -117,10 +117,10 @@ func TestNewInboundListenerCleartext(t *testing.T) {
 }
 
 func TestNewInboundListener_Errors(t *testing.T) {
-	_, err := NewInboundListener(nil, "example.org", false, false)
+	_, err := NewInboundListener(nil, "example.org", false, false, nil, nil)
 	require.Error(t, err)
 
-	_, err = NewInboundListener(&cniv1.CNIPod{Name: "no-netns"}, "example.org", false, false)
+	_, err = NewInboundListener(&cniv1.CNIPod{Name: "no-netns"}, "example.org", false, false, nil, nil)
 	require.Error(t, err)
 }
 
@@ -163,7 +163,7 @@ func TestInboundFilterChains_MultiPort(t *testing.T) {
 		Ips:              []string{"10.0.0.1"},
 		Annotations:      map[string]string{constants.AnnotationEndpointPorts: "8080,9090"},
 	}
-	l, err := NewInboundListener(pod, "example.org", false, false)
+	l, err := NewInboundListener(pod, "example.org", false, false, nil, nil)
 	require.NoError(t, err)
 
 	bySNI := map[string]*listenerv3.FilterChain{}
@@ -207,7 +207,7 @@ func TestInboundChainStatsFilter(t *testing.T) {
 		NetworkNamespace: "/var/run/netns/cni-a",
 		Ips:              []string{"10.0.0.1"},
 	}
-	l, err := NewInboundListener(pod, "aether.internal", false, false)
+	l, err := NewInboundListener(pod, "aether.internal", false, false, nil, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, l.GetFilterChains())
 
@@ -244,7 +244,7 @@ func TestInboundTCPFloorFilterChain(t *testing.T) {
 		NetworkNamespace: "/var/run/netns/cni-tcp",
 		Ips:              []string{"10.0.0.5"},
 	}
-	l, err := NewInboundListener(pod, "aether.internal", false, false)
+	l, err := NewInboundListener(pod, "aether.internal", false, false, nil, nil)
 	require.NoError(t, err)
 
 	// Find the TCP floor chain: the default chain (no match), named in_tcp_<pod>.

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -46,8 +46,8 @@ func OutboundListenerName(cniPod *cniv1.CNIPod) string {
 // cleartext (SPIRE off) builds the inbound listener without a downstream mTLS
 // transport socket — symmetric with the cleartext outbound clusters — so the mesh
 // data path is routable without SPIRE.
-func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string, meshDomain string, emitStatsPod bool, cleartext bool, extensionFilters []*http_connection_managerv3.HttpFilter) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, appClusters []*clusterv3.Cluster, healthCluster *clusterv3.Cluster, err error) {
-	inbound, err = NewInboundListener(cniPod, trustDomain, emitStatsPod, cleartext)
+func GenerateListenersFromRegistryPod(cniPod *cniv1.CNIPod, trustDomain string, meshDomain string, emitStatsPod bool, cleartext bool, extensionFilters []*http_connection_managerv3.HttpFilter, inboundFilter *ExtensionFilter) (inbound *listenerv3.Listener, outbound *listenerv3.Listener, appClusters []*clusterv3.Cluster, healthCluster *clusterv3.Cluster, err error) {
+	inbound, err = NewInboundListener(cniPod, trustDomain, emitStatsPod, cleartext, extensionFilters, inboundFilter)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/agent/internal/xds/proxy/listener_test.go
+++ b/agent/internal/xds/proxy/listener_test.go
@@ -44,7 +44,7 @@ func TestGenerateListenersFromRegistryPod(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(tt.cniPod, "example.org", "example.org", false, false, nil)
+			inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(tt.cniPod, "example.org", "example.org", false, false, nil, nil)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -166,7 +166,7 @@ func TestPerConnectionBufferLimits(t *testing.T) {
 		Name:             "buf-pod",
 		NetworkNamespace: "/var/run/netns/buf",
 	}
-	inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(pod, "aether.internal", "aether.internal", false, false, nil)
+	inbound, outbound, appClusters, healthCluster, err := GenerateListenersFromRegistryPod(pod, "aether.internal", "aether.internal", false, false, nil, nil)
 	require.NotEmpty(t, appClusters)
 	appCluster := appClusters[0]
 	require.NoError(t, err)

--- a/agent/internal/xds/server/server_integration_test.go
+++ b/agent/internal/xds/server/server_integration_test.go
@@ -123,7 +123,7 @@ func setConsistentSnapshot(t *testing.T, ctx context.Context, snapshotCache cach
 		Ips:              []string{"10.0.0.1"},
 	}
 
-	inbound, outbound, appClusters, _, err := proxy.GenerateListenersFromRegistryPod(pod, "example.org", "example.org", false, false, nil)
+	inbound, outbound, appClusters, _, err := proxy.GenerateListenersFromRegistryPod(pod, "example.org", "example.org", false, false, nil, nil)
 	require.NoError(t, err)
 
 	serviceName := "my-service"

--- a/api/aether/config/v1/http_filter.proto
+++ b/api/aether/config/v1/http_filter.proto
@@ -43,6 +43,13 @@ message HTTPFilterSpec {
     SCOPE_UNSPECIFIED = 0;
     SCOPE_ROUTE = 1;
     SCOPE_CHAIN = 2;
+    // INBOUND (proposal 027 M3): destination-side enforcement — the filter is
+    // enabled on the TARGET service's own pods' INBOUND listeners, where the
+    // caller's verified SPIFFE identity (XFCC) is available. Requires a Service
+    // targetRef and (v1) the extAuthz form. NOT propagated cross-cluster: the
+    // enforcement point is co-located with the service's pods, so the owning
+    // cluster's config is authoritative by construction.
+    SCOPE_INBOUND = 3;
   }
 
   // target_refs attaches this filter to Gateway API objects (policy attachment,
@@ -53,11 +60,32 @@ message HTTPFilterSpec {
   // that rides proposal 026's config channel to peer clusters.
   repeated PolicyTargetRef target_refs = 4;
 
+  // ext_authz opts this route/service into the node-local authorization sidecar
+  // (proposal 027). TYPED-ONLY: the transport (target/timeout/failure mode) is
+  // system-owned on the chain entry — this form carries only what
+  // ExtAuthzPerRoute can: per-route policy parameters and toggles. Requires the
+  // sidecar to be enabled on the cluster (proxy.authzSidecar.enabled); the agent
+  // drops it otherwise (logged) so a stray policy cannot NACK the proxy.
+  ExtAuthzRoute ext_authz = 6;
+
   // header_to_metadata is the TYPED form of envoy.filters.http.header_to_metadata
   // (proposal 025 M4 typed promotion): the one allow-listed filter Gateway API cannot
   // express (it powers subset routing). Mutually exclusive with filter/typed_config —
   // set exactly one authoring form; aether renders the Envoy proto internally.
   HeaderToMetadata header_to_metadata = 5;
+}
+
+// ExtAuthzRoute is the per-route external-authorization form (renders to Envoy's
+// ExtAuthzPerRoute). Attaching it ENABLES the (otherwise disabled) system ext_authz
+// filter for the targeted route/service.
+message ExtAuthzRoute {
+  // context_extensions are passed to the authz service with every check for the
+  // targeted routes — the per-route policy parameters (e.g. {"policy": "payments-rw"}).
+  map<string, string> context_extensions = 1;
+  // disable_request_body_buffering skips sending the request body to the authz service.
+  bool disable_request_body_buffering = 2;
+  // disabled exempts the targeted route from a broader (service-wide) authz filter.
+  bool disabled = 3;
 }
 
 // HeaderToMetadata promotes the common header_to_metadata use to typed config: each

--- a/common/extensionfilter/BUILD.bazel
+++ b/common/extensionfilter/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//api/aether/config/v1:config",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/ext_authz/v3:ext_authz",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@org_golang_google_protobuf//proto",
@@ -20,6 +21,7 @@ go_test(
     embed = [":extensionfilter"],
     deps = [
         "//api/aether/config/v1:config",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/ext_authz/v3:ext_authz",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_mutation/v3:header_mutation",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/http/header_to_metadata/v3:header_to_metadata",
         "@com_github_stretchr_testify//assert",

--- a/common/extensionfilter/extensionfilter.go
+++ b/common/extensionfilter/extensionfilter.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
+	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	header_to_metadatav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	"google.golang.org/protobuf/proto"
@@ -28,7 +29,15 @@ import (
 var allowed = map[string]func() proto.Message{
 	"envoy.filters.http.header_to_metadata": func() proto.Message { return &header_to_metadatav3.Config{} },
 	"envoy.filters.http.header_mutation":    func() proto.Message { return &header_mutationv3.HeaderMutation{} },
+	// ext_authz (proposal 027): allow-listed for typed_per_filter_config emission,
+	// but with NO default chain config — its chain entry is the SYSTEM-owned authz
+	// sidecar entry (full transport, disabled), never a per-reference union entry.
+	// A nil builder means CollectExtensionFilters skips it.
+	ExtAuthzFilterName: nil,
 }
+
+// ExtAuthzFilterName is the external-authorization filter (proposal 027).
+const ExtAuthzFilterName = "envoy.filters.http.ext_authz"
 
 // Allowed reports whether name is a supported escape-hatch filter.
 func Allowed(name string) bool {
@@ -40,7 +49,7 @@ func Allowed(name string) bool {
 // (the neutral config carried on its default-disabled HCM entry), or (nil, false).
 func DefaultConfig(name string) (proto.Message, bool) {
 	b, ok := allowed[name]
-	if !ok {
+	if !ok || b == nil {
 		return nil, false
 	}
 	return b(), true
@@ -73,17 +82,35 @@ func ValidateSpec(spec *configprotov1.HTTPFilterSpec) error {
 	if spec == nil {
 		return errors.New("spec is required")
 	}
-	typed := spec.GetHeaderToMetadata() != nil
-	opaque := spec.GetFilter() != "" || spec.GetTypedConfig() != nil
-	if typed && opaque {
-		return errors.New("set exactly one authoring form: headerToMetadata (typed) OR filter+typedConfig (opaque), not both")
+	forms := 0
+	if spec.GetHeaderToMetadata() != nil {
+		forms++
 	}
-	if !typed && !opaque {
-		return errors.New("spec must set an authoring form: headerToMetadata (typed) or filter+typedConfig (opaque)")
+	if spec.GetExtAuthz() != nil {
+		forms++
+	}
+	opaque := spec.GetFilter() != "" || spec.GetTypedConfig() != nil
+	if opaque {
+		forms++
+	}
+	if forms != 1 {
+		return errors.New("set exactly one authoring form: headerToMetadata, extAuthz, or filter+typedConfig (opaque)")
+	}
+	typed := !opaque
+	if spec.GetFilter() == ExtAuthzFilterName {
+		return errors.New("ext_authz must use the typed extAuthz form (the transport is system-owned; opaque payloads could name arbitrary clusters)")
 	}
 	if spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
 		if !targetsAService(spec) {
 			return errors.New("spec.scope CHAIN (service-wide always-on) requires a targetRef of kind Service")
+		}
+	}
+	if spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_INBOUND {
+		if !targetsAService(spec) {
+			return errors.New("spec.scope INBOUND (destination-side enforcement) requires a targetRef of kind Service")
+		}
+		if spec.GetExtAuthz() == nil {
+			return errors.New("spec.scope INBOUND supports only the extAuthz form (v1)")
 		}
 	}
 	if typed {
@@ -91,6 +118,9 @@ func ValidateSpec(spec *configprotov1.HTTPFilterSpec) error {
 			if r.GetHeader() == "" || r.GetMetadataKey() == "" {
 				return fmt.Errorf("headerToMetadata.rules[%d]: header and metadataKey are required", i)
 			}
+		}
+		if ea := spec.GetExtAuthz(); ea != nil && ea.GetDisabled() && len(ea.GetContextExtensions()) > 0 {
+			return errors.New("extAuthz: disabled and contextExtensions are mutually exclusive")
 		}
 		return nil
 	}
@@ -136,6 +166,24 @@ func targetsAService(spec *configprotov1.HTTPFilterSpec) bool {
 // verbatim. Assumes ValidateSpec passed; callers on unvalidated input must check the
 // error.
 func Render(spec *configprotov1.HTTPFilterSpec) (string, *anypb.Any, error) {
+	if ea := spec.GetExtAuthz(); ea != nil {
+		var cfg *ext_authzv3.ExtAuthzPerRoute
+		if ea.GetDisabled() {
+			cfg = &ext_authzv3.ExtAuthzPerRoute{Override: &ext_authzv3.ExtAuthzPerRoute_Disabled{Disabled: true}}
+		} else {
+			cfg = &ext_authzv3.ExtAuthzPerRoute{Override: &ext_authzv3.ExtAuthzPerRoute_CheckSettings{
+				CheckSettings: &ext_authzv3.CheckSettings{
+					ContextExtensions:           ea.GetContextExtensions(),
+					DisableRequestBodyBuffering: ea.GetDisableRequestBodyBuffering(),
+				},
+			}}
+		}
+		a, err := anypb.New(cfg)
+		if err != nil {
+			return "", nil, fmt.Errorf("render extAuthz: %w", err)
+		}
+		return ExtAuthzFilterName, a, nil
+	}
 	if h2m := spec.GetHeaderToMetadata(); h2m != nil {
 		cfg := &header_to_metadatav3.Config{}
 		for _, r := range h2m.GetRules() {

--- a/common/extensionfilter/extensionfilter_test.go
+++ b/common/extensionfilter/extensionfilter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
+	ext_authzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	header_to_metadatav3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_to_metadata/v3"
 	"github.com/stretchr/testify/assert"
@@ -112,4 +113,46 @@ func TestRender(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "envoy.filters.http.header_mutation", name2)
 	assert.Same(t, a, cfg2)
+}
+
+// TestExtAuthzForm (027 M2): typed-only authoring, render both modes, opaque rejected.
+func TestExtAuthzForm(t *testing.T) {
+	withEA := func(ctx map[string]string, disabled bool) *configprotov1.HTTPFilterSpec {
+		sp := &configprotov1.HTTPFilterSpec{}
+		sp.SetExtAuthz(configprotov1.ExtAuthzRoute_builder{
+			ContextExtensions: ctx, Disabled: disabled,
+		}.Build())
+		return sp
+	}
+	// Valid: enable with context extensions.
+	require.NoError(t, ValidateSpec(withEA(map[string]string{"policy": "x"}, false)))
+	// Valid: per-route exemption.
+	require.NoError(t, ValidateSpec(withEA(nil, true)))
+	// Invalid: disabled + context extensions.
+	require.ErrorContains(t, ValidateSpec(withEA(map[string]string{"p": "x"}, true)), "mutually exclusive")
+	// Invalid: opaque ext_authz.
+	op := &configprotov1.HTTPFilterSpec{}
+	op.SetFilter(ExtAuthzFilterName)
+	a, _ := anypb.New(&header_to_metadatav3.Config{})
+	op.SetTypedConfig(a)
+	require.ErrorContains(t, ValidateSpec(op), "typed extAuthz form")
+
+	// Render: check_settings mode.
+	name, cfg, err := Render(withEA(map[string]string{"policy": "x"}, false))
+	require.NoError(t, err)
+	assert.Equal(t, ExtAuthzFilterName, name)
+	msg, err := cfg.UnmarshalNew()
+	require.NoError(t, err)
+	pr := msg.(*ext_authzv3.ExtAuthzPerRoute)
+	assert.Equal(t, "x", pr.GetCheckSettings().GetContextExtensions()["policy"])
+	// Render: disabled mode.
+	_, cfg2, err := Render(withEA(nil, true))
+	require.NoError(t, err)
+	msg2, _ := cfg2.UnmarshalNew()
+	assert.True(t, msg2.(*ext_authzv3.ExtAuthzPerRoute).GetDisabled())
+
+	// The union never emits a chain entry for ext_authz (system entry owns the chain).
+	_, ok := DefaultConfig(ExtAuthzFilterName)
+	assert.False(t, ok, "ext_authz must have no default chain config")
+	assert.True(t, Allowed(ExtAuthzFilterName), "but TPFC emission is allowed")
 }

--- a/common/gammaproject/project.go
+++ b/common/gammaproject/project.go
@@ -245,8 +245,10 @@ func resolveExtensionFilter(ref *gatewayv1.LocalObjectReference, routeNamespace 
 // ExtensionFilter, or (nil,false) when it is nil, CHAIN-scoped (admin-owned, deferred),
 // not allow-listed, or missing typed_config.
 func allowedExtensionFilter(spec *configprotov1.HTTPFilterSpec) (*registryv1.ExtensionFilter, bool) {
-	if spec == nil || spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
-		return nil, false // CHAIN is vhost-level (ServiceChainFilter), never per-route
+	if spec == nil ||
+		spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_CHAIN || // vhost-level (ServiceChainFilter)
+		spec.GetScope() == configprotov1.HTTPFilterSpec_SCOPE_INBOUND { // destination-side (ServiceInboundFilter)
+		return nil, false
 	}
 	return renderedExtensionFilter(spec)
 }
@@ -270,6 +272,18 @@ func renderedExtensionFilter(spec *configprotov1.HTTPFilterSpec) (*registryv1.Ex
 // ALL of the service's traffic; a per-route ExtensionRef overrides it (Envoy
 // most-specific-wins).
 func ServiceChainFilter(serviceKey string, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.ExtensionFilter {
+	return serviceScopedFilter(serviceKey, httpFilters, configprotov1.HTTPFilterSpec_SCOPE_CHAIN)
+}
+
+// ServiceInboundFilter resolves the destination-side (INBOUND scope, proposal 027 M3)
+// filter for serviceKey: enabled on the service's own pods' inbound listeners. Same
+// one-per-service + deterministic tie-break rules as ServiceChainFilter. NOT
+// propagated cross-cluster (enforcement is co-located with the pods).
+func ServiceInboundFilter(serviceKey string, httpFilters map[string]*configprotov1.HTTPFilterSpec) *registryv1.ExtensionFilter {
+	return serviceScopedFilter(serviceKey, httpFilters, configprotov1.HTTPFilterSpec_SCOPE_INBOUND)
+}
+
+func serviceScopedFilter(serviceKey string, httpFilters map[string]*configprotov1.HTTPFilterSpec, scope configprotov1.HTTPFilterSpec_Scope) *registryv1.ExtensionFilter {
 	sref, ok := serviceref.ParseKey(serviceKey)
 	if !ok || len(httpFilters) == 0 {
 		return nil
@@ -281,7 +295,7 @@ func ServiceChainFilter(serviceKey string, httpFilters map[string]*configprotov1
 	sort.Strings(keys)
 	for _, k := range keys {
 		spec := httpFilters[k]
-		if spec == nil || spec.GetScope() != configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+		if spec == nil || spec.GetScope() != scope {
 			continue
 		}
 		fref, ok := serviceref.ParseKey(k)

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -113,7 +113,7 @@ func buildNodeBootstrap() (*bootstrapv3.Bootstrap, error) {
 	pod := testPod()
 
 	authzEntry := proxy.AuthzSidecarHTTPFilter(200*time.Millisecond, false)
-	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false, false, []*http_connection_managerv3.HttpFilter{authzEntry})
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false, false, []*http_connection_managerv3.HttpFilter{authzEntry}, nil)
 	if err != nil {
 		return nil, fmt.Errorf("GenerateListenersFromRegistryPod: %w", err)
 	}
@@ -149,7 +149,7 @@ func authzSidecarCluster() *clusterv3.Cluster {
 func buildNodeCleartextBootstrap() (*bootstrapv3.Bootstrap, error) {
 	pod := testPod()
 
-	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false, true, nil)
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, meshDomain, false, true, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("GenerateListenersFromRegistryPod (cleartext): %w", err)
 	}


### PR DESCRIPTION
**M2**: typed-only `extAuthz` authoring (contextExtensions / disabled / body-buffering) → `ExtAuthzPerRoute`; all 025 scopes work unchanged; allow-listed with NO default chain config (the M1 system entry owns the chain); cache strips extAuthz when the sidecar is off (no-NACK degradation). **M3**: `SCOPE_INBOUND` — destination-side enforcement on the target service's own pods' inbound listeners (verified XFCC identity), one per service, not cross-cluster (co-located by construction); inbound HCMs gain the extension union with probes exempt; listener regen now re-pushes the snapshot synchronously. Full seam tests both sidecar states.