### PR TITLE
refactor(edge): reduce cognitive complexity to <=15 in gatewayapi

### DIFF
--- a/agent/internal/edge/gatewayapi/attachment/attachment.go
+++ b/agent/internal/edge/gatewayapi/attachment/attachment.go
@@ -265,37 +265,48 @@ func (r *Resolver) httpRouteAttachment(
 		if string(p.Name) != gw.Name || parentRefNamespace(p.Namespace, routeNamespace) != gw.Namespace {
 			continue
 		}
-		// The parentRef targets this Gateway. Does its sectionName/port name a
-		// real listener?
 		if !parentRefNamesAnyListener(p, gw.Spec.Listeners) {
-			// NoMatchingParent unless a better (already-found) reason exists.
 			continue
 		}
-		// Walk the listeners this parentRef selects, narrowing the failure reason
-		// from namespace → hostname as we get closer to a match.
 		for _, ln := range gw.Spec.Listeners {
-			if !parentRefSelectsListener(p, ln) {
-				continue
+			lnReason, accepted := r.checkListenerAttach(ctx, gw, p, ln, routeNamespace, routeHostnames, reason)
+			if accepted {
+				return attachAccepted
 			}
-			if !listenerAcceptsKind(ln, "HTTPRoute") {
-				continue
-			}
-			if !r.namespaceAllowed(ctx, gw.Namespace, routeNamespace, ln) {
-				if reason == attachNoMatchingParent {
-					reason = attachNotAllowedByListeners
-				}
-				continue
-			}
-			if !hostnamesIntersect(ln.Hostname, routeHostnames) {
-				reason = attachNoMatchingListenerHostname
-				continue
-			}
-			return attachAccepted
+			reason = lnReason
 		}
-		// This parentRef named a real listener but none accepted; keep the most
-		// specific reason found so far (namespace/hostname over NoMatchingParent).
 	}
 	return reason
+}
+
+// checkListenerAttach tests whether parentRef p attaches to listener ln on Gateway gw
+// for an HTTPRoute in routeNamespace with routeHostnames. Returns the updated reason
+// and whether the listener fully accepted the route.
+func (r *Resolver) checkListenerAttach(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	p gatewayv1.ParentReference,
+	ln gatewayv1.Listener,
+	routeNamespace string,
+	routeHostnames []gatewayv1.Hostname,
+	reason routeAttachReason,
+) (routeAttachReason, bool) {
+	if !parentRefSelectsListener(p, ln) {
+		return reason, false
+	}
+	if !listenerAcceptsKind(ln, "HTTPRoute") {
+		return reason, false
+	}
+	if !r.namespaceAllowed(ctx, gw.Namespace, routeNamespace, ln) {
+		if reason == attachNoMatchingParent {
+			reason = attachNotAllowedByListeners
+		}
+		return reason, false
+	}
+	if !hostnamesIntersect(ln.Hostname, routeHostnames) {
+		return attachNoMatchingListenerHostname, false
+	}
+	return reason, true
 }
 
 // HTTPRouteAcceptance computes the route-level Accepted condition for an HTTPRoute
@@ -349,30 +360,47 @@ func (r *Resolver) AttachedRoutesForListener(
 	gateways map[GatewayKey]struct{},
 	listenerKeys map[GatewayListenerKey]struct{},
 ) int32 {
-	var count int32
 	switch ln.Protocol {
 	case gatewayv1.HTTPProtocolType, gatewayv1.HTTPSProtocolType:
-		for i := range httpRoutes {
-			hr := &httpRoutes[i]
-			if r.httpRouteAttachesToListener(ctx, gw, hr.Spec.ParentRefs, hr.Namespace, hr.Spec.Hostnames, ln) {
-				count++
-			}
-		}
+		return r.countAttachedHTTPRoutes(ctx, gw, ln, httpRoutes)
 	case gatewayv1.TCPProtocolType:
-		for i := range tcpRoutes {
-			tr := &tcpRoutes[i]
-			ports := GatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, listenerKeys)
-			if containsPort(ports, uint32(ln.Port)) {
-				count++
-			}
-		}
+		return countAttachedTCPRoutes(tcpRoutes, gateways, listenerKeys, ln)
 	case gatewayv1.TLSProtocolType:
-		for i := range tlsRoutes {
-			tr := &tlsRoutes[i]
-			ports := GatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, listenerKeys)
-			if containsPort(ports, uint32(ln.Port)) {
-				count++
-			}
+		return countAttachedTLSRoutes(tlsRoutes, gateways, listenerKeys, ln)
+	}
+	return 0
+}
+
+func (r *Resolver) countAttachedHTTPRoutes(ctx context.Context, gw *gatewayv1.Gateway, ln gatewayv1.Listener, httpRoutes []gatewayv1.HTTPRoute) int32 {
+	var count int32
+	for i := range httpRoutes {
+		hr := &httpRoutes[i]
+		if r.httpRouteAttachesToListener(ctx, gw, hr.Spec.ParentRefs, hr.Namespace, hr.Spec.Hostnames, ln) {
+			count++
+		}
+	}
+	return count
+}
+
+func countAttachedTCPRoutes(routes []gatewayv1.TCPRoute, gateways map[GatewayKey]struct{}, listenerKeys map[GatewayListenerKey]struct{}, ln gatewayv1.Listener) int32 {
+	var count int32
+	port := uint32(ln.Port)
+	for i := range routes {
+		tr := &routes[i]
+		if containsPort(GatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TCPProtocolType, listenerKeys), port) {
+			count++
+		}
+	}
+	return count
+}
+
+func countAttachedTLSRoutes(routes []gatewayv1.TLSRoute, gateways map[GatewayKey]struct{}, listenerKeys map[GatewayListenerKey]struct{}, ln gatewayv1.Listener) int32 {
+	var count int32
+	port := uint32(ln.Port)
+	for i := range routes {
+		tr := &routes[i]
+		if containsPort(GatewayParentPorts(tr.Spec.ParentRefs, tr.Namespace, gateways, gatewayv1.TLSProtocolType, listenerKeys), port) {
+			count++
 		}
 	}
 	return count

--- a/agent/internal/edge/gatewayapi/attachment/hostnames.go
+++ b/agent/internal/edge/gatewayapi/attachment/hostnames.go
@@ -106,49 +106,47 @@ func EffectiveHostnames(routeHosts []string, gwKeys []string, gwListenerHostname
 	for _, gwKey := range gwKeys {
 		lnHostnames, ok := gwListenerHostnames[gwKey]
 		if !ok {
-			// Unknown Gateway — should not happen (key was from AttachedGatewayKeys).
 			continue
 		}
 		for _, lh := range lnHostnames {
-			if lh == "" {
-				// Listener has no hostname restriction: admit all route hostnames.
-				if len(routeHosts) == 0 {
-					// route "" + listener "" = "*" (true catch-all). A no-hostname
-					// listener with a no-hostname route admits ALL hosts. Return nil
-					// immediately — no specific hostname from any other listener in
-					// this key's union can narrow a catch-all back down. The caller
-					// treats nil/empty Hosts as the "*" catch-all vhost.
-					//
-					// Previously this was `continue` (add nothing and keep processing),
-					// which caused a multi-listener Gateway (e.g. one listener with no
-					// hostname + two listeners with specific hostnames) to produce a
-					// Hosts set of only the specific listener hostnames — silently
-					// dropping the catch-all listener's "admit all" contribution. A
-					// request like Host:example.org matched neither specific hostname,
-					// fell through to the 404 catch-all vhost, and returned 404 instead
-					// of the expected redirect. (HTTPRouteRedirectPortAndScheme, 443 subtests)
-					return nil
-				}
-				for _, rh := range routeHosts {
-					add(rh)
-				}
-				continue
-			}
-			// Listener has a hostname (exact or wildcard).
-			if len(routeHosts) == 0 {
-				// Route has no hostname constraint: inherits the listener's hostname.
-				add(lh)
-				continue
-			}
-			// Intersect each route hostname against this listener hostname.
-			for _, rh := range routeHosts {
-				if h, ok := hostnameIntersect(lh, rh); ok {
-					add(h)
-				}
+			if catchAll := intersectListenerHostname(lh, routeHosts, add); catchAll {
+				return nil
 			}
 		}
 	}
 	return result
+}
+
+// intersectListenerHostname merges one listener hostname into the effective set
+// via add. Returns true when the combination is a true catch-all (both listener
+// and route have no hostname), which signals the caller to return nil immediately.
+func intersectListenerHostname(lh string, routeHosts []string, add func(string)) bool {
+	if lh != "" {
+		// Listener has a hostname (exact or wildcard).
+		if len(routeHosts) == 0 {
+			// Route has no hostname constraint: inherits the listener's hostname.
+			add(lh)
+			return false
+		}
+		// Intersect each route hostname against this listener hostname.
+		for _, rh := range routeHosts {
+			if h, ok := hostnameIntersect(lh, rh); ok {
+				add(h)
+			}
+		}
+		return false
+	}
+	// Listener has no hostname restriction: admit all route hostnames.
+	if len(routeHosts) == 0 {
+		// route "" + listener "" = "*" (true catch-all). Return nil immediately —
+		// no specific hostname from any other listener can narrow a catch-all back
+		// down. (HTTPRouteRedirectPortAndScheme, 443 subtests)
+		return true
+	}
+	for _, rh := range routeHosts {
+		add(rh)
+	}
+	return false
 }
 
 // hostnameIntersect returns the more-specific of two hostnames if they match,

--- a/agent/internal/edge/gatewayapi/attachment/refs.go
+++ b/agent/internal/edge/gatewayapi/attachment/refs.go
@@ -111,26 +111,38 @@ func GatewayParentPorts(
 		if _, ok := gateways[gk]; !ok {
 			continue
 		}
-		// If a sectionName (listener name) is specified, match only that listener;
-		// otherwise match all listeners of the given protocol on this gateway.
-		if p.Port != nil {
-			port := uint32(*p.Port)
-			key := GatewayListenerKey{Gateway: gk, Port: port, Protocol: protocol}
-			if _, ok := listenerKeys[key]; ok {
-				if _, dup := seen[port]; !dup {
-					seen[port] = struct{}{}
-					ports = append(ports, port)
-				}
+		ports = collectParentRefPorts(p, gk, protocol, listenerKeys, seen, ports)
+	}
+	return ports
+}
+
+// collectParentRefPorts appends the matching ports for a single parentRef/gateway
+// pair, deduplicating via seen.
+func collectParentRefPorts(
+	p gatewayv1.ParentReference,
+	gk GatewayKey,
+	protocol gatewayv1.ProtocolType,
+	listenerKeys map[GatewayListenerKey]struct{},
+	seen map[uint32]struct{},
+	ports []uint32,
+) []uint32 {
+	if p.Port != nil {
+		port := uint32(*p.Port)
+		key := GatewayListenerKey{Gateway: gk, Port: port, Protocol: protocol}
+		if _, ok := listenerKeys[key]; ok {
+			if _, dup := seen[port]; !dup {
+				seen[port] = struct{}{}
+				ports = append(ports, port)
 			}
-			continue
 		}
-		// No port specified: include all matching-protocol listeners on this gateway.
-		for k := range listenerKeys {
-			if k.Gateway == gk && k.Protocol == protocol {
-				if _, dup := seen[k.Port]; !dup {
-					seen[k.Port] = struct{}{}
-					ports = append(ports, k.Port)
-				}
+		return ports
+	}
+	// No port specified: include all matching-protocol listeners on this gateway.
+	for k := range listenerKeys {
+		if k.Gateway == gk && k.Protocol == protocol {
+			if _, dup := seen[k.Port]; !dup {
+				seen[k.Port] = struct{}{}
+				ports = append(ports, k.Port)
 			}
 		}
 	}

--- a/agent/internal/edge/gatewayapi/reconciler.go
+++ b/agent/internal/edge/gatewayapi/reconciler.go
@@ -168,11 +168,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 // attached to them, resolves each Gateway listener's TLS cert, and replaces the
 // cache's virtual-host and L4 route sets.
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
-	// Our Gateways (those of our GatewayClass) and, per listener hostname, the SDS
-	// cert name to present. listenerCerts also accumulates the cert bytes to push.
-	// Cluster-wide ReferenceGrants gate cross-namespace backendRefs and listener
-	// certificateRefs (drop + RefNotPermitted). The edge cache is cluster-wide
-	// (post-#323). Listed first so resolveGateways can enforce them on cert refs.
 	grantList := &gatewayv1beta1.ReferenceGrantList{}
 	if err := r.List(ctx, grantList); err != nil {
 		return reconcile.Result{}, err
@@ -184,22 +179,68 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{}, err
 	}
 
-	// Build a map of Gateway key → listener hostnames so we can compute the
-	// effective hostname intersection for each HTTPRoute (Gateway API §spec:
-	// effective hostnames = route.Hostnames ∩ listener.Hostname; a route with no
-	// hostnames inherits the listener's; a listener with no hostname admits all
-	// route hostnames).
 	gwListenerHostnames := attachment.BuildGatewayListenerHostnames(ourGateways)
 
-	// --- HTTPRoutes (cluster-wide) ---
-	httpRoutes := &gatewayv1.HTTPRouteList{}
-	if err := r.List(ctx, httpRoutes); err != nil {
+	httpRoutes, vhosts, err := r.listAndProjectHTTPRoutes(ctx, gateways, gwListenerHostnames, hostCerts, grants)
+	if err != nil {
 		return reconcile.Result{}, err
 	}
-	// Deterministic order so (a) same-hostname merge in the cache is stable and
-	// (b) the Gateway API tie-break for routes of equal path specificity is correct:
-	// oldest creationTimestamp first, then namespace, then name. The cache's stable
-	// path-specificity sort preserves this order for equal-specificity routes.
+
+	tcpRouteList, tcpRoutes, err := r.listAndProjectTCPRoutes(ctx, gateways, gatewayListeners, grants)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	tlsRouteList, tlsRoutes, err := r.listAndProjectTLSRoutes(ctx, gateways, gatewayListeners, grants)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	httpRedirect, gatewayHTTPRedirect := computeHTTPRedirect(ourGateways)
+	r.Sink.SetEdgeHTTPRedirect(httpRedirect)
+
+	if r.Secrets != nil {
+		if err := r.Sink.SetEdgeTLSSecrets(ctx, certs); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	perGWAssignedIPs := r.reconcilePhase2(ctx, ourGateways, perGWHostCerts, vhosts, gatewayHTTPRedirect)
+
+	r.Sink.SetVirtualHosts(vhosts)
+	r.Sink.SetEdgeTCPRoutes(tcpRoutes)
+	r.Sink.SetEdgeTLSRoutes(tlsRoutes)
+	r.Log.DebugContext(
+		ctx, "projected gateway-api routes",
+		"httpRoutes", len(httpRoutes.Items),
+		"tcpRoutes", len(tcpRouteList.Items),
+		"tlsRoutes", len(tlsRouteList.Items),
+		"virtualHosts", len(vhosts),
+		"tcpListeners", len(tcpRoutes),
+		"tlsListeners", len(tlsRoutes),
+		"tlsCerts", len(certs),
+	)
+
+	r.writeGatewayClassStatus(ctx)
+	r.writeGatewayStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, tlsResults, perGWAssignedIPs)
+	r.writeRouteStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, grants)
+	return reconcile.Result{}, nil
+}
+
+// listAndProjectHTTPRoutes lists all HTTPRoutes and builds virtual hosts for those
+// attached to our Gateways. Returns the raw list (for status) and the projected vhosts.
+func (r *Reconciler) listAndProjectHTTPRoutes(
+	ctx context.Context,
+	gateways map[gatewayKey]struct{},
+	gwListenerHostnames map[string][]string,
+	hostCerts map[string]string,
+	grants []gatewayv1beta1.ReferenceGrant,
+) (*gatewayv1.HTTPRouteList, []cache.VirtualHost, error) {
+	httpRoutes := &gatewayv1.HTTPRouteList{}
+	if err := r.List(ctx, httpRoutes); err != nil {
+		return nil, nil, err
+	}
+	// Deterministic order: oldest creationTimestamp first, then namespace, then name.
 	slices.SortFunc(httpRoutes.Items, func(a, b gatewayv1.HTTPRoute) int {
 		ta := a.CreationTimestamp.Time
 		tb := b.CreationTimestamp.Time
@@ -221,39 +262,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			continue
 		}
 		vh := r.buildVirtualHost(ctx, hr, hostCerts, grants)
-		// A hostname-less route is NOT inert: per Gateway API it matches every host on
-		// its listener, served via the cache's catch-all "*" vhost. Only an empty
-		// route set (no backend/redirect produced a route) makes it skippable.
 		if len(vh.Routes) == 0 {
 			continue
 		}
-		// Scope the vhost to the Gateways the route actually attaches to (Phase 2
-		// assigns by attachment, not by the vhost's cert tag).
-		gwKeys := attachment.AttachedGatewayKeys(hr.Spec.ParentRefs, hr.Namespace, gateways)
-		vh.Gateways = gwKeys
-		// Compute effective hostnames: route.Hostnames ∩ each attached listener's
-		// hostnames. When a parentRef has a sectionName, intersect with that
-		// listener only (not the whole Gateway). This makes hostname-less routes
-		// inherit the specific listener's hostname and ensures routes with explicit
-		// hostnames that don't match any listener are discarded rather than leaking
-		// into the catch-all "*" vhost (where they would incorrectly match requests
-		// to unrelated hosts — the no-intersecting-hosts 500 bug).
+		vh.Gateways = attachment.AttachedGatewayKeys(hr.Spec.ParentRefs, hr.Namespace, gateways)
 		hostnameLookupKeys := attachment.AttachedHostnameLookupKeys(hr.Spec.ParentRefs, hr.Namespace, gateways)
 		vh.Hosts = attachment.EffectiveHostnames(vh.Hosts, hostnameLookupKeys, gwListenerHostnames)
-		// If the route declared explicit hostnames but none intersect with any
-		// attached listener, discard the vhost entirely. An empty effective-hostname
-		// set means "no listener admits this route" — it must not produce routes at
-		// all, not even in the catch-all "*" vhost.
 		if len(hr.Spec.Hostnames) > 0 && len(vh.Hosts) == 0 {
 			continue
 		}
 		vhosts = append(vhosts, vh)
 	}
+	return httpRoutes, vhosts, nil
+}
 
-	// --- TCPRoutes (cluster-wide) ---
+// listAndProjectTCPRoutes lists all TCPRoutes and projects them into per-port backends.
+func (r *Reconciler) listAndProjectTCPRoutes(
+	ctx context.Context,
+	gateways map[gatewayKey]struct{},
+	gatewayListeners map[gatewayListenerKey]struct{},
+	grants []gatewayv1beta1.ReferenceGrant,
+) (*gatewayv1.TCPRouteList, []proxy.EdgeL4TCPRoute, error) {
 	tcpRouteList := &gatewayv1.TCPRouteList{}
 	if err := r.List(ctx, tcpRouteList); err != nil {
-		return reconcile.Result{}, err
+		return nil, nil, err
 	}
 	tcpByPort := make(map[uint32][]proxy.L4Backend)
 	for i := range tcpRouteList.Items {
@@ -278,11 +310,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 		return 0
 	})
+	return tcpRouteList, tcpRoutes, nil
+}
 
-	// --- TLSRoutes (cluster-wide) ---
+// listAndProjectTLSRoutes lists all TLSRoutes and projects them into per-port service routes.
+func (r *Reconciler) listAndProjectTLSRoutes(
+	ctx context.Context,
+	gateways map[gatewayKey]struct{},
+	gatewayListeners map[gatewayListenerKey]struct{},
+	grants []gatewayv1beta1.ReferenceGrant,
+) (*gatewayv1.TLSRouteList, []proxy.EdgeL4TLSRoute, error) {
 	tlsRouteList := &gatewayv1.TLSRouteList{}
 	if err := r.List(ctx, tlsRouteList); err != nil {
-		return reconcile.Result{}, err
+		return nil, nil, err
 	}
 	tlsByPort := make(map[uint32][]proxy.L4ServiceRoute)
 	for i := range tlsRouteList.Items {
@@ -314,9 +354,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 		return 0
 	})
+	return tlsRouteList, tlsRoutes, nil
+}
 
-	// Determine per-Gateway HTTP redirect opt-in (gateway.aether.io/http-redirect).
-	// In Phase 1 this is a single bool; in Phase 2 it is tracked per Gateway key.
+// computeHTTPRedirect scans ourGateways for the http-redirect annotation.
+// Returns the Phase 1 bool and the per-Gateway map.
+func computeHTTPRedirect(ourGateways []gatewayv1.Gateway) (bool, map[gatewayKey]bool) {
 	httpRedirect := false
 	gatewayHTTPRedirect := make(map[gatewayKey]bool, len(ourGateways))
 	for i := range ourGateways {
@@ -326,82 +369,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			gatewayHTTPRedirect[gk] = true
 		}
 	}
-	r.Sink.SetEdgeHTTPRedirect(httpRedirect)
+	return httpRedirect, gatewayHTTPRedirect
+}
 
-	if r.Secrets != nil {
-		if err := r.Sink.SetEdgeTLSSecrets(ctx, certs); err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-
-	// Per-Gateway addressing (proposal 021 Phase 2, unconditional since 031
-	// round 2): when EdgeServiceName is set, we manage per-Gateway LoadBalancer
-	// Services and emit per-Gateway listeners. Phase 1 (shared SetVirtualHosts
-	// path) remains only as the EdgeServiceName-empty / port-allocation-failure
-	// fallback.
-	var perGWAssignedIPs map[gatewayKey]string
-	if r.EdgeServiceName != "" && len(ourGateways) > 0 {
-		allocations, allocErr := allocateGatewayListenerPorts(ourGateways, perGWHostCerts)
-		if allocErr != nil {
-			r.Log.WarnContext(ctx, "per-Gateway port allocation failed, falling back to Phase 1",
-				"error", allocErr.Error())
-			// Fall through to Phase 1 path.
-			r.Sink.SetEdgeGateways(nil)
-		} else {
-			edgeConfigs := make(map[gatewayKey]*configv1.EdgeConfigSpec, len(ourGateways))
-			for i := range ourGateways {
-				gw := &ourGateways[i]
-				edgeConfigs[gatewayKey{Namespace: gw.Namespace, Name: gw.Name}] = r.resolveEdgeConfig(ctx, gw)
-			}
-			ips, svcErr := r.reconcileGatewayServices(ctx, ourGateways, allocations, edgeConfigs)
-			if svcErr != nil {
-				r.Log.WarnContext(ctx, "per-Gateway Service reconcile error", "error", svcErr.Error())
-			}
-			perGWAssignedIPs = ips
-			entries := buildEdgeGatewayEntries(ourGateways, vhosts, allocations, gatewayHTTPRedirect, edgeConfigs)
-			r.Sink.SetEdgeGateways(entries)
-			r.Log.DebugContext(ctx, "projected per-Gateway entries",
-				"gateways", len(entries), "ourGateways", len(ourGateways),
-				"totalVhosts", len(vhosts))
-			// In Phase 2 we still call SetVirtualHosts with the full vhosts so
-			// the Phase 1 fallback route table is up-to-date (no-op at snapshot
-			// time when per-Gateway mode is active, but keeps state consistent
-			// for edge cases like a reconcile that loses the Phase 2 allocations).
-		}
-	} else {
-		// Phase 1 / disabled: clear any stale Phase 2 state, and garbage-collect any
-		// per-Gateway Services left over from a previous Phase 2 run. The Phase 2
-		// reconcile path is skipped here, so without this the Services orphan and
-		// keep holding their LoadBalancer IP (e.g. the pinned edge address), which
-		// blocks the shared Service from reclaiming it on a downgrade.
+// reconcilePhase2 handles the per-Gateway Service / per-Gateway listener (Phase 2) path,
+// or falls back to Phase 1 (SetEdgeGateways(nil)). Returns the assigned IPs map.
+func (r *Reconciler) reconcilePhase2(
+	ctx context.Context,
+	ourGateways []gatewayv1.Gateway,
+	perGWHostCerts map[gatewayKey]map[string]string,
+	vhosts []cache.VirtualHost,
+	gatewayHTTPRedirect map[gatewayKey]bool,
+) map[gatewayKey]string {
+	if r.EdgeServiceName == "" || len(ourGateways) == 0 {
 		r.Sink.SetEdgeGateways(nil)
 		if r.EdgeServiceName != "" {
 			if err := r.gcStaleGatewayServices(ctx, map[string]struct{}{}); err != nil {
 				r.Log.WarnContext(ctx, "GC of stale per-Gateway Services failed", "error", err.Error())
 			}
 		}
+		return nil
 	}
-	r.Sink.SetVirtualHosts(vhosts)
-	r.Sink.SetEdgeTCPRoutes(tcpRoutes)
-	r.Sink.SetEdgeTLSRoutes(tlsRoutes)
-	r.Log.DebugContext(
-		ctx, "projected gateway-api routes",
-		"httpRoutes", len(httpRoutes.Items),
-		"tcpRoutes", len(tcpRouteList.Items),
-		"tlsRoutes", len(tlsRouteList.Items),
-		"virtualHosts", len(vhosts),
-		"tcpListeners", len(tcpRoutes),
-		"tlsListeners", len(tlsRoutes),
-		"tlsCerts", len(certs),
-	)
 
-	// Publish Gateway API status (the conformance on-ramp). Failures are logged,
-	// not fatal — the data plane is already projected and the next reconcile
-	// retries. The GatewayClass, Gateways, and routes we own all get conditions.
-	r.writeGatewayClassStatus(ctx)
-	r.writeGatewayStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, tlsResults, perGWAssignedIPs)
-	r.writeRouteStatuses(ctx, ourGateways, httpRoutes.Items, tcpRouteList.Items, tlsRouteList.Items, gateways, gatewayListeners, grants)
-	return reconcile.Result{}, nil
+	allocations, allocErr := allocateGatewayListenerPorts(ourGateways, perGWHostCerts)
+	if allocErr != nil {
+		r.Log.WarnContext(ctx, "per-Gateway port allocation failed, falling back to Phase 1",
+			"error", allocErr.Error())
+		r.Sink.SetEdgeGateways(nil)
+		return nil
+	}
+
+	edgeConfigs := make(map[gatewayKey]*configv1.EdgeConfigSpec, len(ourGateways))
+	for i := range ourGateways {
+		gw := &ourGateways[i]
+		edgeConfigs[gatewayKey{Namespace: gw.Namespace, Name: gw.Name}] = r.resolveEdgeConfig(ctx, gw)
+	}
+	ips, svcErr := r.reconcileGatewayServices(ctx, ourGateways, allocations, edgeConfigs)
+	if svcErr != nil {
+		r.Log.WarnContext(ctx, "per-Gateway Service reconcile error", "error", svcErr.Error())
+	}
+	entries := buildEdgeGatewayEntries(ourGateways, vhosts, allocations, gatewayHTTPRedirect, edgeConfigs)
+	r.Sink.SetEdgeGateways(entries)
+	r.Log.DebugContext(ctx, "projected per-Gateway entries",
+		"gateways", len(entries), "ourGateways", len(ourGateways),
+		"totalVhosts", len(vhosts))
+	return ips
 }
 
 // gatewayKey / gatewayListenerKey are the attachment package's Gateway and
@@ -535,39 +547,10 @@ func (r *Reconciler) resolveListenerTLS(
 	}
 	var firstResolved string
 	for _, ref := range ln.TLS.CertificateRefs {
-		// Only core ("") group Secret kind is supported; any other group/kind is an
-		// invalid certificateRef.
-		if ref.Group != nil && string(*ref.Group) != "" {
-			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q has unsupported group %q", ref.Name, *ref.Group)}
+		sdsName, fail := r.resolveCertRef(ctx, gw, ref, certs, grants)
+		if fail != nil {
+			return *fail
 		}
-		if ref.Kind != nil && string(*ref.Kind) != "Secret" {
-			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q has unsupported kind %q", ref.Name, *ref.Kind)}
-		}
-		name := string(ref.Name)
-		// The Secret lives in certificateRef.namespace, defaulting to the GATEWAY's
-		// own namespace — NOT the edge's namespace. A cross-namespace ref (namespace
-		// set and != the Gateway's) is permitted only by a ReferenceGrant in the
-		// Secret's namespace; otherwise it is RefNotPermitted (and not resolved).
-		certNS := gw.Namespace
-		if ref.Namespace != nil && string(*ref.Namespace) != "" {
-			certNS = string(*ref.Namespace)
-		}
-		if referencegrant.CrossNamespace(certNS, gw.Namespace) &&
-			!referencegrant.PermitsSecret(grants, gw.Namespace, certNS, name) {
-			return listenerTLSResult{hasTLS: true, resolved: false, reason: string(gatewayv1.ListenerReasonRefNotPermitted), message: fmt.Sprintf("certificateRef %s/%s is not permitted by any ReferenceGrant", certNS, name)}
-		}
-		secretRef := certNS + "/" + name
-		sdsName, sErr := r.Secrets.SDSName(configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, secretRef)
-		if sErr != nil {
-			r.Log.WarnContext(ctx, "gateway listener TLS provider unavailable", "gateway", gw.Name, "secret", secretRef, "error", sErr.Error())
-			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q provider unavailable", name)}
-		}
-		cert, cErr := r.Secrets.Resolve(ctx, configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, secretRef)
-		if cErr != nil {
-			r.Log.WarnContext(ctx, "gateway listener TLS cert unresolved", "gateway", gw.Name, "secret", secretRef, "error", cErr.Error())
-			return listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q did not resolve: %v", name, cErr)}
-		}
-		certs[sdsName] = cache.EdgeTLSCert{Cert: cert.Cert, Key: cert.Key}
 		if firstResolved == "" {
 			firstResolved = sdsName
 		}
@@ -576,6 +559,46 @@ func (r *Reconciler) resolveListenerTLS(
 		hostCerts[host] = firstResolved
 	}
 	return listenerTLSResult{hasTLS: true, resolved: true}
+}
+
+// resolveCertRef validates and resolves a single certificateRef. Returns the SDS name
+// on success, or a non-nil listenerTLSResult on failure.
+func (r *Reconciler) resolveCertRef(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	ref gatewayv1.SecretObjectReference,
+	certs map[string]cache.EdgeTLSCert,
+	grants []gatewayv1beta1.ReferenceGrant,
+) (string, *listenerTLSResult) {
+	if ref.Group != nil && string(*ref.Group) != "" {
+		return "", &listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q has unsupported group %q", ref.Name, *ref.Group)}
+	}
+	if ref.Kind != nil && string(*ref.Kind) != "Secret" {
+		return "", &listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q has unsupported kind %q", ref.Name, *ref.Kind)}
+	}
+	name := string(ref.Name)
+	certNS := gw.Namespace
+	if ref.Namespace != nil && string(*ref.Namespace) != "" {
+		certNS = string(*ref.Namespace)
+	}
+	if referencegrant.CrossNamespace(certNS, gw.Namespace) &&
+		!referencegrant.PermitsSecret(grants, gw.Namespace, certNS, name) {
+		fail := listenerTLSResult{hasTLS: true, resolved: false, reason: string(gatewayv1.ListenerReasonRefNotPermitted), message: fmt.Sprintf("certificateRef %s/%s is not permitted by any ReferenceGrant", certNS, name)}
+		return "", &fail
+	}
+	secretRef := certNS + "/" + name
+	sdsName, sErr := r.Secrets.SDSName(configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, secretRef)
+	if sErr != nil {
+		r.Log.WarnContext(ctx, "gateway listener TLS provider unavailable", "gateway", gw.Name, "secret", secretRef, "error", sErr.Error())
+		return "", &listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q provider unavailable", name)}
+	}
+	cert, cErr := r.Secrets.Resolve(ctx, configv1.SecretProvider_SECRET_PROVIDER_KUBERNETES, secretRef)
+	if cErr != nil {
+		r.Log.WarnContext(ctx, "gateway listener TLS cert unresolved", "gateway", gw.Name, "secret", secretRef, "error", cErr.Error())
+		return "", &listenerTLSResult{hasTLS: true, resolved: false, message: fmt.Sprintf("certificateRef %q did not resolve: %v", name, cErr)}
+	}
+	certs[sdsName] = cache.EdgeTLSCert{Cert: cert.Cert, Key: cert.Key}
+	return sdsName, nil
 }
 
 // buildVirtualHost maps one HTTPRoute to an edge VirtualHost: its hostnames become
@@ -603,181 +626,179 @@ func (r *Reconciler) buildVirtualHost(ctx context.Context, hr *gatewayv1.HTTPRou
 		vh.Hosts = append(vh.Hosts, string(h))
 	}
 	for _, rule := range hr.Spec.Rules {
-		redirect := buildHTTPRedirect(rule.Filters)
-		urlRewrite := buildHTTPURLRewrite(rule.Filters)
-		timeout := buildRouteTimeout(rule.Timeouts)
-
-		// Collect ALL admissible backends in this rule with their weights.
-		// backendRef.weight nil → default 1 (per Gateway API spec).
-		backends := r.buildHTTPRouteBackends(ctx, rule.BackendRefs, hr.Namespace, grants)
-
-		// A rule must have either at least one backend or a redirect to produce a route.
-		// Exception: a rule where all backends are UNRESOLVABLE (InvalidKind /
-		// BackendNotFound / RefNotPermitted) must still produce a route that returns
-		// HTTP 500 — the Gateway API data-plane contract for invalid backends.
-		// Detect this: no admissible backends (buildHTTPRouteBackends filtered them
-		// all out) AND no redirect AND the rule actually has declared backendRefs
-		// (so it is "invalid" rather than "empty").
-		if redirect == nil {
-			if len(backends) == 0 {
-				// Two 500 cases (the Gateway API data-plane contract): a rule whose
-				// backendRefs are all UNRESOLVABLE (invalid kind, missing Service,
-				// ungranted cross-namespace ref), and — since gateway-api 1.6's
-				// HTTPRouteNoBackendRefs test pins it — a rule with NO backendRefs at
-				// all (omitted or empty list). Emit a fixed 500 route with the
-				// path/header match still applied.
-				resolved := false
-				if len(rule.BackendRefs) > 0 {
-					resolved, _, _ = r.backendsResolveHTTP(ctx, hr.Namespace, []gatewayv1.HTTPRouteRule{rule}, grants)
-				}
-				if !resolved {
-					mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
-					if len(rule.Matches) == 0 {
-						vh.Routes = append(vh.Routes, cache.Route{
-							Prefix:               "/",
-							HeaderMutation:       mutation,
-							DirectResponseStatus: 500,
-						})
-					} else {
-						for _, m := range rule.Matches {
-							prefix, exact := "/", ""
-							if m.Path != nil && m.Path.Value != nil {
-								switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
-								case gatewayv1.PathMatchExact:
-									exact = *m.Path.Value
-									prefix = ""
-								default:
-									prefix = *m.Path.Value
-								}
-							}
-							var hdrs []proxy.RouteHeaderMatch
-							for _, h := range m.Headers {
-								hm := proxy.RouteHeaderMatch{Name: string(h.Name), Value: h.Value}
-								if h.Type != nil && *h.Type == gatewayv1.HeaderMatchRegularExpression {
-									hm.Regex = true
-								}
-								hdrs = append(hdrs, hm)
-							}
-							method := ""
-							if m.Method != nil {
-								method = string(*m.Method)
-							}
-							var qps []proxy.RouteQueryParamMatch
-							for _, q := range m.QueryParams {
-								qm := proxy.RouteQueryParamMatch{Name: string(q.Name), Value: q.Value}
-								if q.Type != nil && *q.Type == gatewayv1.QueryParamMatchRegularExpression {
-									qm.Regex = true
-								}
-								qps = append(qps, qm)
-							}
-							vh.Routes = append(vh.Routes, cache.Route{
-								Prefix:               prefix,
-								Exact:                exact,
-								Headers:              hdrs,
-								Method:               method,
-								QueryParams:          qps,
-								HeaderMutation:       mutation,
-								DirectResponseStatus: 500,
-							})
-						}
-					}
-					continue
-				}
-			} else if len(backends) == 0 {
-				// No backends, no redirect, no declared backendRefs → skip (inert rule).
-				continue
-			}
-		}
-
-		mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
-
-		// For backward-compat we also populate the legacy Service/Port/BackendNamespace
-		// from the first backend so that code paths that read those fields still work.
-		var legacySvc, legacyNS string
-		var legacyPort, legacyDialPort uint32
-		if len(backends) > 0 {
-			legacySvc = backends[0].Service
-			legacyPort = backends[0].Port
-			legacyNS = backends[0].BackendNamespace
-			legacyDialPort = backends[0].DialPort
-		}
-
-		if len(rule.Matches) == 0 {
-			vh.Routes = append(vh.Routes, cache.Route{
-				Prefix:           "/",
-				Exact:            "",
-				Service:          legacySvc,
-				Port:             legacyPort,
-				BackendNamespace: legacyNS,
-				DialPort:         legacyDialPort,
-				Backends:         backends,
-				HeaderMutation:   mutation,
-				Redirect:         redirect,
-				URLRewrite:       urlRewrite,
-				Timeout:          timeout,
-			})
+		routes, skip := r.buildRoutesForRule(ctx, hr, rule, grants)
+		if skip {
 			continue
 		}
-		for _, m := range rule.Matches {
-			prefix, exact := "/", ""
-			if m.Path != nil && m.Path.Value != nil {
-				switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
-				case gatewayv1.PathMatchExact:
-					exact = *m.Path.Value
-					prefix = ""
-				default: // PathPrefix (and unimplemented types) → prefix
-					prefix = *m.Path.Value
-				}
-			}
-
-			// Build per-match header predicates.
-			var hdrs []proxy.RouteHeaderMatch
-			for _, h := range m.Headers {
-				hm := proxy.RouteHeaderMatch{Name: string(h.Name), Value: h.Value}
-				if h.Type != nil && *h.Type == gatewayv1.HeaderMatchRegularExpression {
-					hm.Regex = true
-				}
-				hdrs = append(hdrs, hm)
-			}
-
-			// Method match: convert to uppercase string (Gateway API enum).
-			method := ""
-			if m.Method != nil {
-				method = string(*m.Method)
-			}
-
-			// Build per-match query-parameter predicates.
-			var qps []proxy.RouteQueryParamMatch
-			for _, q := range m.QueryParams {
-				qm := proxy.RouteQueryParamMatch{Name: string(q.Name), Value: q.Value}
-				if q.Type != nil && *q.Type == gatewayv1.QueryParamMatchRegularExpression {
-					qm.Regex = true
-				}
-				qps = append(qps, qm)
-			}
-
-			vh.Routes = append(vh.Routes, cache.Route{
-				Prefix:           prefix,
-				Exact:            exact,
-				Service:          legacySvc,
-				Port:             legacyPort,
-				BackendNamespace: legacyNS,
-				DialPort:         legacyDialPort,
-				Backends:         backends,
-				HeaderMutation:   mutation,
-				Redirect:         redirect,
-				URLRewrite:       urlRewrite,
-				Headers:          hdrs,
-				Method:           method,
-				QueryParams:      qps,
-				Timeout:          timeout,
-			})
-		}
+		vh.Routes = append(vh.Routes, routes...)
 	}
 	if cert := certForHosts(vh.Hosts, hostCerts); cert != "" {
 		vh.TLSSecret = cert
 	}
 	return vh
+}
+
+// buildRoutesForRule converts one HTTPRoute rule into cache.Routes. Returns (routes, skip=true)
+// when the rule should be omitted entirely (no backends, no redirect, not an invalid-backend 500 case).
+func (r *Reconciler) buildRoutesForRule(
+	ctx context.Context,
+	hr *gatewayv1.HTTPRoute,
+	rule gatewayv1.HTTPRouteRule,
+	grants []gatewayv1beta1.ReferenceGrant,
+) ([]cache.Route, bool) {
+	redirect := buildHTTPRedirect(rule.Filters)
+	urlRewrite := buildHTTPURLRewrite(rule.Filters)
+	timeout := buildRouteTimeout(rule.Timeouts)
+	backends := r.buildHTTPRouteBackends(ctx, rule.BackendRefs, hr.Namespace, grants)
+
+	if redirect == nil && len(backends) == 0 {
+		return r.buildInvalidOrEmptyRoutes(ctx, hr, rule, grants)
+	}
+
+	mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
+	var legacySvc, legacyNS string
+	var legacyPort, legacyDialPort uint32
+	if len(backends) > 0 {
+		legacySvc = backends[0].Service
+		legacyPort = backends[0].Port
+		legacyNS = backends[0].BackendNamespace
+		legacyDialPort = backends[0].DialPort
+	}
+
+	if len(rule.Matches) == 0 {
+		return []cache.Route{{
+			Prefix:           "/",
+			Service:          legacySvc,
+			Port:             legacyPort,
+			BackendNamespace: legacyNS,
+			DialPort:         legacyDialPort,
+			Backends:         backends,
+			HeaderMutation:   mutation,
+			Redirect:         redirect,
+			URLRewrite:       urlRewrite,
+			Timeout:          timeout,
+		}}, false
+	}
+
+	routes := make([]cache.Route, 0, len(rule.Matches))
+	for _, m := range rule.Matches {
+		prefix, exact := buildMatchPath(m)
+		routes = append(routes, cache.Route{
+			Prefix:           prefix,
+			Exact:            exact,
+			Service:          legacySvc,
+			Port:             legacyPort,
+			BackendNamespace: legacyNS,
+			DialPort:         legacyDialPort,
+			Backends:         backends,
+			HeaderMutation:   mutation,
+			Redirect:         redirect,
+			URLRewrite:       urlRewrite,
+			Headers:          buildMatchHeaders(m),
+			Method:           buildMatchMethod(m),
+			QueryParams:      buildMatchQueryParams(m),
+			Timeout:          timeout,
+		})
+	}
+	return routes, false
+}
+
+// buildInvalidOrEmptyRoutes handles the no-backend / no-redirect case: emits 500 routes for
+// unresolvable backends, or signals skip for truly inert rules.
+func (r *Reconciler) buildInvalidOrEmptyRoutes(
+	ctx context.Context,
+	hr *gatewayv1.HTTPRoute,
+	rule gatewayv1.HTTPRouteRule,
+	grants []gatewayv1beta1.ReferenceGrant,
+) ([]cache.Route, bool) {
+	// No declared backendRefs → inert rule, skip.
+	if len(rule.BackendRefs) == 0 {
+		// gateway-api 1.6 HTTPRouteNoBackendRefs: empty list also emits 500.
+		// Fall through to the unresolved path below.
+	} else {
+		resolved, _, _ := r.backendsResolveHTTP(ctx, hr.Namespace, []gatewayv1.HTTPRouteRule{rule}, grants)
+		if resolved {
+			// All backends resolved but none admissible — inert rule (no redirect, no backend).
+			return nil, true
+		}
+	}
+	// Unresolvable backends or empty list: emit 500 routes.
+	mutation := buildEdgeHTTPHeaderMutation(rule.Filters)
+	if len(rule.Matches) == 0 {
+		return []cache.Route{{
+			Prefix:               "/",
+			HeaderMutation:       mutation,
+			DirectResponseStatus: 500,
+		}}, false
+	}
+	routes := make([]cache.Route, 0, len(rule.Matches))
+	for _, m := range rule.Matches {
+		prefix, exact := buildMatchPath(m)
+		routes = append(routes, cache.Route{
+			Prefix:               prefix,
+			Exact:                exact,
+			Headers:              buildMatchHeaders(m),
+			Method:               buildMatchMethod(m),
+			QueryParams:          buildMatchQueryParams(m),
+			HeaderMutation:       mutation,
+			DirectResponseStatus: 500,
+		})
+	}
+	return routes, false
+}
+
+// buildMatchPath extracts the prefix/exact path values from an HTTPRouteMatch.
+func buildMatchPath(m gatewayv1.HTTPRouteMatch) (prefix, exact string) {
+	prefix = "/"
+	if m.Path == nil || m.Path.Value == nil {
+		return
+	}
+	switch ptrType(m.Path.Type, gatewayv1.PathMatchPathPrefix) {
+	case gatewayv1.PathMatchExact:
+		return "", *m.Path.Value
+	default:
+		return *m.Path.Value, ""
+	}
+}
+
+// buildMatchHeaders converts HTTPRoute header match predicates to proxy types.
+func buildMatchHeaders(m gatewayv1.HTTPRouteMatch) []proxy.RouteHeaderMatch {
+	if len(m.Headers) == 0 {
+		return nil
+	}
+	hdrs := make([]proxy.RouteHeaderMatch, 0, len(m.Headers))
+	for _, h := range m.Headers {
+		hm := proxy.RouteHeaderMatch{Name: string(h.Name), Value: h.Value}
+		if h.Type != nil && *h.Type == gatewayv1.HeaderMatchRegularExpression {
+			hm.Regex = true
+		}
+		hdrs = append(hdrs, hm)
+	}
+	return hdrs
+}
+
+// buildMatchMethod returns the method string from an HTTPRouteMatch (empty when unset).
+func buildMatchMethod(m gatewayv1.HTTPRouteMatch) string {
+	if m.Method == nil {
+		return ""
+	}
+	return string(*m.Method)
+}
+
+// buildMatchQueryParams converts HTTPRoute query-parameter match predicates to proxy types.
+func buildMatchQueryParams(m gatewayv1.HTTPRouteMatch) []proxy.RouteQueryParamMatch {
+	if len(m.QueryParams) == 0 {
+		return nil
+	}
+	qps := make([]proxy.RouteQueryParamMatch, 0, len(m.QueryParams))
+	for _, q := range m.QueryParams {
+		qm := proxy.RouteQueryParamMatch{Name: string(q.Name), Value: q.Value}
+		if q.Type != nil && *q.Type == gatewayv1.QueryParamMatchRegularExpression {
+			qm.Regex = true
+		}
+		qps = append(qps, qm)
+	}
+	return qps
 }
 
 // backendExists reports whether a named backend is admissible on the data plane:
@@ -829,47 +850,51 @@ func (r *Reconciler) backendExists(ctx context.Context, name, namespace string) 
 func (r *Reconciler) buildHTTPRouteBackends(ctx context.Context, refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) []cache.RouteBackend {
 	out := make([]cache.RouteBackend, 0, len(refs))
 	for _, b := range refs {
-		if b.Group != nil && string(*b.Group) != "" {
-			continue // only core Services
+		if rb, ok := r.httpBackendRefToRouteBackend(ctx, b, routeNamespace, grants); ok {
+			out = append(out, rb)
 		}
-		if b.Kind != nil && string(*b.Kind) != "Service" {
-			continue
-		}
-		name := string(b.Name)
-		if name == "" {
-			continue
-		}
-		if !attachment.BackendPermitted(b.Namespace, routeNamespace, "HTTPRoute", name, grants) {
-			continue
-		}
-		ns := routeNamespace
-		if b.Namespace != nil && string(*b.Namespace) != "" {
-			ns = string(*b.Namespace)
-		}
-		// Registry-aware existence check: a backend is admissible if it is a
-		// mesh/registry service OR a real k8s Service. Only drop on confirmed
-		// non-existence in both (BackendNotFound). Transient API errors leave the
-		// backend admitted to avoid false-positive 500s on API server hiccups.
-		if !r.backendExists(ctx, name, ns) {
-			continue // BackendNotFound: drop from admitted set
-		}
-		var port uint32
-		if b.Port != nil {
-			port = uint32(*b.Port)
-		}
-		weight := uint32(1) // default per Gateway API spec
-		if b.Weight != nil {
-			weight = uint32(*b.Weight)
-		}
-		out = append(out, cache.RouteBackend{
-			Service:          name,
-			BackendNamespace: ns,
-			Port:             port,
-			Weight:           weight,
-			DialPort:         r.resolveDialPort(ctx, ns, name, port),
-		})
 	}
 	return out
+}
+
+// httpBackendRefToRouteBackend converts a single HTTPBackendRef to a RouteBackend if admissible.
+// Returns (backend, true) when admitted, (zero, false) when the ref should be skipped.
+func (r *Reconciler) httpBackendRefToRouteBackend(ctx context.Context, b gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) (cache.RouteBackend, bool) {
+	if b.Group != nil && string(*b.Group) != "" {
+		return cache.RouteBackend{}, false
+	}
+	if b.Kind != nil && string(*b.Kind) != "Service" {
+		return cache.RouteBackend{}, false
+	}
+	name := string(b.Name)
+	if name == "" {
+		return cache.RouteBackend{}, false
+	}
+	if !attachment.BackendPermitted(b.Namespace, routeNamespace, "HTTPRoute", name, grants) {
+		return cache.RouteBackend{}, false
+	}
+	ns := routeNamespace
+	if b.Namespace != nil && string(*b.Namespace) != "" {
+		ns = string(*b.Namespace)
+	}
+	if !r.backendExists(ctx, name, ns) {
+		return cache.RouteBackend{}, false
+	}
+	var port uint32
+	if b.Port != nil {
+		port = uint32(*b.Port)
+	}
+	weight := uint32(1)
+	if b.Weight != nil {
+		weight = uint32(*b.Weight)
+	}
+	return cache.RouteBackend{
+		Service:          name,
+		BackendNamespace: ns,
+		Port:             port,
+		Weight:           weight,
+		DialPort:         r.resolveDialPort(ctx, ns, name, port),
+	}, true
 }
 
 // resolveDialPort returns the TCP port the edge's cleartext STRICT_DNS cluster must
@@ -1016,23 +1041,29 @@ func buildHTTPRedirect(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaRedirect
 		if rd.StatusCode != nil {
 			r.StatusCode = *rd.StatusCode
 		}
-		if rd.Path != nil {
-			switch rd.Path.Type {
-			case gatewayv1.FullPathHTTPPathModifier:
-				if rd.Path.ReplaceFullPath != nil {
-					r.PathType = "ReplaceFullPath"
-					r.PathValue = *rd.Path.ReplaceFullPath
-				}
-			case gatewayv1.PrefixMatchHTTPPathModifier:
-				if rd.Path.ReplacePrefixMatch != nil {
-					r.PathType = "ReplacePrefixMatch"
-					r.PathValue = *rd.Path.ReplacePrefixMatch
-				}
-			}
-		}
+		applyRedirectPath(r, rd.Path)
 		return r
 	}
 	return nil
+}
+
+// applyRedirectPath applies a path modifier to a GammaRedirect.
+func applyRedirectPath(r *proxy.GammaRedirect, path *gatewayv1.HTTPPathModifier) {
+	if path == nil {
+		return
+	}
+	switch path.Type {
+	case gatewayv1.FullPathHTTPPathModifier:
+		if path.ReplaceFullPath != nil {
+			r.PathType = "ReplaceFullPath"
+			r.PathValue = *path.ReplaceFullPath
+		}
+	case gatewayv1.PrefixMatchHTTPPathModifier:
+		if path.ReplacePrefixMatch != nil {
+			r.PathType = "ReplacePrefixMatch"
+			r.PathValue = *path.ReplacePrefixMatch
+		}
+	}
 }
 
 // buildHTTPURLRewrite extracts the first URLRewrite filter and converts it to a
@@ -1047,23 +1078,29 @@ func buildHTTPURLRewrite(filters []gatewayv1.HTTPRouteFilter) *proxy.GammaURLRew
 		if rw.Hostname != nil {
 			r.Hostname = string(*rw.Hostname)
 		}
-		if rw.Path != nil {
-			switch rw.Path.Type {
-			case gatewayv1.FullPathHTTPPathModifier:
-				if rw.Path.ReplaceFullPath != nil {
-					r.PathType = "ReplaceFullPath"
-					r.PathValue = *rw.Path.ReplaceFullPath
-				}
-			case gatewayv1.PrefixMatchHTTPPathModifier:
-				if rw.Path.ReplacePrefixMatch != nil {
-					r.PathType = "ReplacePrefixMatch"
-					r.PathValue = *rw.Path.ReplacePrefixMatch
-				}
-			}
-		}
+		applyURLRewritePath(r, rw.Path)
 		return r
 	}
 	return nil
+}
+
+// applyURLRewritePath applies a path modifier to a GammaURLRewrite.
+func applyURLRewritePath(r *proxy.GammaURLRewrite, path *gatewayv1.HTTPPathModifier) {
+	if path == nil {
+		return
+	}
+	switch path.Type {
+	case gatewayv1.FullPathHTTPPathModifier:
+		if path.ReplaceFullPath != nil {
+			r.PathType = "ReplaceFullPath"
+			r.PathValue = *path.ReplaceFullPath
+		}
+	case gatewayv1.PrefixMatchHTTPPathModifier:
+		if path.ReplacePrefixMatch != nil {
+			r.PathType = "ReplacePrefixMatch"
+			r.PathValue = *path.ReplacePrefixMatch
+		}
+	}
 }
 
 // buildEdgeHTTPHeaderMutation merges all RequestHeaderModifier and
@@ -1084,29 +1121,37 @@ func buildEdgeHTTPHeaderMutation(filters []gatewayv1.HTTPRouteFilter) *proxy.Gam
 				continue
 			}
 			ensure()
-			for _, h := range f.RequestHeaderModifier.Set {
-				m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			for _, h := range f.RequestHeaderModifier.Add {
-				m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			m.RemoveRequest = append(m.RemoveRequest, f.RequestHeaderModifier.Remove...)
+			applyRequestHeaderModifier(m, f.RequestHeaderModifier)
 		case gatewayv1.HTTPRouteFilterResponseHeaderModifier:
 			if f.ResponseHeaderModifier == nil {
 				continue
 			}
 			ensure()
-			for _, h := range f.ResponseHeaderModifier.Set {
-				m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			for _, h := range f.ResponseHeaderModifier.Add {
-				m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
-			}
-			m.RemoveResponse = append(m.RemoveResponse, f.ResponseHeaderModifier.Remove...)
+			applyResponseHeaderModifier(m, f.ResponseHeaderModifier)
 			// Redirect, rewrite, mirror: handled by dedicated builders above; skip here.
 		}
 	}
 	return m
+}
+
+func applyRequestHeaderModifier(m *proxy.GammaHeaderMutation, mod *gatewayv1.HTTPHeaderFilter) {
+	for _, h := range mod.Set {
+		m.SetRequest = append(m.SetRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+	}
+	for _, h := range mod.Add {
+		m.AddRequest = append(m.AddRequest, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+	}
+	m.RemoveRequest = append(m.RemoveRequest, mod.Remove...)
+}
+
+func applyResponseHeaderModifier(m *proxy.GammaHeaderMutation, mod *gatewayv1.HTTPHeaderFilter) {
+	for _, h := range mod.Set {
+		m.SetResponse = append(m.SetResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+	}
+	for _, h := range mod.Add {
+		m.AddResponse = append(m.AddResponse, proxy.GammaHeaderKV{Name: string(h.Name), Value: h.Value})
+	}
+	m.RemoveResponse = append(m.RemoveResponse, mod.Remove...)
 }
 
 // boolPtr returns a pointer to the given bool value. Used to set

--- a/agent/internal/edge/gatewayapi/service.go
+++ b/agent/internal/edge/gatewayapi/service.go
@@ -113,7 +113,23 @@ func allocateGatewayListenerPorts(gws []gatewayv1.Gateway, perGWHostCerts map[ga
 		return portalloc.Key{Namespace: ns, GatewayName: name, ListenerName: fmt.Sprintf("port-%d", port)}
 	}
 
-	// One allocator key per (Gateway, external port).
+	keys := collectPortAllocKeys(gws, portKey)
+	ports, err := portalloc.AssignAll(keys)
+	if err != nil {
+		return nil, fmt.Errorf("per-Gateway port allocation: %w", err)
+	}
+
+	result := make(map[gatewayKey][]gatewayListenerAllocation, len(gws))
+	for _, gw := range gws {
+		gk := gatewayKey{Namespace: gw.Namespace, Name: gw.Name}
+		gwHostCerts := perGWHostCerts[gk]
+		result[gk] = buildGatewayAllocations(gw, gwHostCerts, ports, portKey)
+	}
+	return result, nil
+}
+
+// collectPortAllocKeys builds the deduplicated list of portalloc.Keys across all Gateways.
+func collectPortAllocKeys(gws []gatewayv1.Gateway, portKey func(ns, name string, port uint32) portalloc.Key) []portalloc.Key {
 	var keys []portalloc.Key
 	seen := map[portalloc.Key]struct{}{}
 	for _, gw := range gws {
@@ -125,50 +141,38 @@ func allocateGatewayListenerPorts(gws []gatewayv1.Gateway, perGWHostCerts map[ga
 			}
 		}
 	}
-	ports, err := portalloc.AssignAll(keys)
-	if err != nil {
-		return nil, fmt.Errorf("per-Gateway port allocation: %w", err)
-	}
+	return keys
+}
 
-	result := make(map[gatewayKey][]gatewayListenerAllocation, len(gws))
-	for _, gw := range gws {
-		gk := gatewayKey{Namespace: gw.Namespace, Name: gw.Name}
-		// Use this Gateway's own hostCerts map so cert lookup is scoped to certs
-		// resolved for THIS Gateway only. A shared map would let a later-resolved
-		// Gateway overwrite the catch-all entry ("") and contaminate the cert set of
-		// an earlier-resolved Gateway that also had a catch-all TLS listener.
-		gwHostCerts := perGWHostCerts[gk] // nil-safe: listenerCert handles nil map
-		// Group listeners by external port, unioning their certs (an HTTPS port may
-		// host several listeners with different hostnames/certs — SNI selects).
-		certsByPort := map[uint32]map[string]struct{}{}
-		var portOrder []uint32
-		for _, ln := range gw.Spec.Listeners {
-			ep := uint32(ln.Port)
-			if _, ok := certsByPort[ep]; !ok {
-				certsByPort[ep] = map[string]struct{}{}
-				portOrder = append(portOrder, ep)
-			}
-			if c := listenerCert(ln, gwHostCerts); c != "" {
-				certsByPort[ep][c] = struct{}{}
-			}
+// buildGatewayAllocations constructs the allocations for a single Gateway.
+func buildGatewayAllocations(gw gatewayv1.Gateway, gwHostCerts map[string]string, ports map[portalloc.Key]uint32, portKey func(ns, name string, port uint32) portalloc.Key) []gatewayListenerAllocation {
+	certsByPort := map[uint32]map[string]struct{}{}
+	var portOrder []uint32
+	for _, ln := range gw.Spec.Listeners {
+		ep := uint32(ln.Port)
+		if _, ok := certsByPort[ep]; !ok {
+			certsByPort[ep] = map[string]struct{}{}
+			portOrder = append(portOrder, ep)
 		}
-		allocs := make([]gatewayListenerAllocation, 0, len(portOrder))
-		for _, ep := range portOrder {
-			certSet := certsByPort[ep]
-			certs := make([]string, 0, len(certSet))
-			for c := range certSet {
-				certs = append(certs, c)
-			}
-			sort.Strings(certs)
-			allocs = append(allocs, gatewayListenerAllocation{
-				externalPort:   ep,
-				internalPort:   ports[portKey(gw.Namespace, gw.Name, ep)],
-				tlsSecretNames: certs,
-			})
+		if c := listenerCert(ln, gwHostCerts); c != "" {
+			certsByPort[ep][c] = struct{}{}
 		}
-		result[gk] = allocs
 	}
-	return result, nil
+	allocs := make([]gatewayListenerAllocation, 0, len(portOrder))
+	for _, ep := range portOrder {
+		certSet := certsByPort[ep]
+		certs := make([]string, 0, len(certSet))
+		for c := range certSet {
+			certs = append(certs, c)
+		}
+		sort.Strings(certs)
+		allocs = append(allocs, gatewayListenerAllocation{
+			externalPort:   ep,
+			internalPort:   ports[portKey(gw.Namespace, gw.Name, ep)],
+			tlsSecretNames: certs,
+		})
+	}
+	return allocs
 }
 
 // listenerCert resolves the SDS cert name for one listener from the already-resolved
@@ -184,6 +188,35 @@ func listenerCert(ln gatewayv1.Listener, hostCerts map[string]string) string {
 		}
 	}
 	return hostCerts[""]
+}
+
+// buildGatewayServicePorts converts gateway listener allocations into k8s ServicePorts,
+// deduplicating by external port and adding UDP ports when HTTP/3 is enabled on TLS listeners.
+func buildGatewayServicePorts(allocs []gatewayListenerAllocation, gkCfg *configv1.EdgeConfigSpec) []corev1.ServicePort {
+	ports := make([]corev1.ServicePort, 0, len(allocs))
+	seenPort := make(map[uint32]struct{}, len(allocs))
+	for _, a := range allocs {
+		if _, dup := seenPort[a.externalPort]; dup {
+			continue
+		}
+		seenPort[a.externalPort] = struct{}{}
+		portName := fmt.Sprintf("port-%d", a.externalPort)
+		ports = append(ports, corev1.ServicePort{
+			Name:       portName,
+			Port:       int32(a.externalPort),
+			TargetPort: intstr.FromInt32(int32(a.internalPort)),
+			Protocol:   corev1.ProtocolTCP,
+		})
+		if len(a.tlsSecretNames) > 0 && gkCfg.GetHttp3().GetEnabled().GetValue() {
+			ports = append(ports, corev1.ServicePort{
+				Name:       portName + "-udp",
+				Port:       int32(a.externalPort),
+				TargetPort: intstr.FromInt32(int32(a.internalPort)),
+				Protocol:   corev1.ProtocolUDP,
+			})
+		}
+	}
+	return ports
 }
 
 // reconcileGatewayServices creates/updates the per-Gateway LoadBalancer Service
@@ -237,32 +270,7 @@ func (r *Reconciler) reconcileGatewayServices(
 		// that passes multiple allocations for the same external port still yields a
 		// single ServicePort rather than a Service the API server refuses.
 		gkCfg := edgeConfigs[gk]
-		ports := make([]corev1.ServicePort, 0, len(allocs))
-		seenPort := make(map[uint32]struct{}, len(allocs))
-		for _, a := range allocs {
-			if _, dup := seenPort[a.externalPort]; dup {
-				continue
-			}
-			seenPort[a.externalPort] = struct{}{}
-			portName := fmt.Sprintf("port-%d", a.externalPort)
-			ports = append(ports, corev1.ServicePort{
-				Name:       portName,
-				Port:       int32(a.externalPort),
-				TargetPort: intstr.FromInt32(int32(a.internalPort)),
-				Protocol:   corev1.ProtocolTCP,
-			})
-			// UDP port for HTTP/3: same external port, different protocol so k8s
-			// allows it alongside the TCP port. Required for LBs to pass QUIC
-			// datagrams through to the edge pod.
-			if len(a.tlsSecretNames) > 0 && gkCfg.GetHttp3().GetEnabled().GetValue() {
-				ports = append(ports, corev1.ServicePort{
-					Name:       portName + "-udp",
-					Port:       int32(a.externalPort),
-					TargetPort: intstr.FromInt32(int32(a.internalPort)),
-					Protocol:   corev1.ProtocolUDP,
-				})
-			}
-		}
+		ports := buildGatewayServicePorts(allocs, gkCfg)
 		if len(ports) == 0 {
 			// No listeners — skip creating a Service for this Gateway.
 			continue
@@ -330,19 +338,11 @@ func (r *Reconciler) createOrUpdateGatewayService(
 
 	if errors.IsNotFound(err) {
 		apply(svc)
-		if cerr := r.Create(ctx, svc); cerr != nil {
-			// Idempotency: a concurrent reconcile (stale cache) may have created it
-			// between our Get and Create — re-fetch and fall through to the update
-			// path instead of surfacing an AlreadyExists error (reconcile churn).
-			if !errors.IsAlreadyExists(cerr) {
-				return fmt.Errorf("create per-Gateway Service %s: %w", svc.Name, cerr)
-			}
-			if gerr := r.Get(ctx, key, existing); gerr != nil {
-				return fmt.Errorf("get per-Gateway Service %s after create race: %w", svc.Name, gerr)
-			}
-		} else {
-			r.Log.InfoContext(ctx, "created per-Gateway LoadBalancer Service",
-				"gateway", gwNamespace+"/"+gwName, "service", svc.Name, "pinnedIP", pinnedIP)
+		created, cerr := r.tryCreateGatewayService(ctx, svc, key, existing, gwNamespace, gwName, pinnedIP)
+		if cerr != nil {
+			return cerr
+		}
+		if created {
 			return nil
 		}
 	}
@@ -353,6 +353,24 @@ func (r *Reconciler) createOrUpdateGatewayService(
 		return fmt.Errorf("update per-Gateway Service %s: %w", svc.Name, uerr)
 	}
 	return nil
+}
+
+// tryCreateGatewayService attempts to Create svc. On AlreadyExists it re-fetches
+// into existing and returns (false, nil) to fall through to the update path.
+// On success returns (true, nil). On other errors returns (false, err).
+func (r *Reconciler) tryCreateGatewayService(ctx context.Context, svc *corev1.Service, key types.NamespacedName, existing *corev1.Service, gwNamespace, gwName, pinnedIP string) (bool, error) {
+	if cerr := r.Create(ctx, svc); cerr != nil {
+		if !errors.IsAlreadyExists(cerr) {
+			return false, fmt.Errorf("create per-Gateway Service %s: %w", svc.Name, cerr)
+		}
+		if gerr := r.Get(ctx, key, existing); gerr != nil {
+			return false, fmt.Errorf("get per-Gateway Service %s after create race: %w", svc.Name, gerr)
+		}
+		return false, nil
+	}
+	r.Log.InfoContext(ctx, "created per-Gateway LoadBalancer Service",
+		"gateway", gwNamespace+"/"+gwName, "service", svc.Name, "pinnedIP", pinnedIP)
+	return true, nil
 }
 
 // readServiceLBIP returns the first LoadBalancer ingress IP (or hostname) of the

--- a/agent/internal/edge/gatewayapi/status.go
+++ b/agent/internal/edge/gatewayapi/status.go
@@ -90,171 +90,12 @@ func (r *Reconciler) writeGatewayStatuses(
 		gw := &ourGateways[i]
 		gk := gatewayKey{Namespace: gw.Namespace, Name: gw.Name}
 
-		// Compute the SPEC-derived desired status once. These inputs depend on the
-		// Gateway spec + the routes/certs/assigned-IP we resolved this reconcile —
-		// NOT on the Gateway's current status — so they're stable across the
-		// conflict-retry re-Gets in writeGatewayStatus below.
-		listenerInputs := make([]listenerStatusInput, 0, len(gw.Spec.Listeners))
-		allListenersProgrammed := true
-		anyListenerAccepted := false
-		anyUnsupportedProtocol := false
-		for _, ln := range gw.Spec.Listeners {
-			// Unsupported listener protocol (gateway-api 1.6's
-			// GatewayListenerUnsupportedProtocol contract): the listener is not
-			// accepted (UnsupportedProtocol), publishes empty supportedKinds, and
-			// counts against the Gateway's Accepted/Programmed rollup below.
-			if attachment.SupportedKindsFor(ln.Protocol) == nil {
-				// NOTE: deliberately NOT counted against allListenersProgrammed —
-				// the suite's readiness poller requires top-level Programmed=True
-				// on the mixed (supported+unsupported) fixture Gateway; only a
-				// Gateway with NO accepted listener rolls up Programmed=False.
-				anyUnsupportedProtocol = true
-				msg := fmt.Sprintf("Listener protocol %q is not supported by the aether edge (supported: HTTP, HTTPS, TLS, TCP)", ln.Protocol)
-				listenerInputs = append(listenerInputs, listenerStatusInput{
-					name:           ln.Name,
-					supportedKinds: []gatewayv1.RouteGroupKind{},
-					attached:       0,
-					accepted: gatewaystatus.Condition{
-						Type:    string(gatewayv1.ListenerConditionAccepted),
-						Status:  metav1.ConditionFalse,
-						Reason:  string(gatewayv1.ListenerReasonUnsupportedProtocol),
-						Message: msg,
-					},
-					programmed: gatewaystatus.Condition{
-						Type:    string(gatewayv1.ListenerConditionProgrammed),
-						Status:  metav1.ConditionFalse,
-						Reason:  string(gatewayv1.ListenerReasonInvalid),
-						Message: msg,
-					},
-					resolved: gatewaystatus.Condition{
-						Type:    string(gatewayv1.ListenerConditionResolvedRefs),
-						Status:  metav1.ConditionTrue,
-						Reason:  string(gatewayv1.ListenerReasonResolvedRefs),
-						Message: "No references to resolve",
-					},
-				})
-				continue
-			}
-			anyListenerAccepted = true
-			attached := att.AttachedRoutesForListener(ctx, gw, ln, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys)
+		listenerInputs, allProgrammed, anyAccepted, anyUnsupported := r.buildListenerStatusInputs(
+			ctx, gw, gk, att, tlsResults, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys,
+		)
 
-			// ResolvedRefs: InvalidRouteKinds (allowedRoutes.kinds names an
-			// unsupported kind) takes precedence; then InvalidCertificateRef
-			// (a TLS listener whose certificateRefs don't resolve).
-			resolvedStatus := metav1.ConditionTrue
-			resolvedReason := string(gatewayv1.ListenerReasonResolvedRefs)
-			resolvedMsg := "All listener references resolved"
-			programmed := true
-			switch {
-			case attachment.ListenerHasInvalidRouteKinds(ln):
-				resolvedStatus = metav1.ConditionFalse
-				resolvedReason = string(gatewayv1.ListenerReasonInvalidRouteKinds)
-				resolvedMsg = "allowedRoutes.kinds names a Route kind this listener does not support"
-				programmed = false
-			default:
-				if res, ok := tlsResults[listenerStatusKey{Gateway: gk, Name: ln.Name}]; ok && res.hasTLS && !res.resolved {
-					resolvedStatus = metav1.ConditionFalse
-					resolvedReason = string(gatewayv1.ListenerReasonInvalidCertificateRef)
-					if res.reason != "" {
-						resolvedReason = res.reason
-					}
-					resolvedMsg = res.message
-					programmed = false
-				}
-			}
+		acceptedTop, programmedTop := r.computeGatewayTopConditions(ctx, gw, allProgrammed, anyAccepted, anyUnsupported)
 
-			programmedStatus := metav1.ConditionTrue
-			programmedReason := string(gatewayv1.ListenerReasonProgrammed)
-			programmedMsg := "Listener programmed"
-			if !programmed {
-				programmedStatus = metav1.ConditionFalse
-				programmedReason = string(gatewayv1.ListenerReasonInvalid)
-				programmedMsg = "Listener not programmed: " + resolvedMsg
-				allListenersProgrammed = false
-			}
-
-			listenerInputs = append(listenerInputs, listenerStatusInput{
-				name:           ln.Name,
-				supportedKinds: attachment.ListenerSupportedKinds(ln),
-				attached:       attached,
-				accepted: gatewaystatus.Condition{
-					Type:    string(gatewayv1.ListenerConditionAccepted),
-					Status:  metav1.ConditionTrue,
-					Reason:  string(gatewayv1.ListenerReasonAccepted),
-					Message: "Listener accepted",
-				},
-				programmed: gatewaystatus.Condition{
-					Type:    string(gatewayv1.ListenerConditionProgrammed),
-					Status:  programmedStatus,
-					Reason:  programmedReason,
-					Message: programmedMsg,
-				},
-				resolved: gatewaystatus.Condition{
-					Type:    string(gatewayv1.ListenerConditionResolvedRefs),
-					Status:  resolvedStatus,
-					Reason:  resolvedReason,
-					Message: resolvedMsg,
-				},
-			})
-		}
-
-		// Top-level Programmed is False when any listener failed to program (e.g.
-		// invalid TLS or invalid route kinds), so the Gateway is not advertised as
-		// fully programmed while a listener is broken.
-		programmedTop := gatewaystatus.Condition{
-			Type:    string(gatewayv1.GatewayConditionProgrammed),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(gatewayv1.GatewayReasonProgrammed),
-			Message: "Gateway programmed into the aether edge data plane",
-		}
-		if !allListenersProgrammed {
-			programmedTop.Status = metav1.ConditionFalse
-			programmedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
-			programmedTop.Message = "One or more listeners are not programmed (invalid TLS or route kinds)"
-		}
-		if !anyListenerAccepted && len(gw.Spec.Listeners) > 0 {
-			// All listeners rejected (unsupported protocols): nothing programs.
-			programmedTop.Status = metav1.ConditionFalse
-			programmedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
-			programmedTop.Message = "No listener is accepted (unsupported protocols)"
-		}
-		acceptedTop := gatewaystatus.Condition{
-			Type:    string(gatewayv1.GatewayConditionAccepted),
-			Status:  metav1.ConditionTrue,
-			Reason:  string(gatewayv1.GatewayReasonAccepted),
-			Message: "Gateway accepted by the aether edge controller",
-		}
-		// Listener-protocol rollup (1.6 contract): no accepted listener at all →
-		// Accepted=False/ListenersNotValid; some unsupported but ≥1 accepted →
-		// Accepted stays True with reason ListenersNotValid.
-		switch {
-		case !anyListenerAccepted && len(gw.Spec.Listeners) > 0:
-			acceptedTop.Status = metav1.ConditionFalse
-			acceptedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
-			acceptedTop.Message = "No listener is accepted (unsupported protocols)"
-		case anyUnsupportedProtocol:
-			acceptedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
-			acceptedTop.Message = "Gateway accepted; some listeners are not valid (unsupported protocols)"
-		}
-		// An infrastructure.parametersRef that is present but unresolvable rejects
-		// the Gateway (Accepted=False/InvalidParameters — Gateway API spec, pinned
-		// by the GatewayInvalidParametersRef conformance test). The data plane
-		// stays tolerant (listeners keep serving on compiled defaults) so a
-		// briefly-dangling EdgeConfig doesn't drop live traffic; only the
-		// advertised status reflects the invalid ref.
-		if msg, invalid := r.invalidParametersRef(ctx, gw); invalid {
-			acceptedTop.Status = metav1.ConditionFalse
-			acceptedTop.Reason = string(gatewayv1.GatewayReasonInvalidParameters)
-			acceptedTop.Message = msg
-			programmedTop.Status = metav1.ConditionFalse
-			programmedTop.Reason = string(gatewayv1.GatewayReasonInvalid)
-			programmedTop.Message = msg
-		}
-
-		// status.addresses: Phase 2 uses the per-Gateway LB IP; Phase 1 uses the
-		// shared edge LB IP. An empty list never overwrites a previously-published
-		// address (writeGatewayStatus leaves the old one and waits for the next
-		// reconcile once MetalLB assigns an IP).
 		var addrs []gatewayv1.GatewayStatusAddress
 		if ip, ok := perGWAssignedIPs[gk]; ok && ip != "" {
 			addrs = []gatewayv1.GatewayStatusAddress{{
@@ -270,6 +111,181 @@ func (r *Reconciler) writeGatewayStatuses(
 			r.Log.WarnContext(ctx, "failed to write Gateway status", "gateway", gw.Name, "error", err.Error())
 		}
 	}
+}
+
+// buildListenerStatusInputs computes the per-listener status inputs for a Gateway.
+// Returns the inputs slice and three rollup booleans: allProgrammed, anyAccepted, anyUnsupported.
+func (r *Reconciler) buildListenerStatusInputs(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	gk gatewayKey,
+	att *attachment.Resolver,
+	tlsResults map[listenerStatusKey]listenerTLSResult,
+	httpRoutes []gatewayv1.HTTPRoute,
+	tcpRoutes []gatewayv1.TCPRoute,
+	tlsRoutes []gatewayv1.TLSRoute,
+	gateways map[gatewayKey]struct{},
+	listenerKeys map[gatewayListenerKey]struct{},
+) ([]listenerStatusInput, bool, bool, bool) {
+	inputs := make([]listenerStatusInput, 0, len(gw.Spec.Listeners))
+	allProgrammed := true
+	anyAccepted := false
+	anyUnsupported := false
+	for _, ln := range gw.Spec.Listeners {
+		if attachment.SupportedKindsFor(ln.Protocol) == nil {
+			// NOTE: deliberately NOT counted against allProgrammed —
+			// the suite's readiness poller requires top-level Programmed=True
+			// on the mixed (supported+unsupported) fixture Gateway.
+			anyUnsupported = true
+			inputs = append(inputs, unsupportedListenerInput(ln))
+			continue
+		}
+		anyAccepted = true
+		attached := att.AttachedRoutesForListener(ctx, gw, ln, httpRoutes, tcpRoutes, tlsRoutes, gateways, listenerKeys)
+		inp, programmed := buildAcceptedListenerInput(ln, gk, attached, tlsResults)
+		if !programmed {
+			allProgrammed = false
+		}
+		inputs = append(inputs, inp)
+	}
+	return inputs, allProgrammed, anyAccepted, anyUnsupported
+}
+
+// unsupportedListenerInput returns the listenerStatusInput for a listener with an unsupported protocol.
+func unsupportedListenerInput(ln gatewayv1.Listener) listenerStatusInput {
+	msg := fmt.Sprintf("Listener protocol %q is not supported by the aether edge (supported: HTTP, HTTPS, TLS, TCP)", ln.Protocol)
+	return listenerStatusInput{
+		name:           ln.Name,
+		supportedKinds: []gatewayv1.RouteGroupKind{},
+		attached:       0,
+		accepted: gatewaystatus.Condition{
+			Type:    string(gatewayv1.ListenerConditionAccepted),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gatewayv1.ListenerReasonUnsupportedProtocol),
+			Message: msg,
+		},
+		programmed: gatewaystatus.Condition{
+			Type:    string(gatewayv1.ListenerConditionProgrammed),
+			Status:  metav1.ConditionFalse,
+			Reason:  string(gatewayv1.ListenerReasonInvalid),
+			Message: msg,
+		},
+		resolved: gatewaystatus.Condition{
+			Type:    string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayv1.ListenerReasonResolvedRefs),
+			Message: "No references to resolve",
+		},
+	}
+}
+
+// buildAcceptedListenerInput computes the listenerStatusInput for a supported-protocol listener.
+// Returns the input and whether the listener is programmed.
+func buildAcceptedListenerInput(ln gatewayv1.Listener, gk gatewayKey, attached int32, tlsResults map[listenerStatusKey]listenerTLSResult) (listenerStatusInput, bool) {
+	resolvedStatus := metav1.ConditionTrue
+	resolvedReason := string(gatewayv1.ListenerReasonResolvedRefs)
+	resolvedMsg := "All listener references resolved"
+	programmed := true
+
+	switch {
+	case attachment.ListenerHasInvalidRouteKinds(ln):
+		resolvedStatus = metav1.ConditionFalse
+		resolvedReason = string(gatewayv1.ListenerReasonInvalidRouteKinds)
+		resolvedMsg = "allowedRoutes.kinds names a Route kind this listener does not support"
+		programmed = false
+	default:
+		if res, ok := tlsResults[listenerStatusKey{Gateway: gk, Name: ln.Name}]; ok && res.hasTLS && !res.resolved {
+			resolvedStatus = metav1.ConditionFalse
+			resolvedReason = string(gatewayv1.ListenerReasonInvalidCertificateRef)
+			if res.reason != "" {
+				resolvedReason = res.reason
+			}
+			resolvedMsg = res.message
+			programmed = false
+		}
+	}
+
+	programmedStatus := metav1.ConditionTrue
+	programmedReason := string(gatewayv1.ListenerReasonProgrammed)
+	programmedMsg := "Listener programmed"
+	if !programmed {
+		programmedStatus = metav1.ConditionFalse
+		programmedReason = string(gatewayv1.ListenerReasonInvalid)
+		programmedMsg = "Listener not programmed: " + resolvedMsg
+	}
+
+	return listenerStatusInput{
+		name:           ln.Name,
+		supportedKinds: attachment.ListenerSupportedKinds(ln),
+		attached:       attached,
+		accepted: gatewaystatus.Condition{
+			Type:    string(gatewayv1.ListenerConditionAccepted),
+			Status:  metav1.ConditionTrue,
+			Reason:  string(gatewayv1.ListenerReasonAccepted),
+			Message: "Listener accepted",
+		},
+		programmed: gatewaystatus.Condition{
+			Type:    string(gatewayv1.ListenerConditionProgrammed),
+			Status:  programmedStatus,
+			Reason:  programmedReason,
+			Message: programmedMsg,
+		},
+		resolved: gatewaystatus.Condition{
+			Type:    string(gatewayv1.ListenerConditionResolvedRefs),
+			Status:  resolvedStatus,
+			Reason:  resolvedReason,
+			Message: resolvedMsg,
+		},
+	}, programmed
+}
+
+// computeGatewayTopConditions derives the top-level Accepted and Programmed conditions
+// for a Gateway from listener rollup booleans and an optional parametersRef check.
+func (r *Reconciler) computeGatewayTopConditions(
+	ctx context.Context,
+	gw *gatewayv1.Gateway,
+	allListenersProgrammed, anyListenerAccepted, anyUnsupportedProtocol bool,
+) (gatewaystatus.Condition, gatewaystatus.Condition) {
+	programmedTop := gatewaystatus.Condition{
+		Type:    string(gatewayv1.GatewayConditionProgrammed),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayv1.GatewayReasonProgrammed),
+		Message: "Gateway programmed into the aether edge data plane",
+	}
+	if !allListenersProgrammed {
+		programmedTop.Status = metav1.ConditionFalse
+		programmedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
+		programmedTop.Message = "One or more listeners are not programmed (invalid TLS or route kinds)"
+	}
+	if !anyListenerAccepted && len(gw.Spec.Listeners) > 0 {
+		programmedTop.Status = metav1.ConditionFalse
+		programmedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
+		programmedTop.Message = "No listener is accepted (unsupported protocols)"
+	}
+	acceptedTop := gatewaystatus.Condition{
+		Type:    string(gatewayv1.GatewayConditionAccepted),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(gatewayv1.GatewayReasonAccepted),
+		Message: "Gateway accepted by the aether edge controller",
+	}
+	switch {
+	case !anyListenerAccepted && len(gw.Spec.Listeners) > 0:
+		acceptedTop.Status = metav1.ConditionFalse
+		acceptedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
+		acceptedTop.Message = "No listener is accepted (unsupported protocols)"
+	case anyUnsupportedProtocol:
+		acceptedTop.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
+		acceptedTop.Message = "Gateway accepted; some listeners are not valid (unsupported protocols)"
+	}
+	if msg, invalid := r.invalidParametersRef(ctx, gw); invalid {
+		acceptedTop.Status = metav1.ConditionFalse
+		acceptedTop.Reason = string(gatewayv1.GatewayReasonInvalidParameters)
+		acceptedTop.Message = msg
+		programmedTop.Status = metav1.ConditionFalse
+		programmedTop.Reason = string(gatewayv1.GatewayReasonInvalid)
+		programmedTop.Message = msg
+	}
+	return acceptedTop, programmedTop
 }
 
 // listenerStatusInput holds the spec-derived inputs for one listener's status,
@@ -417,26 +433,33 @@ func listenerStatusesEqual(a, b []gatewayv1.ListenerStatus) bool {
 		return false
 	}
 	for i := range a {
-		if a[i].Name != b[i].Name || a[i].AttachedRoutes != b[i].AttachedRoutes {
+		if !listenerStatusEqual(a[i], b[i]) {
 			return false
 		}
-		if len(a[i].SupportedKinds) != len(b[i].SupportedKinds) {
+	}
+	return true
+}
+
+func listenerStatusEqual(a, b gatewayv1.ListenerStatus) bool {
+	if a.Name != b.Name || a.AttachedRoutes != b.AttachedRoutes {
+		return false
+	}
+	if len(a.SupportedKinds) != len(b.SupportedKinds) {
+		return false
+	}
+	for j := range a.SupportedKinds {
+		if a.SupportedKinds[j].Kind != b.SupportedKinds[j].Kind {
 			return false
 		}
-		for j := range a[i].SupportedKinds {
-			if a[i].SupportedKinds[j].Kind != b[i].SupportedKinds[j].Kind {
-				return false
-			}
-		}
-		if len(a[i].Conditions) != len(b[i].Conditions) {
+	}
+	if len(a.Conditions) != len(b.Conditions) {
+		return false
+	}
+	for j := range a.Conditions {
+		ca, cb := a.Conditions[j], b.Conditions[j]
+		if ca.Type != cb.Type || ca.Status != cb.Status || ca.Reason != cb.Reason ||
+			ca.Message != cb.Message || ca.ObservedGeneration != cb.ObservedGeneration {
 			return false
-		}
-		for j := range a[i].Conditions {
-			ca, cb := a[i].Conditions[j], b[i].Conditions[j]
-			if ca.Type != cb.Type || ca.Status != cb.Status || ca.Reason != cb.Reason ||
-				ca.Message != cb.Message || ca.ObservedGeneration != cb.ObservedGeneration {
-				return false
-			}
 		}
 	}
 	return true


### PR DESCRIPTION
## Summary

Structure-only refactoring of `agent/internal/edge/gatewayapi/` (including `attachment/` sub-package) to bring all non-test functions to gocognit ≤15. Zero behavior change.

### Helper extractions per function (before → after)

| Function | Before | After | Helpers extracted |
|---|---|---|---|
| `(*Reconciler).buildVirtualHost` | 109 | ≤15 | `buildRoutesForRule`, `buildInvalidOrEmptyRoutes`, `buildMatchPath`, `buildMatchHeaders`, `buildMatchMethod`, `buildMatchQueryParams` |
| `(*Reconciler).Reconcile` | 62 | ≤15 | `listAndProjectHTTPRoutes`, `listAndProjectTCPRoutes`, `listAndProjectTLSRoutes`, `computeHTTPRedirect`, `reconcilePhase2` |
| `(*Reconciler).writeGatewayStatuses` | 39 | ≤15 | `buildListenerStatusInputs`, `unsupportedListenerInput`, `buildAcceptedListenerInput`, `computeGatewayTopConditions` |
| `GatewayParentPorts` | 28 | ≤15 | `collectParentRefPorts` |
| `EffectiveHostnames` | 28 | ≤15 | `intersectListenerHostname` |
| `(*Resolver).httpRouteAttachment` | 26 | ≤15 | `checkListenerAttach` |
| `buildHTTPRedirect` | 25 | ≤15 | `applyRedirectPath` |
| `(*Reconciler).resolveListenerTLS` | 23 | ≤15 | `resolveCertRef` |
| `(*Reconciler).reconcileGatewayServices` | 23 | ≤15 | `buildGatewayServicePorts` |
| `buildEdgeHTTPHeaderMutation` | 23 | ≤15 | `applyRequestHeaderModifier`, `applyResponseHeaderModifier` |
| `allocateGatewayListenerPorts` | 21 | ≤15 | `collectPortAllocKeys`, `buildGatewayAllocations` |
| `(*Reconciler).createOrUpdateGatewayService` | 20 | ≤15 | `tryCreateGatewayService` |
| `(*Reconciler).buildHTTPRouteBackends` | 20 | ≤15 | `httpBackendRefToRouteBackend` |
| `listenerStatusesEqual` | 20 | ≤15 | `listenerStatusEqual` |
| `buildHTTPURLRewrite` | 19 | ≤15 | `applyURLRewritePath` |
| `(*Resolver).AttachedRoutesForListener` | 16 | ≤15 | `countAttachedHTTPRoutes`, `countAttachedTCPRoutes`, `countAttachedTLSRoutes` |

## Test plan

- [x] `bazel build @com_github_uudashr_gocognit//cmd/gocognit` + `$BIN -over 15 agent/internal/edge/gatewayapi/` filtered to non-test files → **empty output** (all ≤15)
- [x] `bazel test --test_output=errors //agent/internal/edge/...` → **4/4 PASSED**
- [x] `make format` + `make gazelle` → clean

Part of #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR