### PR TITLE
ci: bump actions/upload-artifact + download-artifact v4 → v7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
           cp scripts/ci-impacted-targets.sh "$RUNNER_TEMP/impacted.sh"
           bash "$RUNNER_TEMP/impacted.sh"
       - name: Upload impacted target lists
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: impacted-targets
           path: ${{ runner.temp }}/bazel-diff-out/impacted_*.txt
@@ -118,7 +118,7 @@ jobs:
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: impacted-targets
           path: ${{ runner.temp }}/impacted
@@ -149,7 +149,7 @@ jobs:
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: impacted-targets
           path: ${{ runner.temp }}/impacted
@@ -204,7 +204,7 @@ jobs:
           fi
       - name: Upload logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-logs
           path: /tmp/e2e-logs

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Upload conformance report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gateway-http-conformance-report
           path: ${{ runner.temp }}/gateway-http-report.yaml
@@ -259,7 +259,7 @@ jobs:
 
       - name: Upload logs on failure
         if: failure() || steps.conformance.outcome == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conformance-logs
           path: /tmp/conformance-logs
@@ -406,7 +406,7 @@ jobs:
 
       - name: Upload conformance report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mesh-http-conformance-report
           path: ${{ runner.temp }}/mesh-http-report.yaml
@@ -430,7 +430,7 @@ jobs:
 
       - name: Upload logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mesh-conformance-logs
           path: /tmp/mesh-conformance-logs

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -83,7 +83,7 @@ jobs:
           echo "pushed ${{ matrix.arch }}: $digest"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.arch }}
           path: ${{ runner.temp }}/digest.txt
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: digests
 


### PR DESCRIPTION
Bumps `actions/upload-artifact` and `actions/download-artifact` from v4 to **v7** across `ci.yaml`, `conformance.yaml`, and `proxy-release.yml`.

**Upload and download are bumped together on purpose:** the v4 release changed the artifact backend, so a v7-upload paired with a v4-download would fail to resolve. Both `proxy-release` (per-arch image → manifest handoff) and `ci` (report upload/download) use the pair within a single run.

The new `waypoint-e2e.yaml` (upload-only) is bumped in its own PR (#508).

🤖 Generated with [Claude Code](https://claude.com/claude-code)