### PR TITLE
feat(registrar): origin-heartbeat lease on the mirror (006 Phase 2b)

### DIFF
--- a/docs/proposals/006_multi-region-etcd-federation.md
+++ b/docs/proposals/006_multi-region-etcd-federation.md
@@ -206,9 +206,23 @@ read-only foreign endpoints (EDS priority 2, locality failover — proposal 004)
 
 Nothing in the etcd registry uses a lease today (all `Put`s are bare). The
 replicator adds, **per peer etcd**: `Lease.Grant(TTL)` + a `KeepAlive` goroutine +
-`clientv3.WithLease(id)` on every mirrored `Put` + `Lease.Revoke` on clean
-shutdown. TTL ~30s, keepalive ~TTL/3. The lease lives on the peer; the origin's
-replicator holds the keepalive, so origin liveness == mirror liveness.
+`clientv3.WithLease(id)` on every mirrored `Put`. TTL ~30s, keepalive ~TTL/3. The
+lease lives on the peer; the origin's replicator holds the keepalive, so origin
+liveness == mirror liveness.
+
+Two corrections discovered in implementation (P2b):
+
+- **No `Lease.Revoke` on clean shutdown** (the original sketch had one).
+  Revoking deletes every attached key immediately, so it would wipe the
+  region's mirror off peers on every registrar roll / leader handoff. Instead
+  shutdown just stops the keepalive: the successor re-syncs under a fresh
+  lease well inside the TTL (its puts re-attach the keys), and the old lease
+  expires holding nothing. Only a region that stays down lets the TTL lapse
+  with keys attached — which is exactly the failover semantics.
+- **Sync convergence must compare the lease, not just the value.** A
+  value-equal peer key still attached to a previous incarnation's lease must
+  be re-put to re-attach it, or it silently expires with the old lease after
+  a handoff.
 
 ### Phasing (each a reviewable PR; inert until `--peer-etcd` is set)
 
@@ -222,8 +236,9 @@ replicator holds the keepalive, so origin liveness == mirror liveness.
    leader-elected shape; needs direct access to the `EtcdRegistry`'s `clientv3`
    (add an accessor rather than downcasting). Unit-tested against an embedded etcd.
 2. **P2b — origin-heartbeat lease + failover.** Per-peer `Lease.Grant`/`KeepAlive`/
-   `WithLease`/`Revoke`; the mirror Puts attach the lease. This is the failover
-   mechanism. Test: kill the keepalive → peer keys expire.
+   `WithLease`; the mirror Puts attach the lease (no revoke on shutdown — see
+   above). This is the failover mechanism. Tests: kill the keepalive → peer keys
+   expire; leader handoff → mirror never drops.
 3. **P2c — hardening + metrics.** Replication lag, per-peer error/keepalive-health
    counters; compaction-resync robustness; chart values (`registrar.peerEtcd`).
 4. **P3 — multi-region e2e** (proposal 006 Phase 3). Extend a kind harness to

--- a/registrar/internal/replicator/BUILD.bazel
+++ b/registrar/internal/replicator/BUILD.bazel
@@ -2,7 +2,10 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "replicator",
-    srcs = ["replicator.go"],
+    srcs = [
+        "lease.go",
+        "replicator.go",
+    ],
     importpath = "github.com/bpalermo/aether/registrar/internal/replicator",
     visibility = ["//registrar:__subpackages__"],
     deps = [

--- a/registrar/internal/replicator/lease.go
+++ b/registrar/internal/replicator/lease.go
@@ -1,0 +1,55 @@
+package replicator
+
+import (
+	"context"
+	"fmt"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// DefaultLeaseTTLSeconds is the origin-heartbeat lease TTL (proposal 006
+// Phase 2b). It bounds two windows at once: how long a dead origin's mirror
+// lingers on peers (failover cleanup latency) and how long a leader handoff
+// has to re-sync before the mirror expires mid-roll. 30s comfortably covers
+// registrar leader election while keeping whole-region cleanup prompt.
+const DefaultLeaseTTLSeconds = 30
+
+// peerLease is one peer etcd's origin-heartbeat lease: every key this
+// replicator mirrors into that peer is attached to it, and this replicator's
+// KeepAlive is the only thing refreshing it. Origin liveness == mirror
+// liveness: if this region (or its replicator leader) dies, the lease lapses
+// and the peer drops the whole mirrored subtree together — failover cleanup
+// without any peer judging the origin dead.
+type peerLease struct {
+	id clientv3.LeaseID
+	// done closes when the keepalive stream ends — context cancellation on
+	// clean shutdown, or a lost/expired lease. The mirror loop treats it as
+	// fatal for the connection: redial, re-grant, resync.
+	done <-chan struct{}
+}
+
+// startLease grants a fresh lease on the peer and holds its keepalive until
+// ctx ends. Deliberately NO Revoke on shutdown: revoking deletes every
+// attached key immediately, which would wipe this region's mirror off peers
+// on every registrar roll / leader handoff. Instead the lease rides out its
+// TTL — the next leader re-syncs under a fresh lease well inside it (puts
+// re-attach the keys), and the old lease then expires holding nothing. Only
+// a region that truly stays down lets the TTL lapse with keys attached.
+func startLease(ctx context.Context, peerCli *clientv3.Client, ttlSeconds int64) (*peerLease, error) {
+	grant, err := peerCli.Grant(ctx, ttlSeconds)
+	if err != nil {
+		return nil, fmt.Errorf("grant: %w", err)
+	}
+	ka, err := peerCli.KeepAlive(ctx, grant.ID)
+	if err != nil {
+		return nil, fmt.Errorf("keepalive: %w", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// Drain until the client closes the stream (ctx end or lease loss).
+		for range ka {
+		}
+	}()
+	return &peerLease{id: grant.ID, done: done}, nil
+}

--- a/registrar/internal/replicator/replicator.go
+++ b/registrar/internal/replicator/replicator.go
@@ -9,9 +9,13 @@
 // re-mirrors keys this region wrote into it. Peer registrars see the mirrored
 // keys as read-only foreign endpoints (EDS priority 2, proposal 004 locality).
 //
-// Phase 2a is the mirror loop only: mirrored writes carry no lease yet, so a
-// dead origin's keys persist on peers until it returns. The origin-heartbeat
-// lease (whole-region failover) is Phase 2b.
+// Every mirrored key is attached to a per-peer origin-heartbeat lease (Phase
+// 2b) that only this replicator's KeepAlive refreshes: if the origin region
+// dies, the lease lapses and the peer drops the whole mirrored subtree
+// together — whole-region failover cleanup without any peer judging the
+// origin dead. Clean shutdown deliberately does NOT revoke the lease (that
+// would wipe the mirror on every leader handoff); the next leader re-syncs
+// under a fresh lease well inside the TTL. See lease.go.
 package replicator
 
 import (
@@ -95,9 +99,11 @@ type Replicator struct {
 	Log    *slog.Logger
 
 	// DialTimeout bounds each peer dial; ResyncBackoff spaces mirror-loop
-	// restarts after an error. Zero values take the defaults.
-	DialTimeout   time.Duration
-	ResyncBackoff time.Duration
+	// restarts after an error; LeaseTTLSeconds is the origin-heartbeat lease
+	// TTL on each peer (Phase 2b). Zero values take the defaults.
+	DialTimeout     time.Duration
+	ResyncBackoff   time.Duration
+	LeaseTTLSeconds int64
 
 	log *slog.Logger
 }
@@ -116,6 +122,9 @@ func (r *Replicator) Start(ctx context.Context) error {
 	}
 	if r.ResyncBackoff == 0 {
 		r.ResyncBackoff = defaultResyncBackoff
+	}
+	if r.LeaseTTLSeconds == 0 {
+		r.LeaseTTLSeconds = DefaultLeaseTTLSeconds
 	}
 	r.log.InfoContext(ctx, "starting cross-region replication",
 		"ownPrefix", r.Source.OwnPrefix(), "peers", len(r.Peers))
@@ -146,8 +155,9 @@ func (r *Replicator) runPeer(ctx context.Context, log *slog.Logger, p Peer) {
 	}
 }
 
-// mirrorPeer dials the peer and runs sync→watch cycles until the context ends
-// or an error forces a redial.
+// mirrorPeer dials the peer and runs sync→watch cycles under one
+// origin-heartbeat lease until the context ends or an error forces a redial
+// (which re-grants the lease and resyncs).
 func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) error {
 	peerCli, err := clientv3.New(clientv3.Config{
 		Endpoints:   p.Endpoints,
@@ -159,15 +169,38 @@ func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) e
 	}
 	defer func() { _ = peerCli.Close() }()
 
+	lease, err := startLease(ctx, peerCli, r.LeaseTTLSeconds)
+	if err != nil {
+		return fmt.Errorf("origin-heartbeat lease on peer %s: %w", p.Region, err)
+	}
+	// A lost keepalive means the lease (and with it the whole mirrored
+	// subtree) may expire on the peer: cancel the connection so the outer
+	// loop re-grants and resyncs rather than mirroring onto a dead lease.
+	connCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		select {
+		case <-lease.done:
+			cancel()
+		case <-connCtx.Done():
+		}
+	}()
+
 	for {
-		rev, err := r.syncFull(ctx, peerCli)
+		rev, err := r.syncFull(connCtx, peerCli, lease.id)
 		if err != nil {
+			if ctx.Err() == nil && connCtx.Err() != nil {
+				return errors.New("origin-heartbeat lease keepalive lost")
+			}
 			return fmt.Errorf("full sync: %w", err)
 		}
-		log.InfoContext(ctx, "peer mirror synced; watching", "revision", rev)
-		err = r.watchMirror(ctx, peerCli, rev+1)
+		log.InfoContext(ctx, "peer mirror synced; watching", "revision", rev, "leaseID", lease.id)
+		err = r.watchMirror(connCtx, peerCli, lease.id, rev+1)
 		if ctx.Err() != nil {
 			return nil
+		}
+		if connCtx.Err() != nil {
+			return errors.New("origin-heartbeat lease keepalive lost")
 		}
 		// A compacted start revision just means the watch fell behind: re-range
 		// and resume. Anything else (peer write failure, watch stream error)
@@ -186,7 +219,11 @@ func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) e
 // Reconciling against the peer's existing copy rather than blind re-putting
 // makes restarts resume-safe: deletes that happened while the replicator was
 // down still converge.
-func (r *Replicator) syncFull(ctx context.Context, peerCli *clientv3.Client) (int64, error) {
+//
+// Convergence requires value AND lease equality: a value-equal key attached
+// to a previous incarnation's lease must be re-put to re-attach it to the
+// live lease, or it would silently expire with the old one.
+func (r *Replicator) syncFull(ctx context.Context, peerCli *clientv3.Client, leaseID clientv3.LeaseID) (int64, error) {
 	prefix := r.Source.OwnPrefix()
 	localResp, err := r.Source.Client().Get(ctx, prefix, clientv3.WithPrefix())
 	if err != nil {
@@ -210,12 +247,12 @@ func (r *Replicator) syncFull(ctx context.Context, peerCli *clientv3.Client) (in
 			}
 			continue
 		}
-		if bytes.Equal(kv.Value, want) {
+		if bytes.Equal(kv.Value, want) && kv.Lease == int64(leaseID) {
 			delete(local, key) // already converged; skip the put below
 		}
 	}
 	for key, value := range local {
-		if _, err = peerCli.Put(ctx, key, string(value)); err != nil {
+		if _, err = peerCli.Put(ctx, key, string(value), clientv3.WithLease(leaseID)); err != nil {
 			return 0, fmt.Errorf("put peer key: %w", err)
 		}
 	}
@@ -223,9 +260,9 @@ func (r *Replicator) syncFull(ctx context.Context, peerCli *clientv3.Client) (in
 }
 
 // watchMirror replays local watch events verbatim into the peer, starting at
-// startRev. Returns when the watch or a peer write fails; the caller decides
-// between compaction-resync and redial.
-func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, startRev int64) error {
+// startRev; puts attach the origin-heartbeat lease. Returns when the watch or
+// a peer write fails; the caller decides between compaction-resync and redial.
+func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, leaseID clientv3.LeaseID, startRev int64) error {
 	wch := r.Source.Client().Watch(clientv3.WithRequireLeader(ctx), r.Source.OwnPrefix(),
 		clientv3.WithPrefix(), clientv3.WithRev(startRev))
 	for resp := range wch {
@@ -236,7 +273,7 @@ func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, 
 			key := string(ev.Kv.Key)
 			switch ev.Type {
 			case clientv3.EventTypePut:
-				if _, err := peerCli.Put(ctx, key, string(ev.Kv.Value)); err != nil {
+				if _, err := peerCli.Put(ctx, key, string(ev.Kv.Value), clientv3.WithLease(leaseID)); err != nil {
 					return fmt.Errorf("mirror put: %w", err)
 				}
 			case clientv3.EventTypeDelete:

--- a/registrar/internal/replicator/replicator_test.go
+++ b/registrar/internal/replicator/replicator_test.go
@@ -130,13 +130,14 @@ func newClient(t *testing.T, endpoint string) *clientv3.Client {
 
 // startReplicator runs a replicator for ownPrefix→peer and returns a stop
 // function that cancels it and waits for Start to return.
-func startReplicator(t *testing.T, localCli *clientv3.Client, ownPrefix string) (stop func()) {
+func startReplicator(t *testing.T, localCli *clientv3.Client, ownPrefix string, leaseTTLSeconds int64) (stop func()) {
 	t.Helper()
 	r := &replicator.Replicator{
-		Source:        &testSource{client: localCli, prefix: ownPrefix},
-		Peers:         []replicator.Peer{{Region: "region-b", Endpoints: []string{peerEndpoint}}},
-		Log:           slog.New(slog.DiscardHandler),
-		ResyncBackoff: 100 * time.Millisecond,
+		Source:          &testSource{client: localCli, prefix: ownPrefix},
+		Peers:           []replicator.Peer{{Region: "region-b", Endpoints: []string{peerEndpoint}}},
+		Log:             slog.New(slog.DiscardHandler),
+		ResyncBackoff:   100 * time.Millisecond,
+		LeaseTTLSeconds: leaseTTLSeconds,
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
@@ -190,7 +191,7 @@ func TestReplicator_MirrorsOwnPartition(t *testing.T) {
 	_, err = peerCli.Put(ctx, ownPrefix+"/stale", "gone-local")
 	require.NoError(t, err)
 
-	startReplicator(t, localCli, ownPrefix)
+	startReplicator(t, localCli, ownPrefix, 0)
 
 	// Initial sync: own keys arrive, the stale peer key is pruned.
 	require.Eventually(t, func() bool {
@@ -231,7 +232,7 @@ func TestReplicator_ResumesAfterRestart(t *testing.T) {
 	_, err = localCli.Put(ctx, ownPrefix+"/k2", "v2")
 	require.NoError(t, err)
 
-	stop := startReplicator(t, localCli, ownPrefix)
+	stop := startReplicator(t, localCli, ownPrefix, 0)
 	require.Eventually(t, func() bool {
 		return peerValue(t, peerCli, ownPrefix+"/k1") == "v1" &&
 			peerValue(t, peerCli, ownPrefix+"/k2") == "v2"
@@ -245,9 +246,67 @@ func TestReplicator_ResumesAfterRestart(t *testing.T) {
 	_, err = localCli.Put(ctx, ownPrefix+"/k3", "v3")
 	require.NoError(t, err)
 
-	startReplicator(t, localCli, ownPrefix)
+	startReplicator(t, localCli, ownPrefix, 0)
 	require.Eventually(t, func() bool {
 		return peerValue(t, peerCli, ownPrefix+"/k1") == "" &&
 			peerValue(t, peerCli, ownPrefix+"/k3") == "v3"
 	}, 15*time.Second, 50*time.Millisecond, "resync after restart did not converge")
+}
+
+func TestReplicator_LeaseExpiresOnOriginDeath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	ctx := context.Background()
+	localCli := newClient(t, localEndpoint)
+	peerCli := newClient(t, peerEndpoint)
+
+	ownPrefix := root(t) + "/regions/region-a/clusters/c1"
+	_, err := localCli.Put(ctx, ownPrefix+"/k1", "v1")
+	require.NoError(t, err)
+
+	stop := startReplicator(t, localCli, ownPrefix, 3)
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k1") == "v1"
+	}, 15*time.Second, 50*time.Millisecond, "initial sync did not converge")
+
+	// Origin dies (keepalive stops, no revoke): the mirrored key must expire
+	// with the lease TTL — whole-region failover cleanup on the peer.
+	stop()
+	assert.Equal(t, "v1", peerValue(t, peerCli, ownPrefix+"/k1"), "mirror must not vanish at shutdown (no revoke)")
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k1") == ""
+	}, 20*time.Second, 100*time.Millisecond, "mirrored key did not expire after origin death")
+}
+
+func TestReplicator_LeaseHandoffKeepsMirrorAlive(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	ctx := context.Background()
+	localCli := newClient(t, localEndpoint)
+	peerCli := newClient(t, peerEndpoint)
+
+	ownPrefix := root(t) + "/regions/region-a/clusters/c1"
+	_, err := localCli.Put(ctx, ownPrefix+"/k1", "v1")
+	require.NoError(t, err)
+
+	stop := startReplicator(t, localCli, ownPrefix, 10)
+	require.Eventually(t, func() bool {
+		return peerValue(t, peerCli, ownPrefix+"/k1") == "v1"
+	}, 15*time.Second, 50*time.Millisecond, "initial sync did not converge")
+
+	// Leader handoff: the successor re-puts the (value-unchanged) key under
+	// its fresh lease. If the sync skipped it on value equality alone, it
+	// would stay on the predecessor's lease and expire below.
+	stop()
+	startReplicator(t, localCli, ownPrefix, 10)
+
+	// Watch through the predecessor's TTL expiry (plus slack): the mirrored
+	// key must never disappear across the handoff.
+	deadline := time.Now().Add(14 * time.Second)
+	for time.Now().Before(deadline) {
+		require.Equal(t, "v1", peerValue(t, peerCli, ownPrefix+"/k1"), "mirror dropped during leader handoff")
+		time.Sleep(200 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
## Summary

Phase 2b of the 006 replicator (#511, follows #512): the **origin-heartbeat lease**, the actual failover mechanism.

Every mirrored `Put` now attaches a per-peer lease (`Grant` TTL 30s default + a `KeepAlive` drain goroutine) that only this region's replicator refreshes. Origin liveness == mirror liveness: if the region (or its replicator leader, un-succeeded) dies, the lease lapses on each peer and the whole mirrored subtree expires **together** — whole-region cleanup without any peer judging the origin dead, aligned with the no-unilateral-GC directive. A lost keepalive cancels the peer connection so the loop re-grants and resyncs rather than mirroring onto a dead lease.

### Two corrections to the #510 plan sketch (recorded in the proposal appendix)

1. **No `Lease.Revoke` on clean shutdown.** Revoke deletes every attached key immediately — it would wipe the region's mirror off peers on every registrar roll / leader handoff. Shutdown just stops the keepalive; the successor re-syncs under a fresh lease well inside the TTL, and the old lease expires holding nothing. Only a region that stays down lets the TTL lapse with keys attached — exactly the intended failover semantics.
2. **Sync convergence compares value AND lease.** A value-equal peer key still attached to a predecessor's lease must be re-put to re-attach it to the live lease; skipping on value equality alone would let it silently expire after a handoff.

## Testing

Two new integration tests on the real two-etcd harness, each pinned to one of the corrections:

- **Origin death**: mirror present immediately after shutdown (proves no revoke), then expires at TTL (~3s in-test) — `TestReplicator_LeaseExpiresOnOriginDeath`.
- **Leader handoff**: stop → immediate restart, then continuously assert the mirrored key through the predecessor's full TTL expiry window — fails if either the revoke or the value-only skip were in place — `TestReplicator_LeaseHandoffKeepsMirrorAlive`.

Full `//registrar/...` suite green, lint clean.

Part of #511.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S