### PR TITLE
docs: add developer runbook (build/test/e2e/install)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,210 @@
+# Developer Runbook
+
+A practical guide for **building, testing, and running Aether from a clone** —
+the day-to-day developer loop and the local multi-cluster end-to-end harness.
+
+For **installing and operating** Aether on a real cluster (workload onboarding,
+routing, observability), see [`getting-started.md`](./getting-started.md). For the
+chart values and CLI/annotation reference, see
+[`configuration.md`](./configuration.md).
+
+---
+
+## 1. Prerequisites
+
+| Tool | Why | Notes |
+|---|---|---|
+| **Bazel** via [Bazelisk](https://github.com/bazelbuild/bazelisk) | build system | The pinned version (`9.0.1`) is read from `.bazelversion`; just run `bazel …` and Bazelisk fetches it. |
+| **Go** 1.26.2 | language toolchain | Managed by `rules_go`; you rarely invoke `go` directly (use `bazel run @rules_go//go …`). |
+| **Docker** (or **Colima** on macOS) | container images + integration tests | Integration tests spin up real etcd / DynamoDB Local via testcontainers-go. |
+| **kubectl**, **Helm 3** (OCI) | deploy / e2e | |
+| **kind** | local multi-cluster e2e | Only needed for `e2e/multicluster_config.sh`. |
+
+### macOS + Colima one-time setup
+
+If you use Colima for Docker, generate the Bazel Docker-socket config once:
+
+```bash
+./bazel/configure_colima.sh
+```
+
+This writes `.bazelrc.colima` (gitignored); it is auto-enabled on macOS via
+`--config=colima`, so sandboxed integration tests can reach the Docker socket.
+
+---
+
+## 2. Build
+
+All build/test entry points are in the [`Makefile`](../Makefile) (thin wrappers
+over Bazel).
+
+```bash
+make build              # bazel build //...  (everything)
+
+make build-agent        # //agent/cmd/agent/...        (node agent + edge + supervisor)
+make build-registrar    # //registrar/cmd/registrar/...
+make build-cni-install  # //cni/cmd/cni-install/...
+```
+
+There is no `make build-controller`; build it directly with
+`bazel build //controller/cmd/controller/...`.
+
+> **The `aether-proxy` (custom Envoy) is NOT built here.** It lives in a separate
+> sibling Bazel workspace under `proxy/` (its own `.bazelversion` = 7.7.1) and
+> compiles Envoy from source (multi-hour; use a warm cache / CI). Build/load it
+> with `make load-proxy-image` only when you need a fresh proxy image. See
+> [`proxy/README.md`](../proxy/README.md) and proposal 010.
+
+---
+
+## 3. Test
+
+```bash
+make test               # bazel test //...              (unit + integration; needs Docker)
+make test-unit          # --test_tag_filters=-integration  (no Docker)
+make test-integration   # --test_tag_filters=integration   (needs Docker)
+make test-race          # all tests with the Go race detector
+```
+
+Run a single target directly:
+
+```bash
+bazel test //agent/internal/xds/cache:cache_test
+```
+
+Integration tests are tagged `integration` and sized `medium`; many are also
+guarded by `testing.Short()`, so you can force unit-only behavior on a specific
+target with:
+
+```bash
+bazel test //... --test_arg=-test.short
+```
+
+---
+
+## 4. Format & lint
+
+```bash
+make format             # bazel run //:format        — gofumpt, buildifier, shfmt, buf (in place)
+make format-check       # bazel run //:format.check  — CI-friendly, fails on drift
+make lint               # bazel build --config=lint //...  — buf, buildifier, shellcheck aspects
+```
+
+After changing Go imports or adding/removing Go files, regenerate BUILD files:
+
+```bash
+make gazelle            # bazel run //:gazelle
+```
+
+To add a Go dependency (never edit `go.mod` by hand, and never run `go mod tidy`
+directly):
+
+```bash
+bazel run @rules_go//go get <package>
+make gazelle
+make tidy               # bazel mod tidy
+```
+
+---
+
+## 5. Container images
+
+In-repo images (agent, cni-install, registrar) build with `rules_img`:
+
+```bash
+make load-all           # load agent + cni-install + registrar into local Docker
+make load-agent-image   # a single image (…-registrar-image, …-cni-install-image likewise)
+make push-all           # push all to the registry
+```
+
+The `controller` image is not in `load-all`; load it with
+`bazel run //controller/cmd/controller:image_load`.
+
+---
+
+## 6. Local multi-cluster end-to-end (proposal 026)
+
+[`e2e/multicluster_config.sh`](../e2e/multicluster_config.sh) stands up **two kind
+clusters** (`a` = exporter, `b` = importer) that share **one etcd** (a Docker
+container on kind's network) and drives the cross-cluster GAMMA config loop:
+
+```
+cluster a: HTTPRoute + ServiceExport ──(registrar config-export)──▶ shared etcd
+                                                                       │
+cluster b: agent --import-config  ◀──(registrar ListAllConfig reads same etcd)─┘
+```
+
+### Commands
+
+```bash
+e2e/multicluster_config.sh up      # build+load images, create clusters + etcd, install aether on both
+e2e/multicluster_config.sh test    # apply the Service+ServiceExport+HTTPRoute on 'a', assert propagation
+e2e/multicluster_config.sh verify  # re-run the assertions only
+e2e/multicluster_config.sh down    # delete both clusters + the shared etcd
+e2e/multicluster_config.sh         # up + test (full run)
+```
+
+It builds images via `make load-all`, installs the Gateway API (experimental
+channel) + MCS-API CRDs, then installs both aether charts per cluster with
+`spire.enabled=false`, `agent.gamma=true`, `registrar.registryBackend=etcd`, and
+`agent.importConfig=true` on cluster `b`.
+
+### The `fs.inotify` gotcha
+
+Two kind clusters each run an inotify-heavy agent DaemonSet; the host's default
+limits are easily exhausted, leaving cluster `b`'s agent stuck in `Init:Error`.
+`up` raises the limits (needs sudo):
+
+```bash
+sudo sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288
+```
+
+Without it, the **control-plane** half of the loop (export → shared etcd,
+readable by `b`'s registrar) is still proven; only the agent-side materialization
+on `b` is unobservable. See the script header and `e2e/kind-cluster.yaml` (which
+also assigns non-overlapping pod/service CIDRs per cluster so cross-cluster
+endpoints in the shared registry never collide).
+
+---
+
+## 7. Installing on a real cluster
+
+Aether ships **two** charts, and **install order matters**:
+
+```
+charts/crds     — the CRDs: MeshConfig + HTTPFilter   ← install FIRST
+charts/aether    — the whole system (agent DaemonSet + proxy + registrar + controller)
+```
+
+Install the CRDs before the system chart. **The agent crashes if it starts before
+the `HTTPFilter` CRD exists** (it watches that type at startup); installing the
+`crds` chart first avoids the race (see #453).
+
+```bash
+# 1) CRDs first
+helm upgrade --install aether-crds oci://ghcr.io/bpalermo/aether/charts/crds \
+  --version "$VERSION"
+
+# 2) then the system
+helm upgrade --install aether oci://ghcr.io/bpalermo/aether/charts/aether \
+  --version "$VERSION" -n aether-system --create-namespace \
+  --set clusterName=my-cluster --set meshDomain=aether.internal
+```
+
+From a checkout, the Bazel install targets do the same in order:
+
+```bash
+bazel run //charts/crds:crds.install
+bazel run //charts/aether:aether.install
+```
+
+> Always pass the **full** values on every `helm upgrade` of the `aether` chart —
+> do **not** use `--reuse-values` (it keeps the stale digest-pinned image). Bump
+> the chart's `version:` on any change to its templates/values (CI enforces this).
+
+There is also a standalone **`prober`** chart (`charts/prober`) — an external
+mesh-availability prober (proposal 013), installed independently.
+
+See [`charts/README.md`](../charts/README.md) for chart layout, image mirroring,
+and the `--stamp` versioning scheme, and [`getting-started.md`](./getting-started.md)
+for the full install + onboarding walkthrough.


### PR DESCRIPTION
Deliverable 3: a getting-started **developer** runbook at `docs/runbook.md` (complements the existing operator-focused `docs/getting-started.md`).

Covers:
- **Prerequisites** — Bazelisk (`.bazelversion` 9.0.1), Go 1.26.2 via rules_go, Docker/Colima (+ `bazel/configure_colima.sh`), kubectl, Helm 3 OCI, kind.
- **Build/test/format/lint** — every `make` target mapped to its Bazel command; single-target tests; `--test_arg=-test.short` for unit-only; `make gazelle`/`make tidy` and `bazel run @rules_go//go get`. Notes that `aether-proxy` builds in the separate `proxy/` workspace.
- **Images** — `make load-all` / `load-*-image` / `push-all`.
- **Local multi-cluster e2e** — `e2e/multicluster_config.sh up|test|verify|down`, what it stands up (two kind clusters + shared etcd, the export→etcd→import loop), and the `fs.inotify.max_user_instances=8192` sysctl gotcha from the script header + `e2e/kind-cluster.yaml`.
- **Install order** — crds chart BEFORE aether chart (agent crashes if it starts before the `HTTPFilter` CRD exists, #453); Bazel install targets; `--reuse-values` warning; the standalone `prober` chart.

All commands verified against the Makefile and the e2e script. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S