### PR TITLE
feat(registrar): cross-region etcd replicator mirror loop (006 Phase 2a)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -108,6 +108,7 @@ use_repo(
     "com_github_vladimirvivien_gexe",
     "com_github_zeebo_errs",
     "in_gopkg_natefinch_lumberjack_v2",
+    "io_etcd_go_etcd_api_v3",
     "io_etcd_go_etcd_client_v3",
     "io_etcd_go_etcd_server_v3",
     "io_k8s_api",

--- a/go.mod
+++ b/go.mod
@@ -114,7 +114,6 @@ require (
 	github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
-	go.etcd.io/etcd/api/v3 v3.6.12 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.12 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.6.12 // indirect
 	go.etcd.io/raft/v3 v3.6.0 // indirect
@@ -216,6 +215,7 @@ require (
 require (
 	github.com/google/nftables v0.3.0
 	github.com/miekg/dns v1.1.72
+	go.etcd.io/etcd/api/v3 v3.6.12
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
 	go.opentelemetry.io/otel/log v0.20.0 // indirect

--- a/registrar/internal/cmd/BUILD.bazel
+++ b/registrar/internal/cmd/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//common/spire",
         "//registrar/internal/configexport",
         "//registrar/internal/mcs",
+        "//registrar/internal/replicator",
         "//registrar/internal/server",
         "//registrar/internal/services",
         "//registry",

--- a/registrar/internal/cmd/config.go
+++ b/registrar/internal/cmd/config.go
@@ -49,6 +49,12 @@ type RegistrarConfig struct {
 	// EtcdEndpoints is the list of etcd endpoints when using the etcd backend
 	EtcdEndpoints []string
 
+	// PeerEtcd lists peer regions' etcd endpoints for cross-region replication
+	// (proposal 006 Phase 2), one entry per peer region:
+	// <region>=<endpoint>[,<endpoint>...]. Empty disables replication.
+	// Requires the etcd backend and an explicit --region.
+	PeerEtcd []string
+
 	// SyncInterval is how often the registrar polls the external registry
 	SyncInterval time.Duration
 

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/bpalermo/aether/common/spire"
 	"github.com/bpalermo/aether/registrar/internal/configexport"
 	"github.com/bpalermo/aether/registrar/internal/mcs"
+	"github.com/bpalermo/aether/registrar/internal/replicator"
 	"github.com/bpalermo/aether/registrar/internal/server"
 	"github.com/bpalermo/aether/registrar/internal/services"
 	"github.com/bpalermo/aether/registry"
@@ -71,6 +72,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.Region, "region", cfg.Region, "Region owning this registrar's etcd partition (etcd backend; proposal 006). MUST be unique per regional etcd cluster: one region = one etcd. Pointing two etcds at the same region splits the registry; pointing two regions at one etcd collides their writes.")
 	rootCmd.Flags().StringVar(&cfg.RegistryBackend, "registry-backend", cfg.RegistryBackend, "Registry backend (kubernetes, dynamodb, or etcd)")
 	rootCmd.Flags().StringSliceVar(&cfg.EtcdEndpoints, "etcd-endpoints", cfg.EtcdEndpoints, "Comma-separated etcd endpoints")
+	rootCmd.Flags().StringArrayVar(&cfg.PeerEtcd, "peer-etcd", nil, "Peer region etcd for cross-region replication (proposal 006), repeatable: <region>=<endpoint>[,<endpoint>...]. The leader registrar mirrors this region's own registry subtree verbatim into each peer. Requires the etcd backend and an explicit --region")
 	rootCmd.Flags().DurationVar(&cfg.SyncInterval, "sync-interval", cfg.SyncInterval, "How often to sync from the registry")
 	rootCmd.Flags().BoolVar(&cfg.GenerateMeshServices, "generate-mesh-services", false, "Project the mesh catalog into selectorless k8s Services on the mesh port (transparent-capture VIPs, proposal 018 Phase 3a)")
 	rootCmd.Flags().BoolVar(&cfg.EnableMCS, "enable-mcs", false, "Enable Multi-Cluster Services (MCS-API) phase 1: export ServiceExports to the registry and materialize ServiceImports + clusterset VIPs (proposals 018 + 006; requires the etcd backend)")
@@ -246,6 +248,30 @@ func runRegistrar(ctx context.Context) (retErr error) {
 			}
 			l.InfoContext(ctx, "cross-cluster config export enabled (proposal 026)")
 		}
+	}
+
+	// Cross-region replication (proposal 006 Phase 2a): the leader registrar
+	// mirrors this region's own authoritative etcd subtree verbatim into each
+	// peer region's etcd. Inert unless --peer-etcd is set. Replication is
+	// etcd↔etcd by design (see docs/proposals/006), so any other backend is a
+	// hard misconfiguration, like --enable-mcs.
+	if len(cfg.PeerEtcd) > 0 {
+		src, ok := reg.(replicator.Source)
+		if !ok {
+			return fmt.Errorf("--peer-etcd requires the etcd registry backend; backend %q cannot be replicated", cfg.RegistryBackend)
+		}
+		peers, peersErr := replicator.ParsePeers(cfg.PeerEtcd, cfg.Region)
+		if peersErr != nil {
+			return fmt.Errorf("invalid --peer-etcd: %w", peersErr)
+		}
+		if err = m.Add(&replicator.Replicator{
+			Source: src,
+			Peers:  peers,
+			Log:    l,
+		}); err != nil {
+			return fmt.Errorf("failed to add cross-region replicator: %w", err)
+		}
+		l.InfoContext(ctx, "cross-region etcd replication enabled (proposal 006 Phase 2a)", "region", cfg.Region, "peers", len(peers))
 	}
 
 	var grpcOpts []grpc.ServerOption

--- a/registrar/internal/replicator/BUILD.bazel
+++ b/registrar/internal/replicator/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "replicator",
+    srcs = ["replicator.go"],
+    importpath = "github.com/bpalermo/aether/registrar/internal/replicator",
+    visibility = ["//registrar:__subpackages__"],
+    deps = [
+        "//common/log",
+        "@io_etcd_go_etcd_api_v3//v3rpc/rpctypes",
+        "@io_etcd_go_etcd_client_v3//:client",
+    ],
+)
+
+go_test(
+    name = "replicator_test",
+    size = "medium",
+    srcs = ["replicator_test.go"],
+    tags = [
+        "integration",
+        "no-remote-exec",  # testcontainers needs local Docker, not a remote executor
+    ],
+    deps = [
+        ":replicator",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@com_github_testcontainers_testcontainers_go_modules_etcd//:etcd",
+        "@io_etcd_go_etcd_client_v3//:client",
+    ],
+)

--- a/registrar/internal/replicator/replicator.go
+++ b/registrar/internal/replicator/replicator.go
@@ -1,0 +1,253 @@
+// Package replicator is the registrar's cross-region etcd replicator
+// (proposal 006 Phase 2a). Leader-elected (one mirror stream per region), it
+// watches this region's OWN authoritative subtree
+// (<root>/<region>/clusters/<cluster>/…) in the local etcd and replays every
+// change verbatim (Put→Put, Delete→Delete) into each peer region's etcd.
+//
+// Partitions are origin-first and disjoint, so mirroring is loop-free by
+// construction: a peer's replicator watches only its own subtree and never
+// re-mirrors keys this region wrote into it. Peer registrars see the mirrored
+// keys as read-only foreign endpoints (EDS priority 2, proposal 004 locality).
+//
+// Phase 2a is the mirror loop only: mirrored writes carry no lease yet, so a
+// dead origin's keys persist on peers until it returns. The origin-heartbeat
+// lease (whole-region failover) is Phase 2b.
+package replicator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	commonlog "github.com/bpalermo/aether/common/log"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	defaultDialTimeout   = 5 * time.Second
+	defaultResyncBackoff = 5 * time.Second
+)
+
+// Source is the local authoritative store the replicator mirrors from: the
+// etcd-backed registry's client plus its own-partition root. Implemented by
+// registry.EtcdRegistry; other backends don't, which is what gates the
+// replicator to the etcd backend.
+type Source interface {
+	Client() *clientv3.Client
+	OwnPrefix() string
+}
+
+// Peer is one peer region's etcd, the mirror destination.
+type Peer struct {
+	Region    string
+	Endpoints []string
+}
+
+// ParsePeers parses repeated --peer-etcd values of the form
+// <region>=<endpoint>[,<endpoint>...] into Peers. The region is the
+// replication unit, so the own region must be explicit (not the single-region
+// default) and peer regions must be distinct from it and from each other.
+func ParsePeers(entries []string, ownRegion string) ([]Peer, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	if ownRegion == "" {
+		return nil, errors.New("--region must be set explicitly when peer replication is enabled")
+	}
+	seen := make(map[string]struct{}, len(entries))
+	peers := make([]Peer, 0, len(entries))
+	for _, entry := range entries {
+		region, eps, ok := strings.Cut(entry, "=")
+		if !ok || region == "" || eps == "" {
+			return nil, fmt.Errorf("malformed peer %q: want <region>=<endpoint>[,<endpoint>...]", entry)
+		}
+		if region == ownRegion {
+			return nil, fmt.Errorf("peer region %q is this registrar's own region", region)
+		}
+		if _, dup := seen[region]; dup {
+			return nil, fmt.Errorf("duplicate peer region %q", region)
+		}
+		seen[region] = struct{}{}
+		endpoints := strings.Split(eps, ",")
+		for i := range endpoints {
+			endpoints[i] = strings.TrimSpace(endpoints[i])
+			if endpoints[i] == "" {
+				return nil, fmt.Errorf("peer %q has an empty endpoint", entry)
+			}
+		}
+		peers = append(peers, Peer{Region: region, Endpoints: endpoints})
+	}
+	return peers, nil
+}
+
+// Replicator mirrors the local own-partition subtree into each peer's etcd.
+// It is a leader-elected manager Runnable: exactly one replica per region
+// holds the mirror streams.
+type Replicator struct {
+	Source Source
+	Peers  []Peer
+	Log    *slog.Logger
+
+	// DialTimeout bounds each peer dial; ResyncBackoff spaces mirror-loop
+	// restarts after an error. Zero values take the defaults.
+	DialTimeout   time.Duration
+	ResyncBackoff time.Duration
+
+	log *slog.Logger
+}
+
+// NeedLeaderElection makes the replicator run only on the elected leader
+// (one mirror stream per origin region; two would double-write peers).
+func (r *Replicator) NeedLeaderElection() bool { return true }
+
+// Start runs one independent mirror loop per peer until the context is
+// cancelled. Peers are isolated: a slow or unreachable peer resyncs on its
+// own backoff without stalling the others.
+func (r *Replicator) Start(ctx context.Context) error {
+	r.log = commonlog.Named(r.Log, "replicator")
+	if r.DialTimeout == 0 {
+		r.DialTimeout = defaultDialTimeout
+	}
+	if r.ResyncBackoff == 0 {
+		r.ResyncBackoff = defaultResyncBackoff
+	}
+	r.log.InfoContext(ctx, "starting cross-region replication",
+		"ownPrefix", r.Source.OwnPrefix(), "peers", len(r.Peers))
+
+	var wg sync.WaitGroup
+	for _, p := range r.Peers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.runPeer(ctx, r.log.With("peerRegion", p.Region), p)
+		}()
+	}
+	wg.Wait()
+	return nil
+}
+
+// runPeer redials and re-mirrors one peer until the context ends.
+func (r *Replicator) runPeer(ctx context.Context, log *slog.Logger, p Peer) {
+	for {
+		if err := r.mirrorPeer(ctx, log, p); err != nil && ctx.Err() == nil {
+			log.ErrorContext(ctx, "peer mirror failed; will redial and resync", "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(r.ResyncBackoff):
+		}
+	}
+}
+
+// mirrorPeer dials the peer and runs sync→watch cycles until the context ends
+// or an error forces a redial.
+func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) error {
+	peerCli, err := clientv3.New(clientv3.Config{
+		Endpoints:   p.Endpoints,
+		DialTimeout: r.DialTimeout,
+		Context:     ctx,
+	})
+	if err != nil {
+		return fmt.Errorf("dial peer %s: %w", p.Region, err)
+	}
+	defer func() { _ = peerCli.Close() }()
+
+	for {
+		rev, err := r.syncFull(ctx, peerCli)
+		if err != nil {
+			return fmt.Errorf("full sync: %w", err)
+		}
+		log.InfoContext(ctx, "peer mirror synced; watching", "revision", rev)
+		err = r.watchMirror(ctx, peerCli, rev+1)
+		if ctx.Err() != nil {
+			return nil
+		}
+		// A compacted start revision just means the watch fell behind: re-range
+		// and resume. Anything else (peer write failure, watch stream error)
+		// redials.
+		if errors.Is(err, rpctypes.ErrCompacted) {
+			log.WarnContext(ctx, "watch revision compacted; resyncing")
+			continue
+		}
+		return err
+	}
+}
+
+// syncFull makes the peer's copy of the own-partition subtree equal the local
+// one — put missing/changed keys, delete extras — and returns the local
+// revision the sync is consistent at (the watch resumes right after it).
+// Reconciling against the peer's existing copy rather than blind re-putting
+// makes restarts resume-safe: deletes that happened while the replicator was
+// down still converge.
+func (r *Replicator) syncFull(ctx context.Context, peerCli *clientv3.Client) (int64, error) {
+	prefix := r.Source.OwnPrefix()
+	localResp, err := r.Source.Client().Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return 0, fmt.Errorf("range local: %w", err)
+	}
+	peerResp, err := peerCli.Get(ctx, prefix, clientv3.WithPrefix())
+	if err != nil {
+		return 0, fmt.Errorf("range peer: %w", err)
+	}
+
+	local := make(map[string][]byte, len(localResp.Kvs))
+	for _, kv := range localResp.Kvs {
+		local[string(kv.Key)] = kv.Value
+	}
+	for _, kv := range peerResp.Kvs {
+		key := string(kv.Key)
+		want, ok := local[key]
+		if !ok {
+			if _, err = peerCli.Delete(ctx, key); err != nil {
+				return 0, fmt.Errorf("delete stale peer key: %w", err)
+			}
+			continue
+		}
+		if bytes.Equal(kv.Value, want) {
+			delete(local, key) // already converged; skip the put below
+		}
+	}
+	for key, value := range local {
+		if _, err = peerCli.Put(ctx, key, string(value)); err != nil {
+			return 0, fmt.Errorf("put peer key: %w", err)
+		}
+	}
+	return localResp.Header.Revision, nil
+}
+
+// watchMirror replays local watch events verbatim into the peer, starting at
+// startRev. Returns when the watch or a peer write fails; the caller decides
+// between compaction-resync and redial.
+func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, startRev int64) error {
+	wch := r.Source.Client().Watch(clientv3.WithRequireLeader(ctx), r.Source.OwnPrefix(),
+		clientv3.WithPrefix(), clientv3.WithRev(startRev))
+	for resp := range wch {
+		if err := resp.Err(); err != nil {
+			return err
+		}
+		for _, ev := range resp.Events {
+			key := string(ev.Kv.Key)
+			switch ev.Type {
+			case clientv3.EventTypePut:
+				if _, err := peerCli.Put(ctx, key, string(ev.Kv.Value)); err != nil {
+					return fmt.Errorf("mirror put: %w", err)
+				}
+			case clientv3.EventTypeDelete:
+				if _, err := peerCli.Delete(ctx, key); err != nil {
+					return fmt.Errorf("mirror delete: %w", err)
+				}
+			}
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return errors.New("local watch channel closed")
+}

--- a/registrar/internal/replicator/replicator_test.go
+++ b/registrar/internal/replicator/replicator_test.go
@@ -1,0 +1,253 @@
+package replicator_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bpalermo/aether/registrar/internal/replicator"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tcetcd "github.com/testcontainers/testcontainers-go/modules/etcd"
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+var (
+	localEndpoint string
+	peerEndpoint  string
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Short() {
+		// Unit tests (ParsePeers) need no containers.
+		os.Exit(m.Run())
+	}
+
+	ctx := context.Background()
+
+	localContainer, err := tcetcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.21")
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "failed to start local etcd container: %v\n", err)
+		os.Exit(1)
+	}
+	peerContainer, err := tcetcd.Run(ctx, "gcr.io/etcd-development/etcd:v3.5.21")
+	if err != nil {
+		_ = localContainer.Terminate(ctx)
+		_, _ = fmt.Fprintf(os.Stderr, "failed to start peer etcd container: %v\n", err)
+		os.Exit(1)
+	}
+
+	localEndpoint, err = localContainer.ClientEndpoint(ctx)
+	if err == nil {
+		peerEndpoint, err = peerContainer.ClientEndpoint(ctx)
+	}
+	if err != nil {
+		_ = localContainer.Terminate(ctx)
+		_ = peerContainer.Terminate(ctx)
+		_, _ = fmt.Fprintf(os.Stderr, "failed to get endpoint: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	_ = localContainer.Terminate(ctx)
+	_ = peerContainer.Terminate(ctx)
+	os.Exit(code)
+}
+
+func TestParsePeers(t *testing.T) {
+	t.Run("empty entries disable replication", func(t *testing.T) {
+		peers, err := replicator.ParsePeers(nil, "")
+		require.NoError(t, err)
+		assert.Nil(t, peers)
+	})
+
+	t.Run("parses regions and endpoint lists", func(t *testing.T) {
+		peers, err := replicator.ParsePeers([]string{
+			"region-b=b1:2379,b2:2379",
+			"region-c= c1:2379 ",
+		}, "region-a")
+		require.NoError(t, err)
+		require.Len(t, peers, 2)
+		assert.Equal(t, replicator.Peer{Region: "region-b", Endpoints: []string{"b1:2379", "b2:2379"}}, peers[0])
+		assert.Equal(t, replicator.Peer{Region: "region-c", Endpoints: []string{"c1:2379"}}, peers[1])
+	})
+
+	t.Run("requires explicit own region", func(t *testing.T) {
+		_, err := replicator.ParsePeers([]string{"region-b=b1:2379"}, "")
+		require.ErrorContains(t, err, "--region")
+	})
+
+	t.Run("rejects malformed entries", func(t *testing.T) {
+		for _, entry := range []string{"region-b", "=b1:2379", "region-b=", "region-b=b1:2379,,b2:2379"} {
+			_, err := replicator.ParsePeers([]string{entry}, "region-a")
+			assert.Error(t, err, "entry %q", entry)
+		}
+	})
+
+	t.Run("rejects own region as peer", func(t *testing.T) {
+		_, err := replicator.ParsePeers([]string{"region-a=a1:2379"}, "region-a")
+		require.ErrorContains(t, err, "own region")
+	})
+
+	t.Run("rejects duplicate peer regions", func(t *testing.T) {
+		_, err := replicator.ParsePeers([]string{"region-b=b1:2379", "region-b=b2:2379"}, "region-a")
+		require.ErrorContains(t, err, "duplicate")
+	})
+}
+
+// testSource implements replicator.Source over a raw client, standing in for
+// the etcd registry's accessors with a per-test partition prefix.
+type testSource struct {
+	client *clientv3.Client
+	prefix string
+}
+
+func (s *testSource) Client() *clientv3.Client { return s.client }
+func (s *testSource) OwnPrefix() string        { return s.prefix }
+
+// root returns a unique key root per test so tests share the containers.
+func root(t *testing.T) string {
+	t.Helper()
+	return "/" + strings.ReplaceAll(t.Name(), "/", "_")
+}
+
+func newClient(t *testing.T, endpoint string) *clientv3.Client {
+	t.Helper()
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   []string{endpoint},
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+	return cli
+}
+
+// startReplicator runs a replicator for ownPrefix→peer and returns a stop
+// function that cancels it and waits for Start to return.
+func startReplicator(t *testing.T, localCli *clientv3.Client, ownPrefix string) (stop func()) {
+	t.Helper()
+	r := &replicator.Replicator{
+		Source:        &testSource{client: localCli, prefix: ownPrefix},
+		Peers:         []replicator.Peer{{Region: "region-b", Endpoints: []string{peerEndpoint}}},
+		Log:           slog.New(slog.DiscardHandler),
+		ResyncBackoff: 100 * time.Millisecond,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		assert.NoError(t, r.Start(ctx))
+	}()
+	stopped := false
+	stop = func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		cancel()
+		<-done
+	}
+	t.Cleanup(stop)
+	return stop
+}
+
+// peerValue fetches a single key's value from the peer ("" when absent).
+func peerValue(t *testing.T, peerCli *clientv3.Client, key string) string {
+	t.Helper()
+	resp, err := peerCli.Get(context.Background(), key)
+	require.NoError(t, err)
+	if len(resp.Kvs) == 0 {
+		return ""
+	}
+	return string(resp.Kvs[0].Value)
+}
+
+func TestReplicator_MirrorsOwnPartition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	ctx := context.Background()
+	localCli := newClient(t, localEndpoint)
+	peerCli := newClient(t, peerEndpoint)
+
+	ownPrefix := root(t) + "/regions/region-a/clusters/c1"
+	foreignKey := root(t) + "/regions/region-b/clusters/c9/k"
+
+	// Seed: two own keys + one foreign-region key locally; one stale key on the
+	// peer under the own prefix (must be pruned by the initial sync).
+	_, err := localCli.Put(ctx, ownPrefix+"/k1", "v1")
+	require.NoError(t, err)
+	_, err = localCli.Put(ctx, ownPrefix+"/k2", "v2")
+	require.NoError(t, err)
+	_, err = localCli.Put(ctx, foreignKey, "not-ours")
+	require.NoError(t, err)
+	_, err = peerCli.Put(ctx, ownPrefix+"/stale", "gone-local")
+	require.NoError(t, err)
+
+	startReplicator(t, localCli, ownPrefix)
+
+	// Initial sync: own keys arrive, the stale peer key is pruned.
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k1") == "v1" &&
+			peerValue(t, peerCli, ownPrefix+"/k2") == "v2" &&
+			peerValue(t, peerCli, ownPrefix+"/stale") == ""
+	}, 15*time.Second, 50*time.Millisecond, "initial sync did not converge")
+
+	// The foreign-region key is outside the own partition and never mirrored.
+	assert.Empty(t, peerValue(t, peerCli, foreignKey))
+
+	// Live mirroring: put new, update existing, delete existing.
+	_, err = localCli.Put(ctx, ownPrefix+"/k3", "v3")
+	require.NoError(t, err)
+	_, err = localCli.Put(ctx, ownPrefix+"/k2", "v2-updated")
+	require.NoError(t, err)
+	_, err = localCli.Delete(ctx, ownPrefix+"/k1")
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k3") == "v3" &&
+			peerValue(t, peerCli, ownPrefix+"/k2") == "v2-updated" &&
+			peerValue(t, peerCli, ownPrefix+"/k1") == ""
+	}, 15*time.Second, 50*time.Millisecond, "live mirror did not converge")
+}
+
+func TestReplicator_ResumesAfterRestart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	ctx := context.Background()
+	localCli := newClient(t, localEndpoint)
+	peerCli := newClient(t, peerEndpoint)
+
+	ownPrefix := root(t) + "/regions/region-a/clusters/c1"
+	_, err := localCli.Put(ctx, ownPrefix+"/k1", "v1")
+	require.NoError(t, err)
+	_, err = localCli.Put(ctx, ownPrefix+"/k2", "v2")
+	require.NoError(t, err)
+
+	stop := startReplicator(t, localCli, ownPrefix)
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k1") == "v1" &&
+			peerValue(t, peerCli, ownPrefix+"/k2") == "v2"
+	}, 15*time.Second, 50*time.Millisecond, "initial sync did not converge")
+	stop()
+
+	// Mutate locally while no replicator runs: the restart's reconcile-sync
+	// (not the watch) must converge both the delete and the add.
+	_, err = localCli.Delete(ctx, ownPrefix+"/k1")
+	require.NoError(t, err)
+	_, err = localCli.Put(ctx, ownPrefix+"/k3", "v3")
+	require.NoError(t, err)
+
+	startReplicator(t, localCli, ownPrefix)
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k1") == "" &&
+			peerValue(t, peerCli, ownPrefix+"/k3") == "v3"
+	}, 15*time.Second, 50*time.Millisecond, "resync after restart did not converge")
+}

--- a/registry/internal/etcd/etcd.go
+++ b/registry/internal/etcd/etcd.go
@@ -156,6 +156,20 @@ func (r *EtcdRegistry) Initialize(ctx context.Context) error {
 	return nil
 }
 
+// Client exposes the underlying etcd client for components that mirror this
+// registry's authoritative partition verbatim (the cross-region replicator,
+// proposal 006 Phase 2). Nil until Initialize succeeds.
+func (r *EtcdRegistry) Client() *clientv3.Client {
+	return r.client
+}
+
+// OwnPrefix returns this instance's authoritative partition root
+// (<keyPrefix>/<region>/clusters/<cluster>) — the subtree the cross-region
+// replicator mirrors to peer regions.
+func (r *EtcdRegistry) OwnPrefix() string {
+	return r.ownPrefix
+}
+
 // Changes returns a channel that receives a (coalesced) signal whenever any
 // key under the registry prefix changes. Consumers treat each receive as
 // "something changed, re-read the registry". Satisfies registry.ChangeNotifier.


### PR DESCRIPTION
## Summary

First slice of the proposal 006 Phase 2 cross-region replicator (plan: #510, tracking: #511 P2a): a **leader-elected registrar runnable** that mirrors this region's OWN authoritative etcd subtree (`/aether/v1/regions/<region>/clusters/<cluster>/`) **verbatim** into each peer region's etcd.

- **`--peer-etcd <region>=<endpoint>[,<endpoint>...]`** (repeatable) on the registrar. Inert unless set; hard-errors on a non-etcd backend (same posture as `--enable-mcs`) and requires an explicit `--region` (the single-region default can't be a replication identity).
- **Mirror loop per peer, fully isolated**: initial *reconcile*-sync (put missing/changed, delete extras — resume-safe: deletes that happened while the replicator was down still converge) → watch anchored at the sync revision (Put→Put, Delete→Delete) → compaction triggers a resync, any other error redials on backoff. A dead peer never stalls the others.
- **Loop-free by construction**: origin-first partitions are disjoint; each region's replicator watches only its own subtree, never keys mirrored in from peers.
- `Client()`/`OwnPrefix()` accessors on `EtcdRegistry` (the replicator's `Source`; consumer-side interface instead of downcasting the internal type).

**No lease yet** — mirrored keys persist on peers if the origin dies. The origin-heartbeat lease (whole-region failover) is Phase 2b, next in the stack.

## Testing

- `ParsePeers` unit tests (short-mode friendly, no Docker).
- Integration tests against **two real etcd containers** (testcontainers, repo convention): initial sync + stale-key prune, foreign-region keys excluded, live put/update/delete mirroring, and restart convergence (mutations made while the replicator was down reconcile on restart). All green locally, plus the full `//registrar/... //registry/...` suite.

Part of #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S