### PR TITLE
fix(edge): opt the edge out of redirect-all capture (control-plane blackhole)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.65.0-{GIT_COMMIT}"
+version: "0.65.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -21,6 +21,16 @@ spec:
       maxUnavailable: 0
   template:
     metadata:
+      annotations:
+        # The CNI plugin gates capture by NAMESPACE (ignorableNamespace) and reads
+        # only pod ANNOTATIONS via CRI — it cannot see the aether.io/managed LABEL
+        # the agent uses. So a managed=false pod in a non-ignored namespace still
+        # gets the redirect-all capture (proposal 022, default-on), which blackholes
+        # ALL its egress (apiserver, registrar, collector) to a capture port with no
+        # listener → the edge control plane can't reach anything. Opt out explicitly
+        # via the annotation the CNI DOES honor. (Scoped :18081 redirect is harmless:
+        # the edge dials :443/:4317 and backend :15008, never a mesh :18081.)
+        capture.aether.io/redirect-all: "false"
       labels:
         {{- include "aether.edge.labels" . | nindent 8 }}
         # The edge is an ingress gateway, not a mesh workload: no per-pod proxy.


### PR DESCRIPTION
Edge crashlooped — all informers 'connection refused' to ClusterIPs (apiserver/registrar/collector). Root cause: the CNI gates capture by namespace + reads only annotations via CRI, so it can't see `aether.io/managed=false` (a label) — the edge got redirect-all capture (022, default-on) with no listener → egress blackholed → caches never sync → crashloop → stale Envoy → 503. Latent since the redirect-all default flip. Fix: `capture.aether.io/redirect-all=false` annotation (the opt-out the CNI honors). Follow-up: any managed=false pod in a non-ignored ns needs this pairing.