### PR TITLE
feat(agent): split-horizon EDS rewrite for the 019 east/west waypoint (source side)

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -142,6 +142,18 @@ type AgentConfig struct {
 	// all egress into the listener. Default off.
 	CaptureRedirectAll bool
 
+	// EastWestWaypoint enables the split-horizon east/west waypoint rewrite
+	// (proposal 019): an endpoint in another cluster is dialed at its node's
+	// routable IP + EastWestTunnelPort (the per-node waypoint) instead of its
+	// pod IP, and that node's host-network proxy SNI-forwards to the local pod.
+	// Intra-cluster traffic stays direct pod-to-pod. Default off.
+	EastWestWaypoint bool
+
+	// EastWestTunnelPort is the host-netns port the node proxy will listen on for
+	// cross-cluster waypoint traffic and the port cross-cluster endpoints are
+	// dialed at. Only meaningful with EastWestWaypoint.
+	EastWestTunnelPort uint32
+
 	// MeshDNS enables the per-pod mesh-DNS listener (proposal 018, mesh-global FQDN):
 	// the agent answers <svc>.<meshDomain> from the generated mesh Services' ClusterIPs
 	// and forwards the rest to MeshDNSUpstream. Pairs with the CNI :53 redirect.
@@ -198,6 +210,7 @@ func NewAgentConfig() *AgentConfig {
 		MountedLocalStorageDir:   constants.DefaultHostCNIRegistryDir,
 		RegistrarAddress:         "aether-registrar.aether-system.svc:443",
 		MeshDomain:               commonconstants.DefaultMeshDomain,
+		EastWestTunnelPort:       proxy.DefaultEastWestTunnelPort,
 		SpireEnabled:             true,
 		SpireAdminSocketPath:     constants.DefaultSpireAdminSocketPath,
 		SpireWorkloadSocketPath:  constants.DefaultSpireWorkloadSocketPath,

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -131,6 +131,8 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.L4Routes, "l4-routes", false, "Enable L4 route types (TCPRoute/TLSRoute/UDPRoute) parented to a Service: weighted TCP floor chains and SNI-routed TLS chains on the capture listener (proposal 018, Phase 3b). NOTE: UDPRoute is control-plane only until the CNI UDP redirect lands.")
 	rootCmd.Flags().BoolVar(&cfg.TransparentCapture, "transparent-capture", false, "Enable transparent capture: per-pod capture listeners + cap_http route table from the generated mesh Services (proposal 018, Phase 3a)")
 	rootCmd.Flags().BoolVar(&cfg.CaptureRedirectAll, "capture-redirect-all", false, "Add the dormant ORIGINAL_DST passthrough DefaultFilterChain to capture listeners (proposal 022 M2a spike). Harmless unless a pod is redirect-all'd via the capture.aether.io/redirect-all annotation; only then does non-mesh egress reach the passthrough.")
+	rootCmd.Flags().BoolVar(&cfg.EastWestWaypoint, "east-west-waypoint", false, "Enable the split-horizon east/west waypoint (proposal 019): dial cross-cluster endpoints at their node's routable IP + --east-west-tunnel-port instead of their pod IP, and SNI-forward to the local pod. Intra-cluster stays direct pod-to-pod. Needs cross-cluster endpoint visibility (shared etcd) and a shared SPIRE trust domain.")
+	rootCmd.Flags().Uint32Var(&cfg.EastWestTunnelPort, "east-west-tunnel-port", cfg.EastWestTunnelPort, "Host-netns port for cross-cluster east/west waypoint traffic (only with --east-west-waypoint)")
 	rootCmd.Flags().BoolVar(&cfg.MeshDNS, "mesh-dns", false, "Enable per-pod mesh DNS: answer <svc>.<mesh-domain> from the generated mesh Services and forward the rest to --mesh-dns-upstream (proposal 018, mesh-global FQDN)")
 	rootCmd.Flags().StringSliceVar(&cfg.MeshDNSUpstream, "mesh-dns-upstream", cfg.MeshDNSUpstream, "Upstream resolver(s) (host[:port]) the mesh-DNS filter forwards non-mesh queries to (the cluster kube-dns)")
 }
@@ -285,6 +287,7 @@ func runAgent(ctx context.Context) (retErr error) {
 	snapshotCache.SetSpireEnabled(cfg.SpireEnabled)
 	snapshotCache.SetCaptureEnabled(cfg.TransparentCapture)
 	snapshotCache.SetCaptureRedirectAll(cfg.CaptureRedirectAll)
+	snapshotCache.SetWaypointConfig(cfg.EastWestWaypoint, cfg.EastWestTunnelPort)
 	if cfg.MeshDNS {
 		// In-process DNS resolver (Istio-style): a host-local miekg/dns server that
 		// answers <svc>.<meshDomain> and forwards the rest to kube-dns. The CNI DNATs

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -83,6 +83,13 @@ type SnapshotCache struct {
 	// runtime.
 	meshDomain string
 
+	// waypointEnabled turns on the split-horizon east/west waypoint rewrite
+	// (proposal 019): a cross-cluster endpoint is dialed at its node's routable
+	// IP + waypointTunnelPort instead of its (possibly non-routable) pod IP.
+	// Off by default; set once before the manager starts (SetWaypointConfig).
+	waypointEnabled    bool
+	waypointTunnelPort uint32
+
 	// emitStatsPod enables per-pod labels (source_pod/destination_pod) on the
 	// aether_stats request counter. Off by default to bound cardinality; set
 	// once before the manager starts (SetEmitStatsPod) and read without locking
@@ -443,6 +450,15 @@ func (c *SnapshotCache) SetMeshDomain(domain string) {
 // MeshDomain returns the configured mesh domain.
 func (c *SnapshotCache) MeshDomain() string {
 	return c.meshDomain
+}
+
+// SetWaypointConfig enables the split-horizon east/west waypoint rewrite
+// (proposal 019) and sets the node tunnel port dialed for cross-cluster
+// endpoints. Off by default; must be called before the manager starts (read
+// without locking on every cluster build).
+func (c *SnapshotCache) SetWaypointConfig(enabled bool, tunnelPort uint32) {
+	c.waypointEnabled = enabled
+	c.waypointTunnelPort = tunnelPort
 }
 
 // SetEmitStatsPod enables per-pod labels on the aether_stats request counter

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -204,6 +204,14 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 	// too — the outbound route table serves the same GAMMA/chain config as cap_http.
 	chainFilters := c.serviceChainFiltersSnapshot()
 	localRegion, localZone := c.nodeLocality()
+	// Split-horizon east/west waypoint (proposal 019): remote-cluster endpoints
+	// are dialed at their node's routable IP + tunnel port. clusterName is this
+	// agent's own cluster (the local side of the split). Inert when disabled.
+	waypoint := proxy.WaypointRewrite{
+		Enabled:      c.waypointEnabled,
+		TunnelPort:   c.waypointTunnelPort,
+		LocalCluster: clusterName,
+	}
 
 	// RPC-fill (cold path): a dependency missing from the watch-fed listing —
 	// typically an ODCDS observation made milliseconds ago, whose endpoints
@@ -341,7 +349,7 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 		buckets := make(map[uint32]*portBucket)
 
 		for _, endpoint := range endpoints {
-			lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, localRegion, localZone)
+			lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, localRegion, localZone, waypoint)
 			defaultCla.Endpoints = append(defaultCla.Endpoints, lbEp)
 			defaultEpMap[endpoint.GetIp()] = lbEp
 
@@ -420,7 +428,7 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 		cla := proxy.NewClusterLoadAssignment(serviceName)
 		epMap := make(map[string]*endpointv3.LocalityLbEndpoints, len(endpoints))
 		for _, endpoint := range endpoints {
-			lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, localRegion, localZone)
+			lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, localRegion, localZone, waypoint)
 			cla.Endpoints = append(cla.Endpoints, lbEp)
 			epMap[endpoint.GetIp()] = lbEp
 		}

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -65,6 +65,12 @@ const (
 	// HTTP; it is never exposed via a Service.
 	DefaultEdgeReadinessPort = 15021
 
+	// DefaultEastWestTunnelPort is the host-netns port the node proxy listens on
+	// for cross-cluster east/west waypoint traffic, and the port cross-cluster
+	// endpoints are dialed at (proposal 019). Sits just above the inbound mesh
+	// port (15008); host-network, so the proxy binds the node address directly.
+	DefaultEastWestTunnelPort = 15009
+
 	// defaultEdgeAddress binds the edge listener on all interfaces (it fronts
 	// external traffic, unlike the node proxy's loopback-only outbound listener).
 	defaultEdgeAddress = "0.0.0.0"

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -433,6 +433,42 @@ func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]s
 	cluster.TransportSocketMatches = UpstreamTransportSocketMatches(append(spiffeIDs, nodeSpiffeID), validationContextName, sanURIs, sni)
 }
 
+// remoteClusterPriorityBand is added to a remote-cluster endpoint's locality
+// priority when the east/west waypoint is enabled, so the local cluster's
+// endpoints (band 0-2) are always preferred and a remote cluster (band 3-5) is
+// pure failover. Sparse priority levels are fine — Envoy treats missing ones as
+// empty and spills to the next healthy band (same as the locality tiers).
+const remoteClusterPriorityBand = 3
+
+// WaypointRewrite controls the split-horizon EDS rewrite (proposal 019). When
+// Enabled, an endpoint belonging to a cluster other than LocalCluster is dialed
+// at its node's routable IP + TunnelPort (the per-node east/west waypoint)
+// instead of its (cross-cluster, possibly non-routable) pod IP, and is tagged
+// with waypoint metadata so the cluster's transport-socket matcher can present
+// the structured SNI. When disabled (the default) every endpoint is dialed at
+// pod_ip:15008 — the flat pod-to-pod path (proposal 018 flat-network mode),
+// unchanged. LocalCluster is this agent's own cluster name.
+type WaypointRewrite struct {
+	Enabled      bool
+	TunnelPort   uint32
+	LocalCluster string
+}
+
+// remoteCluster reports whether the endpoint belongs to a cluster other than the
+// local one while waypoint mode is on (independent of whether it has a routable
+// node IP — used for priority banding, which deprioritizes every remote endpoint).
+func (w WaypointRewrite) remoteCluster(endpoint *registryv1.ServiceEndpoint) bool {
+	return w.Enabled && endpoint.GetClusterName() != w.LocalCluster
+}
+
+// viaWaypoint reports whether the endpoint must be dialed through its node's
+// waypoint: waypoint mode is on, the endpoint is in another cluster, AND it
+// advertises a routable node IP. A remote endpoint without a node IP falls back
+// to its pod IP (best effort — only works if the pod network happens to route).
+func (w WaypointRewrite) viaWaypoint(endpoint *registryv1.ServiceEndpoint) bool {
+	return w.remoteCluster(endpoint) && endpoint.GetKubernetesMetadata().GetNodeIp() != ""
+}
+
 // EndpointPriority maps an endpoint's locality distance from this node into
 // an EDS priority (locality-aware failover): same zone 0, same region 1,
 // elsewhere or unknown 2. Envoy keeps traffic at the lowest healthy priority
@@ -442,8 +478,18 @@ func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]s
 // expresses no preference (everything 0). This is deliberately NOT Envoy's
 // zone_aware_lb_config, which needs the local proxy fleet's per-zone
 // membership on every node — O(all nodes) state that demand-scoped
-// distribution (004) exists to eliminate.
-func EndpointPriority(localRegion, localZone string, endpoint *registryv1.ServiceEndpoint) uint32 {
+// distribution (004) exists to eliminate. With the waypoint enabled, a
+// remote-cluster endpoint is shifted into a higher band so the local cluster
+// is always preferred (same-cluster-first).
+func EndpointPriority(localRegion, localZone string, endpoint *registryv1.ServiceEndpoint, wp WaypointRewrite) uint32 {
+	base := localityPriority(localRegion, localZone, endpoint)
+	if wp.remoteCluster(endpoint) {
+		return base + remoteClusterPriorityBand
+	}
+	return base
+}
+
+func localityPriority(localRegion, localZone string, endpoint *registryv1.ServiceEndpoint) uint32 {
 	if localRegion == "" {
 		return 0
 	}
@@ -463,7 +509,9 @@ func EndpointPriority(localRegion, localZone string, endpoint *registryv1.Servic
 // listener, and its host metadata carries the envoy.lb subset keys for affinity.
 // The endpoint health reflects the registry's delegated-liveness status, and
 // its priority the locality distance from this node (EndpointPriority).
-func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEndpoint, localRegion, localZone string) *endpointv3.LocalityLbEndpoints {
+func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEndpoint, localRegion, localZone string, wp WaypointRewrite) *endpointv3.LocalityLbEndpoints {
+	viaWaypoint := wp.viaWaypoint(endpoint)
+
 	subsetKeys := map[string]string{
 		subsetClusterKey: endpoint.GetClusterName(),
 		subsetIPKey:      endpoint.GetIp(),
@@ -474,6 +522,13 @@ func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceE
 	}
 	for k, v := range endpoint.GetMetadata() {
 		subsetKeys[k] = v
+	}
+	if viaWaypoint {
+		// Tag the endpoint so the cluster's transport-socket matcher selects the
+		// waypoint socket (structured SNI) for it (proposal 019 Phase 2b). Lives
+		// in the envoy.lb metadata namespace the EndpointMetadataInput reads; it
+		// is not a subset selector key, so it does not affect subset LB.
+		subsetKeys[subsetWaypointKey] = subsetWaypointValue
 	}
 
 	lb := &structpb.Struct{Fields: map[string]*structpb.Value{}}
@@ -491,16 +546,25 @@ func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceE
 		locality = &corev3.Locality{Region: loc.GetRegion(), Zone: loc.GetZone()}
 	}
 
+	// Local: the destination pod's mesh inbound (pod_ip:15008), reached by the
+	// pod's own netns-bound inbound listener. Remote (waypoint): the destination
+	// node's routable IP + tunnel port, where that node's host-network proxy
+	// SNI-forwards to the local pod — the source's mTLS passes through unchanged.
+	dialAddr := endpoint.GetIp()
+	dialPort := uint32(defaultInboundPort)
+	if viaWaypoint {
+		dialAddr = endpoint.GetKubernetesMetadata().GetNodeIp()
+		dialPort = wp.TunnelPort
+	}
+
 	ep := &endpointv3.Endpoint{
 		Address: &corev3.Address{
 			Address: &corev3.Address_SocketAddress{
 				SocketAddress: &corev3.SocketAddress{
 					Protocol: corev3.SocketAddress_TCP,
-					// The destination pod's mesh inbound; reached by the pod's own
-					// netns-bound inbound listener.
-					Address: endpoint.GetIp(),
+					Address:  dialAddr,
 					PortSpecifier: &corev3.SocketAddress_PortValue{
-						PortValue: defaultInboundPort,
+						PortValue: dialPort,
 					},
 				},
 			},
@@ -524,7 +588,7 @@ func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceE
 			},
 		},
 		Locality: locality,
-		Priority: EndpointPriority(localRegion, localZone, endpoint),
+		Priority: EndpointPriority(localRegion, localZone, endpoint, wp),
 	}
 }
 

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -113,7 +113,7 @@ func TestServiceLocalityLbEndpointFromRegistryEndpoint(t *testing.T) {
 		Health: registryv1.ServiceEndpoint_HEALTH_HEALTHY,
 	}
 
-	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "", "")
+	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "", "", WaypointRewrite{})
 	require.Len(t, lle.GetLbEndpoints(), 1)
 	endpoint := lle.GetLbEndpoints()[0].GetEndpoint()
 
@@ -138,7 +138,7 @@ func TestServiceLocalityLbEndpointFromRegistryEndpoint_EDSMode(t *testing.T) {
 		Ip:              "10.0.0.5",
 		HealthCheckMode: registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS,
 	}
-	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "", "")
+	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "", "", WaypointRewrite{})
 	assert.True(t, lle.GetLbEndpoints()[0].GetEndpoint().GetHealthCheckConfig().GetDisableActiveHealthCheck(),
 		"EDS-mode endpoints opt out of active health checking and rely on EDS health")
 }
@@ -227,14 +227,14 @@ func TestEndpointPriority(t *testing.T) {
 		return &registryv1.ServiceEndpoint{Locality: &registryv1.ServiceEndpoint_Locality{Region: region, Zone: zone}}
 	}
 	// Agent without locality: no preference anywhere.
-	assert.Equal(t, uint32(0), EndpointPriority("", "", ep("r1", "z1")))
+	assert.Equal(t, uint32(0), EndpointPriority("", "", ep("r1", "z1"), WaypointRewrite{}))
 	// Same zone -> 0, same region -> 1, elsewhere/unknown -> 2.
-	assert.Equal(t, uint32(0), EndpointPriority("r1", "z1", ep("r1", "z1")))
-	assert.Equal(t, uint32(1), EndpointPriority("r1", "z1", ep("r1", "z2")))
-	assert.Equal(t, uint32(2), EndpointPriority("r1", "z1", ep("r2", "z1")))
-	assert.Equal(t, uint32(2), EndpointPriority("r1", "z1", ep("", "")))
+	assert.Equal(t, uint32(0), EndpointPriority("r1", "z1", ep("r1", "z1"), WaypointRewrite{}))
+	assert.Equal(t, uint32(1), EndpointPriority("r1", "z1", ep("r1", "z2"), WaypointRewrite{}))
+	assert.Equal(t, uint32(2), EndpointPriority("r1", "z1", ep("r2", "z1"), WaypointRewrite{}))
+	assert.Equal(t, uint32(2), EndpointPriority("r1", "z1", ep("", ""), WaypointRewrite{}))
 	// Agent with region but no zone: whole region is local.
-	assert.Equal(t, uint32(0), EndpointPriority("r1", "", ep("r1", "z9")))
+	assert.Equal(t, uint32(0), EndpointPriority("r1", "", ep("r1", "z9"), WaypointRewrite{}))
 }
 
 // TestServiceLocalityLbEndpoint_Priority verifies the EDS endpoint carries
@@ -244,10 +244,61 @@ func TestServiceLocalityLbEndpoint_Priority(t *testing.T) {
 		Ip:       "10.0.0.5",
 		Locality: &registryv1.ServiceEndpoint_Locality{Region: "r1", Zone: "z2"},
 	}
-	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "r1", "z1")
+	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "r1", "z1", WaypointRewrite{})
 	assert.Equal(t, uint32(1), lle.GetPriority(), "same region, different zone")
-	lle = ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "r1", "z2")
+	lle = ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "r1", "z2", WaypointRewrite{})
 	assert.Equal(t, uint32(0), lle.GetPriority(), "same zone")
+}
+
+// TestServiceLocalityLbEndpoint_Waypoint pins the split-horizon EDS rewrite
+// (proposal 019): a remote-cluster endpoint with a node IP is dialed at
+// node_ip:tunnelPort with waypoint metadata and a remote priority band; local
+// endpoints and the disabled default are dialed at pod_ip:15008 untouched.
+func TestServiceLocalityLbEndpoint_Waypoint(t *testing.T) {
+	remote := func() *registryv1.ServiceEndpoint {
+		return &registryv1.ServiceEndpoint{
+			Ip:          "10.244.9.9",
+			ClusterName: "cluster-b",
+			Locality:    &registryv1.ServiceEndpoint_Locality{Region: "r1", Zone: "z1"},
+			KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+				Namespace: "default", PodName: "svc-b-1", NodeName: "node-b", NodeIp: "192.168.0.42",
+			},
+		}
+	}
+	wp := WaypointRewrite{Enabled: true, TunnelPort: 15009, LocalCluster: "cluster-a"}
+
+	// Remote endpoint via waypoint: node IP + tunnel port, waypoint metadata,
+	// remote priority band (locality 0 + band 3).
+	lle := ServiceLocalityLbEndpointFromRegistryEndpoint(remote(), "r1", "z1", wp)
+	sa := lle.GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "192.168.0.42", sa.GetAddress(), "dial the node, not the pod")
+	assert.Equal(t, uint32(15009), sa.GetPortValue(), "dial the tunnel port")
+	lb := lle.GetLbEndpoints()[0].GetMetadata().GetFilterMetadata()[envoyFilterMetadataSubsetNamespace].GetFields()
+	assert.Equal(t, "true", lb[subsetWaypointKey].GetStringValue(), "tagged for the waypoint transport socket")
+	assert.Equal(t, uint32(remoteClusterPriorityBand), lle.GetPriority(), "remote cluster is a failover band")
+
+	// Disabled (default): the same remote endpoint stays pod-direct, no tag.
+	off := ServiceLocalityLbEndpointFromRegistryEndpoint(remote(), "r1", "z1", WaypointRewrite{})
+	offSA := off.GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress()
+	assert.Equal(t, "10.244.9.9", offSA.GetAddress())
+	assert.Equal(t, uint32(defaultInboundPort), offSA.GetPortValue())
+	assert.NotContains(t, off.GetLbEndpoints()[0].GetMetadata().GetFilterMetadata()[envoyFilterMetadataSubsetNamespace].GetFields(), subsetWaypointKey)
+
+	// Local-cluster endpoint stays pod-direct even with waypoint on.
+	local := remote()
+	local.ClusterName = "cluster-a"
+	loc := ServiceLocalityLbEndpointFromRegistryEndpoint(local, "r1", "z1", wp)
+	assert.Equal(t, "10.244.9.9", loc.GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+	assert.Equal(t, uint32(0), loc.GetPriority(), "local cluster keeps its locality priority")
+
+	// Remote endpoint WITHOUT a node IP falls back to pod-direct (can't waypoint),
+	// but is still deprioritized as a remote cluster.
+	noIP := remote()
+	noIP.KubernetesMetadata.NodeIp = ""
+	fb := ServiceLocalityLbEndpointFromRegistryEndpoint(noIP, "r1", "z1", wp)
+	assert.Equal(t, "10.244.9.9", fb.GetLbEndpoints()[0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress(), "no node IP -> pod fallback")
+	assert.Equal(t, uint32(remoteClusterPriorityBand), fb.GetPriority(), "still a remote cluster")
+	assert.NotContains(t, fb.GetLbEndpoints()[0].GetMetadata().GetFilterMetadata()[envoyFilterMetadataSubsetNamespace].GetFields(), subsetWaypointKey, "not tagged when it can't use the waypoint")
 }
 
 // TestSubsetKeyCombos pins multi-key combination generation: power set in

--- a/agent/internal/xds/proxy/endpoint.go
+++ b/agent/internal/xds/proxy/endpoint.go
@@ -18,6 +18,13 @@ const (
 	subsetPodNamespaceKey = "namespace"
 	// subsetPodNameKey is the metadata key for the pod name
 	subsetPodNameKey = "pod"
+	// subsetWaypointKey marks an endpoint reached via the per-node east/west
+	// waypoint (proposal 019). It lives in the envoy.lb metadata namespace so the
+	// cluster's transport-socket matcher (EndpointMetadataInput) can branch on it
+	// to present the structured waypoint SNI; it is never a subset selector key.
+	subsetWaypointKey = "waypoint"
+	// subsetWaypointValue is the value stamped under subsetWaypointKey.
+	subsetWaypointValue = "true"
 )
 
 // NewClusterLoadAssignment creates an empty cluster load assignment for a service.

--- a/agent/internal/xds/proxy/endpoint_test.go
+++ b/agent/internal/xds/proxy/endpoint_test.go
@@ -36,9 +36,9 @@ func TestSortLocalityLbEndpoints(t *testing.T) {
 		return &registryv1.ServiceEndpoint{Ip: ip}
 	}
 	eps := []*endpointv3.LocalityLbEndpoints{
-		ServiceLocalityLbEndpointFromRegistryEndpoint(mk("10.244.4.9"), "", ""),
-		ServiceLocalityLbEndpointFromRegistryEndpoint(mk("10.244.1.7"), "", ""),
-		ServiceLocalityLbEndpointFromRegistryEndpoint(mk("10.244.3.2"), "", ""),
+		ServiceLocalityLbEndpointFromRegistryEndpoint(mk("10.244.4.9"), "", "", WaypointRewrite{}),
+		ServiceLocalityLbEndpointFromRegistryEndpoint(mk("10.244.1.7"), "", "", WaypointRewrite{}),
+		ServiceLocalityLbEndpointFromRegistryEndpoint(mk("10.244.3.2"), "", "", WaypointRewrite{}),
 	}
 
 	SortLocalityLbEndpoints(eps)

--- a/agent/internal/xds/server/server_integration_test.go
+++ b/agent/internal/xds/server/server_integration_test.go
@@ -130,7 +130,7 @@ func setConsistentSnapshot(t *testing.T, ctx context.Context, snapshotCache cach
 	endpoint := newServiceEndpoint("10.0.0.2", "cluster-1", "remote-pod", "node-2", 8080)
 	cluster := proxy.NewServiceCluster("my-service.aether.internal", serviceName, serviceName, nil, true)
 	cla := proxy.NewClusterLoadAssignment(serviceName)
-	lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, "", "")
+	lbEp := proxy.ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint, "", "", proxy.WaypointRewrite{})
 	cla.Endpoints = append(cla.Endpoints, lbEp)
 	vhost := proxy.BuildOutboundClusterVirtualHost("my-service.aether.internal", []string{"my-service.aether.internal"})
 


### PR DESCRIPTION
**Phase 2a of proposal 019** — the source-side half of the split-horizon EDS rewrite. Builds on #500 (`node_ip`) and the Phase-0b finding that a shared-etcd deployment already exposes remote endpoints.

## What
New flags, **default off**:
- `--east-west-waypoint` — enable the split-horizon rewrite.
- `--east-west-tunnel-port` (default `15009`) — the per-node waypoint port.

When enabled, the snapshot EDS builder (`ServiceLocalityLbEndpointFromRegistryEndpoint`) treats an endpoint whose `cluster_name != localCluster` and that carries a routable `node_ip`:
- **dial target** → `node_ip:<tunnel-port>` instead of `pod_ip:15008`;
- **metadata** → stamps `envoy.lb {waypoint: true}` so the cluster's transport-socket matcher can pick the structured waypoint SNI (Phase 2b — not in this PR);
- **priority** → `EndpointPriority` shifts every remote-cluster endpoint into a higher band (local `0–2`, remote `3–5`), so the local cluster is preferred and the remote cluster is pure failover (same-cluster-first).

## Inert by default
With the flag off, every endpoint is dialed at `pod_ip:15008` exactly as today (018 flat-network path). Intra-cluster traffic is never rewritten. A remote endpoint **without** a `node_ip` falls back to pod-direct (best effort) but is still deprioritized and left untagged.

## Not in this PR (keeps it reviewable)
- **Phase 2b:** the waypoint transport socket (structured SNI `<port>.<svc>.<ns>.<meshDomain>`) + the two-level transport-socket matcher (endpoint `waypoint` metadata → source netns).
- **Phase 3:** the host-netns tunnel listener + the pod-inbound structured server-name (dest side).

So a rewritten endpoint points at `node_ip:<tunnel-port>` where nothing listens *yet* — harmless because the flag is off and no deployment enables it until the path is complete.

## Tests
`TestServiceLocalityLbEndpoint_Waypoint` covers via-waypoint (node IP + tunnel port + tag + band), disabled (pod-direct, untagged), local-cluster (pod-direct), and remote-without-node-ip (pod fallback, deprioritized, untagged). `EndpointPriority`/builder call sites updated; agent build + all affected unit/integration tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)