### PR TITLE
ci(e2e): drop -parallel 1 from the conformance suites (#533)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -195,9 +195,12 @@ jobs:
           cp test/conformance/mesh/manifests.yaml \
             gateway-api/conformance/mesh/manifests.yaml
 
-      # Hard gate (43/43 on kind + talos). -parallel 1: gateway-api 1.6 marked
-      # many tests Parallel; concurrent same-match routes flap between backends
-      # until aether implements cross-route oldest-wins precedence (#533).
+      # Hard gate (43/43 on kind + talos). Runs the suite's native parallelism:
+      # aether's cross-route precedence (oldest creationTimestamp, then ns/name —
+      # the reconciler's pre-projection sort + the cache's stable specificity
+      # sort) resolves same-match routes deterministically (#533). The earlier
+      # wrong-backend failures were per-test-cleanup pollution (1.6 made
+      # CleanupTestResources opt-in; the runner now sets it).
       - name: Run GATEWAY-HTTP conformance
         id: conformance
         working-directory: gateway-api/conformance
@@ -209,7 +212,6 @@ jobs:
           go test . \
             -tags conformance \
             -run TestAetherGatewayHTTP \
-            -parallel 1 \
             -v -timeout 60m
 
       - name: Upload conformance report
@@ -348,7 +350,6 @@ jobs:
           go test . \
             -tags conformance \
             -run TestAetherMeshHTTP \
-            -parallel 1 \
             -v -timeout 60m
 
       - name: Upload conformance report


### PR DESCRIPTION
Closes #533 — with an analysis twist: **no code fix was needed**.

Aether already implements the Gateway API cross-route precedence: the edge reconciler sorts HTTPRoutes by creationTimestamp → namespace → name before projection, and the cache's specificity sort is **stable**, preserving that tie-break for equal-specificity matches (oldest route wins deterministically).

The wrong-backend failures that motivated `-parallel 1` (#532 triage runs 1–3) were **per-test-cleanup pollution**: gateway-api 1.6 made `CleanupTestResources` opt-in, so routes from *finished* tests lingered — and aether routed to them because they were the legitimately-older route. Spec-correct behavior against a polluted suite. Parallel mode was never re-tested after the runner enabled cleanup.

## Validation (both dispatched on this branch at native parallelism)
- gateway-http: **green**, 260 passing assertions (run 29686452778)
- mesh-http: **green** (run 29686457300)

🤖 Generated with [Claude Code](https://claude.com/claude-code)