### PR TITLE
fix(chart): bind OPA sidecar API to a per-pod UDS to end the 8181 host-port bind race

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.71.0-{GIT_COMMIT}"
+version: "0.72.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-proxy-daemonset.yaml
+++ b/charts/aether/templates/agent-proxy-daemonset.yaml
@@ -218,7 +218,13 @@ spec:
             - "run"
             - "--server"
             - "--disable-telemetry"
-            - "--addr=127.0.0.1:8181"
+            # Bind OPA's diagnostic API to a per-pod UDS, NOT a host TCP port. The
+            # proxy DS is hostNetwork=true, so 127.0.0.1:8181 would be host-wide and
+            # collide between the old and surged-in new pod during every rollout
+            # (maxSurge=1) — a deterministic 2-3 restart bind race. The authz-socket
+            # emptyDir is per-pod, so this socket is unique per pod. Envoy reaches OPA
+            # only over the ext_authz gRPC UDS below; nothing consumes 8181.
+            - "--addr=unix:///run/aether/authz/opa-api.sock"
             - "--set=plugins.envoy_ext_authz_grpc.addr=unix:///run/aether/authz/authz.sock"
             - "--set=decision_logs.console=true"
             - "/policy/policy.rego"


### PR DESCRIPTION
## Problem

The OPA authz sidecar (proposal 027 preset) crashloops 2-3 times on **every** proxy roll (and at install) with:

```
listen tcp 127.0.0.1:8181: bind: address already in use
```

## Root cause

- The proxy DaemonSet is **`hostNetwork: true`** → `127.0.0.1:8181` is a **host-wide** port, not pod-local.
- The rollout uses **`maxSurge=1, maxUnavailable=0`** (intentional — the new Envoy hot-restarts from the old across the pod boundary), so during every roll the **old and new proxy pod run simultaneously on the same node**.
- Both pods' OPA sidecars try to bind the same host `8181` → the new one can't until the old pod fully exits → deterministic 2-3 restart bind race.

`8181` is OPA's **diagnostic HTTP API**, which nothing here consumes — Envoy reaches OPA only over the ext_authz **gRPC UDS** (`authz.sock`).

## Fix

Bind OPA's API to a **per-pod UDS** in the (per-pod) `authz-socket` emptyDir:

```diff
- - "--addr=127.0.0.1:8181"
+ - "--addr=unix:///run/aether/authz/opa-api.sock"
```

No host port → no cross-pod collision. Surge / hot-restart is untouched, and the ext_authz gRPC path is already a UDS.

### Alternatives rejected
- `maxSurge=0` — kills the collision but **breaks the hitless hot-restart handoff** (the surge is load-bearing).
- Per-pod distinct TCP port — impossible with an identical DaemonSet template.
- `SO_REUSEADDR` — OPA doesn't expose it, and it wouldn't help across two distinct processes anyway.

### Scope
`8181` appeared only in this one template. The edge OPA sidecar is a normal Deployment (not hostNetwork), so it has no host-port collision — no change needed.

## Validation
- `helm lint` clean; template renders the UDS addr.
- Found in the 2026-07-10 8h churn soak (benign for the data plane thanks to `maxUnavailable=0`+surge keeping the old pod serving, but it stalls roll completion ~2-3 min). Post-merge: roll `ds/aether-proxy` on talos and confirm the authz sidecar comes up with **0 restarts**.

Chart bumped `0.71.0` → `0.72.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)