### PR TITLE
fix(e2e): make multicluster harnesses self-sufficient on fresh checkouts

### DIFF
--- a/e2e/multicluster_replicator.sh
+++ b/e2e/multicluster_replicator.sh
@@ -143,10 +143,21 @@ install_spire() {
 	helm --kube-context "$ctx" repo add spiffe https://spiffe.github.io/helm-charts-hardened/ >/dev/null 2>&1 || true
 	helm --kube-context "$ctx" repo update >/dev/null 2>&1 || true
 	kubectl --context "$ctx" create ns spire-mgmt >/dev/null 2>&1 || true
+	# The shared upstream CA (same bytes in both clusters) is the root of trust.
+	# It lives in e2e/certs which is GITIGNORED — a fresh checkout (CI!) has no
+	# certs, and the old silent "|| true" secret creation let SPIRE hang forever
+	# on the missing mount (every nightly failed this way). Generate the
+	# throwaway CA on demand and fail LOUDLY if the secret can't be created.
+	if [[ ! -f "$REPO_ROOT/e2e/certs/ca.crt" || ! -f "$REPO_ROOT/e2e/certs/ca.key" ]]; then
+		log "e2e/certs missing (fresh checkout); generating throwaway CA"
+		make -C "$REPO_ROOT/e2e" generate-certs >/dev/null
+	fi
 	kubectl --context "$ctx" -n spire-mgmt create secret generic upstream-ca \
 		--from-file=tls.crt="$REPO_ROOT/e2e/certs/ca.crt" \
 		--from-file=tls.key="$REPO_ROOT/e2e/certs/ca.key" \
-		--from-file=bundle.crt="$REPO_ROOT/e2e/certs/ca.crt" >/dev/null 2>&1 || true
+		--from-file=bundle.crt="$REPO_ROOT/e2e/certs/ca.crt" \
+		--dry-run=client -o yaml | kubectl --context "$ctx" apply -f - >/dev/null ||
+		die "failed to create upstream-ca secret on '$1'"
 	helm --kube-context "$ctx" upgrade --install spire-crds spiffe/spire-crds \
 		-n spire-mgmt --version "$SPIRE_CRDS_VERSION" --wait --timeout 3m >/dev/null
 	helm --kube-context "$ctx" upgrade --install spire spiffe/spire \

--- a/e2e/multicluster_waypoint.sh
+++ b/e2e/multicluster_waypoint.sh
@@ -124,11 +124,20 @@ install_spire() {
 	helm --kube-context "$ctx" repo update >/dev/null 2>&1 || true
 	kubectl --context "$ctx" create ns spire-mgmt >/dev/null 2>&1 || true
 	# The shared upstream CA (same bytes in both clusters) is the root of trust.
-	# Must live in the namespace the spire-server runs in (spire-mgmt).
+	# It lives in e2e/certs which is GITIGNORED — a fresh checkout (CI!) has no
+	# certs, and the old silent "|| true" secret creation let SPIRE hang forever
+	# on the missing mount (every nightly failed this way). Generate the
+	# throwaway CA on demand and fail LOUDLY if the secret can't be created.
+	if [[ ! -f "$REPO_ROOT/e2e/certs/ca.crt" || ! -f "$REPO_ROOT/e2e/certs/ca.key" ]]; then
+		log "e2e/certs missing (fresh checkout); generating throwaway CA"
+		make -C "$REPO_ROOT/e2e" generate-certs >/dev/null
+	fi
 	kubectl --context "$ctx" -n spire-mgmt create secret generic upstream-ca \
 		--from-file=tls.crt="$REPO_ROOT/e2e/certs/ca.crt" \
 		--from-file=tls.key="$REPO_ROOT/e2e/certs/ca.key" \
-		--from-file=bundle.crt="$REPO_ROOT/e2e/certs/ca.crt" >/dev/null 2>&1 || true
+		--from-file=bundle.crt="$REPO_ROOT/e2e/certs/ca.crt" \
+		--dry-run=client -o yaml | kubectl --context "$ctx" apply -f - >/dev/null ||
+		die "failed to create upstream-ca secret on '$1'"
 	helm --kube-context "$ctx" upgrade --install spire-crds spiffe/spire-crds \
 		-n spire-mgmt --version "$SPIRE_CRDS_VERSION" --wait --timeout 3m >/dev/null
 	helm --kube-context "$ctx" upgrade --install spire spiffe/spire \


### PR DESCRIPTION
Every scheduled **replicator-e2e** and **waypoint-e2e** nightly has failed since creation (7/7 each). Root cause from the run artifacts (kubelet log, cluster a):

```
MountVolume.SetUp failed for volume "upstream-ca" ... secret "upstream-ca" not found
```

`e2e/certs/` is **gitignored**, so on a fresh CI checkout the harness's `kubectl create secret generic upstream-ca --from-file=e2e/certs/...` silently no-opped (`>/dev/null 2>&1 || true`), spire-server-0 hung forever on the missing secret mount, and `helm --wait --timeout 6m` expired → "SPIRE install failed on 'a'". Local runs passed because the certs exist on the workstation — which is why the 07-11 live validations were green while every scheduled run failed.

Fix (both harnesses):
- generate the throwaway CA on demand via the existing `make -C e2e generate-certs` when `e2e/certs/ca.{crt,key}` are absent
- secret creation is now idempotent (`--dry-run=client -o yaml | kubectl apply`) and **fails loudly** (`die`) instead of masking

## Test plan
- `bash -n` + shfmt clean
- Both workflows dispatched on this branch — links in comments once green

🤖 Generated with [Claude Code](https://claude.com/claude-code)