### PR TITLE
chore(proxy): bump Envoy v1.38.0 → v1.38.3 (latest stable)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -167,11 +167,11 @@ use_repo(buildbuddy, "buildbuddy_toolchain")
 # ---------------------------------------------------------------------------
 # Pinned stock Envoy binary — used by //test/envoy_validate to run
 # "envoy --mode validate" over aether-generated bootstrap configs without
-# building Envoy from source.  Pinned to v1.38.0, matching the custom proxy
+# building Envoy from source.  Pinned to v1.38.3, matching the custom proxy
 # workspace (proxy/bazel/envoy/repository.bzl ENVOY_SHA).
 # SHA-256 values from the upstream checksums.txt.asc release asset.
 #
-# ENVOY_VERSION = "1.38.0"
+# ENVOY_VERSION = "1.38.3"
 # ---------------------------------------------------------------------------
 http_file = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
 
@@ -179,16 +179,16 @@ http_file(
     name = "envoy_binary_linux_amd64",
     downloaded_file_path = "envoy",
     executable = True,
-    sha256 = "cca312a7c3f91852f2849995c895130c59842e21ba787dc90bafa4026d6c5ecc",
-    urls = ["https://github.com/envoyproxy/envoy/releases/download/v1.38.0/envoy-1.38.0-linux-x86_64"],
+    sha256 = "affffb8d08a14fdc375b1f7dd8d0f3004eacdf51ce07f5636d7e168a01c6b373",
+    urls = ["https://github.com/envoyproxy/envoy/releases/download/v1.38.3/envoy-1.38.3-linux-x86_64"],
 )
 
 http_file(
     name = "envoy_binary_linux_arm64",
     downloaded_file_path = "envoy",
     executable = True,
-    sha256 = "9f00678c0cc433d7a342c422415eb3fdd163e77414aee5c5b57c04bd7d579454",
-    urls = ["https://github.com/envoyproxy/envoy/releases/download/v1.38.0/envoy-1.38.0-linux-aarch_64"],
+    sha256 = "eff9766ce1a7af71c38a6d4587367621753049ae3df1bde5b6b9e695752f3167",
+    urls = ["https://github.com/envoyproxy/envoy/releases/download/v1.38.3/envoy-1.38.3-linux-aarch_64"],
 )
 
 pull = use_repo_rule("@rules_img//img:pull.bzl", "pull")

--- a/agent/internal/xds/proxy/edgeconfig.go
+++ b/agent/internal/xds/proxy/edgeconfig.go
@@ -57,9 +57,9 @@ func ApplyEdgeHardening(hcm *http_connection_managerv3.HttpConnectionManager, l 
 
 func underscoresAction(spec *configv1.EdgeConfigSpec) corev3.HttpProtocolOptions_HeadersWithUnderscoresAction {
 	switch spec.GetHeadersWithUnderscoresAction() {
-	case configv1.EdgeConfigSpec_ALLOW:
+	case configv1.EdgeConfigSpec_HEADERS_WITH_UNDERSCORES_ACTION_ALLOW:
 		return corev3.HttpProtocolOptions_ALLOW
-	case configv1.EdgeConfigSpec_DROP_HEADER:
+	case configv1.EdgeConfigSpec_HEADERS_WITH_UNDERSCORES_ACTION_DROP_HEADER:
 		return corev3.HttpProtocolOptions_DROP_HEADER
 	default: // UNSPECIFIED or REJECT_REQUEST → the best-practice default
 		return corev3.HttpProtocolOptions_REJECT_REQUEST

--- a/agent/internal/xds/proxy/edgeconfig_test.go
+++ b/agent/internal/xds/proxy/edgeconfig_test.go
@@ -32,7 +32,7 @@ func TestApplyEdgeHardening_Overrides(t *testing.T) {
 	hcm := &http_connection_managerv3.HttpConnectionManager{}
 	spec := configv1.EdgeConfigSpec_builder{
 		UseRemoteAddress:             wrapperspb.Bool(false),
-		HeadersWithUnderscoresAction: configv1.EdgeConfigSpec_ALLOW.Enum(),
+		HeadersWithUnderscoresAction: configv1.EdgeConfigSpec_HEADERS_WITH_UNDERSCORES_ACTION_ALLOW.Enum(),
 		RequestTimeout:               durationpb.New(0),
 		Http2:                        configv1.Http2Options_builder{MaxConcurrentStreams: wrapperspb.UInt32(50)}.Build(),
 	}.Build()

--- a/api/aether/config/v1/edge_config.proto
+++ b/api/aether/config/v1/edge_config.proto
@@ -24,7 +24,7 @@ message EdgeConfigSpec {
   // HCM and the geoip filter. Default 0.
   google.protobuf.UInt32Value xff_num_trusted_hops = 2;
   // headers_with_underscores_action: how to treat request headers with underscores
-  // (header-smuggling defense). Default REJECT_REQUEST.
+  // (header-smuggling defense). Default HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST.
   HeadersWithUnderscoresAction headers_with_underscores_action = 3 [(buf.validate.field).enum.defined_only = true];
   // http2: downstream HTTP/2 resource caps (malicious-client protection).
   Http2Options http2 = 4;
@@ -41,9 +41,9 @@ message EdgeConfigSpec {
 
   enum HeadersWithUnderscoresAction {
     HEADERS_WITH_UNDERSCORES_ACTION_UNSPECIFIED = 0;
-    ALLOW = 1;
-    REJECT_REQUEST = 2;
-    DROP_HEADER = 3;
+    HEADERS_WITH_UNDERSCORES_ACTION_ALLOW = 1;
+    HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST = 2;
+    HEADERS_WITH_UNDERSCORES_ACTION_DROP_HEADER = 3;
   }
 }
 

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.69.0-{GIT_COMMIT}"
+version: "0.70.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -266,7 +266,8 @@ edge:
   config:
     name: ""                                # default "aether-edge-defaults"
     useRemoteAddress: true                  # edge trusts the connection source, not XFF
-    headersWithUnderscoresAction: REJECT_REQUEST
+    # Canonical enum names (buf ENUM_VALUE_PREFIX): HEADERS_WITH_UNDERSCORES_ACTION_{ALLOW,REJECT_REQUEST,DROP_HEADER}.
+    headersWithUnderscoresAction: HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST
     streamIdleTimeout: 300s
     requestTimeout: 300s                    # 0s disables
     idleTimeout: 3600s

--- a/common/apis/config/v1/BUILD.bazel
+++ b/common/apis/config/v1/BUILD.bazel
@@ -28,7 +28,10 @@ go_library(
 
 go_test(
     name = "config_test",
-    srcs = ["httpfilter_test.go"],
+    srcs = [
+        "edgeconfig_test.go",
+        "httpfilter_test.go",
+    ],
     embed = [":config"],
     deps = [
         "//api/aether/config/v1:config",

--- a/common/apis/config/v1/edgeconfig_test.go
+++ b/common/apis/config/v1/edgeconfig_test.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	configv1 "github.com/bpalermo/aether/api/aether/config/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEdgeConfig_EnumCanonicalName verifies the jsonshim parses the CANONICAL
+// (buf ENUM_VALUE_PREFIX) enum value name the chart writes into the default
+// EdgeConfig CR. Regression guard: after prefixing the enum values, the short form
+// ("REJECT_REQUEST") no longer parses via protojson — the chart + CRs must use the
+// full "HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST".
+func TestEdgeConfig_EnumCanonicalName(t *testing.T) {
+	raw := `{"apiVersion":"config.aether.io/v1","kind":"EdgeConfig","metadata":{"name":"d"},"spec":{"useRemoteAddress":true,"headersWithUnderscoresAction":"HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST"}}`
+	var ec EdgeConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &ec), "canonical enum name must parse through the jsonshim")
+	assert.Equal(t, configv1.EdgeConfigSpec_HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST, ec.Spec.GetHeadersWithUnderscoresAction())
+	assert.True(t, ec.Spec.GetUseRemoteAddress().GetValue())
+
+	// The short (unprefixed) form is the PITFALL: the jsonshim's protojson
+	// DiscardUnknown does NOT error on an unrecognized enum string — it SILENTLY
+	// drops it to UNSPECIFIED. So a chart/CR using the short "ALLOW"/"REJECT_REQUEST"
+	// is silently ignored (falls to the compiled default, not the author's intent).
+	// This is why the chart must emit the canonical prefixed name.
+	short := `{"spec":{"headersWithUnderscoresAction":"ALLOW"}}`
+	var dropped EdgeConfig
+	require.NoError(t, json.Unmarshal([]byte(short), &dropped))
+	assert.Equal(t, configv1.EdgeConfigSpec_HEADERS_WITH_UNDERSCORES_ACTION_UNSPECIFIED,
+		dropped.Spec.GetHeadersWithUnderscoresAction(),
+		"short enum form is silently dropped to UNSPECIFIED — the author's ALLOW is lost")
+}

--- a/docs/proposals/029_edge-config.md
+++ b/docs/proposals/029_edge-config.md
@@ -31,7 +31,7 @@ proto.Merge).
 ```yaml
 useRemoteAddress: true                  # edge trusts the connection source, manages XFF
 xffNumTrustedHops: 0                     # additional trusted proxies in front
-headersWithUnderscoresAction: REJECT_REQUEST
+headersWithUnderscoresAction: HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST
 http2:
   maxConcurrentStreams: 100
   initialStreamWindowSize: 65536         # 64 KiB

--- a/proxy/bazel/envoy/repository.bzl
+++ b/proxy/bazel/envoy/repository.bzl
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # Pinned Envoy source — the single source of truth for the custom proxy build.
 #
-# Pinned to the v1.38.0 release commit. The aether_stats extension is a
+# Pinned to the v1.38.3 release commit. The aether_stats extension is a
 # compiled-in C++ filter (//source/extensions/filters/http/aether_stats), so it
 # is built against this exact Envoy tree — there is no separate SDK to keep in
 # sync. On an Envoy bump:
@@ -12,10 +12,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 #      (`curl -sSL .../archive/$ENVOY_SHA.tar.gz | sha256sum`)
 #   3. Re-check .bazelversion / envoy.bazelrc against the new Envoy release.
 #
-# Envoy tag: v1.38.0
-ENVOY_SHA = "f1dd21b16c244bda00edfb5ffce577e12d0d2ec2"
+# Envoy tag: v1.38.3
+ENVOY_SHA = "0ebfcfe5b0484b89ca85b761da9e05ce75dbda8d"
 
-ENVOY_SHA256 = "e58e6b779aeb0d0efcf67e305c09b4e4f66d935dc1a00dc1cf199437fa93a115"
+ENVOY_SHA256 = "71b8ea63f9acb7fe7a45a8b72da51a9e3e27584632bdb32de5addc6daa785b72"
 
 ENVOY_ORG = "envoyproxy"
 

--- a/proxy/bazel/patches/envoy-dynamic-modules-aarch64-objcopy.patch
+++ b/proxy/bazel/patches/envoy-dynamic-modules-aarch64-objcopy.patch
@@ -1,48 +1,23 @@
---- a/source/extensions/dynamic_modules/dynamic_modules.bzl	2026-06-16 16:41:04.561829129 -0300
-+++ b/source/extensions/dynamic_modules/dynamic_modules.bzl	2026-06-16 16:41:58.139955890 -0300
-@@ -61,19 +61,36 @@
-     # NOTE: The case statement is kept outside $() command substitution for
-     # compatibility with bash 3.2 (macOS default), which cannot parse case
-     # pattern delimiters inside $().
-+    _objcopy_prefix = (
-+        "ARCH=\"\"; " +
-+        "for f in $(SRCS); do case $$f in *.pic.a) continue;; *.a) ARCH=$$f; break;; esac; done; " +
-+        "[ -z \"$$ARCH\" ] && " +
-+        "for f in $(SRCS); do case $$f in *.a) ARCH=$$f; break;; esac; done; "
-+    )
-+    _objcopy_suffix = "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
-+
-     native.genrule(
-         name = renamed_name,
-         srcs = [archive, ":" + redefine_syms_name],
-         outs = [name + "_renamed.a"],
--        cmd = (
--            "ARCH=\"\"; " +
--            "for f in $(SRCS); do case $$f in *.pic.a) continue;; *.a) ARCH=$$f; break;; esac; done; " +
--            "[ -z \"$$ARCH\" ] && " +
--            "for f in $(SRCS); do case $$f in *.a) ARCH=$$f; break;; esac; done; " +
--            "$(location @llvm_toolchain_llvm//:objcopy) " +
--            "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
--        ),
--        tools = ["@llvm_toolchain_llvm//:objcopy"],
-+        cmd = select({
+--- a/source/extensions/dynamic_modules/dynamic_modules.bzl
++++ b/source/extensions/dynamic_modules/dynamic_modules.bzl
+@@ -77,6 +77,12 @@
+                 "%s/bin/llvm-objcopy " % LLVM_PATH +
+                 "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
+             ),
 +            # arm64 exec platform (native aarch64 RBE): use the aarch64 LLVM
 +            # toolchain's llvm-objcopy so the tool runs natively on the executor.
 +            "@platforms//cpu:aarch64": (
-+                _objcopy_prefix +
 +                "$(location @llvm_toolchain_aarch64_llvm//:objcopy) " +
-+                _objcopy_suffix
++                "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
 +            ),
-+            "//conditions:default": (
-+                _objcopy_prefix +
-+                "$(location @llvm_toolchain_llvm//:objcopy) " +
-+                _objcopy_suffix
-+            ),
-+        }),
-+        tools = select({
+             "//conditions:default": (
+                 "$(location @llvm_toolchain_llvm//:objcopy) " +
+                 "--redefine-syms=$(location :" + redefine_syms_name + ") $$ARCH $@"
+@@ -84,6 +90,7 @@
+         }),
+         tools = select({
+             "@envoy_repo//:use_local_llvm": [],
 +            "@platforms//cpu:aarch64": ["@llvm_toolchain_aarch64_llvm//:objcopy"],
-+            "//conditions:default": ["@llvm_toolchain_llvm//:objcopy"],
-+        }),
+             "//conditions:default": ["@llvm_toolchain_llvm//:objcopy"],
+         }),
          tags = tags,
-     )
- 

--- a/proxy/bazel/patches/envoy-rust-sdk-aarch64-libclang.patch
+++ b/proxy/bazel/patches/envoy-rust-sdk-aarch64-libclang.patch
@@ -1,6 +1,6 @@
---- a/source/extensions/dynamic_modules/sdk/rust/BUILD	2026-06-16 16:34:27.031825568 -0300
-+++ b/source/extensions/dynamic_modules/sdk/rust/BUILD	2026-06-16 16:35:10.375941989 -0300
-@@ -26,7 +26,20 @@
+--- a/source/extensions/dynamic_modules/sdk/rust/BUILD
++++ b/source/extensions/dynamic_modules/sdk/rust/BUILD
+@@ -27,7 +27,20 @@
                  "-isystem %s/include/aarch64-unknown-linux-gnu/c++/v1/" % LLVM_PATH,
              ]),
          },
@@ -10,8 +10,8 @@
 +        "@platforms//cpu:aarch64": {
 +            "LIBCLANG_PATH": "$(location @llvm_toolchain_aarch64_llvm//:lib/libclang.so)",
 +            "BINDGEN_EXTRA_CLANG_ARGS": " ".join([
-+                "-resource-dir $${pwd}/external/llvm_toolchain_aarch64_llvm/lib/clang/18",
-+                "-isystem $${pwd}/external/llvm_toolchain_aarch64_llvm/lib_legacy/clang/18/include",
++                "-resource-dir $${pwd}/external/llvm_toolchain_aarch64_llvm/lib/clang/" + LLVM_MAJOR,
++                "-isystem $${pwd}/external/llvm_toolchain_aarch64_llvm/lib_legacy/clang/" + LLVM_MAJOR + "/include",
 +                "-isystem $${pwd}/external/llvm_toolchain_aarch64_llvm/include/aarch64-unknown-linux-gnu/c++/v1/",
 +                "-isystem $${pwd}/external/sysroot_linux_arm64/usr/include",
 +                "-isystem $${pwd}/external/sysroot_linux_arm64/usr/include/aarch64-linux-gnu",
@@ -21,8 +21,8 @@
 +        "@platforms//cpu:x86_64": {
              "LIBCLANG_PATH": "$(location @llvm_toolchain_llvm//:lib/libclang.so)",
              "BINDGEN_EXTRA_CLANG_ARGS": " ".join([
-                 "-resource-dir $${pwd}/external/llvm_toolchain_llvm/lib/clang/18",
-@@ -46,7 +59,14 @@
+                 "-resource-dir $${pwd}/external/llvm_toolchain_llvm/lib/clang/" + LLVM_MAJOR,
+@@ -47,7 +60,14 @@
          "//source/extensions/dynamic_modules/abi:abi.h",
      ] + select({
          "@envoy_repo//:use_local_llvm": [],

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -391,7 +391,7 @@ func buildEdgeBootstrap() (*bootstrapv3.Bootstrap, error) {
 	edgeCfg := configprotov1.EdgeConfigSpec_builder{
 		UseRemoteAddress:             wrapperspb.Bool(true),
 		XffNumTrustedHops:            wrapperspb.UInt32(1),
-		HeadersWithUnderscoresAction: configprotov1.EdgeConfigSpec_REJECT_REQUEST.Enum(),
+		HeadersWithUnderscoresAction: configprotov1.EdgeConfigSpec_HEADERS_WITH_UNDERSCORES_ACTION_REJECT_REQUEST.Enum(),
 		RequestTimeout:               durationpb.New(300 * time.Second),
 		Http3:                        configprotov1.Http3Options_builder{Enabled: wrapperspb.Bool(true)}.Build(),
 	}.Build()


### PR DESCRIPTION
Same-minor patch bump (security + bug fixes; ABI-stable within 1.38.x, aether_stats is compiled-in so it just rebuilds). Bumps both the custom-proxy source pin (repository.bzl) and the stock validate binary (MODULE.bazel). `//test/envoy_validate` passes against stock 1.38.3 locally; `proxy.yml` CI builds the custom Envoy on RBE to confirm patches apply + aether_stats compiles. Follow-up: pin the chart to the rebuilt proxy image digest once proxy-release publishes it.