### PR TITLE
fix(cni): skip capture for pods the agent reports unmanaged (RESULT_IGNORED)

### DIFF
--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -67,8 +67,12 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		return nil, err
 	}
 	if ignorable {
+		// RESULT_IGNORED (not SUCCESS): tells the CNI plugin this pod is not
+		// mesh-managed so it installs NO capture/redirect. The plugin cannot see
+		// the aether.io/managed label (CRI passes annotations, not labels); the
+		// agent fetched it here via the API, so the agent is the single authority.
 		log.DebugContext(ctx, "ignoring pod")
-		return &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_SUCCESS}, nil
+		return &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_IGNORED}, nil
 	}
 
 	// Store in the local storage. Whether this container was already known

--- a/agent/internal/cni/server/pod_test.go
+++ b/agent/internal/cni/server/pod_test.go
@@ -306,7 +306,7 @@ func TestAddPod(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "pod in kube-system is ignored and returns success",
+			name: "pod in kube-system is ignored (RESULT_IGNORED)",
 			setupK8s: func() client.Client {
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -328,7 +328,7 @@ func TestAddPod(t *testing.T) {
 					Ips:              []string{"10.0.0.1"},
 				},
 			},
-			want:    &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_SUCCESS},
+			want:    &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_IGNORED},
 			wantErr: false,
 		},
 		{

--- a/agent/internal/cni/server/server_integration_test.go
+++ b/agent/internal/cni/server/server_integration_test.go
@@ -151,7 +151,7 @@ func TestIntegration_ServerStartsAndAcceptsGRPCConnections(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, cniv1.AddPodResponse_RESULT_SUCCESS, resp.GetResult())
+	assert.Equal(t, cniv1.AddPodResponse_RESULT_IGNORED, resp.GetResult())
 
 	cancel()
 	waitForServerShutdown(t, errCh)
@@ -241,7 +241,7 @@ func TestIntegration_AddPodIgnorableNamespace(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, cniv1.AddPodResponse_RESULT_SUCCESS, resp.GetResult())
+	assert.Equal(t, cniv1.AddPodResponse_RESULT_IGNORED, resp.GetResult())
 
 	// Storage and registry should not have been called for an ignorable pod.
 	assert.False(t, addCalled, "storage should not be called for ignorable pod")

--- a/api/aether/cni/v1/service.proto
+++ b/api/aether/cni/v1/service.proto
@@ -24,6 +24,11 @@ message AddPodResponse {
     RESULT_UNSPECIFIED = 0;
     RESULT_SUCCESS = 1;
     RESULT_ERROR = 2;
+    // RESULT_IGNORED: the pod is not mesh-managed (aether.io/managed != "true",
+    // a system namespace, or no IPs) — the agent stored no config and the CNI
+    // plugin must install NO capture/redirect (the label is only visible to the
+    // agent, which fetches it from the API; the CNI cannot see labels via CRI).
+    RESULT_IGNORED = 3;
   }
 
   Result result = 1;
@@ -51,6 +56,11 @@ message RemovePodResponse {
     RESULT_UNSPECIFIED = 0;
     RESULT_SUCCESS = 1;
     RESULT_ERROR = 2;
+    // RESULT_IGNORED: the pod is not mesh-managed (aether.io/managed != "true",
+    // a system namespace, or no IPs) — the agent stored no config and the CNI
+    // plugin must install NO capture/redirect (the label is only visible to the
+    // agent, which fetches it from the API; the CNI cannot see labels via CRI).
+    RESULT_IGNORED = 3;
   }
 
   Result result = 1;

--- a/cni/internal/plugin/plugin.go
+++ b/cni/internal/plugin/plugin.go
@@ -101,6 +101,24 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
+	// Register with the agent FIRST (before any capture install). The agent fetches
+	// the pod's aether.io/managed LABEL from the API and is the single authority on
+	// whether the pod is mesh-managed — the CNI plugin cannot see labels (CRI passes
+	// annotations, not labels). A RESULT_IGNORED response means "not managed": install
+	// NO capture, or a managed=false pod in a non-ignored namespace would have its
+	// egress redirected to a capture port with no listener → blackholed control plane
+	// (the edge outage, fixed structurally here rather than per-pod annotation).
+	ignored, err := p.sendAddPod(context.Background(), netConf, cniPod, prevResult)
+	if err != nil {
+		return err
+	}
+	if ignored {
+		p.logger.Info("agent reports pod not mesh-managed; skipping capture install",
+			zap.String("namespace", string(k8sArgs.K8S_POD_NAMESPACE)),
+			zap.String("pod", string(k8sArgs.K8S_POD_NAME)))
+		return types.PrintResult(prevResult, netConf.CNIVersion)
+	}
+
 	// Transparent capture (proposal 018, Phase 3a): redirect outbound ClusterIP:18081
 	// to the pod-local capture listener. Best-effort — a failure leaves the explicit
 	// fast-lane working, so it must not fail the pod's networking. Uses the runtime
@@ -145,7 +163,7 @@ func (p *AetherPlugin) CmdAdd(args *skel.CmdArgs) error {
 		}
 	}
 
-	return p.sendAddPod(context.Background(), netConf, cniPod, prevResult)
+	return types.PrintResult(prevResult, netConf.CNIVersion)
 }
 
 // CmdCheck handles the CNI Check operation for plugin health verification.
@@ -362,13 +380,13 @@ func (p *AetherPlugin) resolvePID(netns, criSocket, containerID string) *wrapper
 }
 
 // sendAddPod sends the pod to the agent and returns the previous result on success.
-func (p *AetherPlugin) sendAddPod(ctx context.Context, conf config.AetherConf, pod *cniv1.CNIPod, prevResult *current.Result) (retErr error) {
+func (p *AetherPlugin) sendAddPod(ctx context.Context, conf config.AetherConf, pod *cniv1.CNIPod, prevResult *current.Result) (ignored bool, retErr error) {
 	ctx, span := startPodSpan(ctx, "cni.add_pod", pod.GetName(), pod.GetNamespace(), pod.GetContainerId())
 	defer func() { commontelemetry.EndSpan(span, retErr) }()
 
 	client, err := NewCNIClient(p.logger, conf.AgentCNIPath)
 	if err != nil {
-		return fmt.Errorf("failed to create CNI client: %w", err)
+		return false, fmt.Errorf("failed to create CNI client: %w", err)
 	}
 	defer func() {
 		if cerr := client.Close(); cerr != nil {
@@ -378,11 +396,15 @@ func (p *AetherPlugin) sendAddPod(ctx context.Context, conf config.AetherConf, p
 
 	res, err := client.AddPod(ctx, pod)
 	if err != nil {
-		return fmt.Errorf("failed to add pod to agent: %w", err)
+		return false, fmt.Errorf("failed to add pod to agent: %w", err)
 	}
 
+	// RESULT_IGNORED: the pod is not mesh-managed — caller skips capture install.
+	if res.Result == cniv1.AddPodResponse_RESULT_IGNORED {
+		return true, nil
+	}
 	if res.Result != cniv1.AddPodResponse_RESULT_SUCCESS {
-		return fmt.Errorf("adding pod to agent was not successful: %v", res.Result)
+		return false, fmt.Errorf("adding pod to agent was not successful: %v", res.Result)
 	}
 
 	// Data-plane proof, before pod start completes: probe the outbound capture
@@ -401,7 +423,9 @@ func (p *AetherPlugin) sendAddPod(ctx context.Context, conf config.AetherConf, p
 		}
 	}
 
-	return types.PrintResult(prevResult, conf.CNIVersion)
+	// Managed pod registered + serving: NOT ignored. CmdAdd installs capture next
+	// and prints the CNI result.
+	return false, nil
 }
 
 // delProbeNetns resolves the netns path to probe during DEL: the pinned path


### PR DESCRIPTION
Structural fix for the edge blackhole (#480 was a per-pod band-aid). The CNI can't see the `aether.io/managed` **label** (CRI passes annotations, not labels), so a managed=false pod in a non-ignored namespace got redirect-all capture with no listener → egress blackholed. Now the agent (the label authority) returns `RESULT_IGNORED`; CmdAdd registers first and installs capture only for managed pods — CNI+agent agree by construction. Reorder is safe (readiness probe hits the directly-bound listener, not the redirect). Unit+integration tests updated.