### PR TITLE
chore(chart): digest-pin the Envoy 1.38.3 proxy image (option A)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.70.0-{GIT_COMMIT}"
+version: "0.71.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -195,8 +195,10 @@ proxy:
   # commit SHA. Mirror by overriding `repository`.
   image:
     repository: ghcr.io/bpalermo/aether/aether-proxy
-    tag: d86328b772ee5f6bf86fcd725eff0e2ff3e645f3
-    digest: ""
+    tag: 1a8010d769be7d4c0990f0fded91764011de94db
+    # Digest-pinned (option A): content-addressed, tamper-proof. The aether.image
+    # helper prefers digest over tag. Envoy v1.38.3 multi-arch index (#497).
+    digest: "sha256:60e7ca72e3acce7a6dd14c58a670b01d8546d511085540f48c2496590956a29d"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application logs as one JSON object per line (bootstrap


### PR DESCRIPTION
Pin `proxy.image.digest` to the multi-arch index digest of the rebuilt Envoy 1.38.3 image (#497) — content-addressed, tamper-proof. The `aether.image` helper prefers digest over tag. (The proxy-release `bump-chart` auto-PR failed on a token/permissions issue — separate CI nit; pinned manually.)