### PR TITLE
fix(agent): use prefixed metadata keys for RBAC AUDIT shadow in access log

### DIFF
--- a/agent/internal/xds/proxy/accesslog.go
+++ b/agent/internal/xds/proxy/accesslog.go
@@ -113,6 +113,15 @@ func buildAccessLog(reporter, podName, podNamespace string) []*accesslogv3.Acces
 			kv("route_name", "%ROUTE_NAME%"),
 			kv("traceparent", "%REQ(TRACEPARENT)%"),
 			kv("source_netns", "%FILTER_STATE(aether.network.network_namespace:PLAIN)%"),
+			// RBAC AUDIT shadow decision — populated when the INBOUND listener carries an
+			// AUDIT-mode RBAC filter (scope INBOUND, proposal 026 M4). Envoy prepends the
+			// shadow_rules_stat_prefix ("aether_audit_") to both the stat counter names AND
+			// the dynamic-metadata field names (rbac_filter.cc evaluateShadowEngine →
+			// shadowEngineResultField / shadowEffectivePolicyIdField). The DYNAMIC_METADATA
+			// substitution must therefore use the same prefix; bare "shadow_engine_result"
+			// always returns "-". Returns "-" on requests where RBAC shadow is not active.
+			kv("rbac_shadow_result", "%DYNAMIC_METADATA(envoy.filters.http.rbac:aether_audit_shadow_engine_result)%"),
+			kv("rbac_shadow_policy", "%DYNAMIC_METADATA(envoy.filters.http.rbac:aether_audit_shadow_effective_policy_id)%"),
 		}},
 	}
 

--- a/agent/internal/xds/proxy/accesslog_test.go
+++ b/agent/internal/xds/proxy/accesslog_test.go
@@ -63,8 +63,22 @@ func TestBuildAccessLogEnabled(t *testing.T) {
 		"authority", "upstream_host", "upstream_cluster", "upstream_local_address",
 		"downstream_local_address", "downstream_remote_address", "requested_server_name",
 		"route_name", "traceparent", "source_netns",
+		"rbac_shadow_result", "rbac_shadow_policy",
 	} {
 		assert.Contains(t, attrs, key, "missing access-log attribute %q", key)
 	}
 	assert.Equal(t, "%REQ(TRACEPARENT)%", attrs["traceparent"])
+	// RBAC shadow metadata keys must include the "aether_audit_" prefix — Envoy
+	// prepends shadow_rules_stat_prefix to the metadata field name in
+	// evaluateShadowEngine(), so a bare "shadow_engine_result" key always returns "-".
+	assert.Equal(t,
+		"%DYNAMIC_METADATA(envoy.filters.http.rbac:aether_audit_shadow_engine_result)%",
+		attrs["rbac_shadow_result"],
+		"rbac_shadow_result must use the aether_audit_-prefixed metadata key",
+	)
+	assert.Equal(t,
+		"%DYNAMIC_METADATA(envoy.filters.http.rbac:aether_audit_shadow_effective_policy_id)%",
+		attrs["rbac_shadow_policy"],
+		"rbac_shadow_policy must use the aether_audit_-prefixed metadata key",
+	)
 }


### PR DESCRIPTION
## Summary

- Adds `rbac_shadow_result` and `rbac_shadow_policy` access-log attributes (re-adds what #494 had, but with **correct** metadata key names)
- Root-causes why PR #494 always logged `-` and was reverted in #495
- No production code change beyond `accesslog.go`; no xDS resource structure changes

## Root cause: `shadow_rules_stat_prefix` prefixes metadata field names too

The access log attributes in #494 used:
```
%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_engine_result)%
%DYNAMIC_METADATA(envoy.filters.http.rbac:shadow_effective_policy_id)%
```

These always returned `-`. The reason: Envoy's RBAC filter prepends `shadow_rules_stat_prefix` to **both** the stat counter names AND the dynamic-metadata field names. From `rbac_filter.cc:85-102` (v1.38.0), the macro `DEFINE_RBAC_SHADOW_STAT_GETTER` returns `shadowRulesStatPrefix() + base_field_name`. With `ShadowRulesStatPrefix = "aether_audit_"` the actual metadata keys written by `evaluateShadowEngine()` are:

- `aether_audit_shadow_engine_result`
- `aether_audit_shadow_effective_policy_id`

## Hypothesis refuted: chain-level rework is NOT needed

The task's original hypothesis was that the shadow metadata is only written from the chain-level filter config's shadow engine, not the per-route `RBACPerRoute` TPFC engine.

Confirmed against Envoy source (v1.38.0 `rbac_filter.cc:108-120, 150-195, 272-284`): shadow stats and `setDynamicMetadata` are in the same `evaluateShadowEngine()` block guarded by the same non-null shadow-engine check — they cannot fire independently. The per-route TPFC shadow engine IS evaluated when `resolveMostSpecificPerFilterConfig` returns it, and DOES write shadow metadata under the prefixed keys. A chain-level INBOUND RBAC rework is not needed and is not implemented.

## Fix

Use the correctly-prefixed key names:
```
%DYNAMIC_METADATA(envoy.filters.http.rbac:aether_audit_shadow_engine_result)%
%DYNAMIC_METADATA(envoy.filters.http.rbac:aether_audit_shadow_effective_policy_id)%
```

## Test plan

- [x] `bazel test //agent/internal/xds/proxy:proxy_test` — `TestBuildAccessLogEnabled` asserts the new attributes are present and use the prefixed key strings
- [x] `bazel build //...` — clean build
- [x] `bazel test //test/envoy_validate/...` — `envoy --mode validate` passes all bootstrap scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S