### PR TITLE
feat(agent): host-netns east/west tunnel listener + ingress clusters (019 Phase 3b)

### DIFF
--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "secret.go",
         "snapshot.go",
         "version.go",
+        "waypoint.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/xds/cache",
     visibility = ["//agent:__subpackages__"],
@@ -72,6 +73,7 @@ go_test(
         "snapshot_test.go",
         "tcp_service_test.go",
         "version_test.go",
+        "waypoint_test.go",
     ],
     embed = [":cache"],
     deps = [

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -198,6 +198,12 @@ func (c *SnapshotCache) Listeners() []types.Resource {
 		}
 	}
 	resources = append(resources, proxy.BuildHealthGatewayListener(agentconstants.DefaultProxyHealthSocketPath, probeClusters))
+	// East/west waypoint (proposal 019): one host-netns tunnel listener that
+	// SNI-forwards cross-cluster mTLS to the services this node hosts. nil unless
+	// --east-west-waypoint is set and the node hosts mesh pods.
+	if tunnel := c.waypointTunnelListenerLocked(); tunnel != nil {
+		resources = append(resources, tunnel)
+	}
 	return resources
 }
 

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -58,6 +58,11 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 	// clusters carry their endpoints inline, so they need no EDS resources.
 	clusters = append(clusters, c.appClusters()...)
 
+	// East/west waypoint ingress clusters (proposal 019 Phase 3b): STATIC clusters
+	// of this node's local pods per hosted service, that the tunnel listener
+	// forwards cross-cluster connections to. Empty unless --east-west-waypoint.
+	clusters = append(clusters, c.ewIngressClusters()...)
+
 	// TCP floor clusters (proposal 018, Phase 3a): one per non-HTTP service in the
 	// capture TCP set. These are separate EDS clusters using ALPN "aether-tcp" that
 	// share endpoints with the corresponding HTTP clusters. Only emitted when capture

--- a/agent/internal/xds/cache/waypoint.go
+++ b/agent/internal/xds/cache/waypoint.go
@@ -1,0 +1,84 @@
+package cache
+
+import (
+	"sort"
+
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"github.com/bpalermo/aether/common/serviceref"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+)
+
+// localServicePodsLocked groups this node's local pods by their service FQDN and
+// returns each service's sorted pod IPs. The caller must hold listenerMu (read).
+// Used to build the east/west tunnel listener chains and the ew_ingress clusters
+// (proposal 019 Phase 3b) — both are scoped to the services this node HOSTS.
+func (c *SnapshotCache) localServicePodsLocked() map[string][]string {
+	byFQDN := make(map[string][]string)
+	for _, entry := range c.listeners {
+		pod := entry.cniPod
+		if pod == nil || pod.GetServiceAccount() == "" || pod.GetNamespace() == "" {
+			continue
+		}
+		ips := pod.GetIps()
+		if len(ips) == 0 {
+			continue
+		}
+		fqdn := proxy.ServiceClusterName(serviceref.New(pod.GetNamespace(), pod.GetServiceAccount()).Key(), c.meshDomain)
+		byFQDN[fqdn] = append(byFQDN[fqdn], ips[0])
+	}
+	for fqdn := range byFQDN {
+		sort.Strings(byFQDN[fqdn])
+	}
+	return byFQDN
+}
+
+// waypointTunnelListenerLocked builds the node's host-netns east/west tunnel
+// listener from the services hosted on this node (proposal 019 Phase 3b), or nil
+// when the waypoint is disabled or the node hosts no mesh pods. Caller holds
+// listenerMu (read).
+func (c *SnapshotCache) waypointTunnelListenerLocked() types.Resource {
+	if !c.waypointEnabled {
+		return nil
+	}
+	byFQDN := c.localServicePodsLocked()
+	fqdns := make([]string, 0, len(byFQDN))
+	for fqdn := range byFQDN {
+		fqdns = append(fqdns, fqdn)
+	}
+	sort.Strings(fqdns)
+
+	chains := make([]*listenerv3.FilterChain, 0, len(fqdns))
+	for _, fqdn := range fqdns {
+		chains = append(chains, proxy.BuildWaypointTunnelChain(fqdn))
+	}
+	ln := proxy.BuildWaypointTunnelListener(c.waypointTunnelPort, chains)
+	if ln == nil {
+		return nil
+	}
+	return ln
+}
+
+// ewIngressClusters returns the STATIC clusters (one per hosted service) of this
+// node's local pods at the mesh inbound port, that the tunnel forwards to
+// (proposal 019 Phase 3b). Empty when the waypoint is disabled.
+func (c *SnapshotCache) ewIngressClusters() []types.Resource {
+	if !c.waypointEnabled {
+		return nil
+	}
+	c.listenerMu.RLock()
+	byFQDN := c.localServicePodsLocked()
+	c.listenerMu.RUnlock()
+
+	fqdns := make([]string, 0, len(byFQDN))
+	for fqdn := range byFQDN {
+		fqdns = append(fqdns, fqdn)
+	}
+	sort.Strings(fqdns)
+
+	out := make([]types.Resource, 0, len(fqdns))
+	for _, fqdn := range fqdns {
+		out = append(out, proxy.BuildWaypointIngressCluster(fqdn, byFQDN[fqdn]))
+	}
+	return out
+}

--- a/agent/internal/xds/cache/waypoint_test.go
+++ b/agent/internal/xds/cache/waypoint_test.go
@@ -1,0 +1,63 @@
+package cache
+
+import (
+	"testing"
+
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func waypointTestCache(t *testing.T, enabled bool) *SnapshotCache {
+	t.Helper()
+	c := newTestCache("node-1")
+	c.SetMeshDomain("aether.internal")
+	c.SetWaypointConfig(enabled, 15009)
+	c.listeners = map[string]listenerEntry{
+		"/ns/a": {cniPod: &cniv1.CNIPod{Namespace: "default", ServiceAccount: "echo", Ips: []string{"10.244.2.7"}}},
+		"/ns/b": {cniPod: &cniv1.CNIPod{Namespace: "default", ServiceAccount: "echo", Ips: []string{"10.244.1.5"}}},
+		"/ns/c": {cniPod: &cniv1.CNIPod{Namespace: "team-a", ServiceAccount: "pay", Ips: []string{"10.244.3.9"}}},
+	}
+	return c
+}
+
+// TestWaypointDestSide pins Phase 3b: the node builds one tunnel chain + one
+// ew_ingress STATIC cluster per HOSTED service, with the service's local pods.
+func TestWaypointDestSide(t *testing.T) {
+	c := waypointTestCache(t, true)
+
+	// Two hosted services -> two ew_ingress clusters; echo carries both its pods
+	// (sorted); the ingress port is the mesh inbound port, not the tunnel port.
+	clusters := c.ewIngressClusters()
+	require.Len(t, clusters, 2)
+	byName := map[string]*clusterv3.Cluster{}
+	for _, r := range clusters {
+		cl := r.(*clusterv3.Cluster)
+		byName[cl.GetName()] = cl
+	}
+	echo := byName["ew_ingress_echo.default.aether.internal"]
+	require.NotNil(t, echo)
+	require.NotNil(t, byName["ew_ingress_pay.team-a.aether.internal"])
+	eps := echo.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()
+	require.Len(t, eps, 2)
+	assert.Equal(t, "10.244.1.5", eps[0].GetEndpoint().GetAddress().GetSocketAddress().GetAddress(), "sorted for snapshot stability")
+
+	// One tunnel listener with a chain per hosted service.
+	tunnel := c.waypointTunnelListenerLocked().(*listenerv3.Listener)
+	require.NotNil(t, tunnel)
+	sniSet := map[string]bool{}
+	for _, fc := range tunnel.GetFilterChains() {
+		for _, sn := range fc.GetFilterChainMatch().GetServerNames() {
+			sniSet[sn] = true
+		}
+	}
+	assert.True(t, sniSet["*.echo.default.aether.internal"] && sniSet["*.pay.team-a.aether.internal"])
+}
+
+func TestWaypointDestSide_Disabled(t *testing.T) {
+	c := waypointTestCache(t, false)
+	assert.Empty(t, c.ewIngressClusters(), "no ingress clusters when disabled")
+	assert.Nil(t, c.waypointTunnelListenerLocked(), "no tunnel listener when disabled")
+}

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "transportsocket.go",
         "transportsocketmatch.go",
         "upstreams.go",
+        "waypoint.go",
     ],
     importpath = "github.com/bpalermo/aether/agent/internal/xds/proxy",
     visibility = [
@@ -121,6 +122,7 @@ go_test(
         "transportsocket_test.go",
         "transportsocketmatch_test.go",
         "upstreams_test.go",
+        "waypoint_test.go",
     ],
     embed = [":proxy"],
     deps = [

--- a/agent/internal/xds/proxy/waypoint.go
+++ b/agent/internal/xds/proxy/waypoint.go
@@ -1,0 +1,118 @@
+package proxy
+
+import (
+	"fmt"
+	"time"
+
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// WaypointTunnelListenerName is the node's host-netns east/west tunnel listener
+// (proposal 019). One per node; it accepts cross-cluster mTLS dialed at
+// node_ip:<tunnel-port> and SNI-forwards it to the destination local pod.
+const WaypointTunnelListenerName = "ew_tunnel"
+
+// WaypointIngressClusterName is the STATIC cluster of a service's LOCAL pods (at
+// the mesh inbound port) that the node tunnel forwards a cross-cluster connection
+// to. Keyed by the service FQDN, so it is unique per service on the node.
+func WaypointIngressClusterName(fqdn string) string { return "ew_ingress_" + fqdn }
+
+// BuildWaypointTunnelListener builds the host-netns east/west tunnel listener:
+// tls_inspector reads the ClientHello SNI and each chain (built by
+// BuildWaypointTunnelChain) routes by the SNI suffix to a local service's pods.
+// It binds 0.0.0.0:<tunnel-port> WITHOUT a network-namespace filepath, so it
+// lives in the host netns (the proxy DaemonSet is host-network and can bind the
+// node address). No TLS termination — the source's end-to-end mTLS passes
+// through to the destination pod. Returns nil when there are no chains.
+func BuildWaypointTunnelListener(tunnelPort uint32, chains []*listenerv3.FilterChain) *listenerv3.Listener {
+	if len(chains) == 0 {
+		return nil
+	}
+	return &listenerv3.Listener{
+		Name: WaypointTunnelListenerName,
+		Address: &corev3.Address{
+			Address: &corev3.Address_SocketAddress{
+				SocketAddress: &corev3.SocketAddress{
+					Protocol: corev3.SocketAddress_TCP,
+					Address:  "0.0.0.0",
+					PortSpecifier: &corev3.SocketAddress_PortValue{
+						PortValue: tunnelPort,
+					},
+				},
+			},
+		},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(perConnectionBufferLimitBytes),
+		StatPrefix:                    WaypointTunnelListenerName,
+		TrafficDirection:              corev3.TrafficDirection_INBOUND,
+		ListenerFilters:               []*listenerv3.ListenerFilter{tlsInspector()},
+		FilterChains:                  chains,
+	}
+}
+
+// BuildWaypointTunnelChain builds one local-service chain for the tunnel: it
+// matches the structured waypoint SNI by suffix ("*.<fqdn>" — Envoy's leftmost
+// wildcard is a suffix match, which is safe because aether owns the SNI and each
+// service has a unique .<fqdn> suffix) and tcp_proxies the raw (still-mTLS)
+// stream to that service's local pods at :15008.
+func BuildWaypointTunnelChain(fqdn string) *listenerv3.FilterChain {
+	name := "ew_" + fqdn
+	return &listenerv3.FilterChain{
+		Name: name,
+		FilterChainMatch: &listenerv3.FilterChainMatch{
+			ServerNames:       []string{"*." + fqdn},
+			TransportProtocol: "tls",
+		},
+		Filters: []*listenerv3.Filter{
+			buildTCPProxyNetworkFilter(name, WaypointIngressClusterName(fqdn)),
+		},
+	}
+}
+
+// BuildWaypointIngressCluster builds the STATIC cluster of a service's local pods
+// (podIP:defaultInboundPort) that the node tunnel forwards to. No transport
+// socket: the bytes are already the source's end-to-end mTLS, forwarded raw; the
+// destination pod's inbound listener terminates it. podIPs must be non-empty and
+// pre-sorted by the caller for snapshot stability.
+func BuildWaypointIngressCluster(fqdn string, podIPs []string) *clusterv3.Cluster {
+	name := WaypointIngressClusterName(fqdn)
+	lbEndpoints := make([]*endpointv3.LbEndpoint, 0, len(podIPs))
+	for _, ip := range podIPs {
+		lbEndpoints = append(lbEndpoints, &endpointv3.LbEndpoint{
+			HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+				Endpoint: &endpointv3.Endpoint{
+					Address: &corev3.Address{
+						Address: &corev3.Address_SocketAddress{
+							SocketAddress: &corev3.SocketAddress{
+								Protocol: corev3.SocketAddress_TCP,
+								Address:  ip,
+								PortSpecifier: &corev3.SocketAddress_PortValue{
+									PortValue: defaultInboundPort,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+	}
+	return &clusterv3.Cluster{
+		Name:                 name,
+		ConnectTimeout:       durationpb.New(5 * time.Second),
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{Type: clusterv3.Cluster_STATIC},
+		LoadAssignment: &endpointv3.ClusterLoadAssignment{
+			ClusterName: name,
+			Endpoints: []*endpointv3.LocalityLbEndpoints{{
+				LbEndpoints: lbEndpoints,
+			}},
+		},
+	}
+}
+
+// waypointTunnelChainName is exported indirectly via BuildWaypointTunnelChain; a
+// tiny helper kept for symmetry / tests.
+func waypointTunnelChainName(fqdn string) string { return fmt.Sprintf("ew_%s", fqdn) }

--- a/agent/internal/xds/proxy/waypoint_test.go
+++ b/agent/internal/xds/proxy/waypoint_test.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"testing"
+
+	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildWaypointTunnelChain(t *testing.T) {
+	fc := BuildWaypointTunnelChain("echo.default.aether.internal")
+	// SNI suffix match so any structured <port>.echo.default... lands here.
+	assert.Equal(t, []string{"*.echo.default.aether.internal"}, fc.GetFilterChainMatch().GetServerNames())
+	assert.Equal(t, "tls", fc.GetFilterChainMatch().GetTransportProtocol())
+	require.Len(t, fc.GetFilters(), 1, "a single tcp_proxy filter (raw passthrough)")
+	assert.Equal(t, "ew_echo.default.aether.internal", fc.GetName())
+}
+
+func TestBuildWaypointTunnelListener(t *testing.T) {
+	assert.Nil(t, BuildWaypointTunnelListener(15009, nil), "no chains -> no listener")
+
+	ln := BuildWaypointTunnelListener(15009, []*listenerv3.FilterChain{BuildWaypointTunnelChain("echo.default.aether.internal")})
+	require.NotNil(t, ln)
+	assert.Equal(t, WaypointTunnelListenerName, ln.GetName())
+	// Host netns: a plain socket address, NO network-namespace filepath.
+	sa := ln.GetAddress().GetSocketAddress()
+	assert.Equal(t, "0.0.0.0", sa.GetAddress())
+	assert.Equal(t, uint32(15009), sa.GetPortValue())
+	assert.Empty(t, sa.GetNetworkNamespaceFilepath(), "tunnel binds the host netns")
+	require.Len(t, ln.GetListenerFilters(), 1, "tls_inspector reads the SNI")
+}
+
+func TestBuildWaypointIngressCluster(t *testing.T) {
+	c := BuildWaypointIngressCluster("echo.default.aether.internal", []string{"10.244.1.5", "10.244.2.7"})
+	assert.Equal(t, "ew_ingress_echo.default.aether.internal", c.GetName())
+	assert.Nil(t, c.GetTransportSocket(), "raw passthrough — the bytes are already the source's mTLS")
+	eps := c.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints()
+	require.Len(t, eps, 2)
+	for _, ep := range eps {
+		assert.Equal(t, uint32(defaultInboundPort), ep.GetEndpoint().GetAddress().GetSocketAddress().GetPortValue(),
+			"pods are dialed at the mesh inbound port")
+	}
+	_ = waypointTunnelChainName // symmetry helper
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.72.0-{GIT_COMMIT}"
+version: "0.73.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -100,6 +100,10 @@ spec:
             {{- if .Values.agent.l4Routes }}
             - "--l4-routes"
             {{- end }}
+            {{- if .Values.agent.eastWestWaypoint }}
+            - "--east-west-waypoint"
+            - "--east-west-tunnel-port={{ .Values.agent.eastWestTunnelPort }}"
+            {{- end }}
             {{- if .Values.agent.transparentCapture }}
             - "--transparent-capture"
             {{- if or .Values.agent.captureRedirectAll .Values.agent.captureRedirectAllDefault }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -121,6 +121,16 @@ agent:
   # NOTE: UDPRoute is CONTROL-PLANE ONLY (plaintext floor, no DTLS) — a UDPRoute is
   # accepted and generates listeners but the data path is unvalidated.
   l4Routes: true
+  # East/west waypoint (proposal 019): when true, cross-cluster endpoints (a
+  # different cluster_name than this one) are dialed at their node's routable IP +
+  # eastWestTunnelPort instead of their pod IP, and this node's host-network proxy
+  # SNI-forwards inbound tunnel traffic to local pods. Intra-cluster stays direct
+  # pod-to-pod. Needs cross-cluster endpoint visibility (shared etcd) and a shared
+  # SPIRE trust domain across clusters. Default off.
+  eastWestWaypoint: false
+  # eastWestTunnelPort is the host-netns port the node proxy binds for cross-cluster
+  # waypoint traffic (only with eastWestWaypoint). Must match across the clusterset.
+  eastWestTunnelPort: 15009
   # Transparent capture (proposal 018, Phase 3a): per-pod capture listeners + the
   # cap_http route table built from the generated mesh Services. Pairs with
   # registrar.generateMeshServices (the VIPs) and the CNI dst-18081 redirect.

--- a/test/envoy_validate/builders.go
+++ b/test/envoy_validate/builders.go
@@ -127,12 +127,17 @@ func buildNodeBootstrap() (*bootstrapv3.Bootstrap, error) {
 	// waypoint metadata -> source netns) + the endpoint_metadata matcher input,
 	// so `envoy --mode validate` proves the config is accepted by a real Envoy.
 	waypointCluster := newWaypointServiceCluster("waypoint-echo."+meshDomain, trustDomain, "default", "echo")
+	// Proposal 019 Phase 3b dest side: the host-netns tunnel listener (wildcard
+	// SNI -> tcp_proxy passthrough) and its STATIC ew_ingress cluster.
+	ewIngress := proxy.BuildWaypointIngressCluster("echo."+meshDomain, []string{"10.244.1.5"})
+	tunnel := proxy.BuildWaypointTunnelListener(proxy.DefaultEastWestTunnelPort,
+		[]*listenerv3.FilterChain{proxy.BuildWaypointTunnelChain("echo." + meshDomain)})
 
-	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster, waypointCluster, authzSidecarCluster()}
+	staticClusters := []*clusterv3.Cluster{xdsCluster(), passthrough, svcCluster, waypointCluster, ewIngress, authzSidecarCluster()}
 	staticClusters = append(staticClusters, appClusters...)
 	staticClusters = append(staticClusters, healthCluster)
 
-	return newBootstrap(staticClusters, []*listenerv3.Listener{inbound, outbound}), nil
+	return newBootstrap(staticClusters, []*listenerv3.Listener{inbound, outbound, tunnel}), nil
 }
 
 // newWaypointServiceCluster is newServiceCluster with the proposal 019 waypoint


### PR DESCRIPTION
**Phase 3b of proposal 019** — completes the **dest side**, so an enabled deployment is now end-to-end functional.

## What (host netns, when `--east-west-waypoint` is set)
- **`ew_tunnel` listener** on `0.0.0.0:<tunnel-port>` — the proxy is host-network, so a plain socket address binds the node. `tls_inspector` reads the ClientHello SNI; **one filter chain per service hosted on this node** matches the SNI suffix `*.<svc>.<ns>.<meshDomain>` and `tcp_proxy`s the **raw** stream (no TLS termination — the source's end-to-end mTLS passes through) to
- **`ew_ingress_<fqdn>` STATIC cluster** per hosted service — that service's local pods at `:15008`, where their own inbound listeners terminate the mTLS.

So a cross-cluster connection lands on the destination node (dialed at `node_ip` by the source's split-horizon EDS, #502), the tunnel SNI-forwards it to a local pod, and **mTLS is end-to-end pod↔pod** — the node never decrypts. Both the tunnel and the ingress clusters are scoped to the services the node **hosts** (its local pods), so no extra demand-scoping is needed here.

## Chart
`agent.eastWestWaypoint` (default **false**) + `agent.eastWestTunnelPort` (15009) wire the flag; chart `0.73.0`. Inert by default (renders nothing when off).

## De-risked against real Envoy
The `envoy_validate` node bootstrap gains the tunnel listener (wildcard SNI → `tcp_proxy`) + a STATIC `ew_ingress` cluster, so **`envoy --mode validate` proves a real Envoy accepts them**. Unit tests cover the proxy builders (SNI suffix, host-netns bind, inbound port, no transport socket) and the cache grouping (one chain/cluster per hosted service, sorted pod IPs).

## End-to-end status (flag off by default)
Source: #502 (addressing) + #503 (SNI/matcher). Dest: #504 (pod-inbound SNI) + this. An enabled shared-etcd multi-cluster deployment can now route cross-cluster via the per-node waypoint. Remaining: demand-scope/VIP polish (P4) + the two-kind e2e (P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)