### PR TITLE
revert: RBAC AUDIT access-log fields (Envoy 1.38 doesn't write per-route shadow metadata)

### DIFF
--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -113,13 +113,6 @@ func buildAccessLog(reporter, podName, podNamespace string) []*accesslogv3.Acces
 			kv("route_name", "%ROUTE_NAME%"),
 			kv("traceparent", "%REQ(TRACEPARENT)%"),
 			kv("source_netns", "%FILTER_STATE(aether.network.network_namespace:PLAIN)%"),
-			// RBAC AUDIT-mode visibility (proposal 025): the local-authz filter writes
-			// its shadow decision to dynamic metadata on every request it evaluates in
-			// AUDIT mode. Surfacing it per-request in the access log is the reliable way
-			// to observe "what ENFORCE would block" — the per-route rbac.shadow_* stats
-			// are fleet-collapsed and hard to attribute. "-" for non-audited requests.
-			kv("rbac_shadow_result", "%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_engine_result)%"),
-			kv("rbac_shadow_policy", "%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_effective_policy_id)%"),
 		}},
 	}
 

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -63,11 +63,8 @@ func TestBuildAccessLogEnabled(t *testing.T) {
 		"authority", "upstream_host", "upstream_cluster", "upstream_local_address",
 		"downstream_local_address", "downstream_remote_address", "requested_server_name",
 		"route_name", "traceparent", "source_netns",
-		"rbac_shadow_result", "rbac_shadow_policy",
 	} {
 		assert.Contains(t, attrs, key, "missing access-log attribute %q", key)
 	}
 	assert.Equal(t, "%REQ(TRACEPARENT)%", attrs["traceparent"])
-	// RBAC AUDIT visibility surfaces the filter's shadow dynamic metadata (proposal 025).
-	assert.Equal(t, "%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_engine_result)%", attrs["rbac_shadow_result"])
 }


### PR DESCRIPTION
The talos e2e proved #494's access-log approach is ineffective: Envoy 1.38 does NOT write the RBAC `shadow_engine_result`/`shadow_effective_policy_id` dynamic metadata when the chain filter is `disabled:true` and shadow rules arrive only via per-route TPFC (`RBACPerRoute`). The `rbac_shadow_result`/`rbac_shadow_policy` fields were always `-` — misleading dead weight. Reverting.

The shadow EVALUATION works: the aggregate `http.inbound.rbac.shadow_denied`/`shadow_allowed` counters emit and increment correctly (confirmed live), so AUDIT mode IS observable via those. Per-request granularity would need rendering INBOUND RBAC audit rules at the chain level (per-pod = per-service) — a separate, e2e-gated follow-up.