### PR TITLE
feat(agent): pod-inbound matches the structured waypoint SNI (019 Phase 3a)

### DIFF
--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -407,6 +407,7 @@ func (c *SnapshotCache) regenerateAllHTTPListeners() {
 				"netns", netns, "pod", entry.cniPod.GetName(), "error", err)
 			continue
 		}
+		c.applyWaypointInboundServerNames(newInbound, entry.cniPod)
 		entry.capture = newCapture
 		entry.outbound = newOutbound
 		entry.inbound = newInbound

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/agent/storage"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	"github.com/bpalermo/aether/common/serviceref"
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
@@ -27,6 +28,31 @@ var netnsExists = func(path string) bool {
 // given pod and adds them to the cache keyed by the pod's network namespace, then
 // regenerates the listener snapshot. Returns an error if listener generation or
 // snapshot generation fails.
+// applyWaypointInboundServerNames makes the pod's SNI-matched (secondary-port)
+// inbound chains ALSO match the structured waypoint SNI
+// <port>.<svc>.<ns>.<meshDomain>, so a cross-cluster connection forwarded
+// (un-rewritten) by a node tunnel demuxes to the right served port. The primary
+// port needs no change — it is caught by the no-SNI h2 chain. No-op when the
+// waypoint is disabled, so inbound config is byte-identical for everyone else.
+// (proposal 019 Phase 3, dest side.)
+func (c *SnapshotCache) applyWaypointInboundServerNames(inbound *listenerv3.Listener, cniPod *cniv1.CNIPod) {
+	if !c.waypointEnabled || inbound == nil {
+		return
+	}
+	fqdn := proxy.ServiceClusterName(serviceref.New(cniPod.GetNamespace(), cniPod.GetServiceAccount()).Key(), c.meshDomain)
+	for _, fc := range inbound.GetFilterChains() {
+		m := fc.GetFilterChainMatch()
+		if m == nil || len(m.GetServerNames()) == 0 {
+			continue
+		}
+		structured := make([]string, 0, len(m.GetServerNames()))
+		for _, sn := range m.GetServerNames() {
+			structured = append(structured, sn+"."+fqdn)
+		}
+		m.ServerNames = append(m.GetServerNames(), structured...)
+	}
+}
+
 func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustDomain string) error {
 	netns := cniPod.GetNetworkNamespace()
 	c.log.DebugContext(ctx, "adding listeners for pod", "pod", cniPod.GetName(), "namespace", cniPod.GetNamespace(), "netns", netns)
@@ -35,6 +61,7 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	if err != nil {
 		return err
 	}
+	c.applyWaypointInboundServerNames(inbound, cniPod)
 	capture, err := c.generateCaptureListener(cniPod)
 	if err != nil {
 		return err
@@ -283,6 +310,7 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 			errs = append(errs, listenerErr)
 			continue
 		}
+		c.applyWaypointInboundServerNames(inbound, pod)
 		capture, captureErr := c.generateCaptureListener(pod)
 		if captureErr != nil {
 			c.log.ErrorContext(ctx, "failed to generate capture listener for pod", "error", captureErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())

--- a/agent/internal/xds/cache/listener_test.go
+++ b/agent/internal/xds/cache/listener_test.go
@@ -19,6 +19,38 @@ import (
 // them. TestLoadListenersFromStorage_SkipsMissingNetns overrides this locally.
 func init() { netnsExists = func(string) bool { return true } }
 
+// TestApplyWaypointInboundServerNames pins the Phase 3 dest-side rewrite: a
+// secondary-port inbound chain also matches the structured waypoint SNI; the
+// no-SNI / nil-match chains are untouched; and it is a no-op with the flag off.
+func TestApplyWaypointInboundServerNames(t *testing.T) {
+	pod := &cniv1.CNIPod{Namespace: "team-a", ServiceAccount: "payments"}
+	newListener := func() *listenerv3.Listener {
+		return &listenerv3.Listener{FilterChains: []*listenerv3.FilterChain{
+			{FilterChainMatch: nil}, // TCP floor
+			{FilterChainMatch: &listenerv3.FilterChainMatch{ApplicationProtocols: []string{"h2"}}}, // primary, no SNI
+			{FilterChainMatch: &listenerv3.FilterChainMatch{ServerNames: []string{"8081"}}},        // secondary port
+		}}
+	}
+
+	// Enabled: the secondary-port chain gains "8081.payments.team-a.<meshDomain>".
+	on := newTestCache("node-1")
+	on.SetMeshDomain("aether.internal")
+	on.SetWaypointConfig(true, 15009)
+	l := newListener()
+	on.applyWaypointInboundServerNames(l, pod)
+	assert.Empty(t, l.GetFilterChains()[0].GetFilterChainMatch().GetServerNames(), "TCP floor untouched")
+	assert.Empty(t, l.GetFilterChains()[1].GetFilterChainMatch().GetServerNames(), "no-SNI h2 chain untouched")
+	assert.Equal(t, []string{"8081", "8081.payments.team-a.aether.internal"},
+		l.GetFilterChains()[2].GetFilterChainMatch().GetServerNames(), "secondary port also matches the structured SNI")
+
+	// Disabled: byte-identical.
+	off := newTestCache("node-1")
+	off.SetMeshDomain("aether.internal")
+	l2 := newListener()
+	off.applyWaypointInboundServerNames(l2, pod)
+	assert.Equal(t, []string{"8081"}, l2.GetFilterChains()[2].GetFilterChainMatch().GetServerNames(), "no-op when waypoint disabled")
+}
+
 // namedListenerEntry builds a listenerEntry whose inbound and outbound listeners
 // are well-formed (named) resources. Tests that inject listener entries directly
 // into the map must use named listeners: Listeners() now filters out any


### PR DESCRIPTION
**Phase 3a of proposal 019** — the pod-inbound half of the dest side.

When the waypoint is enabled, each pod's **secondary-port** inbound filter chain (matches `ServerNames:[<port>]`) *also* matches the structured waypoint SNI `<port>.<svc>.<ns>.<meshDomain>`, so a cross-cluster connection forwarded (un-rewritten) by a node tunnel demuxes to the right served port. The **primary port needs no change** — it's caught by the no-SNI `h2` chain regardless of SNI.

Implemented as a cache post-process (`applyWaypointInboundServerNames`) rather than threading `meshDomain` + a flag through `NewInboundListener` and its ~15 callers: the cache already has `meshDomain`, the waypoint flag, and the pod (its service FQDN `<serviceAccount>.<ns>.<meshDomain>` matches the source's `ServiceClusterName`). **No-op when the waypoint is off** (inbound config byte-identical for everyone else). Applied on all three inbound-build paths (AddPod, storage reload, gamma rebuild).

Test: `TestApplyWaypointInboundServerNames` (secondary port gains the structured SNI; TCP-floor + no-SNI chains untouched; no-op when disabled).

Next: **Phase 3b** — the host-netns tunnel listener + `ew_ingress` clusters (the other half of the dest side), after which an enabled deployment is end-to-end functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)