### PR TITLE
docs: refresh stale info + document GAMMA improvements and multi-cluster routing

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,9 +68,11 @@ access-log/tracing policy via the MeshConfig CR.
 
 | Key | Default | Purpose |
 |---|---|---|
-| `agent.gamma` | `false` | GAMMA east-west L7 routing (018 Phase 2): watch `HTTPRoute`s parented to a Service and enrich outbound routes. Requires the Gateway API CRDs. |
+| `agent.gamma` | `false` | GAMMA east-west L7 routing (018): watch `HTTPRoute`s **and `GRPCRoute`s** parented to a Service (plus `ReferenceGrant`s and `HTTPFilter` attachments) and apply them on **both** the explicit outbound path and the transparent-capture path. MESH-HTTP Core conformance-green. Requires the Gateway API CRDs. |
 | `agent.importConfig` | `false` | Cross-cluster config import (026): poll the registrar for peer-exported GAMMA projections and materialize them (merged with local; local wins). Pairs with `registrar.registryBackend=etcd`. |
-| `agent.l4Routes` | `false` | L4 route types (018 Phase 3b): `TCPRoute`/`TLSRoute`/`UDPRoute` parented to a Service → weighted TCP + per-SNI TLS chains on the capture listener. Requires `transparentCapture`. UDPRoute is control-plane only. |
+| `agent.l4Routes` | `true` | L4 route types (018 Phase 3b): `TCPRoute` (weighted, incl. weight-0 drain) / `TLSRoute` (SNI passthrough) / `UDPRoute` parented to a Service → weighted TCP + per-SNI TLS chains on the capture listener. Requires `transparentCapture`. UDPRoute is control-plane only (plaintext floor, no DTLS). |
+| `agent.eastWestWaypoint` | `false` | East/west waypoint (019): dial **cross-cluster** endpoints at their node's routable IP + `eastWestTunnelPort` instead of the (unroutable) pod IP; this node's host-network proxy SNI-forwards inbound tunnel traffic to local pods. Intra-cluster stays direct pod-to-pod. Needs cross-cluster endpoint visibility (shared or replicated etcd) + a shared SPIRE trust domain. |
+| `agent.eastWestTunnelPort` | `18009` | Host-netns tunnel port (must match across the clusterset). |
 | `agent.transparentCapture` | `true` | Transparent capture (018 Phase 3a): per-pod capture listeners + the `cap_http` route table from generated mesh Services. Pairs with `registrar.generateMeshServices`. |
 | `agent.captureRedirectAll` | `false` | Add the dormant ORIGINAL_DST passthrough chain (022) so a pod annotated `capture.aether.io/redirect-all="true"` can redirect ALL outbound TCP. Per-pod opt-in. Requires `transparentCapture`. |
 | `agent.captureRedirectAllDefault` | `true` | Make redirect-all the DEFAULT for managed pods (022 Step 4); opt out per-pod with `capture.aether.io/redirect-all="false"`. Implies `captureRedirectAll`. Requires `transparentCapture`. Riskiest blast radius; soak-validated hitless. |
@@ -127,8 +129,9 @@ access-log/tracing policy via the MeshConfig CR.
 | `registrar.replicaCount` | `2` | Always 2 (exercises the multi-replica write-behind topology). |
 | `registrar.generateMeshServices` | `true` | Project the mesh catalog into selectorless k8s Services (transparent-capture VIPs, 018 Phase 3a) that `transparentCapture` + `meshDns` depend on. |
 | `registrar.enableMCS` | `false` | Multi-Cluster Services phase 1 (018 + 006): export `ServiceExport`s and materialize `ServiceImport`s + clusterset VIPs. Requires the etcd backend + the MCS-API CRDs. |
-| `registrar.region` | `local` | Region owning this registrar's etcd partition (006); keys are `/aether/v1/regions/<region>/clusters/<clusterName>/…`. |
+| `registrar.region` | `local` | Region owning this registrar's etcd partition (006); keys are `/aether/v1/regions/<region>/clusters/<clusterName>/…`. One region = one etcd. |
 | `registrar.etcd.endpoints` | `[]` | etcd client endpoints (etcd backend). |
+| `registrar.peerEtcd` | `[]` | Cross-region replication (006 Phase 2), one entry per peer region: `"<region>=<endpoint>[,<endpoint>...]"`. The leader registrar mirrors this region's own registry subtree verbatim into each peer's etcd under an **origin-heartbeat lease** (TTL ~30s): if this region dies, its mirror expires on the peers — whole-region failover cleanup with no peer-side GC. Requires the etcd backend + a non-default `region`. |
 | `registrar.aws.region` | `us-east-1` | AWS region for the dynamodb backend (IRSA; no static keys). |
 | `registrar.aws.roleArn` | `""` | Role ARN annotated onto the registrar ServiceAccount. Empty = no AWS access. |
 | `registrar.service.{port,targetPort}` | `443` / `8443` | gRPC service ports. |
@@ -184,15 +187,16 @@ over mTLS and routes external traffic via the Gateway API. Disabled by default.
 
 ## 2. CRDs (`charts/crds`)
 
-Both are `config.aether.io/v1`, **Namespaced**, structural-but-permissive
+All are `config.aether.io/v1`, **Namespaced**, structural-but-permissive
 (`x-kubernetes-preserve-unknown-fields`); authoritative validation is the
-controller's protovalidate webhook, not OpenAPI. Both carry
+controller's protovalidate webhook, not OpenAPI. All carry
 `helm.sh/resource-policy: keep`.
 
 | CRD | Kind (short) | Purpose |
 |---|---|---|
 | `meshconfigs.config.aether.io` | `MeshConfig` (`mc`) | Per-namespace proxy observability overrides (access logs, tracing, per-pod stats). A namespace inherits the control-plane namespace's `MeshConfig` field-by-field unless it sets its own (proposal 015). |
 | `httpfilters.config.aether.io` | `HTTPFilter` (`htf`) | The proxy-extension escape hatch (proposal 025): attach a supported Envoy HTTP filter (ext_authz, RBAC, header-to-metadata) at a chosen scope. |
+| `edgeconfigs.config.aether.io` | `EdgeConfig` | Edge Envoy tuning (proposal 029): best-practices hardening defaults, HTTP/3 (QUIC, ALPN `h3`), timeouts/limits. Attached natively via Gateway API `parametersRef` on the `GatewayClass` (fleet default) or per-`Gateway` (override-wins merge). |
 
 **`HTTPFilter` scopes** (`spec.scope`, plus the `target_refs` attachment):
 
@@ -228,12 +232,14 @@ Node-agent-specific:
 | `--mounted-registry-dir` | `/host/var/lib/aether/registry` | Local pod-data dir for the CNI plugin. |
 | `--spire-admin-socket` | `/tmp/spire-agent/private/admin.sock` | SPIRE admin socket for proxy SVID delegation. |
 | `--remove-startup-taint` | `true` | Remove the `aether.io/agent-not-ready` node taint once the CNI server serves. |
-| `--gamma` | `false` | Enable GAMMA east-west routing (018 Phase 2). |
+| `--gamma` | `false` | Enable GAMMA east-west routing (018): HTTPRoute + GRPCRoute parented to Services, on the outbound and capture paths. |
 | `--import-config` | `false` | Enable cross-cluster config import (026). |
 | `--control-cluster` | `""` | Trust imported config ONLY from this origin (026 EM3). Empty = federated. |
 | `--transparent-capture` | `false` | Per-pod capture listeners + `cap_http` (018 Phase 3a). |
 | `--capture-redirect-all` | `false` | Dormant ORIGINAL_DST passthrough chain (022). |
-| `--l4-routes` | `false` | L4 route types (018 Phase 3b). |
+| `--l4-routes` | `false` | L4 route types (018 Phase 3b). The chart passes it (default ON there). |
+| `--east-west-waypoint` | `false` | Per-node east/west waypoint for cross-cluster traffic (019). |
+| `--east-west-tunnel-port` | `18009` | Host-netns tunnel port (clusterset-wide). |
 | `--mesh-dns` | `false` | Per-pod mesh DNS (018). |
 | `--mesh-dns-upstream` | `[]` | Upstream resolver(s) for non-mesh queries. |
 | `--authz-sidecar` | `false` | Node-local ext_authz sidecar entry (027). |
@@ -268,10 +274,12 @@ The Envoy hot-restart supervisor (proposal 001): `--envoy-path`
 
 `--cluster-name` (required), `--mesh-domain` (`aether.internal`),
 `--control-cluster` (`""`), `--region` (`""`), `--registry-backend`
-(`kubernetes`), `--etcd-endpoints` (`[localhost:2379]`), `--sync-interval` (`5s`),
-`--generate-mesh-services` (`false`), `--enable-mcs` (`false`), `--grpc-address`
-(`:8443`), `--spire-enabled` (`true`), `--spire-workload-socket`,
-`--spire-trust-domain` (`ROOTCA` sentinel).
+(`kubernetes`), `--etcd-endpoints` (`[localhost:2379]`), `--peer-etcd`
+(repeatable, `<region>=<endpoint>[,<endpoint>...]` — cross-region replication,
+006 Phase 2; requires the etcd backend + an explicit `--region`),
+`--sync-interval` (`5s`), `--generate-mesh-services` (`false`), `--enable-mcs`
+(`false`), `--grpc-address` (`:8443`), `--spire-enabled` (`true`),
+`--spire-workload-socket`, `--spire-trust-domain` (`ROOTCA` sentinel).
 
 ### `controller`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -6,10 +6,13 @@ A practical guide to installing Aether and onboarding your first workload.
 > in Go. A per-node **agent** (DaemonSet) runs an Envoy xDS control plane and a
 > chained CNI plugin; a per-node **Envoy proxy** (DaemonSet) carries the traffic;
 > an in-cluster **registrar** tracks service endpoints; and a **controller**
-> serves the `MeshConfig` admission webhook. Every pod-to-pod hop is mTLS with
-> SPIFFE identities — including same-node hops. There is **no iptables
-> interception**: applications reach the mesh by dialing a local outbound
-> listener explicitly.
+> serves the admission webhooks. Every pod-to-pod hop is mTLS with SPIFFE
+> identities — including same-node hops. Interception is **transparent by
+> default**: managed pods' outbound traffic is redirected into the mesh by the
+> CNI, mesh names resolve via a per-node mesh DNS, and apps simply dial
+> `http://<svc>.<ns>.<meshDomain>` (or the ordinary Kubernetes Service name).
+> An explicit local outbound listener (`127.0.0.1:18081` + `Host` header)
+> remains available for clients that prefer zero interception assumptions.
 
 ---
 
@@ -24,9 +27,11 @@ A practical guide to installing Aether and onboarding your first workload.
 7. [Call other services](#call-other-services)
 8. [Roll without dropping requests](#hitless-rolls)
 9. [Advanced routing (pinning, subsets, locality)](#advanced-routing)
-10. [North-south ingress (the edge gateway)](#edge)
-11. [Observability](#observability)
-12. [Troubleshooting](#troubleshooting)
+10. [Shape traffic with Gateway API (GAMMA)](#gamma)
+11. [North-south ingress (the edge gateway)](#edge)
+12. [Multi-cluster and multi-region](#multi-cluster)
+13. [Observability](#observability)
+14. [Troubleshooting](#troubleshooting)
 
 ---
 
@@ -41,10 +46,10 @@ flowchart TB
 
     subgraph node["per node"]
         agent["agent (DaemonSet)<br/>CNI plugin + xDS control plane (Unix socket)<br/>builds the Envoy snapshot<br/>(listeners / clusters / endpoints / routes)"]
-        proxy["Envoy proxy (DaemonSet)<br/>binds outbound listener 127.0.0.1:18081<br/>inside EACH managed pod's netns"]
+        proxy["Envoy proxy (DaemonSet)<br/>capture + outbound listeners<br/>inside EACH managed pod's netns"]
         app["app pod"]
         agent -->|xDS snapshot| proxy
-        app -->|"HTTP → 127.0.0.1:18081<br/>(Host: my-svc.aether.internal)"| proxy
+        app -->|"HTTP → my-svc.ns.aether.internal:18081<br/>(transparently captured; mesh DNS)"| proxy
     end
 
     agent -->|"register / deregister<br/>at CNI ADD / DEL"| registrar
@@ -52,12 +57,16 @@ flowchart TB
     proxy -->|"mTLS — SPIFFE identity per workload"| dest["destination pod<br/>(this or another node)"]
 ```
 
-- **Identity = ServiceAccount.** A pod's mesh service name is its
-  **ServiceAccount name**; its SPIFFE ID is
+- **Identity = ServiceAccount, scoped by namespace.** A pod's mesh service is
+  its **ServiceAccount name in its namespace** (`<ns>/<sa>`); its SPIFFE ID is
   `spiffe://<trust-domain>/ns/<namespace>/sa/<serviceaccount>`. Pods sharing a
-  ServiceAccount are endpoints of the same service.
-- **Explicit addressing.** Apps call `http://127.0.0.1:18081` with
-  `Host: <service>.<meshDomain>`. No traffic is transparently captured.
+  ServiceAccount (in one namespace) are endpoints of the same service.
+- **Transparent addressing (default).** The CNI redirects managed pods'
+  outbound TCP into the per-pod capture listener and DNATs `:53` to a per-node
+  mesh DNS. Apps dial `http://<svc>.<ns>.<meshDomain>:18081` — or the
+  generated Kubernetes Service name `<svc>.<ns>.svc.cluster.local:18081` —
+  with no client changes. The explicit listener (`127.0.0.1:18081` +
+  `Host: <svc>.<ns>.<meshDomain>`) still works everywhere.
 - **Demand-scoped.** Each node only receives the config for the services its
   local pods actually call (declared up front, or fetched on first use).
 
@@ -91,7 +100,7 @@ can be upgraded independently), then the system chart.
 # Pick the published version (chart version == git commit of the release).
 VERSION=0.x.0-<commit>
 
-# 1) CRDs (MeshConfig, HTTPFilter) — install/upgrade first.
+# 1) CRDs (MeshConfig, HTTPFilter, EdgeConfig) — install/upgrade first.
 helm upgrade --install aether-crds \
   oci://ghcr.io/bpalermo/aether/charts/crds \
   --version "$VERSION"
@@ -116,7 +125,7 @@ Verify:
 
 ```bash
 kubectl -n aether-system get pods         # agent + proxy per node, registrar ×2, controller
-kubectl get meshconfig                    # the singleton "default" MeshConfig CR
+kubectl -n aether-system get meshconfig   # the seeded "default" MeshConfig CR
 ```
 
 ---
@@ -133,7 +142,7 @@ Set once at the top of the `aether` chart's values; every component inherits it.
 | Value | Default | What it does |
 |---|---|---|
 | `clusterName` | `talos-main` | Cluster name in registry keys (registrars are per-cluster; names need not be unique across clusters). |
-| `meshDomain` | `aether.internal` | The authority suffix services are addressed under (`<svc>.<meshDomain>`). Also defaults the SPIRE trust domain. |
+| `meshDomain` | `aether.internal` | The authority suffix services are addressed under (`<svc>.<ns>.<meshDomain>`). Also defaults the SPIRE trust domain. |
 | `spire.enabled` | `true` | Mesh-wide mTLS switch. |
 | `spire.trustDomain` | `""` (→ `ROOTCA` sentinel) | SPIFFE trust domain authorized for the registrar's mTLS peers. |
 | `spire.workloadSocketPath` | `/run/secrets/workload-spiffe-uds/socket` | Workload API socket. |
@@ -143,17 +152,21 @@ Set once at the top of the `aether` chart's values; every component inherits it.
 | `registrar.aws.region` / `agent.awsCredentials` | — | DynamoDB backend config. |
 | `otel.enabled` / `otel.endpoint` | `false` / `""` | Turn on OTel and point at an OTLP gRPC collector (`host:port`). |
 | `proxy.enabled` | `true` | Deploy the per-node Envoy. Set false to run only the agent. |
-| `edge.enabled` | `false` | Deploy the north-south ingress gateway (see §10). |
+| `edge.enabled` | `false` | Deploy the north-south ingress gateway (see §11). |
 
 ### 4b. Runtime proxy observability (the `MeshConfig` CR)
 
-The controller seeds a **singleton** `MeshConfig` named `default` on first install
-and never overwrites it on upgrade — you own it via `kubectl` thereafter. It
-**only** overrides the proxy data plane's observability (access logs, tracing,
-per-pod stats); everything else stays inherited from the system config.
+`MeshConfig` is **namespaced**: the controller seeds one named `default` in the
+control-plane namespace on first install and never overwrites it on upgrade —
+you own it via `kubectl` thereafter. Every workload namespace inherits it
+field-by-field unless it defines its own `MeshConfig` (at most one per
+namespace). It **only** overrides the proxy data plane's observability (access
+logs, tracing, per-pod stats); everything else stays inherited from the system
+config.
 
 ```bash
-kubectl edit meshconfig default
+kubectl -n aether-system edit meshconfig default   # mesh-wide baseline
+kubectl -n my-namespace apply -f my-meshconfig.yaml  # per-namespace override
 ```
 
 ```yaml
@@ -244,7 +257,8 @@ spec:
             preStop: { sleep: { seconds: 10 } }   # see §8
 ```
 
-Your service is now addressable mesh-wide as `my-svc.aether.internal`.
+Your service is now addressable mesh-wide as `my-svc.<namespace>.aether.internal`
+(and via the generated `my-svc.<namespace>.svc.cluster.local` Service).
 
 ### Optional endpoint annotations
 
@@ -262,18 +276,39 @@ Your service is now addressable mesh-wide as `my-svc.aether.internal`.
 <a name="call-other-services"></a>
 ## 7. Call other services
 
-Send requests to the **local outbound listener** with the destination's mesh FQDN
-in the `Host` header:
+With transparent capture + mesh DNS (both on by default), just dial the
+destination by name — no client changes, no special listener:
 
 ```bash
-# from inside a managed pod
-curl http://127.0.0.1:18081/orders -H 'Host: svc-payments.aether.internal'
+# from inside a managed pod — either form works
+curl http://svc-payments.payments.aether.internal:18081/orders
+curl http://svc-payments.payments.svc.cluster.local:18081/orders
 ```
 
-- **Authorities are FQDN-only:** `<service>.<meshDomain>` is the single accepted
-  form. Bare names (`Host: svc-payments`), foreign domains, or nested labels match
-  no route and **404 immediately**. A `:port` suffix is stripped before routing.
+- **Mesh FQDNs are namespace-qualified:** `<service>.<namespace>.<meshDomain>`
+  (proposal 020). The registrar also generates a selectorless Kubernetes
+  Service per mesh service, so the ordinary
+  `<service>.<namespace>.svc.cluster.local` name is captured too. Port `18081`
+  is the mesh port those generated Services expose.
+- With **redirect-all** (the default, proposal 022) *all* outbound TCP from a
+  managed pod is captured: mesh destinations are routed by the mesh, and
+  anything else (external APIs, non-mesh Services) passes through untouched.
+  Carve-outs are per-pod annotations (`capture.aether.io/*`, see the
+  configuration reference).
 - The callee sees the caller's SPIFFE ID in `x-forwarded-client-cert` (XFCC).
+
+### The explicit listener (still supported)
+
+Clients that prefer zero interception assumptions can keep addressing the
+local outbound listener directly:
+
+```bash
+curl http://127.0.0.1:18081/orders -H 'Host: svc-payments.payments.aether.internal'
+```
+
+Authorities are FQDN-only and deterministic: bare names, foreign domains, or
+nested labels match no route and **404 immediately**. A `:port` suffix is
+stripped before routing.
 
 ### Declare your upstreams (recommended)
 
@@ -376,8 +411,57 @@ labels express no preference.
 
 ---
 
+<a name="gamma"></a>
+## 10. Shape traffic with Gateway API (GAMMA)
+
+East-west traffic management uses the **standard Gateway API route types
+parented to a Service** (the GAMMA pattern) — no custom routing CRDs. Enable
+it with `agent.gamma=true` (requires the Gateway API CRDs); L4 route types are
+on by default (`agent.l4Routes`).
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: my-svc-canary
+  namespace: payments
+spec:
+  parentRefs:
+    - kind: Service            # ← GAMMA: parented to the SERVICE, not a Gateway
+      name: my-svc
+  rules:
+    - backendRefs:
+        - { kind: Service, name: my-svc,    port: 8080, weight: 90 }
+        - { kind: Service, name: my-svc-v2, port: 8080, weight: 10 }
+```
+
+What's supported, all applied **transparently on the capture path** as well as
+the explicit listener (so callers need no changes):
+
+- **`HTTPRoute`** — weighted canary, header/path matching + mutation,
+  redirects, timeouts, mirroring; Mesh conformance profile (MESH-HTTP Core)
+  green.
+- **`GRPCRoute`** — method-based routing (`<svc>/<method>` matched as a path).
+- **`TCPRoute`** — weighted L4 splits across backends; an explicit `weight: 0`
+  drains a backend.
+- **`TLSRoute`** — SNI-based passthrough routing.
+- (`UDPRoute` is accepted but control-plane-only for now.)
+- **Cross-namespace backends** need a standard `ReferenceGrant`.
+- The parent must be a **registry-backed mesh Service** (one with live
+  endpoints) — a selectorless "anchor" Service won't survive reconciliation.
+
+For behavior the route types can't express, the **`HTTPFilter` CRD** (proposal
+025) attaches a vetted set of raw Envoy HTTP filters — `ext_authz` (pairs with
+the node-local authz sidecar + OPA preset, proposal 027), `RBAC` (peer-SAN
+allow/deny), `header-to-metadata` — per route (Gateway API `ExtensionRef`),
+per Service (`targetRefs`), service-wide (`SCOPE_CHAIN`), or on the
+destination's inbound (`SCOPE_INBOUND`). Validation is fail-closed via the
+controller webhook.
+
+---
+
 <a name="edge"></a>
-## 10. North-south ingress (the edge gateway)
+## 11. North-south ingress (the edge gateway)
 
 The optional **edge** is an unprivileged Deployment (its own `aether-ingress`
 namespace by default) running Envoy + an `agent edge` sidecar. It dials mesh pods
@@ -436,8 +520,45 @@ spec:
 
 ---
 
+<a name="multi-cluster"></a>
+## 12. Multi-cluster and multi-region
+
+Multi-cluster is layered: each plane is independent and opt-in, and they
+compose into full cross-cluster routing. All of it requires the **etcd**
+registry backend (the cross-cluster plane) and, for any cross-cluster data
+path, **one SPIFFE trust domain shared across clusters** (e.g. SPIRE with a
+shared upstream CA) so identities verify across the cluster line.
+
+| Plane | What it does | Enable |
+|---|---|---|
+| **Endpoints (MCS)** | `ServiceExport` publishes a service to the clusterset; every cluster materializes a `ServiceImport` + clusterset VIP and sees the remote endpoints. | `registrar.enableMCS=true` (+ the MCS-API CRDs) |
+| **Config (026)** | Exported services' GAMMA routes (`HTTPRoute`/`GRPCRoute`, incl. `HTTPFilter` chain scope) propagate to peer clusters and merge into their proxies (local config wins). | exporter: `registrar.enableMCS=true`; importer: `agent.importConfig=true`. Optionally pin one authoritative exporter with `controlCluster=<name>` |
+| **Data path (019)** | When pod IPs aren't routable across clusters (the usual case), cross-cluster endpoints are dialed at their **node's** routable IP on the east/west tunnel port (`18009`); the destination node's proxy SNI-forwards to the local pod. mTLS stays end-to-end pod↔pod. Intra-cluster traffic is unaffected. | `agent.eastWestWaypoint=true` on all clusters (tunnel port must match clusterset-wide) |
+| **Multi-region (006)** | One etcd per region (`registrar.region`); each region's registrar mirrors its own registry subtree into peer regions' etcds under an **origin-heartbeat lease** — a dead region's mirror expires everywhere at the lease TTL (~30s), and locality keeps foreign endpoints on the failover path (EDS priority 2). | `registrar.region=<region>` + `registrar.peerEtcd=["<peer>=<endpoints>"]` per direction |
+
+Minimal two-cluster recipe (shared regional etcd, cross-cluster service
+`echo` living only in cluster `b`, called from cluster `a`):
+
+```bash
+# both clusters: etcd backend + waypoint + a shared trust domain
+--set registrar.registryBackend=etcd \
+--set "registrar.etcd.endpoints[0]=http://<shared-etcd>:2379" \
+--set registrar.enableMCS=true \
+--set agent.eastWestWaypoint=true \
+--set clusterName=<unique-per-cluster>
+```
+
+Then `kubectl apply` a `ServiceExport` for `echo` in cluster `b`; a client in
+`a` calls `http://echo.<ns>.<meshDomain>:18081/` and the request rides
+mesh DNS → capture → split-horizon EDS → b's node tunnel → the echo pod,
+mTLS end-to-end. (The reusable e2e harnesses under `e2e/` —
+`multicluster_config.sh`, `multicluster_waypoint.sh`,
+`multicluster_replicator.sh` — stand up exactly these topologies with kind.)
+
+---
+
 <a name="observability"></a>
-## 11. Observability
+## 13. Observability
 
 Turn on OTel once at the system level:
 
@@ -461,12 +582,12 @@ otel:
 ---
 
 <a name="troubleshooting"></a>
-## 12. Troubleshooting
+## 14. Troubleshooting
 
 | Symptom | Likely cause | Check |
 |---|---|---|
 | App can't reach the mesh (connection refused to `127.0.0.1:18081`) | Pod isn't managed, or the proxy hasn't programmed the listener yet | Confirm `aether.io/managed: "true"` and that the pod is **not** in an ignored namespace (§5); check the agent log for `adding listeners for pod`. |
-| Request 404s immediately | Authority isn't a valid mesh FQDN | Use `Host: <service>.<meshDomain>` exactly — bare names and foreign domains 404 at the route table. |
+| Request 404s immediately | Authority isn't a valid mesh FQDN | Use the namespace-qualified `<service>.<namespace>.<meshDomain>` (or the k8s Service name) — bare names and foreign domains 404 at the route table. |
 | Request 503s on a pin | The pinned endpoint is gone (drained/ejected/never existed) | Pin-or-fail is by design; drop the `x-aether-ip`/`x-aether-pod` header to load-balance. |
 | First call to a service is slow | Cold path (undeclared upstream) — one xDS round-trip | Declare it in `config.aether.io/upstreams`; watch `aether.agent.upstreams.miss`. |
 | Dropped requests during a roll | Missing `minReadySeconds` / `preStop` / `maxUnavailable: 0` | Apply all three (§8); avoid `--grace-period=0`. |
@@ -477,7 +598,7 @@ otel:
 ```bash
 kubectl -n aether-system logs ds/aether-agent           # control plane + CNI
 kubectl -n aether-system logs ds/aether-proxy           # the Envoy data plane
-kubectl get meshconfig default -o yaml                  # effective proxy observability
+kubectl -n aether-system get meshconfig default -o yaml  # effective proxy observability
 kubectl get httproutes -A                               # north-south + GAMMA routes
 ```
 
@@ -490,4 +611,6 @@ kubectl get httproutes -A                               # north-south + GAMMA ro
 - [`charts/README.md`](../charts/README.md) — chart layout, image mirroring,
   versioning/stamping.
 - `docs/proposals/` — design records: `003` (edge), `004` (demand-scoped),
+  `018` (Gateway API/GAMMA/capture), `019` (east/west waypoint), `006`
+  (multi-region replication), `025`–`027` (filters/authz),
   `013` (prober), `014` (access logs), `015` (MeshConfig).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -393,7 +393,7 @@ metadata:
 
 ```bash
 # on the request (consumer)
-curl http://127.0.0.1:18081/ -H 'Host: my-svc.aether.internal' \
+curl http://127.0.0.1:18081/ -H 'Host: my-svc.my-namespace.aether.internal' \
      -H 'x-aether-subset-version: v2'
 ```
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -165,6 +165,22 @@ on `b` is unobservable. See the script header and `e2e/kind-cluster.yaml` (which
 also assigns non-overlapping pod/service CIDRs per cluster so cross-cluster
 endpoints in the shared registry never collide).
 
+### The other multi-cluster harnesses
+
+Two sibling harnesses reuse the same two-kind pattern (same `up`/`test`/
+`verify`/`down` verbs, same inotify gotcha); both run SPIRE on each cluster
+under a **shared trust domain** (shared upstream CA in `e2e/certs/`):
+
+- [`e2e/multicluster_waypoint.sh`](../e2e/multicluster_waypoint.sh) — the
+  **019 east/west waypoint data path**: two clusters + ONE shared etcd,
+  `agent.eastWestWaypoint=true`; asserts client(a) → echo(b) returns 200 over
+  the node tunnel with mTLS end-to-end (nightly CI: `waypoint-e2e.yaml`).
+- [`e2e/multicluster_replicator.sh`](../e2e/multicluster_replicator.sh) — the
+  **006 two-region replicator failover**: one etcd PER cluster,
+  `registrar.peerEtcd` cross-wired; asserts mirror visibility, the data path
+  over the mirror, lease-lapse failover when a region's registrar dies, and
+  recovery (nightly CI: `replicator-e2e.yaml`).
+
 ---
 
 ## 7. Installing on a real cluster
@@ -172,7 +188,7 @@ endpoints in the shared registry never collide).
 Aether ships **two** charts, and **install order matters**:
 
 ```
-charts/crds     — the CRDs: MeshConfig + HTTPFilter   ← install FIRST
+charts/crds     — the CRDs: MeshConfig + HTTPFilter + EdgeConfig   ← install FIRST
 charts/aether    — the whole system (agent DaemonSet + proxy + registrar + controller)
 ```
 

--- a/docs/workload-requirements.md
+++ b/docs/workload-requirements.md
@@ -50,22 +50,32 @@ spec:
 
 ## Calling other services
 
-Apps reach the mesh through the outbound listener: `http://127.0.0.1:18081`
-with the destination service's mesh FQDN in the `Host` header:
-`Host: my-svc.aether.internal`. Every hop is mTLS between workload
-identities; the callee sees the caller's SPIFFE ID in
+With transparent capture + mesh DNS (both on by default), apps dial the
+destination by name — `http://<service>.<namespace>.<meshDomain>:18081` (mesh
+DNS) or the generated Kubernetes Service
+`<service>.<namespace>.svc.cluster.local:18081` — and the CNI-programmed
+capture listener routes it. Apps that prefer zero interception assumptions
+can instead address the outbound listener explicitly: `http://127.0.0.1:18081`
+with the mesh FQDN in the `Host` header. Either way every hop is mTLS between
+workload identities; the callee sees the caller's SPIFFE ID in
 `x-forwarded-client-cert`.
 
-**Authorities are FQDN-only and deterministic.** `<service>.<mesh-domain>`
-(default domain `aether.internal`, agent `--mesh-domain` / chart
-`meshDomain`) is the single accepted form — it is simultaneously the vhost
-domain, the data-plane cluster name, and the on-demand (ODCDS) lookup key,
-declared or not. A `:port` on the authority is stripped before routing.
-Anything else — bare names (`Host: my-svc`), foreign domains, nested labels —
-matches no route and 404s immediately; only authorities under the mesh domain
-can reach the cold path. The mesh domain also defaults the SPIFFE trust
-domain (`--spire-trust-domain`), so addressing and identity share one domain
-unless explicitly split.
+**Authorities are FQDN-only, namespace-qualified, and deterministic.**
+`<service>.<namespace>.<mesh-domain>` (default domain `aether.internal`,
+agent `--mesh-domain` / chart `meshDomain`; proposal 020) is the accepted
+mesh form — it is simultaneously the vhost domain, the data-plane cluster
+name, and the on-demand (ODCDS) lookup key, declared or not. The capture path
+also honors the standard `<service>.<namespace>.svc.cluster.local` name. A
+`:port` on the authority is stripped before routing. Anything else — bare
+names (`Host: my-svc`), foreign domains, nested labels — matches no route and
+404s immediately; only authorities under the mesh domain can reach the cold
+path. The mesh domain also defaults the SPIFFE trust domain
+(`--spire-trust-domain`), so addressing and identity share one domain unless
+explicitly split.
+
+**Traffic shaping** (canary weights, header routing, timeouts, gRPC method
+routing, L4 splits/SNI) is standard Gateway API routes parented to the
+*Service* (GAMMA) — see the getting-started guide §10.
 
 ### Declaring upstreams
 


### PR DESCRIPTION
Docs-only refresh of the four user-facing docs (getting-started, configuration, workload-requirements, runbook).

**Stale info fixed**
- The intro/addressing story predated proposals 018/020/022: transparent capture, redirect-all, and mesh-DNS are all default-ON, and mesh FQDNs are namespace-qualified (`<svc>.<ns>.<meshDomain>`; the capture path also honors `<svc>.<ns>.svc.cluster.local`). The explicit `127.0.0.1:18081` listener is now documented as the alternative, not the model.
- `agent.l4Routes` default corrected to `true` (#493); `MeshConfig` documented as namespaced with control-plane fallback (#267); the `crds` chart list + CRD table now include `EdgeConfig` (029).

**New coverage**
- **GAMMA** (getting-started §10): HTTPRoute weighted canary example parented to a *Service*, GRPCRoute, TCPRoute weighted splits (weight-0 drain), TLSRoute SNI, capture-path application, ReferenceGrant + registry-backed-parent constraints, and the `HTTPFilter` escape hatch (ext_authz/OPA, RBAC, header-to-metadata) with its four scopes.
- **Multi-cluster & multi-region** (getting-started §12): the four independent planes — MCS endpoint export, 026 config propagation (+ `controlCluster` authority), the 019 east/west waypoint data path (routable node IPs + shared trust domain requirements, tunnel 18009), and 006 per-region etcd replication with the origin-heartbeat lease — plus a minimal two-cluster recipe and pointers to the three e2e harnesses.
- **configuration.md**: `agent.eastWestWaypoint`/`eastWestTunnelPort`, `registrar.peerEtcd`, `--peer-etcd`, `--east-west-*` flags, EdgeConfig CRD row, modernized GAMMA/l4Routes descriptions.
- **runbook**: the waypoint and replicator kind harnesses + their nightly CI gates.

All claims verified against code (`common/serviceref` FQDN forms, chart values, flag defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7oY7W8oDXrqDzFgoZh25S