### PR TITLE
feat(agent): waypoint transport socket + two-level matcher for 019 (source SNI)

### DIFF
--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -138,7 +138,15 @@ func (c *SnapshotCache) clustersEndpointsAndVhosts() ([]types.Resource, []types.
 				// spire_agent SDS cluster (SPIRE directly, no bridge).
 				cl.TransportSocket = proxy.EdgeUpstreamTransportSocket(nodeSpiffeID, validationContextName, sanURIs, entry.sni)
 			} else {
-				proxy.InjectUpstreamMTLS(cl, netnsToID, ids, nodeSpiffeID, validationContextName, sanURIs, entry.sni)
+				// Waypoint (proposal 019): remote endpoints are dialed at the node
+				// tunnel and demux by a structured SNI <port>.<svc>.<ns>.<meshDomain>
+				// (entry.sni is the port). The two-level matcher presents it only for
+				// waypoint-tagged endpoints. Empty when the feature is off.
+				waypointSNI := ""
+				if c.waypointEnabled {
+					waypointSNI = entry.sni + "." + proxy.ServiceClusterName(entry.service, c.meshDomain)
+				}
+				proxy.InjectUpstreamMTLS(cl, netnsToID, ids, nodeSpiffeID, validationContextName, sanURIs, entry.sni, waypointSNI)
 			}
 			cluster = cl
 		}

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -421,16 +421,38 @@ func InjectUpstreamTCPMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[strin
 // would select the first entry for every endpoint.
 // sanURIs (the service's expected server SPIFFE IDs) pin the upstream peer
 // identity on every emitted socket; empty disables pinning (bundle-only).
-func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]string, spiffeIDs []string, nodeSpiffeID, validationContextName string, sanURIs []string, sni string) {
-	matcher := UpstreamTransportSocketMatcher(netnsToSpiffeID)
+// InjectUpstreamMTLS wires the cluster's per-source upstream mTLS. sni is the
+// local (intra-cluster) SNI — the destination port. When waypointSNI is
+// non-empty (proposal 019 waypoint enabled), the cluster additionally carries a
+// waypoint socket per source identity presenting waypointSNI (the structured
+// <port>.<svc>.<ns>.<meshDomain>), selected by the two-level matcher for
+// endpoints tagged waypoint=true; every other endpoint uses the local socket.
+func InjectUpstreamMTLS(cluster *clusterv3.Cluster, netnsToSpiffeID map[string]string, spiffeIDs []string, nodeSpiffeID, validationContextName string, sanURIs []string, sni, waypointSNI string) {
+	allIDs := append(spiffeIDs, nodeSpiffeID)
+
+	if waypointSNI == "" {
+		matcher := UpstreamTransportSocketMatcher(netnsToSpiffeID)
+		if matcher == nil {
+			cluster.TransportSocket = UpstreamTransportSocket(nodeSpiffeID, validationContextName, sanURIs, sni)
+			return
+		}
+		matcher.OnNoMatch = transportSocketNameOnMatch(nodeSpiffeID)
+		cluster.TransportSocketMatcher = matcher
+		cluster.TransportSocketMatches = UpstreamTransportSocketMatches(allIDs, validationContextName, sanURIs, sni)
+		return
+	}
+
+	matcher := WaypointTransportSocketMatcher(netnsToSpiffeID, nodeSpiffeID)
 	if matcher == nil {
+		// No local workloads: nothing originates traffic, so a single plain
+		// socket suffices (mirrors the no-workload path above).
 		cluster.TransportSocket = UpstreamTransportSocket(nodeSpiffeID, validationContextName, sanURIs, sni)
 		return
 	}
-	matcher.OnNoMatch = transportSocketNameOnMatch(nodeSpiffeID)
-
 	cluster.TransportSocketMatcher = matcher
-	cluster.TransportSocketMatches = UpstreamTransportSocketMatches(append(spiffeIDs, nodeSpiffeID), validationContextName, sanURIs, sni)
+	local := upstreamTransportSocketMatchesNamed(allIDs, validationContextName, sanURIs, sni, identitySocketName)
+	waypoint := upstreamTransportSocketMatchesNamed(allIDs, validationContextName, sanURIs, waypointSNI, waypointSocketName)
+	cluster.TransportSocketMatches = append(local, waypoint...)
 }
 
 // remoteClusterPriorityBand is added to a remote-cluster endpoint's locality

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -62,7 +62,7 @@ func TestInjectUpstreamMTLS(t *testing.T) {
 	node := "spiffe://example.org/ns/aether-system/sa/aether-agent"
 
 	c := NewServiceCluster("svc-a.aether.internal", "svc-a", "svc-a", nil, true)
-	InjectUpstreamMTLS(c, netnsToID, ids, node, "spiffe://example.org", nil, "")
+	InjectUpstreamMTLS(c, netnsToID, ids, node, "spiffe://example.org", nil, "8080", "")
 
 	// Per-source mTLS: a match per workload identity + the node identity, and
 	// on-no-match presents the node identity.
@@ -74,6 +74,36 @@ func TestInjectUpstreamMTLS(t *testing.T) {
 	require.NotNil(t, c.GetTransportSocketMatcher().GetOnNoMatch(), "on-no-match present")
 	assert.GreaterOrEqual(t, len(c.GetTransportSocketMatcher().GetMatcherTree().GetExactMatchMap().GetMap()), 1,
 		"exact_match_map must never be empty (proto validation rejects it)")
+}
+
+// TestInjectUpstreamMTLS_Waypoint pins the two-level matcher (proposal 019
+// Design A): each source identity carries a local (port-SNI) AND a waypoint
+// (structured-SNI) socket, and the matcher branches on the endpoint waypoint
+// metadata before the source netns.
+func TestInjectUpstreamMTLS_Waypoint(t *testing.T) {
+	netnsToID := map[string]string{"/ns/a": "spiffe://example.org/ns/test/sa/pod-a"}
+	ids := []string{"spiffe://example.org/ns/test/sa/pod-a"}
+	node := "spiffe://example.org/ns/aether-system/sa/aether-agent"
+
+	c := NewServiceCluster("svc-a.aether.internal", "svc-a", "svc-a", nil, true)
+	InjectUpstreamMTLS(c, netnsToID, ids, node, "spiffe://example.org", nil, "8080", "8080.svc-a.aether.internal")
+
+	names := map[string]bool{}
+	for _, m := range c.GetTransportSocketMatches() {
+		names[m.GetName()] = true
+	}
+	// Both variants for the pod and the node.
+	assert.True(t, names[ids[0]], "local socket for the pod")
+	assert.True(t, names[waypointSocketName(ids[0])], "waypoint socket for the pod")
+	assert.True(t, names[node] && names[waypointSocketName(node)], "both node variants")
+
+	// Level 1 branches on endpoint metadata; the "true" leaf is a nested matcher
+	// (the waypoint sub-tree), and on-no-match is the local sub-tree.
+	tree := c.GetTransportSocketMatcher().GetMatcherTree()
+	assert.Equal(t, endpointMetadataInputName, tree.GetInput().GetName())
+	require.Contains(t, tree.GetExactMatchMap().GetMap(), subsetWaypointValue)
+	assert.NotNil(t, tree.GetExactMatchMap().GetMap()[subsetWaypointValue].GetMatcher(), "waypoint leaf is a sub-matcher")
+	assert.NotNil(t, c.GetTransportSocketMatcher().GetOnNoMatch().GetMatcher(), "default is the local sub-matcher")
 }
 
 // TestInjectUpstreamMTLS_NoLocalWorkloads: an empty netns→SPIFFE-ID map must
@@ -93,7 +123,7 @@ func TestInjectUpstreamMTLS_NoLocalWorkloads(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			c := NewServiceCluster("svc-a.aether.internal", "svc-a", "svc-a", nil, true)
-			InjectUpstreamMTLS(c, netnsToID, nil, node, "spiffe://example.org", nil, "")
+			InjectUpstreamMTLS(c, netnsToID, nil, node, "spiffe://example.org", nil, "8080", "")
 
 			assert.Nil(t, c.GetTransportSocketMatcher(), "no matcher without local workloads")
 			assert.Empty(t, c.GetTransportSocketMatches(), "no legacy matches without the matcher")

--- a/agent/internal/xds/proxy/transportsocketmatch.go
+++ b/agent/internal/xds/proxy/transportsocketmatch.go
@@ -44,7 +44,24 @@ const (
 	// transportSocketNameActionName is the matcher action extension that selects
 	// a named transport socket.
 	transportSocketNameActionName = "envoy.matching.action.transport_socket.name"
+	// endpointMetadataInputName reads the CHOSEN upstream endpoint's metadata in
+	// the transport-socket-matcher context (Envoy TransportSocketMatchingData,
+	// after LB selection). Used to branch on the waypoint tag stamped on
+	// cross-cluster endpoints (proposal 019) so a single cluster can present a
+	// different SNI per endpoint while still selecting the source pod's cert.
+	endpointMetadataInputName = "envoy.matching.inputs.endpoint_metadata"
+	// waypointSocketSuffix distinguishes the waypoint transport socket (structured
+	// SNI) from the local one (port SNI) for the same source identity within one
+	// cluster's transport_socket_matches.
+	waypointSocketSuffix = "|waypoint"
 )
+
+// waypointSocketName is the transport_socket_matches name for the waypoint
+// (structured-SNI) variant of a source identity's socket.
+func waypointSocketName(id string) string { return id + waypointSocketSuffix }
+
+// identitySocketName is the local (port-SNI) variant — the bare identity.
+func identitySocketName(id string) string { return id }
 
 // UpstreamTransportSocketMatches returns one transport socket match per unique
 // SPIFFE ID among the local workloads. Each match presents that workload's
@@ -62,6 +79,14 @@ const (
 // unmodified` + `initial fetch timed out` every push, and unbounded proxy
 // memory growth under long-lived downstream connections).
 func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName string, sanURIs []string, sni string) []*clusterv3.Cluster_TransportSocketMatch {
+	return upstreamTransportSocketMatchesNamed(spiffeIDs, validationContextName, sanURIs, sni, identitySocketName)
+}
+
+// upstreamTransportSocketMatchesNamed builds one transport socket match per
+// unique SPIFFE ID, named by name(id) and presenting UpstreamTransportSocket
+// with the given sni. name lets a cluster carry two variants of each source
+// identity's socket (local + waypoint) that differ only in SNI.
+func upstreamTransportSocketMatchesNamed(spiffeIDs []string, validationContextName string, sanURIs []string, sni string, name func(string) string) []*clusterv3.Cluster_TransportSocketMatch {
 	unique := make([]string, 0, len(spiffeIDs))
 	seen := make(map[string]struct{}, len(spiffeIDs))
 	for _, id := range spiffeIDs {
@@ -79,7 +104,7 @@ func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName st
 	matches := make([]*clusterv3.Cluster_TransportSocketMatch, 0, len(unique))
 	for _, id := range unique {
 		matches = append(matches, &clusterv3.Cluster_TransportSocketMatch{
-			Name:            id,
+			Name:            name(id),
 			Match:           &structpb.Struct{},
 			TransportSocket: UpstreamTransportSocket(id, validationContextName, sanURIs, sni),
 		})
@@ -101,12 +126,19 @@ func UpstreamTransportSocketMatches(spiffeIDs []string, validationContextName st
 // permanent on nodes with zero managed pods (e2e 2026-06-10). Callers fall
 // back to a plain transport socket.
 func UpstreamTransportSocketMatcher(netnsToSpiffeID map[string]string) *matcherv3.Matcher {
+	return upstreamTransportSocketMatcherNamed(netnsToSpiffeID, identitySocketName)
+}
+
+// upstreamTransportSocketMatcherNamed is UpstreamTransportSocketMatcher with the
+// selected socket name derived via name(id) — so the same netns→identity map can
+// drive the local or the waypoint socket variant.
+func upstreamTransportSocketMatcherNamed(netnsToSpiffeID map[string]string, name func(string) string) *matcherv3.Matcher {
 	m := make(map[string]*matcherv3.Matcher_OnMatch, len(netnsToSpiffeID))
 	for netns, id := range netnsToSpiffeID {
 		if netns == "" || id == "" {
 			continue
 		}
-		m[netns] = transportSocketNameOnMatch(id)
+		m[netns] = transportSocketNameOnMatch(name(id))
 	}
 	if len(m) == 0 {
 		return nil
@@ -125,6 +157,53 @@ func UpstreamTransportSocketMatcher(netnsToSpiffeID map[string]string) *matcherv
 					},
 				},
 			},
+		},
+	}
+}
+
+// WaypointTransportSocketMatcher builds the two-level transport-socket matcher
+// (proposal 019 Design A): branch first on the chosen endpoint's envoy.lb
+// "waypoint" metadata, then on the source pod's netns. A waypoint-tagged
+// (cross-cluster) endpoint selects the source's WAYPOINT socket (structured SNI);
+// every other endpoint selects the source's LOCAL socket (port SNI). Both
+// sub-trees fall back to the node identity's respective socket when no local pod
+// matches the source netns. Returns nil when there are no local workloads (the
+// caller then uses a plain single transport socket, as without waypoint).
+func WaypointTransportSocketMatcher(netnsToSpiffeID map[string]string, nodeSpiffeID string) *matcherv3.Matcher {
+	local := upstreamTransportSocketMatcherNamed(netnsToSpiffeID, identitySocketName)
+	if local == nil {
+		return nil
+	}
+	waypoint := upstreamTransportSocketMatcherNamed(netnsToSpiffeID, waypointSocketName)
+	local.OnNoMatch = transportSocketNameOnMatch(identitySocketName(nodeSpiffeID))
+	waypoint.OnNoMatch = transportSocketNameOnMatch(waypointSocketName(nodeSpiffeID))
+
+	return &matcherv3.Matcher{
+		MatcherType: &matcherv3.Matcher_MatcherTree_{
+			MatcherTree: &matcherv3.Matcher_MatcherTree{
+				Input: &xdscorev3.TypedExtensionConfig{
+					Name: endpointMetadataInputName,
+					TypedConfig: config.TypedConfig(&tsinputsv3.EndpointMetadataInput{
+						Filter: envoyFilterMetadataSubsetNamespace,
+						Path: []*tsinputsv3.EndpointMetadataInput_PathSegment{{
+							Segment: &tsinputsv3.EndpointMetadataInput_PathSegment_Key{Key: subsetWaypointKey},
+						}},
+					}),
+				},
+				TreeType: &matcherv3.Matcher_MatcherTree_ExactMatchMap{
+					ExactMatchMap: &matcherv3.Matcher_MatcherTree_MatchMap{
+						Map: map[string]*matcherv3.Matcher_OnMatch{
+							subsetWaypointValue: {
+								OnMatch: &matcherv3.Matcher_OnMatch_Matcher{Matcher: waypoint},
+							},
+						},
+					},
+				},
+			},
+		},
+		// Any endpoint without the waypoint tag: the local (port-SNI) sub-tree.
+		OnNoMatch: &matcherv3.Matcher_OnMatch{
+			OnMatch: &matcherv3.Matcher_OnMatch_Matcher{Matcher: local},
 		},
 	}
 }

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -123,12 +123,46 @@ func buildNodeBootstrap() (*bootstrapv3.Bootstrap, error) {
 
 	passthrough := proxy.NewPassthroughOriginalDstCluster()
 	svcCluster := newServiceCluster("echo."+meshDomain, trustDomain, "default", "echo")
+	// Exercises the proposal 019 two-level transport-socket matcher (endpoint
+	// waypoint metadata -> source netns) + the endpoint_metadata matcher input,
+	// so `envoy --mode validate` proves the config is accepted by a real Envoy.
+	waypointCluster := newWaypointServiceCluster("waypoint-echo."+meshDomain, trustDomain, "default", "echo")
 
-	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster, authzSidecarCluster()}
+	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster, waypointCluster, authzSidecarCluster()}
 	staticClusters = append(staticClusters, appClusters...)
 	staticClusters = append(staticClusters, healthCluster)
 
 	return newBootstrap(staticClusters, []*listenerv3.Listener{inbound, outbound}), nil
+}
+
+// newWaypointServiceCluster is newServiceCluster with the proposal 019 waypoint
+// wiring: the two-level transport-socket matcher (waypoint metadata -> netns) and
+// both the local (port-SNI) and waypoint (structured-SNI) socket sets, injected
+// via the same InjectUpstreamMTLS the agent uses.
+func newWaypointServiceCluster(clusterName, td, namespace, svcName string) *clusterv3.Cluster {
+	nodeID := fmt.Sprintf("spiffe://%s/node/test-node", td)
+	validationCtxName := fmt.Sprintf("spiffe://%s", td)
+	sanURI := fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", td, namespace, svcName)
+	netnsToID := map[string]string{"/var/run/netns/cni-test": sanURI}
+
+	c := &clusterv3.Cluster{
+		Name:           clusterName,
+		ConnectTimeout: durationpb.New(5e9),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_EDS,
+		},
+		EdsClusterConfig: &clusterv3.Cluster_EdsClusterConfig{
+			EdsConfig: config.XDSConfigSourceADS(),
+		},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(32 * 1024),
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": mustAny(
+				config.Http2ProtocolOptions(),
+			),
+		},
+	}
+	proxy.InjectUpstreamMTLS(c, netnsToID, []string{sanURI}, nodeID, validationCtxName, []string{sanURI}, "8080", "8080."+clusterName)
+	return c
 }
 
 // authzSidecarCluster mirrors the chart's static UDS cluster for the authz sidecar.


### PR DESCRIPTION
**Phase 2b of proposal 019** — completes the **source side** of the split-horizon path (2a did the addressing; this does the SNI/identity).

## What
With the waypoint enabled, each service cluster carries **per source identity** two transport sockets:
- **local** — `SNI = <port>` (intra-cluster / pod-direct endpoints, as today);
- **waypoint** — `SNI = <port>.<svc>.<ns>.<meshDomain>` (cross-cluster endpoints reached via the node tunnel).

A **two-level transport-socket matcher** (Design A, confirmed against Envoy source) picks between them:
1. `envoy.matching.inputs.endpoint_metadata` on the chosen endpoint's `envoy.lb {waypoint}` tag (stamped in #502) → waypoint sub-tree; default → local sub-tree.
2. the existing `transport_socket_filter_state` (source netns) → the source pod's client cert.

Per-source identity is preserved end-to-end while SNI differs **per endpoint**, all in **one** cluster. mTLS still terminates at the destination **pod** — the node never decrypts.

## Shape
- `InjectUpstreamMTLS` gains a `waypointSNI` arg; empty keeps the existing single-SNI path byte-for-byte. The cache computes the structured SNI (`<port>.<FQDN>`) only when `--east-west-waypoint` is set.
- Socket names carry a `|waypoint` suffix to distinguish the two variants; both blocks stay individually sorted (the CDS-hash-stability invariant).

## De-risked against real Envoy
The `envoy_validate` fixture gains a waypoint cluster, so **`envoy --mode validate` proves a real Envoy accepts** the two-level matcher + `endpoint_metadata` input + dual socket set. Plus unit tests for the matcher shape and both socket variants.

## Still to come
- **Phase 3:** the host-netns tunnel listener + the pod-inbound structured server-name (dest side) — after which an enabled deployment is end-to-end functional.
- **Phase 4/5:** demand-scope/VIP wiring + two-kind e2e.

Inert by default (flag off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)