### PR TITLE
feat(registry): re-add ServiceEndpoint.node_ip for the 019 east/west waypoint

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -307,7 +307,7 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		if _, ok := registered[ip]; ok {
 			continue
 		}
-		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, pod)
+		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, s.nodeIP, pod)
 		if err != nil {
 			s.log.DebugContext(ctx, "ghost sweep: failed to build endpoint for missing pod", "pod", pod.GetName(), "error", err)
 			continue

--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -152,7 +152,7 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, state *livenessState)
 			continue
 		}
 
-		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, pod)
+		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, s.nodeIP, pod)
 		if err != nil {
 			s.log.DebugContext(ctx, "liveness: failed to build endpoint", "pod", pod.GetName(), "error", err)
 			continue

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -90,7 +90,7 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		// keep storage/xDS for drain, but never (re-)register the endpoint.
 		log.DebugContext(ctx, "pod is terminating; skipping endpoint registration")
 	} else {
-		serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, cniPod)
+		serviceName, protocol, sEndpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, s.nodeIP, cniPod)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to build endpoint: %v", err)
 		}

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -47,6 +47,7 @@ type CNIServer struct {
 	trustDomain string
 	nodeRegion  string
 	nodeZone    string
+	nodeIP      string
 
 	storage  storage.Storage[*cniv1.CNIPod]
 	registry registry.Registry
@@ -137,20 +138,21 @@ func NewCNIServer(clusterName string, nodeName string, proxyID string, trustDoma
 // It retrieves the region and zone labels from the node object.
 func (s *CNIServer) PreListen(ctx context.Context) error {
 	s.log.DebugContext(ctx, "querying node metadata")
-	region, zone, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
+	region, zone, nodeIP, err := queryNodeMetadata(ctx, s.proxyID, s.k8sClient)
 	if err != nil {
 		return err
 	}
 
 	s.nodeRegion = region
 	s.nodeZone = zone
+	s.nodeIP = nodeIP
 
 	// Locality-aware failover: the xDS cache assigns EDS priorities relative
 	// to this node's locality (signals a scoped reload — the initial
 	// snapshot may predate this).
 	s.snapshotCache.SetNodeLocality(region, zone)
 
-	s.log.DebugContext(ctx, "node metadata queried successfully", "region", region, "zone", zone)
+	s.log.DebugContext(ctx, "node metadata queried successfully", "region", region, "zone", zone, "nodeIP", nodeIP)
 
 	// Delegated liveness: reflect each local pod's app health (from the proxy's
 	// active health check) into the registry so it is marked unhealthy in every
@@ -175,13 +177,23 @@ func (s *CNIServer) PreListen(ctx context.Context) error {
 }
 
 // queryNodeMetadata retrieves the topology.kubernetes.io/region and
-// topology.kubernetes.io/zone labels from a Kubernetes node (empty if absent).
-func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (region, zone string, err error) {
+// topology.kubernetes.io/zone labels plus the node's InternalIP from a
+// Kubernetes node (each empty if absent). The InternalIP is the routable dial
+// target advertised on this node's endpoints for cross-cluster consumers whose
+// pod network is not routable (proposal 019 per-node east/west waypoint).
+func queryNodeMetadata(ctx context.Context, proxyID string, client client.Client) (region, zone, nodeIP string, err error) {
 	node := &corev1.Node{}
 	if err := client.Get(ctx, types.NamespacedName{Name: proxyID}, node); err != nil {
-		return "", "", fmt.Errorf("failed to get node: %w", err)
+		return "", "", "", fmt.Errorf("failed to get node: %w", err)
+	}
+
+	for _, addr := range node.Status.Addresses {
+		if addr.Type == corev1.NodeInternalIP {
+			nodeIP = addr.Address
+			break
+		}
 	}
 
 	return node.Labels[constants.AnnotationKubernetesNodeTopologyRegion],
-		node.Labels[constants.AnnotationKubernetesNodeTopologyZone], nil
+		node.Labels[constants.AnnotationKubernetesNodeTopologyZone], nodeIP, nil
 }

--- a/agent/internal/cni/server/termination.go
+++ b/agent/internal/cni/server/termination.go
@@ -120,7 +120,7 @@ func (s *CNIServer) handlePodTerminating(ctx context.Context, pod *corev1.Pod) {
 	// DRAINING hosts from new selections but lets established connections
 	// finish through the grace period — less connection-pool churn than
 	// outright removal. CNI DEL performs the final removal.
-	serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, cur)
+	serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, s.nodeIP, cur)
 	if err != nil {
 		log.ErrorContext(ctx, "termination: failed to build endpoint", "error", err)
 		return

--- a/api/aether/registry/v1/endpoint.proto
+++ b/api/aether/registry/v1/endpoint.proto
@@ -46,10 +46,18 @@ message ServiceEndpoint {
     string namespace = 1 [(buf.validate.field).string.min_len = 1];
     string pod_name = 2 [(buf.validate.field).string.min_len = 1];
     string node_name = 3 [(buf.validate.field).string.min_len = 1];
-    // 4 was node_ip (the node InternalIP, used as the HBONE tunnel target). The
-    // plain mTLS transport routes to pod IPs directly, so it is no longer needed.
+    // 4 was the original node_ip (the node InternalIP used as the HBONE tunnel
+    // target), removed with the plain-mTLS migration when the transport began
+    // routing to pod IPs directly. The field NUMBER stays reserved so it is never
+    // reused on the wire; node_ip is re-added below at field 5.
     reserved 4;
-    reserved node_ip;
+    // node_ip is the node's routable InternalIP. It is the dial target for a
+    // cross-cluster endpoint whose pod IP is not routable across clusters: the
+    // consuming cluster's proxy dials node_ip:<tunnel-port> and that node's
+    // host-network proxy SNI-forwards to the local pod (proposal 019, per-node
+    // east/west waypoint). Empty when unknown (e.g. non-Kubernetes backends) or
+    // for same-cluster endpoints, which are dialed at the pod IP directly.
+    string node_ip = 5;
   }
 
   KubernetesMetadata kubernetes_metadata = 8;

--- a/docs/proposals/019_multicluster-node-waypoint.md
+++ b/docs/proposals/019_multicluster-node-waypoint.md
@@ -184,3 +184,87 @@ Per-pod targeting remains available via `<pod-token>` when a route needs it.
 - **Egress audit.** Unlike a central gateway, the per-node waypoint has no single
   cross-cluster egress point; identity (SPIRE) is the boundary, not a chokepoint — same
   trade-off 018 notes for flat network.
+
+## Implementation plan (2026-07-11)
+
+Grounded in the current data-plane code and an Envoy-source spike. Design decisions:
+**shared trust domain first** (federation deferred); **service-level remote targeting**
+(the node re-LBs locally — works because identity is pinned per-ServiceAccount).
+
+### Resolved mechanism: per-endpoint SNI in one cluster (spike outcome)
+
+The hard question was how to make a service cluster's SNI differ per endpoint — local
+endpoints need `SNI = <port>` (the existing multi-port demux), remote/waypoint endpoints
+need a structured SNI that survives the extra node hop — **without losing per-source
+client-cert selection** (the source pod presents its own SVID; the destination logs the
+real caller). Envoy source (`transport_socket_match_impl.cc`, `TransportSocketMatchingData`)
+confirms the unified `Cluster.transport_socket_matcher` sees the **chosen endpoint's
+metadata** (`envoy.matching.inputs.endpoint_metadata`, already compiled into the aether
+proxy — `extensions_build_config.bzl`) *alongside* the filter-state input we use today.
+
+So the split-horizon lives in **one** service cluster:
+
+- EDS holds local endpoints (`pod_ip:15008`) and remote endpoints (`node_ip:<tunnel-port>`
+  with `LbEndpoint.metadata{envoy.lb: {waypoint: "true"}}`).
+- The transport-socket matcher becomes a **two-level tree**: branch first on the endpoint
+  `waypoint` label → {local socket, waypoint socket}, then on the source netns → the
+  source pod's cert. The two sockets differ **only** in SNI (cert / SAN-pin / ALPN are
+  identical — mTLS still terminates end-to-end at the destination *pod*, never the node).
+- Local endpoints keep `SNI = <port>`; waypoint endpoints get `SNI = <port>.<svc>.<ns>.<meshDomain>`.
+- Local-vs-remote preference reuses `EndpointPriority`, extended with a **same-cluster-first
+  tier** so the local cluster wins even when the remote cluster shares the locality
+  (today priority is locality-only).
+
+*(Fallback if the two-level matcher ever misbehaves: an `envoy.clusters.aggregate` cluster
+over a local + a waypoint sub-cluster, each with a uniform SNI and the existing per-source
+matcher — confirmed viable, but more moving parts.)*
+
+### Structured SNI + the destination double-demux
+
+One wire SNI must satisfy two demuxes and L4 passthrough cannot rewrite it:
+
+- **SNI = `<port>.<svc>.<ns>.<meshDomain>`.**
+- The **host-netns tunnel listener** (`node_ip:<tunnel-port>`, `tls_inspector → tcp_proxy`,
+  reusing the 018 Phase 3b / edge TLSRoute-passthrough primitive) matches per local service
+  on `server_names: ["*.<svc>.<ns>.<meshDomain>"]` → forwards to that service's **local**
+  pods at `:15008`. NB Envoy's leftmost `*` is a **suffix** match, not single-label; this is
+  safe because aether owns the SNI and each service has a unique `.<svc>.<ns>.<meshDomain>`
+  suffix.
+- The **pod inbound** per-port chains add the **exact** server name
+  `<port>.<svc>.<ns>.<meshDomain>` alongside the existing bare `<port>`, so the forwarded
+  (un-rewritten) SNI still selects the right loopback port (exact > wildcard precedence).
+
+### Phased PRs
+
+1. **Registry `node_ip`** *(this PR)* — re-add `node_ip` to
+   `ServiceEndpoint.KubernetesMetadata` at **field 5** (field 4, the old HBONE target,
+   stays reserved — do not reuse the number). Populate from the node's `InternalIP` on
+   every registration path: the CNI server (`queryNodeMetadata` → all
+   `NewServiceEndpointFromCNIPod` call sites) and the Kubernetes backend
+   (`podToEndpoint`). Empty when unknown / for non-Kubernetes backends.
+2. **Split-horizon EDS** — in the snapshot build, key on `endpoint.cluster_name != ownCluster`:
+   local → `pod_ip:15008` (unchanged); remote → `node_ip:<tunnel-port>` + `waypoint`
+   metadata. Add the waypoint transport socket + the two-level matcher; extend
+   `EndpointPriority` with the same-cluster tier. Gate behind `--east-west-waypoint`
+   (default off). Golden-snapshot tests.
+3. **Host tunnel listener + pod-inbound server-name** — the `node_ip:<tunnel-port>`
+   passthrough listener with per-exported-service `*.<svc>.<ns>.<meshDomain>` chains →
+   `ew_ingress_<svc>_<ns>` (local pods at `:15008`, raw passthrough), plus the exact
+   structured server-name on the pod-inbound per-port chains.
+4. **MCS/VIP + demand-scope** — fold the split-horizon behind the clusterset VIP; scope
+   waypoint clusters to the node's dependency set (proposal 004).
+5. **E2E** — extend the 026 two-kind harness with **non-routable pod CIDRs but routable
+   node IPs**: assert A→svc-B lands on B's node proxy → a B pod, B's XFCC = the source
+   SPIFFE ID, mTLS end-to-end (B pod cert); intra-cluster unchanged (no waypoint stats);
+   kill a B node → EDS drops + re-LB.
+
+### Prerequisites / open
+
+- **Cross-cluster endpoint visibility** (MCS `ServiceImport` and/or the 006 replicator,
+  currently deferred) must deliver remote endpoints — carrying `node_ip` + `cluster_name` —
+  into the consumer's registry view before Phase 2 has anything to rewrite.
+- **Shared trust domain** across clusters (one upstream CA) so the source validates the
+  destination pod's SVID; SPIRE federation is a later proposal.
+- Re-verify the matcher-input `type_url`s at the pinned Envoy rev before committing Phase 2
+  config (framework + filter-state input already ship on 1.38.x; `endpoint_metadata` input
+  confirmed compiled).

--- a/docs/proposals/019_multicluster-node-waypoint.md
+++ b/docs/proposals/019_multicluster-node-waypoint.md
@@ -268,3 +268,29 @@ One wire SNI must satisfy two demuxes and L4 passthrough cannot rewrite it:
 - Re-verify the matcher-input `type_url`s at the pinned Envoy rev before committing Phase 2
   config (framework + filter-state input already ship on 1.38.x; `endpoint_metadata` input
   confirmed compiled).
+
+### Deferred possibility: a uniform-waypoint mode (noted, not planned)
+
+The Phase-2 gate is a boolean (`--east-west-waypoint`, default off) that routes **only
+cross-cluster** endpoints through the waypoint; intra-cluster stays direct pod-to-pod. It
+is worth recording that the same mechanism could be widened to route **all cross-node**
+traffic through the dest-node waypoint, e.g. by turning the gate into a mode —
+`off | cross-cluster | always`. In Design A that is a one-line change to the split-horizon
+predicate (`endpoint.cluster != own` becomes `endpoint.cluster != own || (mode==always &&
+endpoint.node != myNode)`) — same clusters, same matcher, same tests; `always` merely widens
+which endpoints get rewritten. Same-node traffic is a local forward regardless, so even
+`always` is not a single uniform path — it just moves the direct/waypoint boundary from
+"same-cluster" to "same-node."
+
+This is **explicitly out of the phased plan** and carries no commitment. It would only be
+justified for a deployment whose CNI can't route pod IPs even intra-cluster, or that wants a
+uniform per-node policy-enforcement point — and aether already enforces authz/RBAC/telemetry
+at the **pod inbound**, so that motivation is weak today. The extra hop is pure overhead on a
+routable intra-cluster network, which is why direct pod-to-pod is and remains the default
+(the deliberate outcome of [[project_transport_migration]]).
+
+Note also that this "uniform addressing" idea is distinct from **node-to-node multiplexing**
+(HBONE-style: the node terminates and re-originates, streams share a node↔node H2 tunnel,
+O(nodes²) connections). Multiplexing would reverse the transport migration, reintroduce
+head-of-line blocking, and put the node proxy in the identity/plaintext path — a separate,
+larger question that must not ride on this proposal.

--- a/registry/cni.go
+++ b/registry/cni.go
@@ -17,7 +17,7 @@ import (
 // The service protocol comes from the endpoint.aether.io/protocol annotation
 // (default HTTP; "tcp" registers a non-HTTP TCP-over-mTLS service). Container
 // and Kubernetes metadata are included along with node locality information.
-func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegion string, nodeZone string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
+func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegion string, nodeZone string, nodeIP string, cniPod *cniv1.CNIPod) (string, registryv1.Service_Protocol, *registryv1.ServiceEndpoint, error) {
 	protocol, err := getProtocolFromAnnotations(cniPod.GetAnnotations())
 	if err != nil {
 		return "", registryv1.Service_PROTOCOL_UNSPECIFIED, nil, err
@@ -59,6 +59,7 @@ func NewServiceEndpointFromCNIPod(clusterName string, nodeName string, nodeRegio
 			Namespace: cniPod.GetNamespace(),
 			PodName:   cniPod.GetName(),
 			NodeName:  nodeName,
+			NodeIp:    nodeIP,
 		},
 		Locality: &registryv1.ServiceEndpoint_Locality{
 			Region: nodeRegion,

--- a/registry/cni_test.go
+++ b/registry/cni_test.go
@@ -57,7 +57,7 @@ func TestNewServiceEndpointFromCNIPod_Protocol(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			service, protocol, ep, err := NewServiceEndpointFromCNIPod(
-				"cluster-a", "node-1", "region-1", "zone-a", testCNIPod(tt.annotation))
+				"cluster-a", "node-1", "region-1", "zone-a", "192.168.0.10", testCNIPod(tt.annotation))
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Equal(t, registryv1.Service_PROTOCOL_UNSPECIFIED, protocol)
@@ -69,6 +69,9 @@ func TestNewServiceEndpointFromCNIPod_Protocol(t *testing.T) {
 			assert.Equal(t, tt.want, protocol)
 			require.NotNil(t, ep)
 			assert.Equal(t, "10.0.0.1", ep.GetIp())
+			// proposal 019: the node's routable IP is advertised for the
+			// per-node east/west waypoint (cross-cluster dial target).
+			assert.Equal(t, "192.168.0.10", ep.GetKubernetesMetadata().GetNodeIp())
 		})
 	}
 }

--- a/registry/internal/k8s/kubernetes.go
+++ b/registry/internal/k8s/kubernetes.go
@@ -182,6 +182,7 @@ func (r *KubernetesRegistry) ListAllEndpoints(ctx context.Context, protocol regi
 type locality struct {
 	region string
 	zone   string
+	nodeIP string
 }
 
 // listManagedPods lists all running pods with the aether.io/managed=true label that have a PodIP.
@@ -225,10 +226,17 @@ func (r *KubernetesRegistry) buildNodeLocalities(ctx context.Context, pods []cor
 			r.log.ErrorContext(ctx, "failed to get node for locality", "error", err, "node", nodeName)
 			return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
 		}
-		localities[nodeName] = locality{
+		loc := locality{
 			region: node.Labels[constants.AnnotationKubernetesNodeTopologyRegion],
 			zone:   node.Labels[constants.AnnotationKubernetesNodeTopologyZone],
 		}
+		for _, addr := range node.Status.Addresses {
+			if addr.Type == corev1.NodeInternalIP {
+				loc.nodeIP = addr.Address
+				break
+			}
+		}
+		localities[nodeName] = loc
 	}
 
 	return localities, nil
@@ -256,6 +264,7 @@ func (r *KubernetesRegistry) podToEndpoint(pod *corev1.Pod, nodeLocalities map[s
 			Namespace: pod.Namespace,
 			PodName:   pod.Name,
 			NodeName:  pod.Spec.NodeName,
+			NodeIp:    nodeLocalities[pod.Spec.NodeName].nodeIP,
 		},
 		// This backend derives endpoints from the API server rather than receiving
 		// agent registrations, so health comes from the pod's readiness condition


### PR DESCRIPTION
**Phase 1 of proposal 019** (per-node east/west waypoint — the node proxy forwards cross-cluster mTLS to local pods when pod IPs aren't routable across clusters). This PR adds the one new registry datum the split-horizon EDS rewrite needs; no data-path behavior changes yet.

## Change
- Re-add `node_ip` to `ServiceEndpoint.KubernetesMetadata` as **field 5**. It was field 4 (the HBONE tunnel target), removed with the plain-mTLS migration — **field 4 stays reserved** so the old wire number is never reused.
- `node_ip` = the node's routable `InternalIP`. For a cross-cluster endpoint whose pod IP isn't routable, the consumer dials `node_ip:<tunnel-port>` and that node's host-network proxy SNI-forwards to the local pod (proposal 019). Empty when unknown / for same-cluster endpoints (dialed at the pod IP directly).

## Population (all registration paths)
- **CNI server**: `queryNodeMetadata` now also returns the node `InternalIP` (from `Node.Status.Addresses`), threaded through `PreListen` → all `NewServiceEndpointFromCNIPod` call sites (register / liveness / ghostsweep / termination).
- **Kubernetes backend**: `podToEndpoint` sets `node_ip` from the per-node locality lookup (extended to capture `InternalIP`).

## Also
Records the **implementation plan** as an appendix on `docs/proposals/019` — the spike outcome (per-endpoint SNI via a two-level transport-socket matcher branching on endpoint metadata then source netns; structured SNI `<port>.<svc>.<ns>.<meshDomain>` + host tunnel listener), the same-cluster-first priority tier, and the 5-phase PR sequence.

## Tests
- `registry_test` asserts `GetNodeIp()` is populated by `NewServiceEndpointFromCNIPod`.
- `registry`, `registry/internal/k8s`, `agent/internal/cni/server` (unit + integration) all pass; proto build + buf lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)