### PR TITLE
ci(publish): allow manual dispatch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
Today's GitHub incident dropped push webhooks for three consecutive main merges (#552/#553/#555), so publish never ran and there was no manual re-trigger. Adds workflow_dispatch. Merging this also re-triggers publish on the new HEAD, covering the missed merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR