### PR TITLE
feat(ports): drop the legacy 15008 inbound bind (030 Phase C)

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -99,7 +99,7 @@ type SnapshotCache struct {
 	// spireEnabled reports whether SPIRE-backed mTLS is on for the mesh. It is
 	// true by default (the production posture). When false (--spire-enabled=false)
 	// no SVIDs are issued and the SPIRE bridge never delivers SDS secrets, so the
-	// per-pod inbound listener (:15008) is built CLEARTEXT — without a downstream
+	// per-pod inbound listener (:18008) is built CLEARTEXT — without a downstream
 	// mTLS transport socket — to stay symmetric with the outbound clusters, which
 	// already degrade to cleartext when no node SVID is set (clustersEndpointsAndVhosts).
 	// This makes the mesh data path routable without SPIRE (e.g. the MESH-HTTP

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -397,7 +397,7 @@ func (c *SnapshotCache) captureUDPClusters() []types.Resource {
 		}
 		// entry.sni carries the backend's registered application port. The UDP floor
 		// has no inbound mTLS hop, so udp_proxy must reach that app port directly (not
-		// the mesh inbound :15008 the shared bare-name EDS carries) — build an inline
+		// the mesh inbound :18008 the shared bare-name EDS carries) — build an inline
 		// app-port UDP load assignment from the service's endpoints.
 		port, err := strconv.Atoi(entry.sni)
 		if err != nil || port <= 0 || port > 65535 {

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -302,7 +302,7 @@ func (c *SnapshotCache) LoadClustersFromRegistry(ctx context.Context, clusterNam
 			continue
 		}
 		// The outbound service cluster speaks per-source mTLS HTTP/2 to each
-		// destination pod's mesh inbound (pod_ip:15008). The per-source mTLS transport
+		// destination pod's mesh inbound (pod_ip:18008). The per-source mTLS transport
 		// socket is injected at snapshot time (clustersEndpointsAndVhosts).
 		// Server-identity pinning: the union of the endpoints' namespaces
 		// renders the service's expected SPIFFE IDs at snapshot time.

--- a/agent/internal/xds/cache/edge.go
+++ b/agent/internal/xds/cache/edge.go
@@ -593,7 +593,7 @@ func (c *SnapshotCache) virtualHostVhosts() []*routev3.VirtualHost {
 // mesh-registered backend — use the existing mTLS mesh cluster path (unchanged).
 // If NOT in the registry, the backend is a plain k8s Service: return the cleartext
 // STRICT_DNS cluster name (EdgeK8sClusterName) so the edge dials the k8s Service
-// FQDN over cleartext instead of attempting a mesh mTLS connection to :15008.
+// FQDN over cleartext instead of attempting a mesh mTLS connection to :18008.
 //
 // Mesh path: Port 0 -> the default cluster (ServiceClusterName). A non-zero port ->
 // its per-port cluster if one exists; otherwise, if the port is the service's

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -338,7 +338,7 @@ func NewTCPServiceCluster(name, edsServiceName, altStatName string, perDownstrea
 //
 // The cluster is STATIC with an inline load assignment rather than EDS: the UDP
 // floor has no inbound mTLS hop, so udp_proxy must reach the backend's application
-// UDP port directly — not the mesh inbound :15008 that the shared bare-name EDS
+// UDP port directly — not the mesh inbound :18008 that the shared bare-name EDS
 // carries. Callers pass a load assignment from UDPLoadAssignment (app-port endpoints).
 func NewUDPServiceCluster(name, altStatName string, loadAssignment *endpointv3.ClusterLoadAssignment) *clusterv3.Cluster {
 	return &clusterv3.Cluster{
@@ -368,7 +368,7 @@ func NewUDPServiceCluster(name, altStatName string, loadAssignment *endpointv3.C
 }
 
 // UDPLoadAssignment derives an inline UDP load assignment from a service's existing
-// (TCP-inbound, :15008) load assignment: it clones it and rewrites every endpoint to
+// (TCP-inbound, :18008) load assignment: it clones it and rewrites every endpoint to
 // the backend's application UDP port and UDP protocol. The UDP floor has no inbound
 // mTLS proxy, so udp_proxy reaches the application port directly. Returns nil if src
 // is nil.
@@ -468,7 +468,7 @@ const remoteClusterPriorityBand = 3
 // instead of its (cross-cluster, possibly non-routable) pod IP, and is tagged
 // with waypoint metadata so the cluster's transport-socket matcher can present
 // the structured SNI. When disabled (the default) every endpoint is dialed at
-// pod_ip:15008 — the flat pod-to-pod path (proposal 018 flat-network mode),
+// pod_ip:18008 — the flat pod-to-pod path (proposal 018 flat-network mode),
 // unchanged. LocalCluster is this agent's own cluster name.
 type WaypointRewrite struct {
 	Enabled      bool
@@ -568,7 +568,7 @@ func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceE
 		locality = &corev3.Locality{Region: loc.GetRegion(), Zone: loc.GetZone()}
 	}
 
-	// Local: the destination pod's mesh inbound (pod_ip:15008), reached by the
+	// Local: the destination pod's mesh inbound (pod_ip:18008), reached by the
 	// pod's own netns-bound inbound listener. Remote (waypoint): the destination
 	// node's routable IP + tunnel port, where that node's host-network proxy
 	// SNI-forwards to the local pod — the source's mTLS passes through unchanged.

--- a/agent/internal/xds/proxy/ingress.go
+++ b/agent/internal/xds/proxy/ingress.go
@@ -26,14 +26,9 @@ const (
 	// defaultInboundPort is the mesh inbound port. The per-pod inbound listener binds
 	// it inside the pod's network namespace, and source proxies dial the destination
 	// pod at <pod_ip>:defaultInboundPort. In aether's 18xxx range, out of Istio's
-	// reserved 15000-15090 band — 15008 is Istio's HBONE number (proposal 030,
-	// Phase B: dialers flipped here after the whole fleet dual-bound in Phase A).
+	// reserved 15000-15090 band — the pre-030 port was 15008, Istio's HBONE
+	// number (migrated via the proposal 030 dual-bind transition).
 	defaultInboundPort = 18008
-	// legacyInboundPort is the pre-030 inbound port, still bound (additional
-	// address) so proxies one release behind — still dialing 15008 — keep
-	// working through the Phase B roll. Phase C (next release, after the fleet
-	// fully rolls) drops this bind.
-	legacyInboundPort = 15008
 
 	// MeshLivePath is the liveness path answered locally by the inbound listener: a
 	// 200 proves the proxy config is loaded and the listener is serving, and (since
@@ -106,24 +101,6 @@ func NewInboundListener(cniPod *cniv1.CNIPod, trustDomain string, emitStatsPod b
 				},
 			},
 		},
-		// Proposal 030 Phase B: the legacy port stays bound (same netns, same
-		// filter chains) so one-release-stale dialers still connect; Phase C
-		// drops it after this release fully rolls. Same-listener
-		// additional address (not a second listener) keeps stats/drain unified.
-		AdditionalAddresses: []*listenerv3.AdditionalAddress{{
-			Address: &corev3.Address{
-				Address: &corev3.Address_SocketAddress{
-					SocketAddress: &corev3.SocketAddress{
-						Protocol: corev3.SocketAddress_TCP,
-						Address:  defaultInboundAddress,
-						PortSpecifier: &corev3.SocketAddress_PortValue{
-							PortValue: legacyInboundPort,
-						},
-						NetworkNamespaceFilepath: cniPod.GetNetworkNamespace(),
-					},
-				},
-			},
-		}},
 		// Per-pod listener stats are kept deliberately (downstream_cx_* per pod
 		// is the connection-leak debugging signal — see the 2026-06-11 cx-leak).
 		// The "inbound_<pod>" shape is what the aether.pod stats_tag extracts, so

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -36,7 +36,7 @@ func OutboundListenerName(cniPod *cniv1.CNIPod) string {
 
 // GenerateListenersFromRegistryPod generates the per-pod inbound and outbound HTTP
 // listeners and the per-pod application and health-probe clusters for a pod.
-// The inbound listener (netns-bound, mTLS) accepts mesh traffic at <pod_ip>:15008
+// The inbound listener (netns-bound, mTLS) accepts mesh traffic at <pod_ip>:18008
 // and forwards it to the pod's application on loopback; the outbound listener routes
 // the pod's traffic to other services. The trustDomain names the pod's SVID and the
 // SDS validation context for the inbound listener's mTLS.

--- a/agent/internal/xds/proxy/waypoint.go
+++ b/agent/internal/xds/proxy/waypoint.go
@@ -58,7 +58,7 @@ func BuildWaypointTunnelListener(tunnelPort uint32, chains []*listenerv3.FilterC
 // matches the structured waypoint SNI by suffix ("*.<fqdn>" — Envoy's leftmost
 // wildcard is a suffix match, which is safe because aether owns the SNI and each
 // service has a unique .<fqdn> suffix) and tcp_proxies the raw (still-mTLS)
-// stream to that service's local pods at :15008.
+// stream to that service's local pods at :18008.
 func BuildWaypointTunnelChain(fqdn string) *listenerv3.FilterChain {
 	name := "ew_" + fqdn
 	return &listenerv3.FilterChain{

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.75.0-{GIT_COMMIT}"
+version: "0.75.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         # ALL its egress (apiserver, registrar, collector) to a capture port with no
         # listener → the edge control plane can't reach anything. Opt out explicitly
         # via the annotation the CNI DOES honor. (Scoped :18081 redirect is harmless:
-        # the edge dials :443/:4317 and backend :15008, never a mesh :18081.)
+        # the edge dials :443/:4317 and backend :18008, never a mesh :18081.)
         capture.aether.io/redirect-all: "false"
       labels:
         {{- include "aether.edge.labels" . | nindent 8 }}


### PR DESCRIPTION
Final phase of proposal 030. The inbound listener now binds **only 18008**; the legacy 15008 additional address and `legacyInboundPort` are gone, and the stale `:15008` comment/doc references are swept to `:18008` (proposal docs stay as historical record).

**Gate satisfied**: Phase B (#520) is fully rolled on talos (rev 168), verified hitless (prober 15,000/15,000 in-window, 0 errors; mesh + edge 200 with all dialers on 18008). Anything still dialing 15008 after this rolls would be two releases stale.

With this, every aether data-plane port is out of Istio's reserved 15000-15090 band: 18081/18001/18054/18008/18009/18021, fwmark 0xae7e. Exit check = consolidated soak on the rolled build (armed for tonight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S