### PR TITLE
feat(agent): surface RBAC AUDIT shadow decision in the access log

### DIFF
--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -113,6 +113,13 @@ func buildAccessLog(reporter, podName, podNamespace string) []*accesslogv3.Acces
 			kv("route_name", "%ROUTE_NAME%"),
 			kv("traceparent", "%REQ(TRACEPARENT)%"),
 			kv("source_netns", "%FILTER_STATE(aether.network.network_namespace:PLAIN)%"),
+			// RBAC AUDIT-mode visibility (proposal 025): the local-authz filter writes
+			// its shadow decision to dynamic metadata on every request it evaluates in
+			// AUDIT mode. Surfacing it per-request in the access log is the reliable way
+			// to observe "what ENFORCE would block" — the per-route rbac.shadow_* stats
+			// are fleet-collapsed and hard to attribute. "-" for non-audited requests.
+			kv("rbac_shadow_result", "%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_engine_result)%"),
+			kv("rbac_shadow_policy", "%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_effective_policy_id)%"),
 		}},
 	}
 

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -63,8 +63,11 @@ func TestBuildAccessLogEnabled(t *testing.T) {
 		"authority", "upstream_host", "upstream_cluster", "upstream_local_address",
 		"downstream_local_address", "downstream_remote_address", "requested_server_name",
 		"route_name", "traceparent", "source_netns",
+		"rbac_shadow_result", "rbac_shadow_policy",
 	} {
 		assert.Contains(t, attrs, key, "missing access-log attribute %q", key)
 	}
 	assert.Equal(t, "%REQ(TRACEPARENT)%", attrs["traceparent"])
+	// RBAC AUDIT visibility surfaces the filter's shadow dynamic metadata (proposal 025).
+	assert.Equal(t, "%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_engine_result)%", attrs["rbac_shadow_result"])
 }


### PR DESCRIPTION
RBAC AUDIT mode was effectively blind — the per-route rbac.shadow_* stats are fleet-collapsed and unattributable, so operators couldn't see what ENFORCE would block (the point of audit). The RBAC filter already writes its shadow decision to dynamic metadata per request; surface `shadow_engine_result`/`shadow_effective_policy_id` as `rbac_shadow_result`/`rbac_shadow_policy` in the OTLP access log — per-request, with the matched policy id, into VictoriaLogs. `-` for non-audited requests. Replaces the unreliable counter approach.