### PR TITLE
refactor(registrar,agent): reduce cognitive complexity to ≤15 in registrar + route reconcilers

### DIFF
--- a/agent/internal/configimport/importer.go
+++ b/agent/internal/configimport/importer.go
@@ -103,12 +103,24 @@ func (i *Importer) poll(ctx context.Context) {
 // returns the oldest materialized projection's export time (zero when none parseable)
 // for the EM4 propagation-lag metric.
 func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection) (map[string][]proxy.GammaRoute, map[string]proxy.ExtensionFilter, time.Time) {
-	type chosen struct {
-		version string
-		routes  []proxy.GammaRoute
-		filter  *registryv1.ExtensionFilter
+	picked := i.selectProjections(projections)
+	if len(picked) == 0 {
+		return nil, nil, time.Time{}
 	}
-	picked := make(map[string]chosen, len(projections))
+	return i.buildRouteOutputs(picked)
+}
+
+// chosenProjection holds the winning projection for a service.
+type chosenProjection struct {
+	version string
+	routes  []proxy.GammaRoute
+	filter  *registryv1.ExtensionFilter
+}
+
+// selectProjections picks the highest-version projection per service from peer origins,
+// filtering out this cluster's own exports and (when set) non-control-cluster origins.
+func (i *Importer) selectProjections(projections []*registryv1.ServiceConfigProjection) map[string]chosenProjection {
+	picked := make(map[string]chosenProjection, len(projections))
 	for _, p := range projections {
 		if p.GetOriginCluster() == i.ownCluster {
 			continue // own export — local routes already cover it
@@ -124,11 +136,14 @@ func (i *Importer) materialize(projections []*registryv1.ServiceConfigProjection
 		if cur, ok := picked[svc]; ok && cur.version >= p.GetVersion() {
 			continue
 		}
-		picked[svc] = chosen{version: p.GetVersion(), routes: proxy.FromConfigProjection(p), filter: p.GetServiceFilter()}
+		picked[svc] = chosenProjection{version: p.GetVersion(), routes: proxy.FromConfigProjection(p), filter: p.GetServiceFilter()}
 	}
-	if len(picked) == 0 {
-		return nil, nil, time.Time{}
-	}
+	return picked
+}
+
+// buildRouteOutputs converts the winning-projection map into the routes map, chain
+// filters map, and oldest export timestamp (for the EM4 propagation-lag metric).
+func (i *Importer) buildRouteOutputs(picked map[string]chosenProjection) (map[string][]proxy.GammaRoute, map[string]proxy.ExtensionFilter, time.Time) {
 	out := make(map[string][]proxy.GammaRoute, len(picked))
 	var chainFilters map[string]proxy.ExtensionFilter
 	var oldest time.Time

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -140,120 +140,21 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // Reconcile re-lists every HTTPRoute and GRPCRoute, keeps those attached to a Service,
 // and replaces the cache's per-service rule set.
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
-	httpList := &gatewayv1.HTTPRouteList{}
-	if err := r.List(ctx, httpList); err != nil {
+	httpList, grpcList, grants, err := r.listGammaResources(ctx)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
-	// Optional types (CRD-gated in SetupWithManager, proposal 031): listing a
-	// kind whose CRD is absent errors every reconcile, so skip when disabled.
-	grpcList := &gatewayv1.GRPCRouteList{}
-	if r.grpcRouteEnabled {
-		if err := r.List(ctx, grpcList); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs.
-	grantList := &gatewayv1beta1.ReferenceGrantList{}
-	if r.referenceGrantEnabled {
-		if err := r.List(ctx, grantList); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	grants := grantList.Items
 
-	// HTTPFilters (config.aether.io, proposal 025) referenced by route ExtensionRefs,
-	// indexed by "<ns>/<name>". ExtensionRef is same-namespace (a LocalObjectReference),
-	// so no ReferenceGrant applies. Only listed when the CRD is present (gated in
-	// SetupWithManager); otherwise the escape hatch is inert and the map stays empty.
-	httpFilters := map[string]*configapisv1.HTTPFilter{}
-	if r.httpFilterEnabled {
-		httpFilterList := &configapisv1.HTTPFilterList{}
-		if err := r.List(ctx, httpFilterList); err != nil {
-			return reconcile.Result{}, err
-		}
-		for i := range httpFilterList.Items {
-			hf := &httpFilterList.Items[i]
-			httpFilters[hf.Namespace+"/"+hf.Name] = hf
-		}
+	httpFilters, err := r.listHTTPFilters(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
-	routes := map[string][]proxy.GammaRoute{}
-	// routeTargetPorts: the real Service port(s) each route target is addressed on
-	// (proposal 023 M2), accumulated from the parentRef ports. A target may be
-	// addressed on several ports across routes; collect the distinct set.
-	portSets := map[string]map[uint32]struct{}{}
-	collectPort := func(key string, port uint32) {
-		if port == 0 {
-			return
-		}
-		if portSets[key] == nil {
-			portSets[key] = map[uint32]struct{}{}
-		}
-		portSets[key][port] = struct{}{}
-	}
-	// serviceFilters caches the M3 targetRef-attached HTTPFilters per route-target Service
-	// (they apply to every route of that service).
 	specs := httpFilterSpecs(httpFilters)
-	serviceFiltersFor := func(key string) []*registryv1.ExtensionFilter {
-		return gammaproject.ServiceFilters(key, specs)
-	}
-	// Service-wide always-on filters (M4 CHAIN scope) + destination-side INBOUND
-	// filters (027 M3): resolve per targeted service.
-	chainFilters := map[string]proxy.ExtensionFilter{}
-	inboundFilters := map[string]proxy.ExtensionFilter{}
-	for key, spec := range specs {
-		scope := spec.GetScope()
-		if scope != configprotov1.HTTPFilterSpec_SCOPE_CHAIN && scope != configprotov1.HTTPFilterSpec_SCOPE_INBOUND {
-			continue
-		}
-		ns, _, _ := strings.Cut(key, "/")
-		for _, t := range spec.GetTargetRefs() {
-			if (t.GetGroup() != "" && t.GetGroup() != "core") || t.GetKind() != "Service" {
-				continue
-			}
-			svcKey := ns + "/" + t.GetName()
-			// Deterministic pick delegated to the shared projector (name-sorted).
-			if scope == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
-				if ef := gammaproject.ServiceChainFilter(svcKey, specs); ef != nil {
-					chainFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
-				}
-			} else {
-				if ef := gammaproject.ServiceInboundFilter(svcKey, specs); ef != nil {
-					inboundFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
-				}
-			}
-		}
-	}
-	for i := range httpList.Items {
-		hr := &httpList.Items[i]
-		for _, p := range gammaproject.ServiceParents(hr.Spec.ParentRefs, hr.Namespace) {
-			collectPort(p.Key, p.Port)
-			svcFilters := serviceFiltersFor(p.Key)
-			for _, rule := range hr.Spec.Rules {
-				routes[p.Key] = append(routes[p.Key], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants, httpFilters, svcFilters))
-			}
-		}
-	}
-	for i := range grpcList.Items {
-		gr := &grpcList.Items[i]
-		for _, p := range gammaproject.ServiceParents(gr.Spec.ParentRefs, gr.Namespace) {
-			collectPort(p.Key, p.Port)
-			svcFilters := serviceFiltersFor(p.Key)
-			for _, rule := range gr.Spec.Rules {
-				routes[p.Key] = append(routes[p.Key], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants, httpFilters, svcFilters))
-			}
-		}
-	}
+	chainFilters, inboundFilters := r.buildScopedFilters(specs)
 
-	routeTargetPorts := make(map[string][]uint32, len(portSets))
-	for key, set := range portSets {
-		ports := make([]uint32, 0, len(set))
-		for p := range set {
-			ports = append(ports, p)
-		}
-		slices.Sort(ports) // stable order so the cache's change-detection is deterministic
-		routeTargetPorts[key] = ports
-	}
+	routes, portSets := r.projectAllRoutes(httpList, grpcList, grants, httpFilters, specs)
+	routeTargetPorts := buildRouteTargetPorts(portSets)
 
 	r.Sink.SetServiceRoutes(routes)
 	r.Sink.SetServiceChainFilters(chainFilters)
@@ -266,6 +167,184 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// Accepted + ResolvedRefs RouteParentStatus per Service parentRef. Status write
 	// failures are logged but don't fail the reconcile (the data plane is already
 	// projected); the next reconcile retries.
+	r.writeHTTPRouteStatuses(ctx, httpList, grants)
+	r.writeGRPCRouteStatuses(ctx, grpcList, grants)
+	return reconcile.Result{}, nil
+}
+
+// listGammaResources lists HTTPRoutes, GRPCRoutes, and ReferenceGrants (all CRD-gated).
+func (r *Reconciler) listGammaResources(ctx context.Context) (*gatewayv1.HTTPRouteList, *gatewayv1.GRPCRouteList, []gatewayv1beta1.ReferenceGrant, error) {
+	httpList := &gatewayv1.HTTPRouteList{}
+	if err := r.List(ctx, httpList); err != nil {
+		return nil, nil, nil, err
+	}
+	// Optional types (CRD-gated in SetupWithManager, proposal 031): listing a
+	// kind whose CRD is absent errors every reconcile, so skip when disabled.
+	grpcList := &gatewayv1.GRPCRouteList{}
+	if r.grpcRouteEnabled {
+		if err := r.List(ctx, grpcList); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs.
+	grantList := &gatewayv1beta1.ReferenceGrantList{}
+	if r.referenceGrantEnabled {
+		if err := r.List(ctx, grantList); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	return httpList, grpcList, grantList.Items, nil
+}
+
+// listHTTPFilters lists HTTPFilter objects indexed by "<ns>/<name>", or returns an
+// empty map when the CRD is absent. HTTPFilters (proposal 025) are gated on
+// httpFilterEnabled (set in SetupWithManager).
+func (r *Reconciler) listHTTPFilters(ctx context.Context) (map[string]*configapisv1.HTTPFilter, error) {
+	httpFilters := map[string]*configapisv1.HTTPFilter{}
+	if !r.httpFilterEnabled {
+		return httpFilters, nil
+	}
+	// HTTPFilters (config.aether.io, proposal 025) referenced by route ExtensionRefs,
+	// indexed by "<ns>/<name>". ExtensionRef is same-namespace (a LocalObjectReference),
+	// so no ReferenceGrant applies. Only listed when the CRD is present (gated in
+	// SetupWithManager); otherwise the escape hatch is inert and the map stays empty.
+	httpFilterList := &configapisv1.HTTPFilterList{}
+	if err := r.List(ctx, httpFilterList); err != nil {
+		return nil, err
+	}
+	for i := range httpFilterList.Items {
+		hf := &httpFilterList.Items[i]
+		httpFilters[hf.Namespace+"/"+hf.Name] = hf
+	}
+	return httpFilters, nil
+}
+
+// buildScopedFilters resolves per-service CHAIN and INBOUND scope extension filters
+// from the HTTPFilter specs (proposal 025 M4 / 027 M3).
+func (r *Reconciler) buildScopedFilters(specs map[string]*configprotov1.HTTPFilterSpec) (chainFilters, inboundFilters map[string]proxy.ExtensionFilter) {
+	// Service-wide always-on filters (M4 CHAIN scope) + destination-side INBOUND
+	// filters (027 M3): resolve per targeted service.
+	chainFilters = map[string]proxy.ExtensionFilter{}
+	inboundFilters = map[string]proxy.ExtensionFilter{}
+	for key, spec := range specs {
+		scope := spec.GetScope()
+		if scope != configprotov1.HTTPFilterSpec_SCOPE_CHAIN && scope != configprotov1.HTTPFilterSpec_SCOPE_INBOUND {
+			continue
+		}
+		ns, _, _ := strings.Cut(key, "/")
+		r.resolveTargetRefFilters(ns, spec, specs, scope, chainFilters, inboundFilters)
+	}
+	return chainFilters, inboundFilters
+}
+
+// resolveTargetRefFilters resolves CHAIN/INBOUND filters for each targetRef in the spec.
+func (r *Reconciler) resolveTargetRefFilters(ns string, spec *configprotov1.HTTPFilterSpec, specs map[string]*configprotov1.HTTPFilterSpec, scope configprotov1.HTTPFilterSpec_Scope, chainFilters, inboundFilters map[string]proxy.ExtensionFilter) {
+	for _, t := range spec.GetTargetRefs() {
+		if (t.GetGroup() != "" && t.GetGroup() != "core") || t.GetKind() != "Service" {
+			continue
+		}
+		svcKey := ns + "/" + t.GetName()
+		// Deterministic pick delegated to the shared projector (name-sorted).
+		if scope == configprotov1.HTTPFilterSpec_SCOPE_CHAIN {
+			if ef := gammaproject.ServiceChainFilter(svcKey, specs); ef != nil {
+				chainFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
+			}
+		} else {
+			if ef := gammaproject.ServiceInboundFilter(svcKey, specs); ef != nil {
+				inboundFilters[svcKey] = proxy.ExtensionFilter{Name: ef.GetName(), Config: ef.GetConfig()}
+			}
+		}
+	}
+}
+
+// projectAllRoutes projects HTTP and GRPC routes into per-service route maps.
+// It returns the route map and port sets for target-port collection.
+func (r *Reconciler) projectAllRoutes(
+	httpList *gatewayv1.HTTPRouteList,
+	grpcList *gatewayv1.GRPCRouteList,
+	grants []gatewayv1beta1.ReferenceGrant,
+	httpFilters map[string]*configapisv1.HTTPFilter,
+	specs map[string]*configprotov1.HTTPFilterSpec,
+) (map[string][]proxy.GammaRoute, map[string]map[uint32]struct{}) {
+	routes := map[string][]proxy.GammaRoute{}
+	// routeTargetPorts: the real Service port(s) each route target is addressed on
+	// (proposal 023 M2), accumulated from the parentRef ports. A target may be
+	// addressed on several ports across routes; collect the distinct set.
+	portSets := map[string]map[uint32]struct{}{}
+	r.projectHTTPRouteItems(httpList, grants, httpFilters, specs, routes, portSets)
+	r.projectGRPCRouteItems(grpcList, grants, httpFilters, specs, routes, portSets)
+	return routes, portSets
+}
+
+// projectHTTPRouteItems projects each HTTPRoute item into the routes and portSets maps.
+func (r *Reconciler) projectHTTPRouteItems(
+	httpList *gatewayv1.HTTPRouteList,
+	grants []gatewayv1beta1.ReferenceGrant,
+	httpFilters map[string]*configapisv1.HTTPFilter,
+	specs map[string]*configprotov1.HTTPFilterSpec,
+	routes map[string][]proxy.GammaRoute,
+	portSets map[string]map[uint32]struct{},
+) {
+	for i := range httpList.Items {
+		hr := &httpList.Items[i]
+		for _, p := range gammaproject.ServiceParents(hr.Spec.ParentRefs, hr.Namespace) {
+			addToPortSets(portSets, p.Key, p.Port)
+			svcFilters := gammaproject.ServiceFilters(p.Key, specs)
+			for _, rule := range hr.Spec.Rules {
+				routes[p.Key] = append(routes[p.Key], r.buildGammaRoute(rule, hr.Namespace, "HTTPRoute", grants, httpFilters, svcFilters))
+			}
+		}
+	}
+}
+
+// projectGRPCRouteItems projects each GRPCRoute item into the routes and portSets maps.
+func (r *Reconciler) projectGRPCRouteItems(
+	grpcList *gatewayv1.GRPCRouteList,
+	grants []gatewayv1beta1.ReferenceGrant,
+	httpFilters map[string]*configapisv1.HTTPFilter,
+	specs map[string]*configprotov1.HTTPFilterSpec,
+	routes map[string][]proxy.GammaRoute,
+	portSets map[string]map[uint32]struct{},
+) {
+	for i := range grpcList.Items {
+		gr := &grpcList.Items[i]
+		for _, p := range gammaproject.ServiceParents(gr.Spec.ParentRefs, gr.Namespace) {
+			addToPortSets(portSets, p.Key, p.Port)
+			svcFilters := gammaproject.ServiceFilters(p.Key, specs)
+			for _, rule := range gr.Spec.Rules {
+				routes[p.Key] = append(routes[p.Key], r.buildGammaRouteFromGRPC(rule, gr.Namespace, "GRPCRoute", grants, httpFilters, svcFilters))
+			}
+		}
+	}
+}
+
+// addToPortSets records port in portSets[key], skipping zero ports.
+func addToPortSets(portSets map[string]map[uint32]struct{}, key string, port uint32) {
+	if port == 0 {
+		return
+	}
+	if portSets[key] == nil {
+		portSets[key] = map[uint32]struct{}{}
+	}
+	portSets[key][port] = struct{}{}
+}
+
+// buildRouteTargetPorts converts portSets (keyed by service) into sorted port slices.
+func buildRouteTargetPorts(portSets map[string]map[uint32]struct{}) map[string][]uint32 {
+	routeTargetPorts := make(map[string][]uint32, len(portSets))
+	for key, set := range portSets {
+		ports := make([]uint32, 0, len(set))
+		for p := range set {
+			ports = append(ports, p)
+		}
+		slices.Sort(ports) // stable order so the cache's change-detection is deterministic
+		routeTargetPorts[key] = ports
+	}
+	return routeTargetPorts
+}
+
+// writeHTTPRouteStatuses publishes Gateway API status for every Service-parented HTTPRoute.
+func (r *Reconciler) writeHTTPRouteStatuses(ctx context.Context, httpList *gatewayv1.HTTPRouteList, grants []gatewayv1beta1.ReferenceGrant) {
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
 		resolved, reason, msg := r.backendsResolve(ctx, hr.Namespace, "HTTPRoute", httpBackendRefs(hr.Spec.Rules), grants)
@@ -273,6 +352,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			r.Log.WarnContext(ctx, "failed to write HTTPRoute status", "route", hr.Name, "namespace", hr.Namespace, "error", err.Error())
 		}
 	}
+}
+
+// writeGRPCRouteStatuses publishes Gateway API status for every Service-parented GRPCRoute.
+func (r *Reconciler) writeGRPCRouteStatuses(ctx context.Context, grpcList *gatewayv1.GRPCRouteList, grants []gatewayv1beta1.ReferenceGrant) {
 	for i := range grpcList.Items {
 		gr := &grpcList.Items[i]
 		resolved, reason, msg := r.backendsResolve(ctx, gr.Namespace, "GRPCRoute", grpcBackendRefs(gr.Spec.Rules), grants)
@@ -280,7 +363,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			r.Log.WarnContext(ctx, "failed to write GRPCRoute status", "route", gr.Name, "namespace", gr.Namespace, "error", err.Error())
 		}
 	}
-	return reconcile.Result{}, nil
 }
 
 // writeRouteStatus upserts our (mesh controller) RouteParentStatus for each

--- a/agent/internal/l4route/reconciler.go
+++ b/agent/internal/l4route/reconciler.go
@@ -134,68 +134,14 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // attached to a Service (parentRef kind=Service, empty group), and replaces
 // the sink's per-service rule sets.
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
-	// Every List is CRD-gated (proposal 031): listing a kind whose CRD is
-	// absent errors every reconcile, so disabled types keep empty lists.
-	tcpList := &gatewayv1.TCPRouteList{}
-	if r.tcpEnabled {
-		if err := r.List(ctx, tcpList); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	tlsList := &gatewayv1.TLSRouteList{}
-	if r.tlsEnabled {
-		if err := r.List(ctx, tlsList); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	udpList := &gatewayv1.UDPRouteList{}
-	if r.udpEnabled {
-		if err := r.List(ctx, udpList); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs.
-	grantList := &gatewayv1beta1.ReferenceGrantList{}
-	if r.referenceGrantEnabled {
-		if err := r.List(ctx, grantList); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-	grants := grantList.Items
-
-	tcpRoutes := map[string][]proxy.L4ServiceRoute{}
-	for i := range tcpList.Items {
-		tr := &tcpList.Items[i]
-		for _, svc := range serviceParents(tr.Spec.ParentRefs, tr.Namespace) {
-			for _, rule := range tr.Spec.Rules {
-				tcpRoutes[svc] = append(tcpRoutes[svc], r.buildTCPRoute(rule, tr.Namespace, "TCPRoute", grants))
-			}
-		}
+	tcpList, tlsList, udpList, grants, err := r.listL4Resources(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
 
-	tlsRoutes := map[string][]proxy.L4ServiceRoute{}
-	for i := range tlsList.Items {
-		tr := &tlsList.Items[i]
-		for _, svc := range serviceParents(tr.Spec.ParentRefs, tr.Namespace) {
-			hostnames := make([]string, 0, len(tr.Spec.Hostnames))
-			for _, h := range tr.Spec.Hostnames {
-				hostnames = append(hostnames, string(h))
-			}
-			for _, rule := range tr.Spec.Rules {
-				tlsRoutes[svc] = append(tlsRoutes[svc], r.buildTLSRoute(rule, hostnames, tr.Namespace, "TLSRoute", grants))
-			}
-		}
-	}
-
-	udpRoutes := map[string][]proxy.L4Backend{}
-	for i := range udpList.Items {
-		ur := &udpList.Items[i]
-		for _, svc := range serviceParents(ur.Spec.ParentRefs, ur.Namespace) {
-			for _, rule := range ur.Spec.Rules {
-				udpRoutes[svc] = append(udpRoutes[svc], r.buildUDPBackends(rule, ur.Namespace, "UDPRoute", grants)...)
-			}
-		}
-	}
+	tcpRoutes := r.projectTCPRoutes(tcpList, grants)
+	tlsRoutes := r.projectTLSRoutes(tlsList, grants)
+	udpRoutes := r.projectUDPRoutes(udpList, grants)
 
 	r.Sink.SetTCPServiceRoutes(tcpRoutes)
 	r.Sink.SetTLSServiceRoutes(tlsRoutes)
@@ -215,6 +161,92 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	// every Service parentRef of each route we own (mesh controller). Failures are
 	// logged, not fatal — the data plane is already projected and the next
 	// reconcile retries.
+	r.writeTCPRouteStatuses(ctx, tcpList, grants)
+	r.writeTLSRouteStatuses(ctx, tlsList, grants)
+	r.writeUDPRouteStatuses(ctx, udpList, grants)
+	return reconcile.Result{}, nil
+}
+
+// listL4Resources lists TCPRoutes, TLSRoutes, UDPRoutes, and ReferenceGrants (all CRD-gated).
+func (r *Reconciler) listL4Resources(ctx context.Context) (*gatewayv1.TCPRouteList, *gatewayv1.TLSRouteList, *gatewayv1.UDPRouteList, []gatewayv1beta1.ReferenceGrant, error) {
+	// Every List is CRD-gated (proposal 031): listing a kind whose CRD is
+	// absent errors every reconcile, so disabled types keep empty lists.
+	tcpList := &gatewayv1.TCPRouteList{}
+	if r.tcpEnabled {
+		if err := r.List(ctx, tcpList); err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+	tlsList := &gatewayv1.TLSRouteList{}
+	if r.tlsEnabled {
+		if err := r.List(ctx, tlsList); err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+	udpList := &gatewayv1.UDPRouteList{}
+	if r.udpEnabled {
+		if err := r.List(ctx, udpList); err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs.
+	grantList := &gatewayv1beta1.ReferenceGrantList{}
+	if r.referenceGrantEnabled {
+		if err := r.List(ctx, grantList); err != nil {
+			return nil, nil, nil, nil, err
+		}
+	}
+	return tcpList, tlsList, udpList, grantList.Items, nil
+}
+
+// projectTCPRoutes builds the per-service TCPRoute map from the listed routes.
+func (r *Reconciler) projectTCPRoutes(tcpList *gatewayv1.TCPRouteList, grants []gatewayv1beta1.ReferenceGrant) map[string][]proxy.L4ServiceRoute {
+	tcpRoutes := map[string][]proxy.L4ServiceRoute{}
+	for i := range tcpList.Items {
+		tr := &tcpList.Items[i]
+		for _, svc := range serviceParents(tr.Spec.ParentRefs, tr.Namespace) {
+			for _, rule := range tr.Spec.Rules {
+				tcpRoutes[svc] = append(tcpRoutes[svc], r.buildTCPRoute(rule, tr.Namespace, "TCPRoute", grants))
+			}
+		}
+	}
+	return tcpRoutes
+}
+
+// projectTLSRoutes builds the per-service TLSRoute map from the listed routes.
+func (r *Reconciler) projectTLSRoutes(tlsList *gatewayv1.TLSRouteList, grants []gatewayv1beta1.ReferenceGrant) map[string][]proxy.L4ServiceRoute {
+	tlsRoutes := map[string][]proxy.L4ServiceRoute{}
+	for i := range tlsList.Items {
+		tr := &tlsList.Items[i]
+		for _, svc := range serviceParents(tr.Spec.ParentRefs, tr.Namespace) {
+			hostnames := make([]string, 0, len(tr.Spec.Hostnames))
+			for _, h := range tr.Spec.Hostnames {
+				hostnames = append(hostnames, string(h))
+			}
+			for _, rule := range tr.Spec.Rules {
+				tlsRoutes[svc] = append(tlsRoutes[svc], r.buildTLSRoute(rule, hostnames, tr.Namespace, "TLSRoute", grants))
+			}
+		}
+	}
+	return tlsRoutes
+}
+
+// projectUDPRoutes builds the per-service UDPRoute map from the listed routes.
+func (r *Reconciler) projectUDPRoutes(udpList *gatewayv1.UDPRouteList, grants []gatewayv1beta1.ReferenceGrant) map[string][]proxy.L4Backend {
+	udpRoutes := map[string][]proxy.L4Backend{}
+	for i := range udpList.Items {
+		ur := &udpList.Items[i]
+		for _, svc := range serviceParents(ur.Spec.ParentRefs, ur.Namespace) {
+			for _, rule := range ur.Spec.Rules {
+				udpRoutes[svc] = append(udpRoutes[svc], r.buildUDPBackends(rule, ur.Namespace, "UDPRoute", grants)...)
+			}
+		}
+	}
+	return udpRoutes
+}
+
+// writeTCPRouteStatuses publishes Gateway API status for every Service-parented TCPRoute.
+func (r *Reconciler) writeTCPRouteStatuses(ctx context.Context, tcpList *gatewayv1.TCPRouteList, grants []gatewayv1beta1.ReferenceGrant) {
 	for i := range tcpList.Items {
 		tr := &tcpList.Items[i]
 		resolved, reason, msg := r.backendsResolve(ctx, tr.Namespace, "TCPRoute", tcpBackendRefs(tr.Spec.Rules), grants)
@@ -222,6 +254,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			r.Log.WarnContext(ctx, "failed to write TCPRoute status", "route", tr.Name, "namespace", tr.Namespace, "error", err.Error())
 		}
 	}
+}
+
+// writeTLSRouteStatuses publishes Gateway API status for every Service-parented TLSRoute.
+func (r *Reconciler) writeTLSRouteStatuses(ctx context.Context, tlsList *gatewayv1.TLSRouteList, grants []gatewayv1beta1.ReferenceGrant) {
 	for i := range tlsList.Items {
 		tr := &tlsList.Items[i]
 		resolved, reason, msg := r.backendsResolve(ctx, tr.Namespace, "TLSRoute", tlsBackendRefs(tr.Spec.Rules), grants)
@@ -229,6 +265,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			r.Log.WarnContext(ctx, "failed to write TLSRoute status", "route", tr.Name, "namespace", tr.Namespace, "error", err.Error())
 		}
 	}
+}
+
+// writeUDPRouteStatuses publishes Gateway API status for every Service-parented UDPRoute.
+func (r *Reconciler) writeUDPRouteStatuses(ctx context.Context, udpList *gatewayv1.UDPRouteList, grants []gatewayv1beta1.ReferenceGrant) {
 	for i := range udpList.Items {
 		ur := &udpList.Items[i]
 		resolved, reason, msg := r.backendsResolve(ctx, ur.Namespace, "UDPRoute", udpBackendRefs(ur.Spec.Rules), grants)
@@ -236,7 +276,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			r.Log.WarnContext(ctx, "failed to write UDPRoute status", "route", ur.Name, "namespace", ur.Namespace, "error", err.Error())
 		}
 	}
-	return reconcile.Result{}, nil
 }
 
 // writeRouteStatus upserts our (mesh controller) RouteParentStatus for each

--- a/registrar/internal/configexport/controller.go
+++ b/registrar/internal/configexport/controller.go
@@ -76,33 +76,70 @@ func (c *Controller) SetupWithManager(mgr ctrl.Manager) error {
 // and reconciles it into the registry: SetConfig changed/new projections, UnsetConfig
 // the ones this cluster previously exported but no longer has.
 func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	httpList, grpcList, grantList, exportList, err := c.listExportResources(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	exported := buildExportedSet(exportList)
+	httpFilters := c.httpFilterSpecs(ctx)
+
+	desired := c.projectHTTPRoutes(httpList, exported, grantList.Items, httpFilters)
+	for svc, routes := range c.projectGRPCRoutes(grpcList, exported, grantList.Items, httpFilters) {
+		desired[svc] = append(desired[svc], routes...)
+	}
+	desiredFilter := c.resolveChainFilters(exported, httpFilters, desired)
+
+	current, err := c.Exporter.ListConfig(ctx)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	own := ownCurrentProjections(current, c.Cluster)
+
+	version := time.Now().UTC().Format(time.RFC3339Nano)
+	if err := c.applyDesired(ctx, desired, desiredFilter, own, version); err != nil {
+		return reconcile.Result{}, err
+	}
+	if err := c.pruneStale(ctx, desired, own); err != nil {
+		return reconcile.Result{}, err
+	}
+	c.metrics.observe(ctx, len(desired))
+	return reconcile.Result{}, nil
+}
+
+// listExportResources lists all resources needed for the export reconciliation.
+func (c *Controller) listExportResources(ctx context.Context) (*gatewayv1.HTTPRouteList, *gatewayv1.GRPCRouteList, *gatewayv1beta1.ReferenceGrantList, *mcsv1alpha1.ServiceExportList, error) {
 	httpList := &gatewayv1.HTTPRouteList{}
 	if err := c.List(ctx, httpList); err != nil {
-		return reconcile.Result{}, err
+		return nil, nil, nil, nil, err
 	}
 	grpcList := &gatewayv1.GRPCRouteList{}
 	if err := c.List(ctx, grpcList); err != nil {
-		return reconcile.Result{}, err
+		return nil, nil, nil, nil, err
 	}
 	grantList := &gatewayv1beta1.ReferenceGrantList{}
 	if err := c.List(ctx, grantList); err != nil {
-		return reconcile.Result{}, err
+		return nil, nil, nil, nil, err
 	}
 	exportList := &mcsv1alpha1.ServiceExportList{}
 	if err := c.List(ctx, exportList); err != nil {
-		return reconcile.Result{}, err
+		return nil, nil, nil, nil, err
 	}
+	return httpList, grpcList, grantList, exportList, nil
+}
+
+// buildExportedSet builds the set of exported service keys from a ServiceExportList.
+func buildExportedSet(exportList *mcsv1alpha1.ServiceExportList) map[string]struct{} {
 	exported := make(map[string]struct{}, len(exportList.Items))
 	for i := range exportList.Items {
 		se := &exportList.Items[i]
 		exported[se.Namespace+"/"+se.Name] = struct{}{}
 	}
-	httpFilters := c.httpFilterSpecs(ctx)
+	return exported
+}
 
-	// Desired: per EXPORTED route-target, the projected GAMMA routes (+ the
-	// service-wide chain filter, 025 M4 — resolved after the route loops).
+// projectHTTPRoutes projects exported HTTPRoute rules into GammaRoute protos.
+func (c *Controller) projectHTTPRoutes(httpList *gatewayv1.HTTPRouteList, exported map[string]struct{}, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec) map[string][]*registryv1.GammaRoute {
 	desired := map[string][]*registryv1.GammaRoute{}
-	desiredFilter := map[string]*registryv1.ExtensionFilter{}
 	for i := range httpList.Items {
 		hr := &httpList.Items[i]
 		for _, p := range gammaproject.ServiceParents(hr.Spec.ParentRefs, hr.Namespace) {
@@ -111,10 +148,16 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			}
 			svcFilters := gammaproject.ServiceFilters(p.Key, httpFilters) // M3 targetRef-attached
 			for _, rule := range hr.Spec.Rules {
-				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectHTTPRule(rule, hr.Namespace, "HTTPRoute", c.MeshDomain, grantList.Items, httpFilters, svcFilters))
+				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectHTTPRule(rule, hr.Namespace, "HTTPRoute", c.MeshDomain, grants, httpFilters, svcFilters))
 			}
 		}
 	}
+	return desired
+}
+
+// projectGRPCRoutes projects exported GRPCRoute rules into GammaRoute protos.
+func (c *Controller) projectGRPCRoutes(grpcList *gatewayv1.GRPCRouteList, exported map[string]struct{}, grants []gatewayv1beta1.ReferenceGrant, httpFilters map[string]*configprotov1.HTTPFilterSpec) map[string][]*registryv1.GammaRoute {
+	desired := map[string][]*registryv1.GammaRoute{}
 	for i := range grpcList.Items {
 		gr := &grpcList.Items[i]
 		for _, p := range gammaproject.ServiceParents(gr.Spec.ParentRefs, gr.Namespace) {
@@ -123,13 +166,18 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			}
 			svcFilters := gammaproject.ServiceFilters(p.Key, httpFilters) // M3 targetRef-attached
 			for _, rule := range gr.Spec.Rules {
-				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectGRPCRule(rule, gr.Namespace, "GRPCRoute", c.MeshDomain, grantList.Items, httpFilters, svcFilters))
+				desired[p.Key] = append(desired[p.Key], gammaproject.ProjectGRPCRule(rule, gr.Namespace, "GRPCRoute", c.MeshDomain, grants, httpFilters, svcFilters))
 			}
 		}
 	}
+	return desired
+}
 
-	// Service-wide chain filters (025 M4): for every exported service — including one
-	// with a chain filter but NO routes (the filter alone is exportable config).
+// resolveChainFilters resolves the service-wide chain filters (025 M4) for every
+// exported service, including filter-only projections (no routes). Mutates desired
+// to add filter-only entries.
+func (c *Controller) resolveChainFilters(exported map[string]struct{}, httpFilters map[string]*configprotov1.HTTPFilterSpec, desired map[string][]*registryv1.GammaRoute) map[string]*registryv1.ExtensionFilter {
+	desiredFilter := map[string]*registryv1.ExtensionFilter{}
 	for svc := range exported {
 		if ef := gammaproject.ServiceChainFilter(svc, httpFilters); ef != nil {
 			desiredFilter[svc] = ef
@@ -138,20 +186,22 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			}
 		}
 	}
+	return desiredFilter
+}
 
-	// Current state this cluster authored (origin == self), to diff against.
-	current, err := c.Exporter.ListConfig(ctx)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
+// ownCurrentProjections filters a config projection list to those authored by cluster.
+func ownCurrentProjections(current []*registryv1.ServiceConfigProjection, cluster string) map[string]*registryv1.ServiceConfigProjection {
 	own := map[string]*registryv1.ServiceConfigProjection{}
 	for _, p := range current {
-		if p.GetOriginCluster() == c.Cluster {
+		if p.GetOriginCluster() == cluster {
 			own[p.GetService()] = p
 		}
 	}
+	return own
+}
 
-	version := time.Now().UTC().Format(time.RFC3339Nano)
+// applyDesired writes new or changed config projections to the exporter.
+func (c *Controller) applyDesired(ctx context.Context, desired map[string][]*registryv1.GammaRoute, desiredFilter map[string]*registryv1.ExtensionFilter, own map[string]*registryv1.ServiceConfigProjection, version string) error {
 	for svc, routes := range desired {
 		// Skip when unchanged — avoid churning importers with a fresh version every reconcile.
 		if existing, ok := own[svc]; ok && routesEqual(existing.GetRoutes(), routes) && proto.Equal(existing.GetServiceFilter(), desiredFilter[svc]) {
@@ -160,11 +210,16 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		if err := c.Exporter.SetConfig(ctx, &registryv1.ServiceConfigProjection{Service: svc, Version: version, Routes: routes, ServiceFilter: desiredFilter[svc]}); err != nil {
 			c.metrics.writeError(ctx)
 			c.Log.ErrorContext(ctx, "failed to export config projection", "service", svc, "error", err)
-			return reconcile.Result{}, err
+			return err
 		}
 		c.Log.InfoContext(ctx, "exported config projection", "service", svc, "routes", len(routes))
 	}
-	// Unexport: services this cluster authored that are no longer exported/configured.
+	return nil
+}
+
+// pruneStale removes config projections this cluster authored that are no longer
+// exported or configured.
+func (c *Controller) pruneStale(ctx context.Context, desired map[string][]*registryv1.GammaRoute, own map[string]*registryv1.ServiceConfigProjection) error {
 	for svc := range own {
 		if _, ok := desired[svc]; ok {
 			continue
@@ -172,12 +227,11 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		if err := c.Exporter.UnsetConfig(ctx, svc); err != nil {
 			c.metrics.writeError(ctx)
 			c.Log.ErrorContext(ctx, "failed to unexport config projection", "service", svc, "error", err)
-			return reconcile.Result{}, err
+			return err
 		}
 		c.Log.InfoContext(ctx, "unexported config projection", "service", svc)
 	}
-	c.metrics.observe(ctx, len(desired))
-	return reconcile.Result{}, nil
+	return nil
 }
 
 // httpFilterSpecs builds the ExtensionRef lookup (proposal 025) keyed "<ns>/<name>",

--- a/registrar/internal/replicator/replicator.go
+++ b/registrar/internal/replicator/replicator.go
@@ -190,6 +190,13 @@ func (r *Replicator) mirrorPeer(ctx context.Context, log *slog.Logger, p Peer) e
 		}
 	}()
 
+	return r.runSyncWatchLoop(ctx, connCtx, log, peerCli, p, lease)
+}
+
+// runSyncWatchLoop runs the full-sync → watch cycle until the context ends or
+// an unrecoverable error occurs. Compaction causes a resync; lease keepalive
+// loss or write errors force a redial (returned as error).
+func (r *Replicator) runSyncWatchLoop(ctx, connCtx context.Context, log *slog.Logger, peerCli *clientv3.Client, p Peer, lease *peerLease) error {
 	for {
 		syncStart := time.Now()
 		rev, err := r.syncFull(connCtx, peerCli, lease.id)
@@ -277,18 +284,8 @@ func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, 
 			return err
 		}
 		for _, ev := range resp.Events {
-			key := string(ev.Kv.Key)
-			switch ev.Type {
-			case clientv3.EventTypePut:
-				if _, err := peerCli.Put(ctx, key, string(ev.Kv.Value), clientv3.WithLease(leaseID)); err != nil {
-					return fmt.Errorf("mirror put: %w", err)
-				}
-				r.metrics.event(ctx, region, "put")
-			case clientv3.EventTypeDelete:
-				if _, err := peerCli.Delete(ctx, key); err != nil {
-					return fmt.Errorf("mirror delete: %w", err)
-				}
-				r.metrics.event(ctx, region, "delete")
+			if err := r.mirrorEvent(ctx, peerCli, region, ev, leaseID); err != nil {
+				return err
 			}
 		}
 	}
@@ -296,4 +293,22 @@ func (r *Replicator) watchMirror(ctx context.Context, peerCli *clientv3.Client, 
 		return err
 	}
 	return errors.New("local watch channel closed")
+}
+
+// mirrorEvent applies one watch event (Put or Delete) to the peer.
+func (r *Replicator) mirrorEvent(ctx context.Context, peerCli *clientv3.Client, region string, ev *clientv3.Event, leaseID clientv3.LeaseID) error {
+	key := string(ev.Kv.Key)
+	switch ev.Type {
+	case clientv3.EventTypePut:
+		if _, err := peerCli.Put(ctx, key, string(ev.Kv.Value), clientv3.WithLease(leaseID)); err != nil {
+			return fmt.Errorf("mirror put: %w", err)
+		}
+		r.metrics.event(ctx, region, "put")
+	case clientv3.EventTypeDelete:
+		if _, err := peerCli.Delete(ctx, key); err != nil {
+			return fmt.Errorf("mirror delete: %w", err)
+		}
+		r.metrics.event(ctx, region, "delete")
+	}
+	return nil
 }

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -158,10 +158,6 @@ func (b *Broadcaster) filteredCountLocked() int {
 func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 	// Collect overflowed watchers under the read lock; closing them requires
 	// the write lock, taken afterwards to avoid lock-upgrade deadlocks.
-	type droppedWatcher struct {
-		id string
-		w  *watcher
-	}
 	var dropped []droppedWatcher
 
 	send := func(id string, w *watcher, event *registrarv1.WatchEndpointsResponse) {
@@ -198,10 +194,21 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 	}
 	b.mu.RUnlock()
 
-	if len(dropped) == 0 {
-		return
+	if len(dropped) > 0 {
+		b.closeDroppedWatchers(dropped)
 	}
+}
 
+type droppedWatcher struct {
+	id string
+	w  *watcher
+}
+
+// closeDroppedWatchers acquires the write lock and closes the channels of
+// overflowed watchers, forcing them to reconnect for a fresh snapshot.
+// Re-checks identity before closing (watcher may have reconnected or been
+// unsubscribed between the read and write locks).
+func (b *Broadcaster) closeDroppedWatchers(dropped []droppedWatcher) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	for _, d := range dropped {

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -188,20 +188,7 @@ func (s *RegistrarServer) UnregisterEndpoint(ctx context.Context, req *registrar
 // reconnect, and an unset filter preserves the full watch.
 func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest, stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse]) error {
 	watcherID := fmt.Sprintf("%s/%s", req.GetClusterName(), req.GetNodeName())
-
-	// nil = full watch; non-nil (possibly empty) = scoped to these services.
-	var filterServices []string
-	var filterSet map[string]struct{}
-	if f := req.GetFilter(); f != nil {
-		filterServices = f.GetServices()
-		if filterServices == nil {
-			filterServices = []string{}
-		}
-		filterSet = make(map[string]struct{}, len(filterServices))
-		for _, svc := range filterServices {
-			filterSet[svc] = struct{}{}
-		}
-	}
+	filterServices, filterSet := buildWatchFilter(req)
 	s.log.DebugContext(stream.Context(), "WatchEndpoints", "watcher", watcherID, "lastVersion", req.GetLastVersion(),
 		"filtered", filterSet != nil, "filterServices", len(filterServices))
 
@@ -210,34 +197,17 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 		return err
 	}
 
-	// Send current snapshot (scoped to the filter) unless the client is
-	// already up-to-date.
 	events, currentVersion := s.snapshot.FullSnapshotEvents()
 	if req.GetLastVersion() != currentVersion {
-		for _, event := range events {
-			if filterSet != nil {
-				if _, inScope := filterSet[event.GetServiceName()]; !inScope {
-					continue
-				}
-			}
-			if err := stream.Send(event); err != nil {
-				return fmt.Errorf("failed to send snapshot event: %w", err)
-			}
+		if err := sendFilteredSnapshot(stream, events, filterSet); err != nil {
+			return err
 		}
-	}
-	// Replay the full service catalog (every watcher, regardless of filter):
-	// agents keep a local index of service names so the on-demand cold path
-	// answers existence locally. Skipped when the client is current (its
-	// catalog is too: transitions ride the same versioned stream).
-	if req.GetLastVersion() != currentVersion {
-		for _, name := range s.snapshot.ServiceNames() {
-			if err := stream.Send(&registrarv1.WatchEndpointsResponse{
-				Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED,
-				ServiceName: name,
-				Version:     currentVersion,
-			}); err != nil {
-				return fmt.Errorf("failed to send service catalog event: %w", err)
-			}
+		// Replay the full service catalog (every watcher, regardless of filter):
+		// agents keep a local index of service names so the on-demand cold path
+		// answers existence locally. Skipped when the client is current (its
+		// catalog is too: transitions ride the same versioned stream).
+		if err := sendServiceCatalog(stream, s.snapshot.ServiceNames(), currentVersion); err != nil {
+			return err
 		}
 	}
 
@@ -253,7 +223,60 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 	// Subscribe and stream incremental events (fan-out indexed by service).
 	ch := s.broadcaster.Subscribe(watcherID, filterServices)
 	defer s.broadcaster.Unsubscribe(watcherID, ch)
+	return streamEvents(stream, ch)
+}
 
+// buildWatchFilter parses the request filter into a service list and lookup set.
+// nil filterSet = full watch; non-nil (possibly empty) = scoped watch.
+func buildWatchFilter(req *registrarv1.WatchEndpointsRequest) ([]string, map[string]struct{}) {
+	f := req.GetFilter()
+	if f == nil {
+		return nil, nil
+	}
+	filterServices := f.GetServices()
+	if filterServices == nil {
+		filterServices = []string{}
+	}
+	filterSet := make(map[string]struct{}, len(filterServices))
+	for _, svc := range filterServices {
+		filterSet[svc] = struct{}{}
+	}
+	return filterServices, filterSet
+}
+
+// sendFilteredSnapshot sends snapshot events scoped to filterSet (nil = send all).
+func sendFilteredSnapshot(stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse], events []*registrarv1.WatchEndpointsResponse, filterSet map[string]struct{}) error {
+	for _, event := range events {
+		if filterSet != nil {
+			if _, inScope := filterSet[event.GetServiceName()]; !inScope {
+				continue
+			}
+		}
+		if err := stream.Send(event); err != nil {
+			return fmt.Errorf("failed to send snapshot event: %w", err)
+		}
+	}
+	return nil
+}
+
+// sendServiceCatalog sends SERVICE_ADDED events for all names to the stream.
+// Catalog events are sent to ALL watchers regardless of filter (see Broadcast).
+func sendServiceCatalog(stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse], names []string, version string) error {
+	for _, name := range names {
+		if err := stream.Send(&registrarv1.WatchEndpointsResponse{
+			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED,
+			ServiceName: name,
+			Version:     version,
+		}); err != nil {
+			return fmt.Errorf("failed to send service catalog event: %w", err)
+		}
+	}
+	return nil
+}
+
+// streamEvents forwards incremental events from ch until the stream context ends
+// or the channel is closed (overflow/reconnect).
+func streamEvents(stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse], ch <-chan *registrarv1.WatchEndpointsResponse) error {
 	for {
 		select {
 		case <-stream.Context().Done():

--- a/registrar/internal/server/snapshot.go
+++ b/registrar/internal/server/snapshot.go
@@ -208,6 +208,13 @@ func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol]
 	for key := range s.entries {
 		newServices[key.ServiceName] = struct{}{}
 	}
+
+	return s.nextVersion(), computeTransitions(oldServices, newServices)
+}
+
+// computeTransitions builds the sorted list of SERVICE_ADDED/SERVICE_REMOVED
+// catalog events that describe the diff between oldServices and newServices.
+func computeTransitions(oldServices, newServices map[string]struct{}) []*registrarv1.WatchEndpointsResponse {
 	var transitions []*registrarv1.WatchEndpointsResponse
 	for name := range newServices {
 		if _, ok := oldServices[name]; !ok {
@@ -226,8 +233,7 @@ func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol]
 		}
 		return transitions[i].GetServiceName() < transitions[j].GetServiceName()
 	})
-
-	return s.nextVersion(), transitions
+	return transitions
 }
 
 // Apply applies a set of events to the snapshot, updating it in place.

--- a/registrar/internal/server/writebehind.go
+++ b/registrar/internal/server/writebehind.go
@@ -134,7 +134,16 @@ func (q *WriteBehindQueue) Start(ctx context.Context) error {
 // flushDue attempts every due, unflushed op once.
 func (q *WriteBehindQueue) flushDue(ctx context.Context) {
 	now := time.Now()
+	due := q.collectDueOps(ctx, now)
+	for key, op := range due {
+		q.flushOp(ctx, key, op)
+	}
+}
 
+// collectDueOps locks the queue, collects ops that are due (not flushed, not
+// waiting, not expired), drops those that exceeded wbMaxAge, and returns the
+// collected ops. The caller must not hold q.mu.
+func (q *WriteBehindQueue) collectDueOps(ctx context.Context, now time.Time) map[wbKey]wbOp {
 	q.mu.Lock()
 	due := make(map[wbKey]wbOp)
 	for key, op := range q.ops {
@@ -151,39 +160,43 @@ func (q *WriteBehindQueue) flushDue(ctx context.Context) {
 		due[key] = *op
 	}
 	q.mu.Unlock()
+	return due
+}
 
-	for key, op := range due {
-		var err error
-		switch op.kind {
-		case wbRegister:
-			err = q.registry.RegisterEndpoint(ctx, key.service, key.protocol, op.endpoint)
-		case wbUnregister:
-			err = q.registry.UnregisterEndpoint(ctx, key.service, key.ip)
-		}
+// flushOp performs one registry write for the given op and updates the op's
+// state (backoff or flushed) under the queue lock. Skips the update when a
+// newer op has superseded this one mid-flight.
+func (q *WriteBehindQueue) flushOp(ctx context.Context, key wbKey, op wbOp) {
+	var err error
+	switch op.kind {
+	case wbRegister:
+		err = q.registry.RegisterEndpoint(ctx, key.service, key.protocol, op.endpoint)
+	case wbUnregister:
+		err = q.registry.UnregisterEndpoint(ctx, key.service, key.ip)
+	}
 
-		q.mu.Lock()
-		cur, ok := q.ops[key]
-		// A newer op may have superseded this one mid-flight; never touch it.
-		superseded := !ok || cur.kind != op.kind || (op.kind == wbRegister && !proto.Equal(cur.endpoint, op.endpoint))
-		if !superseded {
-			if err != nil {
-				cur.attempts++
-				backoff := wbInitialBackoff << min(cur.attempts, 5) // 2s,4s,...,32s≈cap
-				if backoff > wbMaxBackoff {
-					backoff = wbMaxBackoff
-				}
-				cur.nextAttempt = time.Now().Add(backoff)
-			} else {
-				cur.flushed = true // kept for shielding until Overlay observes it
-			}
-		}
-		q.mu.Unlock()
-
+	q.mu.Lock()
+	cur, ok := q.ops[key]
+	// A newer op may have superseded this one mid-flight; never touch it.
+	superseded := !ok || cur.kind != op.kind || (op.kind == wbRegister && !proto.Equal(cur.endpoint, op.endpoint))
+	if !superseded {
 		if err != nil {
-			q.metrics.wbFlushFailed(ctx)
-			q.log.DebugContext(ctx, "write-behind flush failed; will retry",
-				"service", key.service, "ip", key.ip, "error", err.Error())
+			cur.attempts++
+			backoff := wbInitialBackoff << min(cur.attempts, 5) // 2s,4s,...,32s≈cap
+			if backoff > wbMaxBackoff {
+				backoff = wbMaxBackoff
+			}
+			cur.nextAttempt = time.Now().Add(backoff)
+		} else {
+			cur.flushed = true // kept for shielding until Overlay observes it
 		}
+	}
+	q.mu.Unlock()
+
+	if err != nil {
+		q.metrics.wbFlushFailed(ctx)
+		q.log.DebugContext(ctx, "write-behind flush failed; will retry",
+			"service", key.service, "ip", key.ip, "error", err.Error())
 	}
 }
 

--- a/registrar/internal/services/generator.go
+++ b/registrar/internal/services/generator.go
@@ -72,6 +72,22 @@ var protocolAppProtocol = map[registryv1.Service_Protocol]string{
 // reconcile makes the managed Services equal the snapshot catalog: create missing,
 // update drifted, prune stale (only Services this generator owns, by label).
 func (g *Generator) reconcile(ctx context.Context) {
+	desired := g.buildDesiredServices(ctx)
+
+	var managed corev1.ServiceList
+	if err := g.List(ctx, &managed, client.MatchingLabels{aetherlabels.LabelMeshService: "true"}); err != nil {
+		g.Log.ErrorContext(ctx, "list managed mesh Services failed", "error", err)
+		return
+	}
+	g.pruneServices(ctx, managed, desired)
+	for _, d := range desired {
+		g.apply(ctx, d)
+	}
+}
+
+// buildDesiredServices iterates all protocols in the snapshot and builds the
+// desired map of mesh VIP Services. Ordered (HTTP before TCP) for determinism.
+func (g *Generator) buildDesiredServices(ctx context.Context) map[client.ObjectKey]desiredService {
 	desired := map[client.ObjectKey]desiredService{}
 	// A service is registered under exactly one protocol (the registry key is
 	// name+protocol; the pod annotation picks it). Iterate every protocol so an
@@ -104,12 +120,11 @@ func (g *Generator) reconcile(ctx context.Context) {
 			}
 		}
 	}
+	return desired
+}
 
-	var managed corev1.ServiceList
-	if err := g.List(ctx, &managed, client.MatchingLabels{aetherlabels.LabelMeshService: "true"}); err != nil {
-		g.Log.ErrorContext(ctx, "list managed mesh Services failed", "error", err)
-		return
-	}
+// pruneServices deletes managed mesh Services that are no longer in desired.
+func (g *Generator) pruneServices(ctx context.Context, managed corev1.ServiceList, desired map[client.ObjectKey]desiredService) {
 	for i := range managed.Items {
 		s := &managed.Items[i]
 		key := client.ObjectKeyFromObject(s)
@@ -121,9 +136,6 @@ func (g *Generator) reconcile(ctx context.Context) {
 		} else {
 			g.Log.InfoContext(ctx, "pruned mesh Service (service gone from registry)", "service", key.String())
 		}
-	}
-	for _, d := range desired {
-		g.apply(ctx, d)
 	}
 }
 


### PR DESCRIPTION
## Summary

Structure-only refactoring to reduce gocognit cognitive complexity to ≤15 in all non-test functions across the Lane 5 scope. Zero behavior change — guard clauses and helper extractions only. Part of #556.

## Per-function extraction summary

| Function | Before | After | Helpers extracted |
|----------|--------|-------|-------------------|
| `gamma (*Reconciler).Reconcile` | 59 | ≤15 | `listGammaResources`, `listHTTPFilters`, `buildScopedFilters`, `resolveTargetRefFilters`, `projectAllRoutes`, `buildRouteTargetPorts`, `writeHTTPRouteStatuses`, `writeGRPCRouteStatuses` |
| `configexport (*Controller).Reconcile` | 44 | ≤15 | `listExportResources`, `buildExportedSet`, `projectHTTPRoutes`, `projectGRPCRoutes`, `resolveChainFilters`, `ownCurrentProjections`, `applyDesired`, `pruneStale` |
| `l4route (*Reconciler).Reconcile` | 42 | ≤15 | `listL4Resources`, `projectTCPRoutes`, `projectTLSRoutes`, `projectUDPRoutes`, `writeTCPRouteStatuses`, `writeTLSRouteStatuses`, `writeUDPRouteStatuses` |
| `server (*RegistrarServer).WatchEndpoints` | 35 | ≤15 | `buildWatchFilter`, `sendFilteredSnapshot`, `sendServiceCatalog`, `streamEvents` |
| `configimport (*Importer).materialize` | 24 | ≤15 | `selectProjections`, `buildRouteOutputs`, `chosenProjection` type |
| `server (*WriteBehindQueue).flushDue` | 23 | ≤15 | `collectDueOps`, `flushOp` |
| `services (*Generator).reconcile` | 21 | ≤15 | `buildDesiredServices`, `pruneServices` |
| `server (*Broadcaster).Broadcast` | 18 | ≤15 | `closeDroppedWatchers`, package-level `droppedWatcher` type |
| `replicator (*Replicator).mirrorPeer` | 17 | ≤15 | `runSyncWatchLoop` |
| `replicator (*Replicator).watchMirror` | 17 | ≤15 | `mirrorEvent` |
| `server (*Snapshot).Replace` | 16 | ≤15 | `computeTransitions` |

## Caution zones preserved

- **WatchEndpoints / Broadcast**: catalog events (SERVICE_ADDED/SERVICE_REMOVED) deliberately bypass watch filters — preserved exactly; `sendServiceCatalog` sends to all watchers regardless of filter; `server_test` "catalog bypasses the filter" assertion still passes.
- **gamma/l4route Reconcilers**: CRD-detection gating, status writes, and projected-route ordering (portSets/sorting) preserved verbatim.
- **Replicator**: origin-heartbeat lease semantics unchanged — lease is granted before `runSyncWatchLoop`, keepalive goroutine wires the same `connCtx`; no revoke on shutdown.

## Verification

- `gocognit -over 15 <all scope dirs>` (excl `_test.go`) → **no output**
- `bazel test //registrar/... //agent/...` → **33/33 PASSED**
- `make gazelle && make format` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR