### PR TITLE
perf(xds): memoize the dependency set behind an input generation counter (#539)

### DIFF
--- a/agent/internal/xds/cache/BUILD.bazel
+++ b/agent/internal/xds/cache/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "chain_seam_test.go",
         "cluster_alias_test.go",
         "cluster_test.go",
+        "dependencies_memo_test.go",
         "dependencies_test.go",
         "edge_test.go",
         "listener_address_test.go",

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -248,6 +248,23 @@ type SnapshotCache struct {
 	udpServiceRoutes map[string][]proxy.L4Backend
 	// observedTTL overrides defaultObservedTTL when > 0 (test hook).
 	observedTTL time.Duration
+	// depGen counts mutations of the dependency-set inputs (issue #539): EVERY
+	// writer of ANY depMu-guarded field bumps it via bumpDepGenLocked, even for
+	// fields dependencySetLocked does not read today — over-invalidation costs
+	// one rebuild, a missed bump serves a stale dependency set (the demand-
+	// scoping bug class: clusters silently missing from the snapshot).
+	depGen uint64
+	// depSet/depSetGen/depSetTTL/depSetExpiry/depSetValid memoize
+	// dependencySetLocked: the cached set is served while depGen is unchanged,
+	// the TTL is unchanged, and no memoized observed dependency has crossed its
+	// TTL (depSetExpiry is the earliest such wall-clock instant; zero = none).
+	// depSet is shared with callers and must never be mutated after it is
+	// stored. All guarded by depMu.
+	depSet       map[string]struct{}
+	depSetGen    uint64
+	depSetTTL    time.Duration
+	depSetExpiry time.Time
+	depSetValid  bool
 	// depChanged receives a (coalesced) signal when the dependency set
 	// changes; the registry refresher rebuilds the scoped snapshot on it.
 	depChanged chan struct{}
@@ -597,6 +614,7 @@ func (c *SnapshotCache) SetStaticDependencies(services []string) {
 	c.depMu.Lock()
 	before := c.dependencySetLocked()
 	c.staticDeps = next
+	c.bumpDepGenLocked()
 	after := c.dependencySetLocked()
 	c.depMu.Unlock()
 

--- a/agent/internal/xds/cache/cache_test.go
+++ b/agent/internal/xds/cache/cache_test.go
@@ -72,6 +72,7 @@ func newTestCache(nodeName string) *SnapshotCache {
 func declareDeps(c *SnapshotCache, services ...string) {
 	c.depMu.Lock()
 	c.podDeps["test-netns"] = podDependencies{upstreams: services}
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 }
 

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -178,6 +178,7 @@ func (c *SnapshotCache) SetCaptureTCPServices(services []capture.CaptureTCPServi
 	}
 	c.depMu.Lock()
 	c.captureTCPDeps = names
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 
 	// Per-pod capture listeners embed TCP floor chains; regenerate all of them.

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -44,6 +44,7 @@ func (c *SnapshotCache) setPodDependencies(netns string, cniPod *cniv1.CNIPod) {
 	c.depMu.Lock()
 	before := c.dependencySetLocked()
 	c.podDeps[netns] = deps
+	c.bumpDepGenLocked()
 	after := c.dependencySetLocked()
 	c.depMu.Unlock()
 
@@ -58,6 +59,7 @@ func (c *SnapshotCache) removePodDependencies(netns string) {
 	c.depMu.Lock()
 	before := c.dependencySetLocked()
 	delete(c.podDeps, netns)
+	c.bumpDepGenLocked()
 	after := c.dependencySetLocked()
 	c.depMu.Unlock()
 
@@ -81,6 +83,10 @@ func (c *SnapshotCache) ObserveDependency(ctx context.Context, service string) b
 	c.depMu.Lock()
 	_, known := c.dependencySetLocked()[service]
 	c.observedDeps[service] = time.Now()
+	// Bump even on a pure timestamp refresh: the memoized expiry horizon
+	// (depSetExpiry) may extend, and a stale horizon would expire this
+	// entry from the served set too early.
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 
 	if known {
@@ -110,6 +116,9 @@ func (c *SnapshotCache) PruneObservedDependencies() {
 			expired++
 		}
 	}
+	if expired > 0 {
+		c.bumpDepGenLocked()
+	}
 	c.depMu.Unlock()
 
 	if expired > 0 {
@@ -131,13 +140,46 @@ func (c *SnapshotCache) observedTTLValue() time.Duration {
 // dependencies. LoadClustersFromRegistry scopes the cluster/endpoint/route
 // snapshot to this set (demand-scoped distribution, proposal 004).
 func (c *SnapshotCache) DependencySet() map[string]struct{} {
-	c.depMu.RLock()
-	defer c.depMu.RUnlock()
-	return c.dependencySetLocked()
+	// Write lock (not RLock): dependencySetLocked may rebuild and store the
+	// memoized set. External callers get a copy — the memo is shared state.
+	c.depMu.Lock()
+	set := c.dependencySetLocked()
+	out := make(map[string]struct{}, len(set))
+	for svc := range set {
+		out[svc] = struct{}{}
+	}
+	c.depMu.Unlock()
+	return out
 }
 
-// dependencySetLocked builds the dependency set. Caller must hold depMu.
+// bumpDepGenLocked invalidates the memoized dependency set. EVERY writer of
+// ANY depMu-guarded field must call it after the write (rule of thumb: any
+// write under depMu bumps, even for fields dependencySetLocked does not read
+// today). Over-invalidation costs one recompute; a missed bump serves a stale
+// dependency set — clusters silently missing from the scoped snapshot.
+// Caller must hold depMu for writing.
+func (c *SnapshotCache) bumpDepGenLocked() {
+	c.depGen++
+}
+
+// dependencySetLocked returns the dependency set, memoized on the input
+// generation counter (issue #539): while depGen is unchanged the previously
+// built set is still exact and is returned as-is, EXCEPT that observed
+// dependencies expire by wall clock at read time without any mutator running
+// — so the memo also records the earliest observed-entry expiry
+// (depSetExpiry) and rebuilds once that instant passes, keeping expiry
+// semantics identical to the from-scratch build (PruneObservedDependencies
+// merely deletes already-expired entries later). The returned map is shared
+// across calls until the next rebuild and must be treated as read-only
+// (DependencySet hands external callers a copy). Caller must hold depMu for
+// writing (a rebuild stores the memo).
 func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
+	now := time.Now()
+	ttl := c.observedTTLValue()
+	if c.depSetValid && c.depSetGen == c.depGen && c.depSetTTL == ttl &&
+		(c.depSetExpiry.IsZero() || !now.After(c.depSetExpiry)) {
+		return c.depSet
+	}
 	set := make(map[string]struct{}, len(c.podDeps)*4+len(c.observedDeps)+len(c.staticDeps))
 	// Static (edge) dependencies: the explicitly exposed services.
 	for svc := range c.staticDeps {
@@ -170,11 +212,16 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 			set[u] = struct{}{}
 		}
 	}
-	now := time.Now()
-	ttl := c.observedTTLValue()
+	// Live observed dependencies, tracking the earliest wall-clock instant a
+	// memoized entry expires (an entry is live while now <= last+ttl, so the
+	// memo stays valid through that exact instant and rebuilds after).
+	var nextExpiry time.Time
 	for svc, last := range c.observedDeps {
 		if now.Sub(last) <= ttl {
 			set[svc] = struct{}{}
+			if exp := last.Add(ttl); nextExpiry.IsZero() || exp.Before(nextExpiry) {
+				nextExpiry = exp
+			}
 		}
 	}
 	// Service-based routing (proposal 023): a GAMMA route TARGET — the k8s Service an
@@ -208,6 +255,11 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 			}
 		}
 	}
+	c.depSet = set
+	c.depSetGen = c.depGen
+	c.depSetTTL = ttl
+	c.depSetExpiry = nextExpiry
+	c.depSetValid = true
 	return set
 }
 

--- a/agent/internal/xds/cache/dependencies_memo_test.go
+++ b/agent/internal/xds/cache/dependencies_memo_test.go
@@ -1,0 +1,235 @@
+package cache
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/bpalermo/aether/agent/internal/capture"
+	"github.com/bpalermo/aether/agent/internal/xds/proxy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests for the memoized dependency set (issue #539): every mutator of an
+// input dependencySetLocked reads must bump the generation counter so the
+// served set reflects the mutation IMMEDIATELY — a missed bump is the
+// demand-scoping bug class (clusters silently missing from the snapshot).
+
+// memoPointer returns the identity of the internal memoized map, to assert
+// cache hits (same map served) vs rebuilds (new map built).
+func memoPointer(c *SnapshotCache) uintptr {
+	c.depMu.Lock()
+	defer c.depMu.Unlock()
+	return reflect.ValueOf(c.dependencySetLocked()).Pointer()
+}
+
+// TestDependencySetMemo_CacheHitWithoutMutation verifies repeated reads with
+// no intervening mutation are served from the memo (same underlying map), and
+// that any mutation rebuilds (different map).
+func TestDependencySetMemo_CacheHitWithoutMutation(t *testing.T) {
+	c := newTestCache("node-1")
+	require.NoError(t, c.AddPod(context.Background(), makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/svc-x"), "example.org"))
+
+	p1 := memoPointer(c)
+	p2 := memoPointer(c)
+	assert.Equal(t, p1, p2, "no mutation: the memoized map must be served")
+
+	assert.True(t, c.ObserveDependency(context.Background(), "default/svc-obs"))
+	p3 := memoPointer(c)
+	assert.NotEqual(t, p1, p3, "a mutation must invalidate the memo and rebuild")
+}
+
+// TestDependencySetMemo_RepeatedCallsEqualAndCopied verifies repeated
+// DependencySet calls without mutations return equal content, and that the
+// returned map is the caller's copy — mutating it must not corrupt the memo.
+func TestDependencySetMemo_RepeatedCallsEqualAndCopied(t *testing.T) {
+	c := newTestCache("node-1")
+	require.NoError(t, c.AddPod(context.Background(), makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/svc-x,default/svc-y"), "example.org"))
+
+	d1 := c.DependencySet()
+	d2 := c.DependencySet()
+	assert.Equal(t, d1, d2, "repeated calls without mutations must return equal content")
+
+	// Vandalize the returned copy: the memo must be unaffected.
+	delete(d1, "default/svc-x")
+	d1["default/svc-injected"] = struct{}{}
+	d3 := c.DependencySet()
+	assert.Equal(t, d2, d3, "mutating a returned set must not leak into the memo")
+}
+
+// TestDependencySetMemo_EveryMutatorInvalidates covers each input class: the
+// set must reflect a mutation on the very next read (generation-bump coverage
+// per mutator).
+func TestDependencySetMemo_EveryMutatorInvalidates(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("setPodDependencies via AddPod", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime the memo
+		require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/svc-x"), "example.org"))
+		deps := c.DependencySet()
+		assert.Contains(t, deps, "default/svc-a")
+		assert.Contains(t, deps, "default/svc-x")
+	})
+
+	t.Run("removePodDependencies via RemovePod", func(t *testing.T) {
+		c := newTestCache("node-1")
+		require.NoError(t, c.AddPod(ctx, makeDepPod("a-1", "svc-a", "/proc/1/ns/net", "default/svc-x"), "example.org"))
+		require.Contains(t, c.DependencySet(), "default/svc-x") // prime
+		require.NoError(t, c.RemovePod(ctx, "/proc/1/ns/net"))
+		deps := c.DependencySet()
+		assert.NotContains(t, deps, "default/svc-a")
+		assert.NotContains(t, deps, "default/svc-x")
+	})
+
+	t.Run("ObserveDependency", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		assert.True(t, c.ObserveDependency(ctx, "default/svc-obs"))
+		assert.Contains(t, c.DependencySet(), "default/svc-obs")
+	})
+
+	t.Run("PruneObservedDependencies", func(t *testing.T) {
+		c := newTestCache("node-1")
+		c.observedTTL = 50 * time.Millisecond
+		assert.True(t, c.ObserveDependency(ctx, "default/svc-obs"))
+		require.Contains(t, c.DependencySet(), "default/svc-obs") // prime
+		time.Sleep(60 * time.Millisecond)
+		c.PruneObservedDependencies()
+		assert.NotContains(t, c.DependencySet(), "default/svc-obs")
+		c.depMu.Lock()
+		assert.Empty(t, c.observedDeps, "prune must delete the expired entry")
+		c.depMu.Unlock()
+	})
+
+	t.Run("SetStaticDependencies", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		c.SetStaticDependencies([]string{"edge/svc-exposed"})
+		assert.Contains(t, c.DependencySet(), "edge/svc-exposed")
+		c.SetStaticDependencies(nil)
+		assert.NotContains(t, c.DependencySet(), "edge/svc-exposed")
+	})
+
+	t.Run("SetCaptureTCPServices", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		c.SetCaptureTCPServices([]capture.CaptureTCPService{{ServiceName: "default/tcp-svc", ClusterIP: "10.96.0.9"}})
+		assert.Contains(t, c.DependencySet(), "default/tcp-svc")
+		c.SetCaptureTCPServices(nil)
+		assert.NotContains(t, c.DependencySet(), "default/tcp-svc")
+	})
+
+	t.Run("SetServiceRoutes", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		c.SetServiceRoutes(map[string][]proxy.GammaRoute{
+			"team-a/echo": {{Backends: []proxy.GammaBackend{{Service: "team-a/echo-v1", Cluster: "echo-v1.team-a.example.org", Weight: 1}}}},
+		})
+		deps := c.DependencySet()
+		assert.Contains(t, deps, "team-a/echo", "route target joins the set")
+		assert.Contains(t, deps, "team-a/echo-v1", "route backend joins the set")
+		c.SetServiceRoutes(nil)
+		assert.NotContains(t, c.DependencySet(), "team-a/echo")
+	})
+
+	t.Run("SetImportedServiceRoutes", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		c.SetImportedServiceRoutes(map[string][]proxy.GammaRoute{
+			"team-b/echo": {{Backends: []proxy.GammaBackend{{Service: "team-b/echo-v2", Cluster: "echo-v2.team-b.example.org", Weight: 1}}}},
+		})
+		deps := c.DependencySet()
+		assert.Contains(t, deps, "team-b/echo")
+		assert.Contains(t, deps, "team-b/echo-v2")
+	})
+
+	t.Run("SetServiceChainFilters", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		c.SetServiceChainFilters(map[string]proxy.ExtensionFilter{
+			"default/chained": {Name: "envoy.filters.http.header_to_metadata"},
+		})
+		assert.Contains(t, c.DependencySet(), "default/chained")
+	})
+
+	t.Run("SetImportedServiceChainFilters", func(t *testing.T) {
+		c := newTestCache("node-1")
+		_ = c.DependencySet() // prime
+		c.SetImportedServiceChainFilters(map[string]proxy.ExtensionFilter{
+			"peer/chained": {Name: "envoy.filters.http.header_to_metadata"},
+		})
+		assert.Contains(t, c.DependencySet(), "peer/chained")
+	})
+
+	t.Run("SetTCPServiceRoutes", func(t *testing.T) {
+		c := newTestCache("node-1")
+		declareDeps(c, "default/parent")
+		require.Contains(t, c.DependencySet(), "default/parent") // prime
+		c.SetTCPServiceRoutes(map[string][]proxy.L4ServiceRoute{
+			"default/parent": {{Backends: []proxy.L4Backend{{Service: "default/tcp-be", Cluster: "tcp:tcp-be.default.example.org", Weight: 1}}}},
+		})
+		assert.Contains(t, c.DependencySet(), "default/tcp-be", "TCPRoute backends of an in-scope parent join the set")
+	})
+
+	t.Run("SetTLSServiceRoutes", func(t *testing.T) {
+		c := newTestCache("node-1")
+		declareDeps(c, "default/parent")
+		require.Contains(t, c.DependencySet(), "default/parent") // prime
+		c.SetTLSServiceRoutes(map[string][]proxy.L4ServiceRoute{
+			"default/parent": {{SNIHostnames: []string{"tls.example.org"}, Backends: []proxy.L4Backend{{Service: "default/tls-be", Cluster: "tcp:tls-be.default.example.org", Weight: 1}}}},
+		})
+		assert.Contains(t, c.DependencySet(), "default/tls-be", "TLSRoute backends of an in-scope parent join the set")
+	})
+
+	t.Run("SetUDPServiceRoutes", func(t *testing.T) {
+		c := newTestCache("node-1")
+		declareDeps(c, "default/parent")
+		require.Contains(t, c.DependencySet(), "default/parent") // prime
+		c.SetUDPServiceRoutes(map[string][]proxy.L4Backend{
+			"default/parent": {{Service: "default/udp-be", Cluster: "udp:udp-be.default.example.org", Weight: 1}},
+		})
+		assert.Contains(t, c.DependencySet(), "default/udp-be", "UDPRoute backends of an in-scope parent join the set")
+	})
+}
+
+// TestDependencySetMemo_ObservedTTLExpiresWithoutMutator is the critical TTL
+// edge: observed dependencies expire by wall clock at read time, WITHOUT any
+// mutator running to bump the generation. The memo must not serve an expired
+// entry just because the generation is unchanged.
+func TestDependencySetMemo_ObservedTTLExpiresWithoutMutator(t *testing.T) {
+	c := newTestCache("node-1")
+	c.observedTTL = 200 * time.Millisecond
+
+	assert.True(t, c.ObserveDependency(context.Background(), "default/svc-cold"))
+	require.Contains(t, c.DependencySet(), "default/svc-cold", "live within the TTL")
+
+	// NO mutator from here on — only time passes.
+	time.Sleep(250 * time.Millisecond)
+	assert.NotContains(t, c.DependencySet(), "default/svc-cold",
+		"an observed entry past its TTL must leave the served set even though no mutator ran")
+}
+
+// TestDependencySetMemo_ObserveRefreshExtendsTTL verifies a re-observation
+// (pure timestamp touch — same key, same membership) still bumps the memo so
+// the expiry horizon extends: the entry must survive past the ORIGINAL
+// observation's TTL when it was refreshed in between.
+func TestDependencySetMemo_ObserveRefreshExtendsTTL(t *testing.T) {
+	c := newTestCache("node-1")
+	c.observedTTL = 600 * time.Millisecond
+	ctx := context.Background()
+
+	assert.True(t, c.ObserveDependency(ctx, "default/svc-cold"))
+	require.Contains(t, c.DependencySet(), "default/svc-cold") // prime the memo
+
+	time.Sleep(350 * time.Millisecond)
+	assert.False(t, c.ObserveDependency(ctx, "default/svc-cold"), "refresh, not a miss")
+	time.Sleep(350 * time.Millisecond)
+
+	// 700ms since the FIRST observation (past the 600ms TTL), but only 350ms
+	// since the refresh: the entry must still be served.
+	assert.Contains(t, c.DependencySet(), "default/svc-cold",
+		"a refreshed observation must extend the memoized expiry horizon")
+}

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -18,6 +18,7 @@ func (c *SnapshotCache) SetServiceRoutes(routes map[string][]proxy.GammaRoute) {
 	c.depMu.Lock()
 	changed := !equalServiceRoutes(c.serviceRoutes, routes)
 	c.serviceRoutes = routes
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if changed {
 		// Route-referenced extension filters live default-disabled in the per-pod
@@ -36,6 +37,7 @@ func (c *SnapshotCache) SetImportedServiceRoutes(routes map[string][]proxy.Gamma
 	c.depMu.Lock()
 	changed := !equalServiceRoutes(c.importedServiceRoutes, routes)
 	c.importedServiceRoutes = routes
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if changed {
 		c.regenerateAllHTTPListeners()
@@ -119,6 +121,9 @@ func (c *SnapshotCache) SetRouteTargetPorts(ports map[string][]uint32) {
 	c.depMu.Lock()
 	changed := !equalRouteTargetPorts(c.routeTargetPorts, ports)
 	c.routeTargetPorts = ports
+	// Not read by dependencySetLocked today; bumped under the blanket
+	// "every depMu write bumps" rule (over-invalidation is harmless).
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if changed {
 		c.signalDependencyChange()
@@ -308,6 +313,7 @@ func (c *SnapshotCache) SetServiceChainFilters(filters map[string]proxy.Extensio
 	c.depMu.Lock()
 	changed := !equalServiceChainFilters(c.serviceChainFilters, filters)
 	c.serviceChainFilters = filters
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if changed {
 		// INFO on change: the in-vivo debugging signal for "the filter never
@@ -324,6 +330,7 @@ func (c *SnapshotCache) SetImportedServiceChainFilters(filters map[string]proxy.
 	c.depMu.Lock()
 	changed := !equalServiceChainFilters(c.importedServiceChainFilters, filters)
 	c.importedServiceChainFilters = filters
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if changed {
 		c.log.Info("imported service chain filters updated", "count", len(filters))
@@ -429,6 +436,9 @@ func (c *SnapshotCache) SetServiceInboundFilters(filters map[string]proxy.Extens
 	c.depMu.Lock()
 	changed := !equalServiceChainFilters(c.serviceInboundFilters, filters)
 	c.serviceInboundFilters = filters
+	// Not read by dependencySetLocked today; bumped under the blanket
+	// "every depMu write bumps" rule (over-invalidation is harmless).
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if changed {
 		c.log.Info("service inbound filters updated", "count", len(filters))

--- a/agent/internal/xds/cache/l4route.go
+++ b/agent/internal/xds/cache/l4route.go
@@ -12,6 +12,7 @@ func (c *SnapshotCache) SetTCPServiceRoutes(routes map[string][]proxy.L4ServiceR
 	c.depMu.Lock()
 	changed := !equalL4ServiceRoutes(c.tcpServiceRoutes, routes)
 	c.tcpServiceRoutes = routes
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if !changed {
 		return
@@ -31,6 +32,7 @@ func (c *SnapshotCache) SetTLSServiceRoutes(routes map[string][]proxy.L4ServiceR
 	c.depMu.Lock()
 	changed := !equalL4ServiceRoutes(c.tlsServiceRoutes, routes)
 	c.tlsServiceRoutes = routes
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if !changed {
 		return
@@ -50,6 +52,7 @@ func (c *SnapshotCache) SetUDPServiceRoutes(routes map[string][]proxy.L4Backend)
 	c.depMu.Lock()
 	changed := !equalUDPRoutes(c.udpServiceRoutes, routes)
 	c.udpServiceRoutes = routes
+	c.bumpDepGenLocked()
 	c.depMu.Unlock()
 	if !changed {
 		return


### PR DESCRIPTION
Fixes #539

## What

`dependencySetLocked()` rebuilt the node dependency set from scratch on every call — per pod event, per GAMMA/L4 update, per refresh, plus the extra before/after diff calls in the change-signal paths (`setPodDependencies`, `removePodDependencies`, `SetStaticDependencies`, `ObserveDependency`). This memoizes the build behind an input generation counter (the safer of the two approaches in the issue — no hand-maintained incremental deltas).

## How

- **`depGen`** (guarded by `depMu`) counts input mutations. Rule kept trivially auditable: **every write under `depMu` bumps** via `bumpDepGenLocked()`, even for fields the rebuild does not read today (`routeTargetPorts`, `serviceInboundFilters`) — over-invalidation costs one recompute, a missed bump serves a stale set (the demand-scoping bug class).
- Mutators wired: `setPodDependencies`, `removePodDependencies`, `ObserveDependency` (incl. pure timestamp refresh), `PruneObservedDependencies` (when entries expired), `SetStaticDependencies`, `SetCaptureTCPServices`, `SetServiceRoutes`, `SetImportedServiceRoutes`, `SetRouteTargetPorts`, `SetServiceChainFilters`, `SetImportedServiceChainFilters`, `SetServiceInboundFilters`, `SetTCPServiceRoutes`, `SetTLSServiceRoutes`, `SetUDPServiceRoutes`, plus the `declareDeps` test helper.
- **TTL edge**: observed (ODCDS) dependencies expire by wall clock *at read time*, without any mutator running — a purely generation-keyed cache would serve expired entries until the next prune. The memo therefore also records the earliest observed-entry expiry (`depSetExpiry`, exact boundary `now <= last+ttl`) and rebuilds once that instant passes. `PruneObservedDependencies` stays the deletion point and bumps like any mutator; *when* entries expire is unchanged. The `observedTTL` test hook is part of the memo key too (`depSetTTL`).
- **Sharing/copies**: `dependencySetLocked` returns the shared memoized map (documented read-only; a rebuild always allocates a fresh map, so the internal before/after diff paths still compare distinct sets). `DependencySet()` now takes the write lock (a call may store the memo) and returns a **copy**, preserving the old caller-owns-the-map contract.

## Tests

New `dependencies_memo_test.go`:
- per-mutator invalidation coverage (pod add/remove, observe, prune, static, capture-TCP, local+imported GAMMA routes incl. backends, local+imported chain filters, TCP/TLS/UDP L4 route backends)
- TTL expiry with **no** mutator running (wall-clock invalidation), and a refresh-extends-TTL case (touch bumps the horizon)
- repeated calls without mutations return equal content; mutating a returned copy does not leak into the memo
- memo identity: same map served without mutation, new map after a bump

`bazel test //agent/...` green (23/23); `//agent/internal/xds/cache:cache_test` also green with `--@rules_go//go/config:race=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR