### PR TITLE
feat(registrar): replicator metrics + registrar.peerEtcd chart values (006 Phase 2c)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.73.0-{GIT_COMMIT}"
+version: "0.74.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/registrar-deployment.yaml
+++ b/charts/aether/templates/registrar-deployment.yaml
@@ -49,6 +49,9 @@ spec:
             {{- if eq .Values.registrar.registryBackend "etcd" }}
             - "--etcd-endpoints={{ join "," .Values.registrar.etcd.endpoints }}"
             - "--region={{ .Values.registrar.region }}"
+            {{- range .Values.registrar.peerEtcd }}
+            - "--peer-etcd={{ . }}"
+            {{- end }}
             {{- end }}
             - "--grpc-address=:{{ .Values.registrar.service.targetPort }}"
             {{- if .Values.registrar.generateMeshServices }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -485,6 +485,14 @@ registrar:
   # etcd client endpoints (used when registryBackend == etcd).
   etcd:
     endpoints: []
+  # Peer regions' etcd endpoints for cross-region replication (proposal 006
+  # Phase 2), one entry per peer region: "<region>=<endpoint>[,<endpoint>...]".
+  # The leader registrar mirrors this region's own registry subtree verbatim
+  # into each peer's etcd under an origin-heartbeat lease: if this region dies,
+  # its mirror expires on the peers (TTL ~30s) — whole-region failover cleanup.
+  # Requires registryBackend=etcd and a non-default region (one region = one
+  # etcd). Empty = no replication.
+  peerEtcd: []
   # AWS config for the dynamodb registry backend (IRSA web-identity, no static
   # keys; issue #257). roleArn annotates the registrar ServiceAccount with
   # eks.amazonaws.com/role-arn so the pod-identity webhook injects AWS_ROLE_ARN +

--- a/registrar/internal/replicator/BUILD.bazel
+++ b/registrar/internal/replicator/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "replicator",
     srcs = [
         "lease.go",
+        "metrics.go",
         "replicator.go",
     ],
     importpath = "github.com/bpalermo/aether/registrar/internal/replicator",
@@ -12,6 +13,9 @@ go_library(
         "//common/log",
         "@io_etcd_go_etcd_api_v3//v3rpc/rpctypes",
         "@io_etcd_go_etcd_client_v3//:client",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_metric//:metric",
     ],
 )
 

--- a/registrar/internal/replicator/metrics.go
+++ b/registrar/internal/replicator/metrics.go
@@ -1,0 +1,90 @@
+package replicator
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// metrics holds the replicator OTel instruments (proposal 006 P2c). All
+// methods are nil-receiver-safe so the replicator runs unchanged when
+// telemetry is disabled. Every measurement carries a peer.region attribute
+// (bounded: one value per configured peer).
+type metrics struct {
+	connected metric.Int64Gauge
+	events    metric.Int64Counter
+	errors    metric.Int64Counter
+	resyncs   metric.Int64Counter
+	syncSecs  metric.Float64Histogram
+}
+
+// newMetrics builds the instruments on the global MeterProvider (a no-op
+// meter until a provider is installed). Returns nil on registration error
+// (methods are nil-safe).
+func newMetrics() *metrics {
+	meter := otel.Meter("aether/replicator")
+	m := &metrics{}
+	var err error
+	if m.connected, err = meter.Int64Gauge("aether.replicator.peer.connected",
+		metric.WithDescription("1 while the peer mirror stream is live (lease held + synced + watching), 0 while disconnected/redialing (proposal 006)")); err != nil {
+		return nil
+	}
+	if m.events, err = meter.Int64Counter("aether.replicator.events",
+		metric.WithDescription("Watch events mirrored into the peer (op = put|delete)")); err != nil {
+		return nil
+	}
+	if m.errors, err = meter.Int64Counter("aether.replicator.errors",
+		metric.WithDescription("Mirror stream failures (dial, lease grant/keepalive loss, sync, watch, or peer write) that force a redial + resync")); err != nil {
+		return nil
+	}
+	if m.resyncs, err = meter.Int64Counter("aether.replicator.resyncs",
+		metric.WithDescription("Full range-syncs against the peer (initial, post-redial, and compaction-forced)")); err != nil {
+		return nil
+	}
+	if m.syncSecs, err = meter.Float64Histogram("aether.replicator.sync.duration",
+		metric.WithUnit("s"),
+		metric.WithDescription("Full range-sync duration")); err != nil {
+		return nil
+	}
+	return m
+}
+
+func peerAttrs(region string) metric.MeasurementOption {
+	return metric.WithAttributes(attribute.String("peer.region", region))
+}
+
+func (m *metrics) setConnected(ctx context.Context, region string, up bool) {
+	if m == nil {
+		return
+	}
+	v := int64(0)
+	if up {
+		v = 1
+	}
+	m.connected.Record(ctx, v, peerAttrs(region))
+}
+
+func (m *metrics) event(ctx context.Context, region, op string) {
+	if m == nil {
+		return
+	}
+	m.events.Add(ctx, 1, peerAttrs(region), metric.WithAttributes(attribute.String("op", op)))
+}
+
+func (m *metrics) mirrorError(ctx context.Context, region string) {
+	if m == nil {
+		return
+	}
+	m.errors.Add(ctx, 1, peerAttrs(region))
+}
+
+func (m *metrics) resync(ctx context.Context, region string, took time.Duration) {
+	if m == nil {
+		return
+	}
+	m.resyncs.Add(ctx, 1, peerAttrs(region))
+	m.syncSecs.Record(ctx, took.Seconds(), peerAttrs(region))
+}

--- a/registrar/internal/replicator/replicator.go
+++ b/registrar/internal/replicator/replicator.go
@@ -105,7 +105,8 @@ type Replicator struct {
 	ResyncBackoff   time.Duration
 	LeaseTTLSeconds int64
 
-	log *slog.Logger
+	log     *slog.Logger
+	metrics *metrics
 }
 
 // NeedLeaderElection makes the replicator run only on the elected leader
@@ -117,6 +118,7 @@ func (r *Replicator) NeedLeaderElection() bool { return true }
 // own backoff without stalling the others.
 func (r *Replicator) Start(ctx context.Context) error {
 	r.log = commonlog.Named(r.Log, "replicator")
+	r.metrics = newMetrics()
 	if r.DialTimeout == 0 {
 		r.DialTimeout = defaultDialTimeout
 	}
@@ -146,7 +148,9 @@ func (r *Replicator) runPeer(ctx context.Context, log *slog.Logger, p Peer) {
 	for {
 		if err := r.mirrorPeer(ctx, log, p); err != nil && ctx.Err() == nil {
 			log.ErrorContext(ctx, "peer mirror failed; will redial and resync", "error", err)
+			r.metrics.mirrorError(ctx, p.Region)
 		}
+		r.metrics.setConnected(ctx, p.Region, false)
 		select {
 		case <-ctx.Done():
 			return
@@ -187,6 +191,7 @@ func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) e
 	}()
 
 	for {
+		syncStart := time.Now()
 		rev, err := r.syncFull(connCtx, peerCli, lease.id)
 		if err != nil {
 			if ctx.Err() == nil && connCtx.Err() != nil {
@@ -194,8 +199,10 @@ func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) e
 			}
 			return fmt.Errorf("full sync: %w", err)
 		}
+		r.metrics.resync(ctx, p.Region, time.Since(syncStart))
+		r.metrics.setConnected(ctx, p.Region, true)
 		log.InfoContext(ctx, "peer mirror synced; watching", "revision", rev, "leaseID", lease.id)
-		err = r.watchMirror(connCtx, peerCli, lease.id, rev+1)
+		err = r.watchMirror(connCtx, peerCli, p.Region, lease.id, rev+1)
 		if ctx.Err() != nil {
 			return nil
 		}
@@ -262,7 +269,7 @@ func (r *Replicator) syncFull(ctx context.Context, peerCli *clientv3.Client, lea
 // watchMirror replays local watch events verbatim into the peer, starting at
 // startRev; puts attach the origin-heartbeat lease. Returns when the watch or
 // a peer write fails; the caller decides between compaction-resync and redial.
-func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, leaseID clientv3.LeaseID, startRev int64) error {
+func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, region string, leaseID clientv3.LeaseID, startRev int64) error {
 	wch := r.Source.Client().Watch(clientv3.WithRequireLeader(ctx), r.Source.OwnPrefix(),
 		clientv3.WithPrefix(), clientv3.WithRev(startRev))
 	for resp := range wch {
@@ -276,10 +283,12 @@ func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, 
 				if _, err := peerCli.Put(ctx, key, string(ev.Kv.Value), clientv3.WithLease(leaseID)); err != nil {
 					return fmt.Errorf("mirror put: %w", err)
 				}
+				r.metrics.event(ctx, region, "put")
 			case clientv3.EventTypeDelete:
 				if _, err := peerCli.Delete(ctx, key); err != nil {
 					return fmt.Errorf("mirror delete: %w", err)
 				}
+				r.metrics.event(ctx, region, "delete")
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

P2c of the 006 replicator (#511, follows #512/#513): observability + deployment surface.

**Metrics** — five instruments on the `aether/replicator` meter, every measurement attributed by `peer.region` (bounded cardinality: one value per configured peer), nil-receiver-safe like the config-export metrics so telemetry-off deployments run unchanged:

| instrument | type | meaning |
|---|---|---|
| `aether.replicator.peer.connected` | gauge | 1 while the mirror stream is live (lease held + synced + watching) |
| `aether.replicator.events` | counter | mirrored watch events (`op` = put/delete) |
| `aether.replicator.errors` | counter | stream failures forcing redial + resync (incl. keepalive loss) |
| `aether.replicator.resyncs` | counter | full range-syncs (initial, post-redial, compaction-forced) |
| `aether.replicator.sync.duration` | histogram (s) | full range-sync duration |

`peer.connected` is the alerting primitive: a peer stuck at 0 means this region's mirror on that peer is one lease-TTL from expiring.

**Chart** — `registrar.peerEtcd` (list of `"<region>=<endpoint>[,<endpoint>...]"`) rendered as repeated `--peer-etcd` args inside the etcd-backend block; empty default = replication off, zero behavior change. Chart bumped to 0.74.0. Render-verified with `helm template`.

## Testing

Full `//registrar/...` suite green (replicator integration tests re-run against the two-etcd harness with metrics wired — global no-op meter path exercised); lint clean; chart rendering verified for the single- and multi-endpoint peer forms.

Part of #511 — P2 (a+b+c) complete; remaining = P3 two-region e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S