### PR TITLE
perf(registry): cache node localities in the k8s backend (#541)

### DIFF
--- a/registry/internal/k8s/BUILD.bazel
+++ b/registry/internal/k8s/BUILD.bazel
@@ -27,6 +27,8 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake",
+        "@io_k8s_sigs_controller_runtime//pkg/client/interceptor",
     ],
 )

--- a/registry/internal/k8s/kubernetes.go
+++ b/registry/internal/k8s/kubernetes.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"log/slog"
 	"strconv"
+	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -25,6 +27,13 @@ type Config struct {
 	ClusterName string
 }
 
+// nodeLocalityCacheTTL bounds how long cached node localities are served without
+// re-listing nodes. Topology labels essentially never change and a node's
+// InternalIP is stable for its lifetime, so a few minutes of staleness is safe;
+// a pod landing on a node that is not yet cached forces an immediate refresh
+// regardless of the TTL (see buildNodeLocalities).
+const nodeLocalityCacheTTL = 5 * time.Minute
+
 // KubernetesRegistry is a Registry implementation backed by the Kubernetes API server.
 // It reads pods labeled with aether.io/managed=true and converts them to ServiceEndpoints.
 // Write operations (Register/Unregister) are no-ops since the API server is the source of truth.
@@ -32,6 +41,17 @@ type KubernetesRegistry struct {
 	log         *slog.Logger
 	clusterName string
 	reader      client.Reader
+
+	// Node-locality cache (issue #541): List/ListAll run on every registry
+	// reload — dozens of times per minute during churn — and used to resolve
+	// node localities with serial per-node Gets each call. The cache is
+	// refreshed with a single node List and then served from memory until the
+	// TTL lapses or an unknown node shows up.
+	nodeMu          sync.Mutex
+	nodeCache       map[string]locality
+	nodeCacheExpiry time.Time
+	nodeCacheTTL    time.Duration
+	now             func() time.Time
 }
 
 // NewKubernetesRegistry creates a new Kubernetes API server backed Registry.
@@ -39,9 +59,11 @@ type KubernetesRegistry struct {
 // cache synchronization issues during startup.
 func NewKubernetesRegistry(log *slog.Logger, reader client.Reader, cfg Config) *KubernetesRegistry {
 	return &KubernetesRegistry{
-		log:         commonlog.Named(log, "registry-kubernetes"),
-		clusterName: cfg.ClusterName,
-		reader:      reader,
+		log:          commonlog.Named(log, "registry-kubernetes"),
+		clusterName:  cfg.ClusterName,
+		reader:       reader,
+		nodeCacheTTL: nodeLocalityCacheTTL,
+		now:          time.Now,
 	}
 }
 
@@ -106,6 +128,10 @@ func (r *KubernetesRegistry) ListEndpoints(ctx context.Context, service string, 
 	var endpoints []*registryv1.ServiceEndpoint
 	for i := range pods {
 		pod := &pods[i]
+		// The ServiceAccount filter stays in memory: spec.serviceAccountName is
+		// NOT a supported server-side pod field selector, and managed pods carry
+		// no per-service label — only aether.io/managed=true (issue #541).
+		//
 		// The registry key is the namespace-qualified "<ns>/<sa>" (020 Part 1),
 		// matching the CNI registration path (registry/cni.go) and the etcd/ddb
 		// backends. Keying by the bare ServiceAccount would collide same-named SAs
@@ -209,8 +235,12 @@ func (r *KubernetesRegistry) listManagedPods(ctx context.Context) ([]corev1.Pod,
 	return pods, nil
 }
 
-// buildNodeLocalities fetches topology labels for all unique nodes referenced by the given pods.
-// Results are cached by node name to avoid redundant API calls.
+// buildNodeLocalities resolves topology labels for all unique nodes referenced by the
+// given pods, served from a TTL'd in-memory cache (issue #541). On a cache miss —
+// TTL lapsed or a pod referencing a node the cache has never seen (node added) —
+// the whole cache is rebuilt with a single node List instead of the old serial
+// per-node Gets. As before, a pod referencing a node that does not exist fails the
+// listing.
 func (r *KubernetesRegistry) buildNodeLocalities(ctx context.Context, pods []corev1.Pod) (map[string]locality, error) {
 	// Collect unique node names
 	nodeNames := make(map[string]struct{})
@@ -219,14 +249,47 @@ func (r *KubernetesRegistry) buildNodeLocalities(ctx context.Context, pods []cor
 			nodeNames[nodeName] = struct{}{}
 		}
 	}
+	if len(nodeNames) == 0 {
+		return map[string]locality{}, nil
+	}
+
+	r.nodeMu.Lock()
+	defer r.nodeMu.Unlock()
+
+	if r.nodeCache == nil || !r.now().Before(r.nodeCacheExpiry) || !nodeCacheContainsAll(r.nodeCache, nodeNames) {
+		if err := r.refreshNodeCacheLocked(ctx); err != nil {
+			return nil, err
+		}
+	}
 
 	localities := make(map[string]locality, len(nodeNames))
 	for nodeName := range nodeNames {
-		var node corev1.Node
-		if err := r.reader.Get(ctx, client.ObjectKey{Name: nodeName}, &node); err != nil {
-			r.log.ErrorContext(ctx, "failed to get node for locality", "error", err, "node", nodeName)
-			return nil, fmt.Errorf("failed to get node %s: %w", nodeName, err)
+		loc, ok := r.nodeCache[nodeName]
+		if !ok {
+			// The refresh just listed every node and this one is absent: the pod
+			// references a node that no longer exists. Fail the listing, matching
+			// the pre-cache per-node Get behavior (NotFound propagated as error).
+			r.log.ErrorContext(ctx, "failed to get node for locality", "node", nodeName)
+			return nil, fmt.Errorf("failed to get node %s: node not found", nodeName)
 		}
+		localities[nodeName] = loc
+	}
+
+	return localities, nil
+}
+
+// refreshNodeCacheLocked rebuilds the node-locality cache from a single node List.
+// Callers must hold nodeMu.
+func (r *KubernetesRegistry) refreshNodeCacheLocked(ctx context.Context) error {
+	var nodeList corev1.NodeList
+	if err := r.reader.List(ctx, &nodeList); err != nil {
+		r.log.ErrorContext(ctx, "failed to list nodes for locality", "error", err)
+		return fmt.Errorf("failed to list nodes: %w", err)
+	}
+
+	cache := make(map[string]locality, len(nodeList.Items))
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
 		loc := locality{
 			region: node.Labels[constants.AnnotationKubernetesNodeTopologyRegion],
 			zone:   node.Labels[constants.AnnotationKubernetesNodeTopologyZone],
@@ -237,10 +300,22 @@ func (r *KubernetesRegistry) buildNodeLocalities(ctx context.Context, pods []cor
 				break
 			}
 		}
-		localities[nodeName] = loc
+		cache[node.Name] = loc
 	}
 
-	return localities, nil
+	r.nodeCache = cache
+	r.nodeCacheExpiry = r.now().Add(r.nodeCacheTTL)
+	return nil
+}
+
+// nodeCacheContainsAll reports whether every requested node name is present in the cache.
+func nodeCacheContainsAll(cache map[string]locality, names map[string]struct{}) bool {
+	for name := range names {
+		if _, ok := cache[name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // podToEndpoint converts a Kubernetes Pod to a ServiceEndpoint.

--- a/registry/internal/k8s/kubernetes_test.go
+++ b/registry/internal/k8s/kubernetes_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/constants"
@@ -938,6 +941,171 @@ func TestKubernetesRegistry_TCPProtocolReturnsEmpty(t *testing.T) {
 	httpOne, err := r.ListEndpoints(context.Background(), "team-a/echo-v1", registryv1.Service_PROTOCOL_HTTP)
 	require.NoError(t, err)
 	require.Len(t, httpOne, 1)
+}
+
+// ─── Node-locality cache (issue #541) ────────────────────────────────────────
+
+// nodeReadCounter tracks how many node reads (List/Get) hit the underlying client.
+type nodeReadCounter struct {
+	lists int
+	gets  int
+}
+
+// newCountingRegistry builds a KubernetesRegistry over a fake client whose node
+// reads are counted, returning the registry, the writable client (to mutate the
+// cluster mid-test), and the counter.
+func newCountingRegistry(objects ...client.Object) (*KubernetesRegistry, client.WithWatch, *nodeReadCounter) {
+	counter := &nodeReadCounter{}
+	c := fake.NewClientBuilder().
+		WithObjects(objects...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*corev1.NodeList); ok {
+					counter.lists++
+				}
+				return cl.List(ctx, list, opts...)
+			},
+			Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*corev1.Node); ok {
+					counter.gets++
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	return NewKubernetesRegistry(slog.New(slog.DiscardHandler), c, Config{ClusterName: "test-cluster"}), c, counter
+}
+
+// TestNodeLocalityCache_HitAvoidsNodeReads verifies the perf contract of #541:
+// repeated listings within the TTL resolve node localities from the cache — one
+// node List on the first call, zero node reads afterwards, and never per-node Gets.
+func TestNodeLocalityCache_HitAvoidsNodeReads(t *testing.T) {
+	r, _, counter := newCountingRegistry(
+		managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1"),
+		managedPod("pod-b", "default", "svc-b", "10.0.0.2", "node-2"),
+		topologyNode("node-1", "us-east-1", "us-east-1a"),
+		topologyNode("node-2", "us-east-1", "us-east-1b"),
+	)
+
+	first, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, first, 2)
+	assert.Equal(t, 1, counter.lists, "first listing refreshes the cache with a single node List")
+	assert.Equal(t, 0, counter.gets, "node localities must never be resolved via per-node Gets")
+
+	// Repeated reloads (the hot path) are served entirely from the cache.
+	for range 5 {
+		got, err := r.ListAllEndpoints(context.Background(), registryv1.Service_PROTOCOL_HTTP)
+		require.NoError(t, err)
+		assert.Equal(t, first, got, "cached localities must yield identical endpoints")
+	}
+	eps, err := r.ListEndpoints(context.Background(), "default/svc-a", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, eps, 1)
+	assert.Equal(t, "us-east-1a", eps[0].GetLocality().GetZone())
+
+	assert.Equal(t, 1, counter.lists, "cache hits must not re-list nodes")
+	assert.Equal(t, 0, counter.gets)
+}
+
+// TestNodeLocalityCache_NodeAddedForcesRefresh verifies that a pod scheduled onto
+// a node the cache has never seen refreshes the cache immediately (no TTL wait)
+// and resolves the new node's locality correctly.
+func TestNodeLocalityCache_NodeAddedForcesRefresh(t *testing.T) {
+	r, c, counter := newCountingRegistry(
+		managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1"),
+		topologyNode("node-1", "us-east-1", "us-east-1a"),
+	)
+	ctx := context.Background()
+
+	_, err := r.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Equal(t, 1, counter.lists)
+
+	// A new node joins and a managed pod lands on it.
+	require.NoError(t, c.Create(ctx, topologyNode("node-2", "eu-west-1", "eu-west-1b")))
+	require.NoError(t, c.Create(ctx, managedPod("pod-b", "default", "svc-a", "10.0.0.2", "node-2")))
+
+	got, err := r.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, got["default/svc-a"], 2)
+	byPod := map[string]*registryv1.ServiceEndpoint{}
+	for _, ep := range got["default/svc-a"] {
+		byPod[ep.GetKubernetesMetadata().GetPodName()] = ep
+	}
+	require.Contains(t, byPod, "pod-b")
+	assert.Equal(t, "eu-west-1", byPod["pod-b"].GetLocality().GetRegion())
+	assert.Equal(t, "eu-west-1b", byPod["pod-b"].GetLocality().GetZone())
+	assert.Equal(t, 2, counter.lists, "unknown node must force a cache refresh")
+
+	// The refreshed cache serves subsequent calls without new node reads.
+	_, err = r.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	assert.Equal(t, 2, counter.lists)
+	assert.Equal(t, 0, counter.gets)
+}
+
+// TestNodeLocalityCache_TTLExpiryRefreshes verifies the staleness bound: a node
+// label change is served stale within the TTL and picked up after it lapses.
+func TestNodeLocalityCache_TTLExpiryRefreshes(t *testing.T) {
+	r, c, counter := newCountingRegistry(
+		managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-1"),
+		topologyNode("node-1", "us-east-1", "us-east-1a"),
+	)
+	ctx := context.Background()
+
+	// Deterministic clock.
+	now := time.Now()
+	r.now = func() time.Time { return now }
+
+	first, err := r.ListEndpoints(ctx, "default/svc-a", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, first, 1)
+	assert.Equal(t, "us-east-1a", first[0].GetLocality().GetZone())
+	require.Equal(t, 1, counter.lists)
+
+	// The node's zone label changes (essentially never happens in practice).
+	var node corev1.Node
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "node-1"}, &node))
+	node.Labels[constants.AnnotationKubernetesNodeTopologyZone] = "us-east-1z"
+	require.NoError(t, c.Update(ctx, &node))
+
+	// Within the TTL the cached locality is served.
+	stale, err := r.ListEndpoints(ctx, "default/svc-a", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1a", stale[0].GetLocality().GetZone())
+	assert.Equal(t, 1, counter.lists)
+
+	// After the TTL lapses the next listing refreshes and observes the change.
+	now = now.Add(nodeLocalityCacheTTL + time.Second)
+	fresh, err := r.ListEndpoints(ctx, "default/svc-a", registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	assert.Equal(t, "us-east-1z", fresh[0].GetLocality().GetZone())
+	assert.Equal(t, 2, counter.lists)
+}
+
+// TestNodeLocalityCache_MissingNodeStillErrors pins the pre-cache error contract:
+// a managed pod referencing a node that does not exist fails the listing even
+// though node resolution now goes through the cache, and the failure is not
+// poisoned into the cache (the node appearing later heals the listing).
+func TestNodeLocalityCache_MissingNodeStillErrors(t *testing.T) {
+	r, c, _ := newCountingRegistry(
+		managedPod("pod-a", "default", "svc-a", "10.0.0.1", "node-gone"),
+	)
+	ctx := context.Background()
+
+	_, err := r.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	require.ErrorContains(t, err, "node-gone")
+
+	_, err = r.ListEndpoints(ctx, "default/svc-a", registryv1.Service_PROTOCOL_HTTP)
+	require.ErrorContains(t, err, "node-gone")
+
+	// The node shows up (e.g., registration race): the next listing succeeds.
+	require.NoError(t, c.Create(ctx, topologyNode("node-gone", "us-east-1", "us-east-1a")))
+	got, err := r.ListAllEndpoints(ctx, registryv1.Service_PROTOCOL_HTTP)
+	require.NoError(t, err)
+	require.Len(t, got["default/svc-a"], 1)
+	assert.Equal(t, "us-east-1a", got["default/svc-a"][0].GetLocality().GetZone())
 }
 
 // ─── Annotation parsing helpers (unit-level) ─────────────────────────────────


### PR DESCRIPTION
Fixes #541

## Problem

`registry/internal/k8s` runs on every registry reload (dozens of times per minute during churn) and resolved node localities with **serial per-node `Get` calls** on each `ListEndpoints`/`ListAllEndpoints`. `ListEndpoints` also lists all managed pods and filters by ServiceAccount in memory.

## Approach

The backend holds a direct API reader (`m.GetAPIReader()`, deliberately uncached per the constructor contract), so an informer index on `spec.serviceAccountName` (option c) is not available, and managed pods carry no per-service label — only `aether.io/managed=true` — so a server-side label selector for the per-service list (option a) is not available either (`spec.serviceAccountName` is not a supported pod field selector). That leaves option (b), which is also the least invasive fix:

- **TTL'd node-locality cache** (5 min) keyed by node name, guarded by a mutex. Steady-state reloads perform **zero** node reads.
- On a cache miss — TTL lapsed **or** a pod references a node the cache has never seen (node added ⇒ picked up immediately, no TTL wait) — the cache is rebuilt with a **single node `List`** instead of N serial `Get`s.
- The in-memory ServiceAccount filter stays (documented why), keyed off the label-selected managed-pod list as before.

Behavior is unchanged: identical endpoint sets and localities, `Registry` interface untouched, and a pod referencing a nonexistent node still fails the listing (and is not poisoned into the cache — the node appearing later heals it).

## Tests

New coverage in `kubernetes_test.go` using a counting fake-client interceptor:
- cache hit: 1 node `List` on first call, zero node reads across repeated reloads, zero per-node `Get`s ever
- node added: unknown node forces an immediate refresh and resolves the new locality
- TTL expiry: label change served stale within the TTL, observed after it lapses (injected clock)
- missing node: still errors, then heals once the node exists

`bazel test //registry/... //registrar/...` — all green (etcd/ddb integration targets ran via cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR