### PR TITLE
feat(029): native parametersRef resolution for EdgeConfig (M2)

### DIFF
--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	xdsServer "github.com/bpalermo/aether/agent/internal/xds/server"
+	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
 	"github.com/bpalermo/aether/common/manager"
 	commonspire "github.com/bpalermo/aether/common/spire"
 	"github.com/spf13/cobra"
@@ -151,6 +152,11 @@ func runEdge(ctx context.Context) (retErr error) {
 	// cross-namespace backendRefs.
 	if err := gatewayv1beta1.Install(scheme); err != nil {
 		return fmt.Errorf("register gateway.networking.k8s.io/v1beta1 scheme: %w", err)
+	}
+	// EdgeConfig / MeshConfig / HTTPFilter (config.aether.io) — the edge resolves
+	// per-Gateway EdgeConfig via the parametersRef chain (proposal 029).
+	if err := configapisv1.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("register config.aether.io scheme: %w", err)
 	}
 
 	result, err := manager.Bootstrap(ctx, cfg.Config, edgeName, Version, func(o *ctrl.Options) {

--- a/agent/internal/edge/gatewayapi/BUILD.bazel
+++ b/agent/internal/edge/gatewayapi/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "gatewayapi",
     srcs = [
         "attachment.go",
+        "edgeconfig_resolve.go",
         "features.go",
         "reconciler.go",
         "service.go",
@@ -18,6 +19,7 @@ go_library(
         "//agent/internal/xds/cache",
         "//agent/internal/xds/proxy",
         "//api/aether/config/v1:config",
+        "//common/apis/config/v1:config",
         "//common/constants",
         "//common/log",
         "//common/referencegrant",
@@ -38,6 +40,7 @@ go_library(
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@io_k8s_sigs_gateway_api//pkg/features",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/durationpb",
     ],
 )
@@ -46,6 +49,7 @@ go_test(
     name = "gatewayapi_test",
     srcs = [
         "edge_cases_test.go",
+        "edgeconfig_resolve_test.go",
         "reconciler_test.go",
         "service_test.go",
         "status_test.go",
@@ -57,6 +61,8 @@ go_test(
         "//agent/internal/gatewaystatus",
         "//agent/internal/xds/cache",
         "//agent/internal/xds/proxy",
+        "//api/aether/config/v1:config",
+        "//common/apis/config/v1:config",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_k8s_api//core/v1:core",
@@ -76,5 +82,6 @@ go_test(
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1alpha2",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
     ],
 )

--- a/agent/internal/edge/gatewayapi/edgeconfig_resolve.go
+++ b/agent/internal/edge/gatewayapi/edgeconfig_resolve.go
@@ -1,0 +1,77 @@
+package gatewayapi
+
+import (
+	"context"
+
+	"google.golang.org/protobuf/proto"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// edgeConfigGroup/Kind identify an EdgeConfig referent in a parametersRef.
+const (
+	edgeConfigGroup = "config.aether.io"
+	edgeConfigKind  = "EdgeConfig"
+)
+
+// resolveEdgeConfig computes the effective EdgeConfigSpec for one Gateway (proposal
+// 029), via the NATIVE Gateway API parameters chain:
+//
+//   - GatewayClass.spec.parametersRef → the fleet-default EdgeConfig (chart-shipped).
+//   - Gateway.spec.infrastructure.parametersRef → the per-instance override.
+//
+// effective = proto.Merge(classDefault, gatewayOverride): the override wins field by
+// field; unset fields inherit the class default; anything unset in both falls to the
+// compiled best-practice default in ApplyEdgeHardening. Returns nil when neither ref
+// resolves to an EdgeConfig (→ pure compiled defaults). Missing/mistyped refs are
+// tolerated (logged, skipped) so a dangling parametersRef degrades to defaults rather
+// than dropping the Gateway's listeners.
+func (r *Reconciler) resolveEdgeConfig(ctx context.Context, gw *gatewayv1.Gateway) *configv1.EdgeConfigSpec {
+	var effective *configv1.EdgeConfigSpec
+
+	// Class default.
+	if def := r.classDefaultEdgeConfig(ctx); def != nil {
+		effective = proto.Clone(def).(*configv1.EdgeConfigSpec)
+	}
+
+	// Per-Gateway override (same namespace as the Gateway — LocalParametersReference).
+	if inf := gw.Spec.Infrastructure; inf != nil && inf.ParametersRef != nil {
+		ref := inf.ParametersRef
+		if string(ref.Group) == edgeConfigGroup && string(ref.Kind) == edgeConfigKind {
+			if ov := r.getEdgeConfig(ctx, gw.Namespace, string(ref.Name)); ov != nil {
+				effective = configapisv1.MergeEdgeConfigSpec(effective, ov)
+			}
+		}
+	}
+	return effective
+}
+
+// classDefaultEdgeConfig loads the EdgeConfig named by our GatewayClass's
+// spec.parametersRef, or nil.
+func (r *Reconciler) classDefaultEdgeConfig(ctx context.Context) *configv1.EdgeConfigSpec {
+	gc := &gatewayv1.GatewayClass{}
+	if err := r.Get(ctx, client.ObjectKey{Name: r.GatewayClassName}, gc); err != nil {
+		return nil
+	}
+	ref := gc.Spec.ParametersRef
+	if ref == nil || string(ref.Group) != edgeConfigGroup || string(ref.Kind) != edgeConfigKind {
+		return nil
+	}
+	ns := ""
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+	return r.getEdgeConfig(ctx, ns, ref.Name)
+}
+
+// getEdgeConfig fetches an EdgeConfig CR and returns its proto spec, or nil.
+func (r *Reconciler) getEdgeConfig(ctx context.Context, namespace, name string) *configv1.EdgeConfigSpec {
+	ec := &configapisv1.EdgeConfig{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, ec); err != nil {
+		return nil
+	}
+	return ec.Spec
+}

--- a/agent/internal/edge/gatewayapi/edgeconfig_resolve_test.go
+++ b/agent/internal/edge/gatewayapi/edgeconfig_resolve_test.go
@@ -1,0 +1,80 @@
+package gatewayapi
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func edgeConfigScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, gatewayv1.Install(s))
+	require.NoError(t, configapisv1.AddToScheme(s))
+	return s
+}
+
+func gwClassWithParams(name, ecName, ecNs string) *gatewayv1.GatewayClass {
+	ns := gatewayv1.Namespace(ecNs)
+	return &gatewayv1.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: gatewayv1.GatewayClassSpec{
+			ControllerName: "gateway.aether.io/edge",
+			ParametersRef: &gatewayv1.ParametersReference{
+				Group: "config.aether.io", Kind: "EdgeConfig", Name: ecName, Namespace: &ns,
+			},
+		},
+	}
+}
+
+// class default supplies request_timeout; the per-Gateway override flips
+// use_remote_address — proto.Merge yields both.
+func TestResolveEdgeConfig_ClassDefaultPlusGatewayOverride(t *testing.T) {
+	def := &configapisv1.EdgeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "defaults", Namespace: "aether-ingress"},
+		Spec: configv1.EdgeConfigSpec_builder{
+			UseRemoteAddress:  wrapperspb.Bool(true),
+			XffNumTrustedHops: wrapperspb.UInt32(2),
+		}.Build(),
+	}
+	override := &configapisv1.EdgeConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw-override", Namespace: "team-a"},
+		Spec: configv1.EdgeConfigSpec_builder{
+			UseRemoteAddress: wrapperspb.Bool(false), // wins
+		}.Build(),
+	}
+	ref := gatewayv1.LocalParametersReference{Group: "config.aether.io", Kind: "EdgeConfig", Name: "gw-override"}
+	gw := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "team-a"},
+		Spec:       gatewayv1.GatewaySpec{Infrastructure: &gatewayv1.GatewayInfrastructure{ParametersRef: &ref}},
+	}
+	c := fake.NewClientBuilder().WithScheme(edgeConfigScheme(t)).
+		WithObjects(gwClassWithParams("aether", "defaults", "aether-ingress"), def, override).Build()
+	r := &Reconciler{Client: c, GatewayClassName: "aether"}
+
+	eff := r.resolveEdgeConfig(context.Background(), gw)
+	require.NotNil(t, eff)
+	assert.False(t, eff.GetUseRemoteAddress().GetValue(), "override wins")
+	assert.Equal(t, uint32(2), eff.GetXffNumTrustedHops().GetValue(), "inherited from class default")
+}
+
+// no parametersRef anywhere → nil (compiled defaults apply downstream).
+func TestResolveEdgeConfig_NoRefs(t *testing.T) {
+	gw := &gatewayv1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "team-a"}}
+	c := fake.NewClientBuilder().WithScheme(edgeConfigScheme(t)).
+		WithObjects(&gatewayv1.GatewayClass{ObjectMeta: metav1.ObjectMeta{Name: "aether"}}).Build()
+	r := &Reconciler{Client: c, GatewayClassName: "aether"}
+	assert.Nil(t, r.resolveEdgeConfig(context.Background(), gw))
+}

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
 	constants "github.com/bpalermo/aether/common/constants"
 	commonlog "github.com/bpalermo/aether/common/log"
 	"github.com/bpalermo/aether/common/referencegrant"
@@ -140,6 +141,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		// GatewayClass: a spec change must re-publish status (observedGeneration
 		// bump). We reconcile any GatewayClass bearing our controllerName.
 		Watches(&gatewayv1.GatewayClass{}, resync).
+		Watches(&configapisv1.EdgeConfig{}, resync).
 		Watches(&gatewayv1.Gateway{}, resync).
 		Watches(&gatewayv1alpha2.TCPRoute{}, resync).
 		Watches(&gatewayv1.TLSRoute{}, resync).
@@ -345,7 +347,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 				r.Log.WarnContext(ctx, "per-Gateway Service reconcile error", "error", svcErr.Error())
 			}
 			perGWAssignedIPs = ips
-			entries := buildEdgeGatewayEntries(ourGateways, vhosts, allocations, gatewayHTTPRedirect)
+			edgeConfigs := make(map[gatewayKey]*configv1.EdgeConfigSpec, len(ourGateways))
+			for i := range ourGateways {
+				gw := &ourGateways[i]
+				edgeConfigs[gatewayKey{Namespace: gw.Namespace, Name: gw.Name}] = r.resolveEdgeConfig(ctx, gw)
+			}
+			entries := buildEdgeGatewayEntries(ourGateways, vhosts, allocations, gatewayHTTPRedirect, edgeConfigs)
 			r.Sink.SetEdgeGateways(entries)
 			r.Log.DebugContext(ctx, "projected per-Gateway entries",
 				"gateways", len(entries), "ourGateways", len(ourGateways),

--- a/agent/internal/edge/gatewayapi/service.go
+++ b/agent/internal/edge/gatewayapi/service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/edge/portalloc"
 	"github.com/bpalermo/aether/agent/internal/xds/cache"
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -399,6 +400,7 @@ func buildEdgeGatewayEntries(
 	allVhosts []cache.VirtualHost,
 	allocations map[gatewayKey][]gatewayListenerAllocation,
 	gatewayHTTPRedirect map[gatewayKey]bool,
+	edgeConfigs map[gatewayKey]*configv1.EdgeConfigSpec,
 ) []cache.EdgeGatewayEntry {
 	entries := make([]cache.EdgeGatewayEntry, 0, len(ourGateways))
 
@@ -442,6 +444,7 @@ func buildEdgeGatewayEntries(
 			Name:         gw.Name,
 			Listeners:    lns,
 			VirtualHosts: gwVhosts,
+			EdgeConfig:   edgeConfigs[gk],
 		})
 	}
 	return entries

--- a/agent/internal/edge/gatewayapi/service_test.go
+++ b/agent/internal/edge/gatewayapi/service_test.go
@@ -276,7 +276,7 @@ func TestBuildEdgeGatewayEntries_AssignByAttachment(t *testing.T) {
 		},
 	}
 
-	entries := buildEdgeGatewayEntries(gws, allVhosts, allocs, nil)
+	entries := buildEdgeGatewayEntries(gws, allVhosts, allocs, nil, nil)
 	require.Len(t, entries, 2)
 
 	byName := map[string]cache.EdgeGatewayEntry{}

--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//api/aether/cni/v1:cni",
         "//api/aether/config/v1:config",
         "//api/aether/registry/v1:registry",
+        "//common/apis/config/v1:config",
         "//common/constants",
         "//common/log",
         "//common/serviceref",

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	configapisv1 "github.com/bpalermo/aether/common/apis/config/v1"
 	"github.com/bpalermo/aether/common/serviceref"
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
@@ -128,6 +129,11 @@ type EdgeGatewayEntry struct {
 	Listeners []EdgeGatewayListenerEntry
 	// VirtualHosts are the HTTPRoute virtual hosts attached to this Gateway.
 	VirtualHosts []VirtualHost
+	// EdgeConfig is the effective edge-hardening/HTTP3 config for THIS Gateway
+	// (proposal 029): GatewayClass.parametersRef default ⊕ Gateway
+	// infrastructure.parametersRef override, resolved by the reconciler. Nil = the
+	// compiled best-practice defaults (ApplyEdgeHardening handles nil).
+	EdgeConfig *configv1.EdgeConfigSpec
 }
 
 // VirtualHost is the cache's projection of an HTTPRoute (and the legacy
@@ -309,9 +315,9 @@ func (c *SnapshotCache) edgeGatewayListeners() []types.Resource {
 	for _, gw := range gws {
 		for _, ln := range gw.Listeners {
 			if len(ln.TLSSecretNames) > 0 {
-				out = append(out, proxy.BuildEdgeGatewayHTTPSListener(gw.Namespace, gw.Name, ln.InternalPort, ln.TLSSecretNames, c.edgeGeoFilters(), c.edgeConfigSpec()))
+				out = append(out, proxy.BuildEdgeGatewayHTTPSListener(gw.Namespace, gw.Name, ln.InternalPort, ln.TLSSecretNames, c.edgeGeoFilters(), c.effectiveEdgeConfig(gw)))
 			} else {
-				out = append(out, proxy.BuildEdgeGatewayHTTPListener(gw.Namespace, gw.Name, ln.InternalPort, ln.HTTPRedirect, c.edgeGeoFilters(), c.edgeConfigSpec()))
+				out = append(out, proxy.BuildEdgeGatewayHTTPListener(gw.Namespace, gw.Name, ln.InternalPort, ln.HTTPRedirect, c.edgeGeoFilters(), c.effectiveEdgeConfig(gw)))
 			}
 		}
 	}
@@ -1119,12 +1125,16 @@ func (c *SnapshotCache) SetEdgeGeoip(gc proxy.GeoipConfig, xffTrustedHops uint32
 // (proposal 029). M1: derived from the existing chart-driven values (xff hops); the
 // GatewayClass/Gateway parametersRef resolution (proto.Merge) lands in M2. Unset
 // fields fall to the compiled best-practice defaults in ApplyEdgeHardening.
-func (c *SnapshotCache) edgeConfigSpec() *configv1.EdgeConfigSpec {
-	b := configv1.EdgeConfigSpec_builder{}
+func (c *SnapshotCache) effectiveEdgeConfig(gw EdgeGatewayEntry) *configv1.EdgeConfigSpec {
+	// Base: the chart-derived xff hops (legacy edge.xffNumTrustedHops), so the
+	// existing knob keeps working until callers migrate to EdgeConfig CRs.
+	base := configv1.EdgeConfigSpec_builder{}.Build()
 	if c.edgeXffTrustedHops > 0 {
-		b.XffNumTrustedHops = wrapperspb.UInt32(c.edgeXffTrustedHops)
+		base.SetXffNumTrustedHops(wrapperspb.UInt32(c.edgeXffTrustedHops))
 	}
-	return b.Build()
+	// Per-Gateway resolved config (proposal 029 M2) wins field-by-field (explicit
+	// false/zero included — see MergeEdgeConfigSpec).
+	return configapisv1.MergeEdgeConfigSpec(base, gw.EdgeConfig)
 }
 
 // edgeGeoFilters returns [strip] or [strip, geoip, route-cache-clear] for the edge

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.66.0-{GIT_COMMIT}"
+version: "0.67.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/_helpers.tpl
+++ b/charts/aether/templates/_helpers.tpl
@@ -169,3 +169,8 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 {{- end -}}
+
+{{/* Name of the chart-shipped fleet-default EdgeConfig (proposal 029). */}}
+{{- define "aether.edge.defaultConfigName" -}}
+{{- default "aether-edge-defaults" .Values.edge.config.name -}}
+{{- end -}}

--- a/charts/aether/templates/controller-rbac.yaml
+++ b/charts/aether/templates/controller-rbac.yaml
@@ -17,6 +17,10 @@ rules:
   - apiGroups: ["config.aether.io"]
     resources: ["httpfilters"]
     verbs: ["get", "list"]
+  # EdgeConfig validating webhook (proposal 029).
+  - apiGroups: ["config.aether.io"]
+    resources: ["edgeconfigs"]
+    verbs: ["get", "list"]
   # List HTTPRoutes cluster-wide for the hostname-conflict validating webhook
   # (proposal 018).
   - apiGroups: ["gateway.networking.k8s.io"]

--- a/charts/aether/templates/controller-webhook.yaml
+++ b/charts/aether/templates/controller-webhook.yaml
@@ -88,6 +88,12 @@ webhooks:
         operations: ["CREATE", "UPDATE"]
         resources: ["httpfilters"]
         scope: "Namespaced"
+      # EdgeConfig: proto-validate the edge-hardening/HTTP3 spec (proposal 029).
+      - apiGroups: ["config.aether.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["edgeconfigs"]
+        scope: "Namespaced"
       - apiGroups: ["gateway.networking.k8s.io"]
         apiVersions: ["v1"]
         operations: ["CREATE", "UPDATE"]

--- a/charts/aether/templates/edge-defaultconfig.yaml
+++ b/charts/aether/templates/edge-defaultconfig.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.edge.enabled }}
+# The fleet-default EdgeConfig (proposal 029): the GatewayClass's parametersRef points
+# here, so every edge Gateway inherits these Envoy edge best-practices unless it
+# overrides them via spec.infrastructure.parametersRef → its own EdgeConfig. Fields left
+# unset here fall to the agent's compiled best-practice defaults; the values below are
+# the recommended edge settings, surfaced for discoverability/tuning.
+apiVersion: config.aether.io/v1
+kind: EdgeConfig
+metadata:
+  name: {{ include "aether.edge.defaultConfigName" . }}
+  namespace: {{ include "aether.edge.namespace" . }}
+  labels:
+    {{- include "aether.edge.labels" . | nindent 4 }}
+spec:
+  useRemoteAddress: {{ .Values.edge.config.useRemoteAddress }}
+  xffNumTrustedHops: {{ .Values.edge.xffNumTrustedHops }}
+  headersWithUnderscoresAction: {{ .Values.edge.config.headersWithUnderscoresAction }}
+  streamIdleTimeout: {{ .Values.edge.config.streamIdleTimeout }}
+  requestTimeout: {{ .Values.edge.config.requestTimeout }}
+  idleTimeout: {{ .Values.edge.config.idleTimeout }}
+  perConnectionBufferLimitBytes: {{ .Values.edge.config.perConnectionBufferLimitBytes }}
+  http2:
+    maxConcurrentStreams: {{ .Values.edge.config.http2.maxConcurrentStreams }}
+    initialStreamWindowSize: {{ .Values.edge.config.http2.initialStreamWindowSize }}
+    initialConnectionWindowSize: {{ .Values.edge.config.http2.initialConnectionWindowSize }}
+  http3:
+    enabled: {{ .Values.edge.config.http3.enabled }}
+{{- end }}

--- a/charts/aether/templates/edge-gatewayclass.yaml
+++ b/charts/aether/templates/edge-gatewayclass.yaml
@@ -10,4 +10,11 @@ metadata:
     {{- include "aether.edge.labels" . | nindent 4 }}
 spec:
   controllerName: gateway.aether.io/edge
+  # Fleet-default edge config (proposal 029): every Gateway of this class inherits it,
+  # overridable per-Gateway via spec.infrastructure.parametersRef.
+  parametersRef:
+    group: config.aether.io
+    kind: EdgeConfig
+    name: {{ include "aether.edge.defaultConfigName" . }}
+    namespace: {{ include "aether.edge.namespace" . }}
 {{- end }}

--- a/charts/aether/templates/edge-rbac.yaml
+++ b/charts/aether/templates/edge-rbac.yaml
@@ -35,6 +35,11 @@ rules:
   - apiGroups: ["gateway.networking.k8s.io"]
     resources: ["referencegrants"]
     verbs: ["get", "list", "watch"]
+  # EdgeConfig (proposal 029): resolve the per-Gateway effective edge config via the
+  # GatewayClass/Gateway parametersRef chain. Read-only, cluster-wide.
+  - apiGroups: ["config.aether.io"]
+    resources: ["edgeconfigs"]
+    verbs: ["get", "list", "watch"]
   # Resolve backendRef Services cluster-wide for the ResolvedRefs condition.
   - apiGroups: [""]
     resources: ["services"]

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -256,6 +256,23 @@ edge:
   # Trusted proxies in front of the edge (topology fact, proposal 028): feeds BOTH
   # the HCM's client-address resolution and the geoip filter's XFF config.
   xffNumTrustedHops: 0
+  # Edge best-practices config (proposal 029) — the fleet-default EdgeConfig the
+  # GatewayClass parametersRef points at. Override per-Gateway with your own EdgeConfig
+  # via Gateway.spec.infrastructure.parametersRef. Values are the Envoy edge defaults.
+  config:
+    name: ""                                # default "aether-edge-defaults"
+    useRemoteAddress: true                  # edge trusts the connection source, not XFF
+    headersWithUnderscoresAction: REJECT_REQUEST
+    streamIdleTimeout: 300s
+    requestTimeout: 300s                    # 0s disables
+    idleTimeout: 3600s
+    perConnectionBufferLimitBytes: 32768    # 32 KiB
+    http2:
+      maxConcurrentStreams: 100
+      initialStreamWindowSize: 65536        # 64 KiB
+      initialConnectionWindowSize: 1048576  # 1 MiB
+    http3:
+      enabled: false                        # QUIC/HTTP3 UDP listener on the HTTPS port (M3)
   # GeoIP at the edge (proposal 028): emit x-geo-* request headers from a MaxMind
   # database. The reserved x-geo-* namespace is ALWAYS stripped from client
   # requests at the edge (the Envoy filter passes spoofed values through on a

--- a/common/apis/config/v1/BUILD.bazel
+++ b/common/apis/config/v1/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/schema",
         "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
     ],
 )
 

--- a/common/apis/config/v1/edgeconfig_types.go
+++ b/common/apis/config/v1/edgeconfig_types.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,4 +35,25 @@ type EdgeConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []EdgeConfig `json:"items"`
+}
+
+// MergeEdgeConfigSpec returns base with every POPULATED field of override replacing
+// base's (proposal 029 default ⊕ override). Unlike proto.Merge — which recurses into
+// wrapper messages so a BoolValue{false} override cannot beat a BoolValue{true} base —
+// this replaces whole top-level fields the override sets, so "override wins per field"
+// holds for explicit false/zero overrides. Fields unset in override (nil, given the
+// spec's EXPLICIT presence) are left as base's. base may be nil.
+func MergeEdgeConfigSpec(base, override *configv1.EdgeConfigSpec) *configv1.EdgeConfigSpec {
+	if override == nil {
+		return base
+	}
+	if base == nil {
+		base = &configv1.EdgeConfigSpec{}
+	}
+	bm := base.ProtoReflect()
+	override.ProtoReflect().Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		bm.Set(fd, v)
+		return true
+	})
+	return base
 }

--- a/controller/internal/cmd/BUILD.bazel
+++ b/controller/internal/cmd/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//common/apis/config/v1:config",
         "//common/manager",
         "//common/spire",
+        "//controller/internal/edgeconfig",
         "//controller/internal/gatewayapi",
         "//controller/internal/httpfilter",
         "//controller/internal/meshconfig",

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
 	"github.com/bpalermo/aether/common/manager"
 	"github.com/bpalermo/aether/common/spire"
+	"github.com/bpalermo/aether/controller/internal/edgeconfig"
 	"github.com/bpalermo/aether/controller/internal/gatewayapi"
 	"github.com/bpalermo/aether/controller/internal/httpfilter"
 	"github.com/bpalermo/aether/controller/internal/meshconfig"
@@ -165,6 +166,7 @@ func runController(ctx context.Context) (retErr error) {
 	// list (uncached, correct regardless of the manager cache scope).
 	cwebhook.NewHandler(l, map[string]admission.Handler{
 		crdv1.MeshConfigKind:     &meshconfig.Validator{Log: l},
+		crdv1.EdgeConfigKind:     &edgeconfig.Validator{Log: l},
 		crdv1.HTTPFilterKind:     &httpfilter.Validator{Reader: m.GetAPIReader(), Log: l},
 		gatewayapi.HTTPRouteKind: &gatewayapi.Validator{Reader: m.GetAPIReader(), Log: l},
 	}).SetupWithManager(m)

--- a/controller/internal/edgeconfig/BUILD.bazel
+++ b/controller/internal/edgeconfig/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "edgeconfig",
+    srcs = ["webhook.go"],
+    importpath = "github.com/bpalermo/aether/controller/internal/edgeconfig",
+    visibility = ["//controller:__subpackages__"],
+    deps = [
+        "//api/aether/config/v1:config",
+        "//common/apis/config/v1:config",
+        "@build_buf_go_protovalidate//:protovalidate",
+        "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
+    ],
+)

--- a/controller/internal/edgeconfig/webhook.go
+++ b/controller/internal/edgeconfig/webhook.go
@@ -1,0 +1,46 @@
+// Package edgeconfig provides the admission validator for EdgeConfig resources
+// (proposal 029): it proto-validates the spec so a CR can never describe a config
+// the edge would refuse. Served by the controller's shared /validate dispatcher,
+// keyed by the EdgeConfig Kind.
+package edgeconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"buf.build/go/protovalidate"
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	crdv1 "github.com/bpalermo/aether/common/apis/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// Validator rejects EdgeConfig resources whose spec fails protovalidate.
+type Validator struct {
+	Log *slog.Logger
+}
+
+// Handle validates the incoming EdgeConfig's spec.
+func (v *Validator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	ec := &crdv1.EdgeConfig{}
+	if err := json.Unmarshal(req.Object.Raw, ec); err != nil {
+		return admission.Denied(fmt.Sprintf("EdgeConfig spec is invalid: %v", err))
+	}
+	if err := Validate(ec.Spec); err != nil {
+		v.Log.InfoContext(ctx, "rejected invalid EdgeConfig", "name", ec.GetName(), "error", err)
+		return admission.Denied(err.Error())
+	}
+	return admission.Allowed("")
+}
+
+// Validate proto-validates an EdgeConfig spec. A nil spec is valid (pure defaults).
+func Validate(spec *configv1.EdgeConfigSpec) error {
+	if spec == nil {
+		return nil
+	}
+	if err := protovalidate.Validate(spec); err != nil {
+		return fmt.Errorf("EdgeConfig spec failed validation: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
M2: resolve the effective EdgeConfig per Gateway via the NATIVE chain — GatewayClass.parametersRef (fleet default) + Gateway.infrastructure.parametersRef (override), override wins per field. Key correctness bit: `MergeEdgeConfigSpec` does field-level replacement via protoreflect (NOT proto.Merge, which recurses into wrappers so a `false` override couldn't beat a `true` default — caught by the unit test). Reconciler watches EdgeConfig; validating webhook; chart ships the default EdgeConfig + wires the GatewayClass parametersRef + RBAC. HTTP/3 = M3, e2e = M4.