### PR TITLE
fix(029): QUIC transport socket must advertise h3 ALPN, not h2/http-1.1

### DIFF
--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -153,6 +153,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/filters/network/tcp_proxy/v3:tcp_proxy",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/geoip_providers/maxmind/v3:maxmind",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/matching/common_inputs/transport_socket/v3:transport_socket",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/quic/v3:quic",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
         "@com_github_envoyproxy_go_control_plane_envoy//type/matcher/v3:matcher",
         "@com_github_stretchr_testify//assert",

--- a/agent/internal/xds/proxy/http3.go
+++ b/agent/internal/xds/proxy/http3.go
@@ -97,9 +97,13 @@ func edgeQuicDownstreamTransport(sdsSecretNames []string) *corev3.TransportSocke
 		CommonTlsContext: &transport_sockets_v3.CommonTlsContext{
 			TlsCertificateSdsSecretConfigs: certs,
 			TlsParams: &transport_sockets_v3.TlsParameters{
+				// QUIC mandates TLS 1.3 at the crypto layer regardless of this floor.
 				TlsMinimumProtocolVersion: transport_sockets_v3.TlsParameters_TLSv1_2,
 			},
-			AlpnProtocols: []string{"h2", "http/1.1"},
+			// QUIC carries HTTP/3 ONLY: the ALPN must offer "h3", not the TCP ALPNs.
+			// With "h2"/"http/1.1" here a h3 client's handshake is rejected with TLS
+			// alert 120 no_application_protocol (found in the 029 M4 e2e).
+			AlpnProtocols: []string{"h3"},
 		},
 	}
 	return &corev3.TransportSocket{

--- a/agent/internal/xds/proxy/http3_test.go
+++ b/agent/internal/xds/proxy/http3_test.go
@@ -9,6 +9,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	quicv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/quic/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -52,6 +53,12 @@ func TestBuildEdgeGatewayHTTP3Listener_Structure(t *testing.T) {
 	ts := fc.GetTransportSocket()
 	require.NotNil(t, ts)
 	assert.Equal(t, "envoy.transport_sockets.quic", ts.GetName(), "transport socket must be the QUIC extension")
+
+	// QUIC ALPN must be exactly ["h3"] — TCP ALPNs (h2/http-1.1) make a h3 client's
+	// handshake fail with TLS alert 120 no_application_protocol (029 M4 e2e bug).
+	var quic quicv3.QuicDownstreamTransport
+	require.NoError(t, proto.Unmarshal(ts.GetTypedConfig().GetValue(), &quic))
+	assert.Equal(t, []string{"h3"}, quic.GetDownstreamTlsContext().GetCommonTlsContext().GetAlpnProtocols())
 
 	// HCM in the filter chain uses HTTP3 codec.
 	require.Len(t, fc.GetFilters(), 1)

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.68.0-{GIT_COMMIT}"
+version: "0.68.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether


### PR DESCRIPTION
The M4 e2e (talos, aioquic client) found the HTTP/3 handshake failing with TLS alert 120 no_application_protocol: the QUIC DownstreamTlsContext advertised the TCP ALPNs `[h2, http/1.1]` instead of `[h3]`, so a real h3 client was rejected at the QUIC crypto layer. QUIC carries HTTP/3 only → ALPN must be `[h3]`. All other HTTP/3 structure (UDP listener, reuse_port, quic transport socket, HTTP3 HCM, alt-svc, UDP Service port) was already correct and e2e-verified. Regression test added.