### PR TITLE
feat(agent): enable L4 routes (TCPRoute/TLSRoute) by default

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.68.2-{GIT_COMMIT}"
+version: "0.69.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -114,9 +114,13 @@ agent:
   importConfig: false
   # L4 route types (proposal 018, Phase 3b): watch TCPRoutes/TLSRoutes/UDPRoutes
   # parented to a Service and project weighted TCP floor chains + per-SNI TLS chains
-  # onto the capture listener. Requires --transparent-capture. Default off.
-  # NOTE: UDPRoute is control-plane only; the CNI UDP redirect is not yet wired.
-  l4Routes: false
+  # onto the capture listener. Requires --transparent-capture (default on).
+  # Default ON: TCPRoute weighted routing + TLSRoute SNI passthrough are e2e-validated
+  # on talos (weighted split, weight:0 drain, SNI exclusivity). Inert when no L4 routes
+  # exist (services keep the passthrough floor chain).
+  # NOTE: UDPRoute is CONTROL-PLANE ONLY (plaintext floor, no DTLS) — a UDPRoute is
+  # accepted and generates listeners but the data path is unvalidated.
+  l4Routes: true
   # Transparent capture (proposal 018, Phase 3a): per-pod capture listeners + the
   # cap_http route table built from the generated mesh Services. Pairs with
   # registrar.generateMeshServices (the VIPs) and the CNI dst-18081 redirect.


### PR DESCRIPTION
Phase 3b L4 routing is e2e-validated on talos (TCPRoute weighted + TLSRoute SNI live; weight:0 drain fixed #492). Flip `agent.l4Routes` false→true so it works out of the box like transparentCapture/meshDns. Inert when no L4 routes exist (services keep the passthrough floor). UDPRoute stays control-plane-only (plaintext, no DTLS).