### PR TITLE
feat(029): EdgeConfig CRD + edge best-practices hardening (M1)

### DIFF
--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//agent/internal/xds/proxy",
         "//agent/storage",
         "//api/aether/cni/v1:cni",
+        "//api/aether/config/v1:config",
         "//api/aether/registry/v1:registry",
         "//common/constants",
         "//common/log",
@@ -47,6 +48,7 @@ go_library(
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
         "@org_uber_go_atomic//:atomic",
     ],
 )

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strconv"
 
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	"github.com/bpalermo/aether/common/serviceref"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -13,6 +14,7 @@ import (
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // routeSpecificity returns a composite sort key for a Route per Gateway API
@@ -307,9 +309,9 @@ func (c *SnapshotCache) edgeGatewayListeners() []types.Resource {
 	for _, gw := range gws {
 		for _, ln := range gw.Listeners {
 			if len(ln.TLSSecretNames) > 0 {
-				out = append(out, proxy.BuildEdgeGatewayHTTPSListener(gw.Namespace, gw.Name, ln.InternalPort, ln.TLSSecretNames, c.edgeGeoFilters(), c.edgeXffTrustedHops))
+				out = append(out, proxy.BuildEdgeGatewayHTTPSListener(gw.Namespace, gw.Name, ln.InternalPort, ln.TLSSecretNames, c.edgeGeoFilters(), c.edgeConfigSpec()))
 			} else {
-				out = append(out, proxy.BuildEdgeGatewayHTTPListener(gw.Namespace, gw.Name, ln.InternalPort, ln.HTTPRedirect, c.edgeGeoFilters(), c.edgeXffTrustedHops))
+				out = append(out, proxy.BuildEdgeGatewayHTTPListener(gw.Namespace, gw.Name, ln.InternalPort, ln.HTTPRedirect, c.edgeGeoFilters(), c.edgeConfigSpec()))
 			}
 		}
 	}
@@ -1111,6 +1113,18 @@ func equalEdgeGatewayListeners(a, b []EdgeGatewayListenerEntry) bool {
 func (c *SnapshotCache) SetEdgeGeoip(gc proxy.GeoipConfig, xffTrustedHops uint32) {
 	c.edgeGeo = &gc
 	c.edgeXffTrustedHops = xffTrustedHops
+}
+
+// edgeConfigSpec returns the effective EdgeConfigSpec applied to the edge listeners
+// (proposal 029). M1: derived from the existing chart-driven values (xff hops); the
+// GatewayClass/Gateway parametersRef resolution (proto.Merge) lands in M2. Unset
+// fields fall to the compiled best-practice defaults in ApplyEdgeHardening.
+func (c *SnapshotCache) edgeConfigSpec() *configv1.EdgeConfigSpec {
+	b := configv1.EdgeConfigSpec_builder{}
+	if c.edgeXffTrustedHops > 0 {
+		b.XffNumTrustedHops = wrapperspb.UInt32(c.edgeXffTrustedHops)
+	}
+	return b.Build()
 }
 
 // edgeGeoFilters returns [strip] or [strip, geoip, route-cache-clear] for the edge

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "capture.go",
         "cluster.go",
         "edge.go",
+        "edgeconfig.go",
         "egress.go",
         "endpoint.go",
         "extension_filter.go",
@@ -37,6 +38,7 @@ go_library(
     deps = [
         "//agent/internal/xds/config",
         "//api/aether/cni/v1:cni",
+        "//api/aether/config/v1:config",
         "//api/aether/registry/v1:registry",
         "//common/constants",
         "//common/extensionfilter",
@@ -93,6 +95,7 @@ go_test(
         "authz_test.go",
         "capture_test.go",
         "edge_test.go",
+        "edgeconfig_test.go",
         "egress_test.go",
         "endpoint_test.go",
         "extension_filter_test.go",
@@ -120,6 +123,7 @@ go_test(
     deps = [
         "//agent/internal/xds/config",
         "//api/aether/cni/v1:cni",
+        "//api/aether/config/v1:config",
         "//api/aether/registry/v1:registry",
         "//common/constants",
         "@com_github_cncf_xds_go//xds/type/v3:type",
@@ -154,5 +158,6 @@ go_test(
         "@org_golang_google_protobuf//types/known/anypb",
         "@org_golang_google_protobuf//types/known/durationpb",
         "@org_golang_google_protobuf//types/known/structpb",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
     ],
 )

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/bpalermo/aether/agent/internal/xds/config"
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
@@ -108,7 +109,7 @@ type EdgeGatewayListener struct {
 // redirect listener. Listener name and RDS route config name are unique per
 // Gateway (proposal 021 Phase 2). When httpRedirect is true, the listener emits
 // a 301 redirect to HTTPS (no RDS reference); otherwise it serves routes via RDS.
-func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort uint32, httpRedirect bool, geoFilters []*http_connection_managerv3.HttpFilter, xffTrustedHops uint32) *listenerv3.Listener {
+func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort uint32, httpRedirect bool, geoFilters []*http_connection_managerv3.HttpFilter, edgeCfg *configv1.EdgeConfigSpec) *listenerv3.Listener {
 	name := EdgeGatewayListenerName(namespace, gatewayName, internalPort)
 	if httpRedirect {
 		// Redirect listener: inline route config (no RDS), no separate route config
@@ -119,6 +120,9 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 		// client's original authority.
 		hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", buildEdgeRedirectRouteConfig())
 		hcm.GetRouteConfig().Name = name // unique inline config name avoids any residual collision
+		// The redirect listener is edge-facing too: apply the same hardening
+		// (use_remote_address, header-underscore rejection, timeouts, h2 caps).
+		ApplyEdgeHardening(hcm, nil, edgeCfg)
 		filterChain := &listenerv3.FilterChain{
 			Name:    name,
 			Filters: []*listenerv3.Filter{buildHTTPConnectionManagerFilter(hcm)},
@@ -142,7 +146,9 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 	// with the geoip filter's XffConfig (one topology fact, two consumers).
 	prefix := append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, geoFilters...)
 	hcm.HttpFilters = append(prefix, hcm.HttpFilters...)
-	hcm.XffNumTrustedHops = xffTrustedHops
+	// Envoy edge best-practices from the effective EdgeConfig (proposal 029):
+	// use_remote_address, header-underscore rejection, downstream h2 caps, timeouts.
+	ApplyEdgeHardening(hcm, nil, edgeCfg)
 	hcm.RouteSpecifier = &http_connection_managerv3.HttpConnectionManager_Rds{
 		Rds: &http_connection_managerv3.Rds{
 			RouteConfigName: routeName,
@@ -159,13 +165,15 @@ func BuildEdgeGatewayHTTPListener(namespace, gatewayName string, internalPort ui
 // BuildEdgeGatewayHTTPSListener builds a per-Gateway TLS-terminating HTTPS listener.
 // It terminates downstream TLS using the named SDS cert(s) and routes via the
 // per-Gateway RDS route config. The listener name is unique per (Gateway, port).
-func BuildEdgeGatewayHTTPSListener(namespace, gatewayName string, internalPort uint32, tlsSecretNames []string, geoFilters []*http_connection_managerv3.HttpFilter, xffTrustedHops uint32) *listenerv3.Listener {
+func BuildEdgeGatewayHTTPSListener(namespace, gatewayName string, internalPort uint32, tlsSecretNames []string, geoFilters []*http_connection_managerv3.HttpFilter, edgeCfg *configv1.EdgeConfigSpec) *listenerv3.Listener {
 	name := EdgeGatewayListenerName(namespace, gatewayName, internalPort)
 	routeName := EdgeGatewayRouteName(namespace, gatewayName)
 	hcm := buildHTTPConnectionManager(name, ReporterSource, "", "", nil)
 	prefix := append([]*http_connection_managerv3.HttpFilter{readinessHttpFilter()}, geoFilters...)
 	hcm.HttpFilters = append(prefix, hcm.HttpFilters...)
-	hcm.XffNumTrustedHops = xffTrustedHops
+	// Envoy edge best-practices from the effective EdgeConfig (proposal 029):
+	// use_remote_address, header-underscore rejection, downstream h2 caps, timeouts.
+	ApplyEdgeHardening(hcm, nil, edgeCfg)
 	// Port-agnostic hostname matching is handled by the route config's
 	// ignore_port_in_host_matching, NOT strip_any_host_port — see
 	// BuildEdgeGatewayHTTPListener. HTTPS clients connecting on a non-standard port

--- a/agent/internal/xds/proxy/edge_test.go
+++ b/agent/internal/xds/proxy/edge_test.go
@@ -266,7 +266,7 @@ func TestEdgeGatewayRouteNameUnique(t *testing.T) {
 // and the host-port NOT stripped on the HCM (matching is port-agnostic via the
 // route config's ignore_port_in_host_matching).
 func TestBuildEdgeGatewayHTTPListener(t *testing.T) {
-	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18150, false, nil, 0)
+	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18150, false, nil, nil)
 	assert.Equal(t, "edge_gw_ns-a_my-gw_18150", l.GetName())
 	assert.Equal(t, uint32(18150), l.GetAddress().GetSocketAddress().GetPortValue())
 	assert.Equal(t, corev3.TrafficDirection_INBOUND, l.GetTrafficDirection())
@@ -290,7 +290,7 @@ func TestBuildEdgeGatewayHTTPListener(t *testing.T) {
 // and does NOT strip the host-port (so the 301 Location preserves the client's
 // original authority).
 func TestBuildEdgeGatewayHTTPListener_Redirect(t *testing.T) {
-	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18151, true, nil, 0)
+	l := BuildEdgeGatewayHTTPListener("ns-a", "my-gw", 18151, true, nil, nil)
 	assert.Equal(t, "edge_gw_ns-a_my-gw_18151", l.GetName())
 	assert.Equal(t, uint32(18151), l.GetAddress().GetSocketAddress().GetPortValue())
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
@@ -312,7 +312,7 @@ func TestBuildEdgeGatewayHTTPListener_Redirect(t *testing.T) {
 // terminates TLS, uses the per-Gateway route config, has the unique name, and
 // does NOT strip the host-port (matching is port-agnostic via the route config).
 func TestBuildEdgeGatewayHTTPSListener(t *testing.T) {
-	l := BuildEdgeGatewayHTTPSListener("ns-b", "secure-gw", 18160, []string{"kubernetes/my-cert"}, nil, 0)
+	l := BuildEdgeGatewayHTTPSListener("ns-b", "secure-gw", 18160, []string{"kubernetes/my-cert"}, nil, nil)
 	assert.Equal(t, "edge_gw_ns-b_secure-gw_18160", l.GetName())
 	assert.Equal(t, uint32(18160), l.GetAddress().GetSocketAddress().GetPortValue())
 
@@ -350,7 +350,7 @@ func TestBuildEdgeGatewayHTTPSListener(t *testing.T) {
 // vhost while the backend still observes the original ":1234".
 func TestBuildEdgeGatewayHTTPListener_MultiListenerHostPort(t *testing.T) {
 	// Build the per-Gateway HTTP listener (one per (ns, gw, internal-port) tuple).
-	l := BuildEdgeGatewayHTTPListener("gateway-conformance-infra", "httproute-hostname-intersection", 18100, false, nil, 0)
+	l := BuildEdgeGatewayHTTPListener("gateway-conformance-infra", "httproute-hostname-intersection", 18100, false, nil, nil)
 
 	// 1. HCM must NOT strip the port (preserve it on the upstream-forwarded authority).
 	hcm := &http_connection_managerv3.HttpConnectionManager{}

--- a/agent/internal/xds/proxy/edgeconfig.go
+++ b/agent/internal/xds/proxy/edgeconfig.go
@@ -1,0 +1,90 @@
+package proxy
+
+import (
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+)
+
+// Edge best-practice defaults (Envoy edge doc; proposal 029). Applied when the
+// corresponding EdgeConfigSpec field is unset — so an empty/absent EdgeConfig still
+// yields a hardened edge.
+const (
+	edgeDefaultStreamIdleTimeout       = 300 * time.Second
+	edgeDefaultRequestTimeout          = 300 * time.Second
+	edgeDefaultIdleTimeout             = 3600 * time.Second
+	edgeDefaultMaxConcurrentStreams    = 100
+	edgeDefaultInitialStreamWindow     = 65536   // 64 KiB
+	edgeDefaultInitialConnectionWindow = 1048576 // 1 MiB
+	edgeDefaultPerConnBufferBytes      = 32 * 1024
+)
+
+// ApplyEdgeHardening applies the Envoy edge best-practices to an edge HCM +
+// listener from the effective EdgeConfigSpec (proposal 029). A nil spec (or any
+// unset field) uses the compiled best-practice default. Edge-only — the node-proxy
+// HCMs have a different (mesh-internal) threat model.
+func ApplyEdgeHardening(hcm *http_connection_managerv3.HttpConnectionManager, l *listenerv3.Listener, spec *configv1.EdgeConfigSpec) {
+	// use_remote_address: default TRUE (the edge trusts the connection source, not a
+	// forgeable XFF). This is also the fix for the previously-missing setting.
+	hcm.UseRemoteAddress = wrapperspb.Bool(boolOr(spec.GetUseRemoteAddress(), true))
+	hcm.XffNumTrustedHops = spec.GetXffNumTrustedHops().GetValue()
+
+	if hcm.GetCommonHttpProtocolOptions() == nil {
+		hcm.CommonHttpProtocolOptions = &corev3.HttpProtocolOptions{}
+	}
+	hcm.CommonHttpProtocolOptions.IdleTimeout = durationpb.New(durationOr(spec.GetIdleTimeout(), edgeDefaultIdleTimeout))
+	hcm.CommonHttpProtocolOptions.HeadersWithUnderscoresAction = underscoresAction(spec)
+
+	hcm.StreamIdleTimeout = durationpb.New(durationOr(spec.GetStreamIdleTimeout(), edgeDefaultStreamIdleTimeout))
+	hcm.RequestTimeout = durationpb.New(durationOr(spec.GetRequestTimeout(), edgeDefaultRequestTimeout))
+
+	hcm.Http2ProtocolOptions = &corev3.Http2ProtocolOptions{
+		MaxConcurrentStreams:        wrapperspb.UInt32(uint32Or(spec.GetHttp2().GetMaxConcurrentStreams(), edgeDefaultMaxConcurrentStreams)),
+		InitialStreamWindowSize:     wrapperspb.UInt32(uint32Or(spec.GetHttp2().GetInitialStreamWindowSize(), edgeDefaultInitialStreamWindow)),
+		InitialConnectionWindowSize: wrapperspb.UInt32(uint32Or(spec.GetHttp2().GetInitialConnectionWindowSize(), edgeDefaultInitialConnectionWindow)),
+	}
+
+	if l != nil {
+		l.PerConnectionBufferLimitBytes = wrapperspb.UInt32(uint32Or(spec.GetPerConnectionBufferLimitBytes(), edgeDefaultPerConnBufferBytes))
+	}
+}
+
+func underscoresAction(spec *configv1.EdgeConfigSpec) corev3.HttpProtocolOptions_HeadersWithUnderscoresAction {
+	switch spec.GetHeadersWithUnderscoresAction() {
+	case configv1.EdgeConfigSpec_ALLOW:
+		return corev3.HttpProtocolOptions_ALLOW
+	case configv1.EdgeConfigSpec_DROP_HEADER:
+		return corev3.HttpProtocolOptions_DROP_HEADER
+	default: // UNSPECIFIED or REJECT_REQUEST → the best-practice default
+		return corev3.HttpProtocolOptions_REJECT_REQUEST
+	}
+}
+
+func boolOr(v *wrapperspb.BoolValue, def bool) bool {
+	if v == nil {
+		return def
+	}
+	return v.GetValue()
+}
+
+func uint32Or(v *wrapperspb.UInt32Value, def uint32) uint32 {
+	if v == nil || v.GetValue() == 0 {
+		return def
+	}
+	return v.GetValue()
+}
+
+// durationOr returns d, or def when d is nil. A zero duration is honored (request
+// timeout 0 = disabled), so only nil falls to the default.
+func durationOr(d *durationpb.Duration, def time.Duration) time.Duration {
+	if d == nil {
+		return def
+	}
+	return d.AsDuration()
+}

--- a/agent/internal/xds/proxy/edgeconfig_test.go
+++ b/agent/internal/xds/proxy/edgeconfig_test.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"testing"
+	"time"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+)
+
+// nil spec → all best-practice defaults (an empty EdgeConfig still hardens).
+func TestApplyEdgeHardening_Defaults(t *testing.T) {
+	hcm := &http_connection_managerv3.HttpConnectionManager{}
+	ApplyEdgeHardening(hcm, nil, nil)
+	assert.True(t, hcm.GetUseRemoteAddress().GetValue(), "use_remote_address defaults true")
+	assert.Equal(t, corev3.HttpProtocolOptions_REJECT_REQUEST, hcm.GetCommonHttpProtocolOptions().GetHeadersWithUnderscoresAction())
+	assert.Equal(t, uint32(100), hcm.GetHttp2ProtocolOptions().GetMaxConcurrentStreams().GetValue())
+	assert.Equal(t, uint32(65536), hcm.GetHttp2ProtocolOptions().GetInitialStreamWindowSize().GetValue())
+	assert.Equal(t, uint32(1048576), hcm.GetHttp2ProtocolOptions().GetInitialConnectionWindowSize().GetValue())
+	assert.Equal(t, 300*time.Second, hcm.GetStreamIdleTimeout().AsDuration())
+	assert.Equal(t, 300*time.Second, hcm.GetRequestTimeout().AsDuration())
+	assert.Equal(t, 3600*time.Second, hcm.GetCommonHttpProtocolOptions().GetIdleTimeout().AsDuration())
+}
+
+// explicit spec overrides the defaults; request_timeout 0 is honored (disabled).
+func TestApplyEdgeHardening_Overrides(t *testing.T) {
+	hcm := &http_connection_managerv3.HttpConnectionManager{}
+	spec := configv1.EdgeConfigSpec_builder{
+		UseRemoteAddress:             wrapperspb.Bool(false),
+		HeadersWithUnderscoresAction: configv1.EdgeConfigSpec_ALLOW.Enum(),
+		RequestTimeout:               durationpb.New(0),
+		Http2:                        configv1.Http2Options_builder{MaxConcurrentStreams: wrapperspb.UInt32(50)}.Build(),
+	}.Build()
+	ApplyEdgeHardening(hcm, nil, spec)
+	assert.False(t, hcm.GetUseRemoteAddress().GetValue())
+	assert.Equal(t, corev3.HttpProtocolOptions_ALLOW, hcm.GetCommonHttpProtocolOptions().GetHeadersWithUnderscoresAction())
+	assert.Equal(t, int64(0), hcm.GetRequestTimeout().AsDuration().Nanoseconds(), "request_timeout 0 = disabled honored")
+	assert.Equal(t, uint32(50), hcm.GetHttp2ProtocolOptions().GetMaxConcurrentStreams().GetValue())
+}

--- a/agent/internal/xds/proxy/geoip_test.go
+++ b/agent/internal/xds/proxy/geoip_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"testing"
 
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	mutation_rulesv3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
 	geoip_filterv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/geoip/v3"
 	header_mutationv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
@@ -11,6 +12,7 @@ import (
 	geoip_maxmindv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/geoip_providers/maxmind/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // TestGeoStripHTTPFilter (028): the strip removes EVERY reserved x-geo-* header —
@@ -64,7 +66,7 @@ func TestBuildEdgeGatewayHTTPListener_Geo(t *testing.T) {
 		GeoStripHTTPFilter(),
 		GeoipHTTPFilter(GeoipConfig{CityDBPath: "/db", Headers: []string{"country"}, XffNumTrustedHops: 1}),
 	}
-	l := BuildEdgeGatewayHTTPListener("ns", "gw", 18150, false, filters, 1)
+	l := BuildEdgeGatewayHTTPListener("ns", "gw", 18150, false, filters, configv1.EdgeConfigSpec_builder{XffNumTrustedHops: wrapperspb.UInt32(1)}.Build())
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
 	require.NoError(t, l.GetFilterChains()[0].GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
 	require.GreaterOrEqual(t, len(hcm.GetHttpFilters()), 4)
@@ -98,7 +100,7 @@ func TestBuildEdgeGatewayHTTPListener_GeoOrder(t *testing.T) {
 		GeoipHTTPFilter(GeoipConfig{CityDBPath: "/db", Headers: []string{"country"}}),
 		GeoRouteCacheClearHTTPFilter(),
 	}
-	l := BuildEdgeGatewayHTTPListener("ns", "gw", 18150, false, geo, 0)
+	l := BuildEdgeGatewayHTTPListener("ns", "gw", 18150, false, geo, nil)
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
 	require.NoError(t, l.GetFilterChains()[0].GetFilters()[0].GetTypedConfig().UnmarshalTo(hcm))
 	names := []string{}

--- a/api/aether/config/v1/BUILD.bazel
+++ b/api/aether/config/v1/BUILD.bazel
@@ -12,6 +12,7 @@ load("//bazel/lint:linters.bzl", "buf_test")
 proto_library(
     name = "configv1_proto",
     srcs = [
+        "edge_config.proto",
         "http_filter.proto",
         "mesh_config.proto",
         "secret.proto",
@@ -19,6 +20,8 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "@protobuf//:any_proto",
+        "@protobuf//:duration_proto",
+        "@protobuf//:wrappers_proto",
         "@protovalidate//proto/protovalidate/buf/validate:validate_proto",
     ],
 )

--- a/api/aether/config/v1/edge_config.proto
+++ b/api/aether/config/v1/edge_config.proto
@@ -1,0 +1,59 @@
+edition = "2024";
+
+package aether.config.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
+
+option features.field_presence = EXPLICIT;
+option go_package = "github.com/bpalermo/aether/api/aether/config/v1;configv1";
+
+// EdgeConfigSpec is the `.spec` of the EdgeConfig custom resource (proposal 029):
+// Envoy edge-hardening + HTTP/3 settings for a set of edge Gateways, resolved via the
+// native Gateway API parametersRef chain (GatewayClass default + Gateway
+// infrastructure override, proto.Merge). Every field is OPTIONAL with a best-practice
+// compiled default — an empty EdgeConfig still hardens the edge. EXPLICIT presence so
+// proto.Merge distinguishes "unset (inherit)" from an explicit zero.
+message EdgeConfigSpec {
+  // use_remote_address: the edge trusts the immediate downstream connection address as
+  // the client and manages XFF from it (correct for an internet-facing edge; forgeable
+  // XFF otherwise). Default true.
+  google.protobuf.BoolValue use_remote_address = 1;
+  // xff_num_trusted_hops: additional trusted proxy hops in front of the edge; feeds the
+  // HCM and the geoip filter. Default 0.
+  google.protobuf.UInt32Value xff_num_trusted_hops = 2;
+  // headers_with_underscores_action: how to treat request headers with underscores
+  // (header-smuggling defense). Default REJECT_REQUEST.
+  HeadersWithUnderscoresAction headers_with_underscores_action = 3 [(buf.validate.field).enum.defined_only = true];
+  // http2: downstream HTTP/2 resource caps (malicious-client protection).
+  Http2Options http2 = 4;
+  // stream_idle_timeout: bound on an idle stream (slowloris). Default 300s.
+  google.protobuf.Duration stream_idle_timeout = 5;
+  // request_timeout: bound on the whole request. Default 300s; zero disables.
+  google.protobuf.Duration request_timeout = 6;
+  // idle_timeout: downstream connection idle timeout. Default 3600s.
+  google.protobuf.Duration idle_timeout = 7;
+  // per_connection_buffer_limit_bytes: listener + edge-cluster buffer cap. Default 32768.
+  google.protobuf.UInt32Value per_connection_buffer_limit_bytes = 8;
+  // http3: QUIC/HTTP3 UDP listener on the HTTPS port (proposal 029 M3).
+  Http3Options http3 = 9;
+
+  enum HeadersWithUnderscoresAction {
+    HEADERS_WITH_UNDERSCORES_ACTION_UNSPECIFIED = 0;
+    ALLOW = 1;
+    REJECT_REQUEST = 2;
+    DROP_HEADER = 3;
+  }
+}
+
+message Http2Options {
+  google.protobuf.UInt32Value max_concurrent_streams = 1; // default 100
+  google.protobuf.UInt32Value initial_stream_window_size = 2; // default 65536 (64 KiB)
+  google.protobuf.UInt32Value initial_connection_window_size = 3; // default 1048576 (1 MiB)
+}
+
+message Http3Options {
+  // enabled adds the QUIC UDP listener on the HTTPS port + alt-svc advertisement.
+  google.protobuf.BoolValue enabled = 1;
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.65.1-{GIT_COMMIT}"
+version: "0.66.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/crds/Chart.yaml
+++ b/charts/crds/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   channel); the VirtualHost CRD was retired (proposal 018).
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.6.0-{GIT_COMMIT}"
+version: "0.7.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/crds/templates/edgeconfig.yaml
+++ b/charts/crds/templates/edgeconfig.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: edgeconfigs.config.aether.io
+  annotations:
+    # Keep the CRD (and the CRs it owns) if this chart is uninstalled.
+    helm.sh/resource-policy: keep
+spec:
+  group: config.aether.io
+  # Namespaced: an EdgeConfig lives beside the Gateway that references it via
+  # spec.infrastructure.parametersRef (or is the chart-shipped fleet default referenced
+  # by the GatewayClass parametersRef).
+  scope: Namespaced
+  names:
+    kind: EdgeConfig
+    listKind: EdgeConfigList
+    plural: edgeconfigs
+    singular: edgeconfig
+    shortNames:
+      - edgecfg
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          description: |
+            EdgeConfig (aether.config.v1.EdgeConfigSpec, proposal 029) carries the Envoy
+            edge best-practices + HTTP/3 settings for a set of edge Gateways, resolved
+            per instance via the native Gateway API parametersRef chain (GatewayClass
+            default + Gateway infrastructure override, proto.Merge). Every field is
+            optional with a best-practice compiled default. The aether-controller webhook
+            proto-validates the spec; the structural schema is permissive.
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: HTTP3
+          type: string
+          jsonPath: .spec.http3.enabled
+        - name: Accepted
+          type: string
+          jsonPath: .status.conditions[?(@.type=="Accepted")].status
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/common/apis/config/v1/BUILD.bazel
+++ b/common/apis/config/v1/BUILD.bazel
@@ -3,6 +3,9 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "config",
     srcs = [
+        "edgeconfig_deepcopy.go",
+        "edgeconfig_jsonshim.go",
+        "edgeconfig_types.go",
         "httpfilter_deepcopy.go",
         "httpfilter_jsonshim.go",
         "httpfilter_types.go",

--- a/common/apis/config/v1/edgeconfig_deepcopy.go
+++ b/common/apis/config/v1/edgeconfig_deepcopy.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"google.golang.org/protobuf/proto"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DeepCopyInto copies the receiver into out. The proto spec is cloned via proto.Clone
+// (never shallow-copied — proto messages, and the opaque typedConfig Any, hold
+// internal state).
+func (in *EdgeConfig) DeepCopyInto(out *EdgeConfig) {
+	out.TypeMeta = in.TypeMeta
+	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.Spec != nil {
+		out.Spec = proto.Clone(in.Spec).(*configv1.EdgeConfigSpec)
+	} else {
+		out.Spec = nil
+	}
+	in.Status.DeepCopyInto(&out.Status)
+}
+
+// DeepCopy returns a deep copy of the EdgeConfig.
+func (in *EdgeConfig) DeepCopy() *EdgeConfig {
+	if in == nil {
+		return nil
+	}
+	out := new(EdgeConfig)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyObject implements runtime.Object.
+func (in *EdgeConfig) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}
+
+// DeepCopyInto copies the status into out.
+func (in *EdgeConfigStatus) DeepCopyInto(out *EdgeConfigStatus) {
+	*out = *in
+	if in.Conditions != nil {
+		out.Conditions = make([]metav1.Condition, len(in.Conditions))
+		for i := range in.Conditions {
+			in.Conditions[i].DeepCopyInto(&out.Conditions[i])
+		}
+	}
+}
+
+// DeepCopyInto copies the list into out.
+func (in *EdgeConfigList) DeepCopyInto(out *EdgeConfigList) {
+	out.TypeMeta = in.TypeMeta
+	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	if in.Items != nil {
+		out.Items = make([]EdgeConfig, len(in.Items))
+		for i := range in.Items {
+			in.Items[i].DeepCopyInto(&out.Items[i])
+		}
+	}
+}
+
+// DeepCopy returns a deep copy of the EdgeConfigList.
+func (in *EdgeConfigList) DeepCopy() *EdgeConfigList {
+	if in == nil {
+		return nil
+	}
+	out := new(EdgeConfigList)
+	in.DeepCopyInto(out)
+	return out
+}
+
+// DeepCopyObject implements runtime.Object.
+func (in *EdgeConfigList) DeepCopyObject() runtime.Object {
+	if c := in.DeepCopy(); c != nil {
+		return c
+	}
+	return nil
+}

--- a/common/apis/config/v1/edgeconfig_jsonshim.go
+++ b/common/apis/config/v1/edgeconfig_jsonshim.go
@@ -1,0 +1,63 @@
+package v1
+
+import (
+	"encoding/json"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// edgeConfigShim is the wire shape of an EdgeConfig: standard Kubernetes
+// TypeMeta/ObjectMeta/Status with the spec held as raw JSON so it is (un)marshalled
+// through protojson (which honours proto JSON names, the google.protobuf.Any
+// `@type` envelope of spec.typedConfig, and well-known types) rather than
+// encoding/json.
+type edgeConfigShim struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Spec              json.RawMessage  `json:"spec,omitempty"`
+	Status            EdgeConfigStatus `json:"status,omitempty"`
+}
+
+// MarshalJSON serializes the EdgeConfig, encoding `.spec` with protojson.
+func (in *EdgeConfig) MarshalJSON() ([]byte, error) {
+	shim := edgeConfigShim{
+		TypeMeta:   in.TypeMeta,
+		ObjectMeta: in.ObjectMeta,
+		Status:     in.Status,
+	}
+	if in.Spec != nil {
+		raw, err := protojson.Marshal(in.Spec)
+		if err != nil {
+			return nil, err
+		}
+		shim.Spec = raw
+	}
+	return json.Marshal(shim)
+}
+
+// UnmarshalJSON parses an EdgeConfig, decoding `.spec` with protojson.
+//
+// Decoding is LENIENT (DiscardUnknown) for forward-compatibility across rolling
+// upgrades — same contract as MeshConfig. The EdgeConfigSpec decodes by proto JSON names;
+// its `@type`; an unknown/garbage `@type` surfaces here (and is rejected cleanly by
+// the admission webhook). Semantic validation of the payload is proto-validate's job.
+func (in *EdgeConfig) UnmarshalJSON(data []byte) error {
+	var shim edgeConfigShim
+	if err := json.Unmarshal(data, &shim); err != nil {
+		return err
+	}
+	in.TypeMeta = shim.TypeMeta
+	in.ObjectMeta = shim.ObjectMeta
+	in.Status = shim.Status
+	in.Spec = nil
+	if len(shim.Spec) > 0 && string(shim.Spec) != "null" {
+		spec := &configv1.EdgeConfigSpec{}
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(shim.Spec, spec); err != nil {
+			return err
+		}
+		in.Spec = spec
+	}
+	return nil
+}

--- a/common/apis/config/v1/edgeconfig_types.go
+++ b/common/apis/config/v1/edgeconfig_types.go
@@ -1,0 +1,37 @@
+package v1
+
+import (
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EdgeConfigKind is the CRD kind.
+const EdgeConfigKind = "EdgeConfig"
+
+// EdgeConfig is a namespaced custom resource carrying the edge-hardening + HTTP/3
+// settings for a set of edge Gateways (proposal 029). Resolved per edge instance via
+// the native Gateway API parametersRef chain: GatewayClass.spec.parametersRef (fleet
+// default) + Gateway.spec.infrastructure.parametersRef (per-instance override),
+// merged with proto.Merge. Every field has a best-practice compiled default. Its
+// `.spec` is the protobuf EdgeConfigSpec.
+type EdgeConfig struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec is the protobuf EdgeConfigSpec, serialized via protojson (see the jsonshim).
+	Spec *configv1.EdgeConfigSpec `json:"spec,omitempty"`
+
+	Status EdgeConfigStatus `json:"status,omitempty"`
+}
+
+// EdgeConfigStatus reports the last admission/validation result.
+type EdgeConfigStatus struct {
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+// EdgeConfigList is the list type for EdgeConfig.
+type EdgeConfigList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []EdgeConfig `json:"items"`
+}

--- a/common/apis/config/v1/meshconfig_types.go
+++ b/common/apis/config/v1/meshconfig_types.go
@@ -30,6 +30,7 @@ func AddToScheme(s *runtime.Scheme) error {
 func addKnownTypes(s *runtime.Scheme) error {
 	s.AddKnownTypes(GroupVersion, &MeshConfig{}, &MeshConfigList{})
 	s.AddKnownTypes(GroupVersion, &HTTPFilter{}, &HTTPFilterList{})
+	s.AddKnownTypes(GroupVersion, &EdgeConfig{}, &EdgeConfigList{})
 	metav1.AddToGroupVersion(s, GroupVersion)
 	return nil
 }

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -378,7 +378,15 @@ func buildEdgeBootstrap() (*bootstrapv3.Bootstrap, error) {
 		// compiles in stock Envoy alongside geoip (proposal 028).
 		proxy.GeoRouteCacheClearHTTPFilter(),
 	}
-	edgeHTTP := proxy.BuildEdgeGatewayHTTPListener("edge-ns", "edge-gw", 18150, false, geo, 1)
+	// Full edge hardening (proposal 029): validate use_remote_address, header-underscore
+	// rejection, downstream h2 caps and timeouts are accepted by stock Envoy.
+	edgeCfg := configprotov1.EdgeConfigSpec_builder{
+		UseRemoteAddress:             wrapperspb.Bool(true),
+		XffNumTrustedHops:            wrapperspb.UInt32(1),
+		HeadersWithUnderscoresAction: configprotov1.EdgeConfigSpec_REJECT_REQUEST.Enum(),
+		RequestTimeout:               durationpb.New(300 * time.Second),
+	}.Build()
+	edgeHTTP := proxy.BuildEdgeGatewayHTTPListener("edge-ns", "edge-gw", 18150, false, geo, edgeCfg)
 
 	return newBootstrap(
 		[]*clusterv3.Cluster{xdsCluster(), spire, edgeSvc},


### PR DESCRIPTION
M1 of proposal 029. EdgeConfig CRD (config.aether.io/v1, edition-2024 EXPLICIT presence) carrying the Envoy edge best-practices; `ApplyEdgeHardening` applies them to the edge listeners with compiled best-practice defaults (empty config still hardens). Ships the missing `use_remote_address` (default true — the edge must trust the connection source, not forgeable XFF; 028 geoip depends on it). Native parametersRef resolution = M2, HTTP/3 = M3, talos e2e = M4. Tests: applier defaults/overrides + CRD roundtrip + `envoy --mode validate` over the full hardening.