### PR TITLE
fix(chart): OPA preset default image (1.9.0-envoy unpullable)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.64.0-{GIT_COMMIT}"
+version: "0.64.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -223,7 +223,7 @@ proxy:
     # Built-in OPA preset (opt-in): runs the OPA envoy plugin with the policy below.
     opa:
       enabled: false
-      image: openpolicyagent/opa:1.9.0-envoy
+      image: openpolicyagent/opa:1.18.2-envoy-static
       # Rego policy mounted via ConfigMap; must define the decision the plugin
       # queries (envoy/authz/allow by default). Required when opa.enabled.
       policy: ""


### PR DESCRIPTION
openpolicyagent/opa:1.9.0-envoy has no platform manifest for the nodes; default to 1.18.2-envoy-static. Found deploying 027 M4.