### PR TITLE
refactor(agent): reduce cognitive complexity <=15 in cni server, hotrestart, spire (part of #556)

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -126,6 +126,44 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		telemetry.EndSpan(span, retErr)
 	}()
 
+	all, err := s.listRegistryEndpoints(ctx)
+	if err != nil {
+		retErr = err
+		return
+	}
+
+	// Serialize against pod lifecycle so an in-flight AddPod (stored after the
+	// registry write) or RemovePod cannot race the liveness judgment.
+	s.lifecycleMu.Lock()
+	defer s.lifecycleMu.Unlock()
+
+	pods, err := s.storage.GetAll(ctx)
+	if err != nil {
+		s.log.DebugContext(ctx, "ghost sweep: failed to list local pods", "error", err)
+		retErr = err
+		return
+	}
+	storedPods = len(pods)
+
+	// Ground-truth reconcile: the manager cache is scoped to spec.nodeName=<this
+	// node>, so this lists exactly this node's pods, cheaply. Used to prune
+	// storage entries whose pod K8s no longer has, and to surface live pods
+	// storage is missing. If the list fails we must NOT prune by pod-absence (an
+	// empty list would nuke every entry), so that half is skipped this cycle.
+	nodePods, nodePodsOK := s.listNodePods(ctx)
+
+	pods, stalePruned, orphansPruned = s.pruneStaleStoragePods(ctx, pods, nodePods, nodePodsOK)
+	missingStorage = s.reportMissingStoragePods(ctx, pods, nodePods, nodePodsOK)
+
+	live, terminating := s.classifyPods(pods)
+	ghostsRemoved = s.deregisterGhostEndpoints(ctx, all, live, terminating)
+	missingRegistered = s.registerMissingEndpoints(ctx, live, all)
+}
+
+// listRegistryEndpoints fetches all registry endpoints for this node across all
+// swept protocols. It uses the authoritative lister when available to avoid
+// cache-staleness (see sweepGhostEndpoints comment).
+func (s *CNIServer) listRegistryEndpoints(ctx context.Context) (map[string][]*registryv1.ServiceEndpoint, error) {
 	// The sweep decides what to (de)register, so it must diff against the
 	// AUTHORITATIVE registry state, never the watch-fed cache: a fresh or
 	// failed-over registrar with an empty snapshot emits no events, the cache
@@ -150,34 +188,19 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		}
 		if err != nil {
 			s.log.DebugContext(ctx, "ghost sweep: failed to list registry endpoints", "protocol", protocol.String(), "error", err)
-			retErr = err
-			return
+			return nil, err
 		}
 		for svc, eps := range listed {
 			all[svc] = append(all[svc], eps...)
 		}
 	}
+	return all, nil
+}
 
-	// Serialize against pod lifecycle so an in-flight AddPod (stored after the
-	// registry write) or RemovePod cannot race the liveness judgment.
-	s.lifecycleMu.Lock()
-	defer s.lifecycleMu.Unlock()
-
-	pods, err := s.storage.GetAll(ctx)
-	if err != nil {
-		s.log.DebugContext(ctx, "ghost sweep: failed to list local pods", "error", err)
-		retErr = err
-		return
-	}
-	storedPods = len(pods)
-
-	// Ground-truth reconcile: the manager cache is scoped to spec.nodeName=<this
-	// node>, so this lists exactly this node's pods, cheaply. Used to prune
-	// storage entries whose pod K8s no longer has, and to surface live pods
-	// storage is missing. If the list fails we must NOT prune by pod-absence (an
-	// empty list would nuke every entry), so that half is skipped this cycle.
-	nodePods, nodePodsOK := s.listNodePods(ctx)
-
+// pruneStaleStoragePods removes pods from storage whose network namespace is
+// gone or whose Kubernetes pod no longer exists. Returns the surviving pods
+// and the counts of stale and orphaned pods pruned.
+func (s *CNIServer) pruneStaleStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) ([]*cniv1.CNIPod, int, int) {
 	// Prune storage entries that no longer correspond to a live pod: a missed CNI
 	// DEL left the file behind. Keeping it both re-registers a dead endpoint (the
 	// missing-direction loop would treat it as a live local pod) and makes Envoy
@@ -191,6 +214,7 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	// clusters (which carry the netns) — so the dead-netns cluster leaves the
 	// snapshot. The pruned pod's registry endpoints then fall through to ghost
 	// deregistration below.
+	stalePruned, orphansPruned := 0, 0
 	fresh := pods[:0]
 	for _, p := range pods {
 		netns := p.GetNetworkNamespace()
@@ -200,63 +224,87 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 			fresh = append(fresh, p)
 			continue
 		}
-		if err := s.storage.RemoveResource(ctx, types.ContainerID(p.GetContainerId())); err != nil {
-			s.log.ErrorContext(ctx, "ghost sweep: failed to prune pod storage", "pod", p.GetName(), "netns", netns, "error", err)
-			fresh = append(fresh, p) // keep it; retry next sweep
+		kept, wasOrphaned := s.pruneOnePod(ctx, p, netns, orphaned)
+		if kept {
+			fresh = append(fresh, p)
 			continue
 		}
-		if netns != "" {
-			if err := s.snapshotCache.RemovePod(ctx, netns); err != nil {
-				s.log.ErrorContext(ctx, "ghost sweep: failed to drop listener for pruned pod", "pod", p.GetName(), "netns", netns, "error", err)
-			}
-		}
-		if orphaned {
+		if wasOrphaned {
 			orphansPruned++
-			s.log.InfoContext(ctx, "ghost sweep: pruned orphaned pod (Kubernetes pod gone; CNI DEL missed, netns pin lingered)",
-				"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
 		} else {
 			stalePruned++
-			s.log.InfoContext(ctx, "ghost sweep: pruned stale pod (network namespace gone; CNI DEL missed)",
-				"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
 		}
 	}
-	pods = fresh
+	return fresh, stalePruned, orphansPruned
+}
 
+// pruneOnePod removes a single stale or orphaned pod from storage and drops its
+// listener from the snapshot. Returns (kept=true) if the pod should be retained
+// in the fresh list (storage removal failed), and (orphaned) for log/metric routing.
+func (s *CNIServer) pruneOnePod(ctx context.Context, p *cniv1.CNIPod, netns string, orphaned bool) (kept bool, wasOrphaned bool) {
+	if err := s.storage.RemoveResource(ctx, types.ContainerID(p.GetContainerId())); err != nil {
+		s.log.ErrorContext(ctx, "ghost sweep: failed to prune pod storage", "pod", p.GetName(), "netns", netns, "error", err)
+		return true, orphaned // keep it; retry next sweep
+	}
+	if netns != "" {
+		if err := s.snapshotCache.RemovePod(ctx, netns); err != nil {
+			s.log.ErrorContext(ctx, "ghost sweep: failed to drop listener for pruned pod", "pod", p.GetName(), "netns", netns, "error", err)
+		}
+	}
+	if orphaned {
+		s.log.InfoContext(ctx, "ghost sweep: pruned orphaned pod (Kubernetes pod gone; CNI DEL missed, netns pin lingered)",
+			"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+	} else {
+		s.log.InfoContext(ctx, "ghost sweep: pruned stale pod (network namespace gone; CNI DEL missed)",
+			"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+	}
+	return false, orphaned
+}
+
+// reportMissingStoragePods emits warnings for live mesh-managed K8s pods that
+// have no entry in local storage (a lost CNI ADD). Returns the count of such
+// pods found.
+func (s *CNIServer) reportMissingStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) int {
 	// Surface live mesh-managed pods on this node that local storage has no entry
 	// for: a lost CNI ADD (talos worker-01, 2026-06-22: prober-k7vsm running with
 	// no listener). The agent has no CNI data (netns, IPs) to synthesize a
 	// listener, so it cannot self-heal — emit a metric + warning so the gap is
 	// visible (the pod must be rolled) instead of silently serving no listener.
-	if nodePodsOK {
-		stored := make(map[string]struct{}, len(pods))
-		for _, p := range pods {
-			stored[podKey(p.GetNamespace(), p.GetName())] = struct{}{}
-		}
-		for key, kp := range nodePods {
-			if _, ok := stored[key]; ok {
-				continue
-			}
-			// Only a Running, non-terminating, mesh-managed pod is a genuine lost
-			// ADD; a Pending pod is mid-CNI-ADD and a terminating one is mid-removal
-			// — both have a legitimately transient storage gap.
-			if kp.Status.Phase != corev1.PodRunning || kp.DeletionTimestamp != nil {
-				continue
-			}
-			if !isMeshManagedK8sPod(kp) {
-				continue
-			}
-			missingStorage++
-			s.log.WarnContext(ctx, "ghost sweep: live mesh pod missing from local storage (CNI ADD lost; pod has no listener and must be rolled)",
-				"pod", kp.GetName(), "namespace", kp.GetNamespace(), "podIP", kp.Status.PodIP)
-		}
+	if !nodePodsOK {
+		return 0
 	}
+	missingStorage := 0
+	stored := make(map[string]struct{}, len(pods))
+	for _, p := range pods {
+		stored[podKey(p.GetNamespace(), p.GetName())] = struct{}{}
+	}
+	for key, kp := range nodePods {
+		if _, ok := stored[key]; ok {
+			continue
+		}
+		// Only a Running, non-terminating, mesh-managed pod is a genuine lost
+		// ADD; a Pending pod is mid-CNI-ADD and a terminating one is mid-removal
+		// — both have a legitimately transient storage gap.
+		if kp.Status.Phase != corev1.PodRunning || kp.DeletionTimestamp != nil {
+			continue
+		}
+		if !isMeshManagedK8sPod(kp) {
+			continue
+		}
+		missingStorage++
+		s.log.WarnContext(ctx, "ghost sweep: live mesh pod missing from local storage (CNI ADD lost; pod has no listener and must be rolled)",
+			"pod", kp.GetName(), "namespace", kp.GetNamespace(), "podIP", kp.Status.PodIP)
+	}
+	return missingStorage
+}
 
-	// Live local pods by IP. Terminating pods are tracked separately: their
-	// endpoints are deliberately still registered (marked DRAINING by the
-	// termination watch, removed at CNI DEL) — they are neither ghosts to
-	// deregister nor missing entries to re-register.
-	live := make(map[string]*cniv1.CNIPod, len(pods))
-	terminating := make(map[string]struct{})
+// classifyPods splits a slice of stored pods into a live-by-IP map and a
+// terminating-IP set. Terminating pods are tracked separately: their endpoints
+// are deliberately still registered (marked DRAINING by the termination watch,
+// removed at CNI DEL) — they are neither ghosts nor missing entries.
+func (s *CNIServer) classifyPods(pods []*cniv1.CNIPod) (live map[string]*cniv1.CNIPod, terminating map[string]struct{}) {
+	live = make(map[string]*cniv1.CNIPod, len(pods))
+	terminating = make(map[string]struct{})
 	for _, p := range pods {
 		if isIgnorablePod(p) {
 			continue
@@ -271,39 +319,75 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 			live[ip] = p
 		}
 	}
+	return live, terminating
+}
 
-	registered := make(map[string]struct{})
+// deregisterGhostEndpoints removes registry entries for this node that no live
+// local pod accounts for. Returns the count of ghost endpoints removed.
+func (s *CNIServer) deregisterGhostEndpoints(ctx context.Context, all map[string][]*registryv1.ServiceEndpoint, live map[string]*cniv1.CNIPod, terminating map[string]struct{}) int {
+	ghostsRemoved := 0
 	for service, endpoints := range all {
+		ghostsRemoved += s.deregisterGhostEndpointsForService(ctx, service, endpoints, live, terminating)
+	}
+	return ghostsRemoved
+}
+
+// deregisterGhostEndpointsForService removes ghost endpoints for a single service.
+// Returns the count of endpoints deregistered.
+func (s *CNIServer) deregisterGhostEndpointsForService(ctx context.Context, service string, endpoints []*registryv1.ServiceEndpoint, live map[string]*cniv1.CNIPod, terminating map[string]struct{}) int {
+	removed := 0
+	for _, ep := range endpoints {
+		// Own only this cluster's slice of this node's endpoints: registrars
+		// run per cluster against a shared mesh registry, and node names are
+		// NOT unique across clusters — matching on NodeName alone could
+		// deregister another cluster's endpoints.
+		if ep.GetClusterName() != s.clusterName || ep.GetKubernetesMetadata().GetNodeName() != s.nodeName {
+			continue // another agent's (or cluster's) responsibility
+		}
+		if _, ok := live[ep.GetIp()]; ok {
+			continue
+		}
+		if _, ok := terminating[ep.GetIp()]; ok {
+			continue // draining; CNI DEL owns the final removal
+		}
+		if err := s.registry.UnregisterEndpoint(ctx, service, ep.GetIp()); err != nil {
+			s.log.ErrorContext(ctx, "ghost sweep: failed to deregister ghost endpoint", "error", err,
+				"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
+			continue
+		}
+		removed++
+		s.log.InfoContext(ctx, "ghost sweep: deregistered ghost endpoint",
+			"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
+	}
+	return removed
+}
+
+// registeredIPs returns the set of IPs present in the registry for this node,
+// derived from the all-endpoints map and the live-pods map.
+func (s *CNIServer) registeredIPs(all map[string][]*registryv1.ServiceEndpoint, live map[string]*cniv1.CNIPod) map[string]struct{} {
+	registered := make(map[string]struct{})
+	for _, endpoints := range all {
 		for _, ep := range endpoints {
-			// Own only this cluster's slice of this node's endpoints: registrars
-			// run per cluster against a shared mesh registry, and node names are
-			// NOT unique across clusters — matching on NodeName alone could
-			// deregister another cluster's endpoints.
 			if ep.GetClusterName() != s.clusterName || ep.GetKubernetesMetadata().GetNodeName() != s.nodeName {
-				continue // another agent's (or cluster's) responsibility
+				continue
 			}
 			if _, ok := live[ep.GetIp()]; ok {
 				registered[ep.GetIp()] = struct{}{}
-				continue
 			}
-			if _, ok := terminating[ep.GetIp()]; ok {
-				continue // draining; CNI DEL owns the final removal
-			}
-			if err := s.registry.UnregisterEndpoint(ctx, service, ep.GetIp()); err != nil {
-				s.log.ErrorContext(ctx, "ghost sweep: failed to deregister ghost endpoint", "error", err,
-					"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
-				continue
-			}
-			ghostsRemoved++
-			s.log.InfoContext(ctx, "ghost sweep: deregistered ghost endpoint",
-				"service", service, "ip", ep.GetIp(), "pod", ep.GetKubernetesMetadata().GetPodName())
 		}
 	}
+	return registered
+}
 
+// registerMissingEndpoints registers live local pods absent from the registry
+// (lost ADD registration, registry data loss). Returns the count registered.
+func (s *CNIServer) registerMissingEndpoints(ctx context.Context, live map[string]*cniv1.CNIPod, all map[string][]*registryv1.ServiceEndpoint) int {
 	// Missing direction: live local pods absent from the registry (lost ADD
 	// registration, registry data loss). Register at the mode-default health
 	// (EDS mode: UNHEALTHY) and reset the liveness transition cache so the next
 	// healthy observation re-promotes.
+	registered := s.registeredIPs(all, live)
+	missingRegistered := 0
 	for ip, pod := range live {
 		if _, ok := registered[ip]; ok {
 			continue
@@ -326,6 +410,7 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 		s.log.InfoContext(ctx, "ghost sweep: registered missing endpoint",
 			"service", serviceName, "ip", ip, "pod", pod.GetName())
 	}
+	return missingRegistered
 }
 
 // listNodePods returns this node's pods keyed by namespace/name. The agent's

--- a/agent/internal/cni/server/liveness.go
+++ b/agent/internal/cni/server/liveness.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	"github.com/bpalermo/aether/agent/types"
+	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	registryv1 "github.com/bpalermo/aether/api/aether/registry/v1"
 	"github.com/bpalermo/aether/common/telemetry"
 	"github.com/bpalermo/aether/registry"
@@ -110,94 +111,128 @@ func (s *CNIServer) reconcileLiveness(ctx context.Context, state *livenessState)
 			continue // pod's gateway filter not yet programmed / propagated
 		}
 
-		key := pod.GetContainerId()
-		if _, ok := state.firstSeen[key]; !ok {
-			state.firstSeen[key] = time.Now()
+		if s.applyPodLiveness(ctx, state, pod, healthy) {
+			return // gateway unreachable (applyPodLiveness signals abort via return true — reserved for future)
 		}
-		_, servedBefore := state.sawHealthy[key]
-		if healthy {
-			state.sawHealthy[key] = struct{}{}
-		}
-
-		want := registryv1.ServiceEndpoint_HEALTH_HEALTHY
-		if !healthy {
-			want = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
-		}
-
-		eds := registry.HealthCheckModeFromAnnotations(pod.GetAnnotations()) == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS
-
-		// Warm-up grace (active mode only): hosts start failed until their first
-		// passing check, so a 503 on a never-yet-serving pod inside the grace
-		// window is startup, not an app failure. EDS-mode pods need no grace —
-		// they are registered UNHEALTHY, so warm-up 503s are not transitions.
-		if !healthy && !eds {
-			if !servedBefore && time.Since(state.firstSeen[key]) < livenessWarmupGrace {
-				continue
-			}
-		}
-
-		// Absent prior state is seeded with the endpoint's registration health so
-		// only a real transition triggers a re-register: EDS-mode endpoints are
-		// registered UNHEALTHY (gated until this proxy vets the app — the first
-		// healthy observation here is the promotion), active-mode endpoints
-		// register HEALTHY.
-		prev, ok := state.last[key]
-		if !ok {
-			prev = registryv1.ServiceEndpoint_HEALTH_HEALTHY
-			if eds {
-				prev = registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
-			}
-		}
-		if prev == want {
-			continue
-		}
-
-		serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, s.nodeIP, pod)
-		if err != nil {
-			s.log.DebugContext(ctx, "liveness: failed to build endpoint", "pod", pod.GetName(), "error", err)
-			continue
-		}
-		endpoint.Health = want
-
-		// Health transitions are rare and meaningful, so each gets its own trace
-		// (a per-tick span would be a 5s-interval no-op most of the time).
-		spanCtx, span := otel.Tracer(tracerName).Start(ctx, "agent.liveness.health_transition",
-			trace.WithAttributes(
-				telemetry.AttrPodName.String(pod.GetName()),
-				telemetry.AttrPodNamespace.String(pod.GetNamespace()),
-				attribute.String("aether.health.from", prev.String()),
-				attribute.String("aether.health.to", want.String()),
-			))
-
-		// Re-check the pod still exists in storage — and is not terminating —
-		// under lifecycleMu before re-registering: the pods slice is a snapshot
-		// from the start of this tick, and a concurrent RemovePod (which holds
-		// lifecycleMu across unregister + storage delete) or termination-watch
-		// deregistration may have unregistered the endpoint — re-registering
-		// then would resurrect a deleted endpoint in the registry permanently.
-		s.lifecycleMu.Lock()
-		if cur, getErr := s.storage.GetResource(spanCtx, types.ContainerID(pod.GetContainerId())); getErr != nil || cur.GetTerminating() {
-			s.lifecycleMu.Unlock()
-			span.End()
-			state.forget(key)
-			s.log.DebugContext(ctx, "liveness: pod gone or terminating; skipping health update", "pod", pod.GetName())
-			continue
-		}
-		err = s.registry.RegisterEndpoint(spanCtx, serviceName, protocol, endpoint)
-		s.lifecycleMu.Unlock()
-		telemetry.EndSpan(span, err)
-		if err != nil {
-			s.log.ErrorContext(ctx, "liveness: failed to re-register endpoint health", "error", err, "pod", pod.GetName())
-			continue
-		}
-		s.metrics.healthTransition(ctx, prev.String(), want.String())
-		// First-ever promotion to HEALTHY: record how long the pod waited between
-		// its gateway becoming observable and mesh routability (the gap that lets
-		// k8s rolls outpace mesh promotion when it grows).
-		if want == registryv1.ServiceEndpoint_HEALTH_HEALTHY && !servedBefore {
-			s.metrics.promotionDelayObserved(ctx, time.Since(state.firstSeen[key]).Seconds())
-		}
-		state.last[key] = want
-		s.log.DebugContext(ctx, "liveness: updated endpoint health", "pod", pod.GetName(), "health", want.String())
 	}
+}
+
+// livenessWant maps a healthy flag to the registry health enum.
+func livenessWant(healthy bool) registryv1.ServiceEndpoint_Health {
+	if healthy {
+		return registryv1.ServiceEndpoint_HEALTH_HEALTHY
+	}
+	return registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
+}
+
+// livenessPrev returns the previously reported health for a pod, seeding it from
+// the endpoint's registration health when not yet seen.
+func livenessPrev(state *livenessState, key string, eds bool) registryv1.ServiceEndpoint_Health {
+	if prev, ok := state.last[key]; ok {
+		return prev
+	}
+	if eds {
+		return registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
+	}
+	return registryv1.ServiceEndpoint_HEALTH_HEALTHY
+}
+
+// applyPodLiveness updates the per-pod state machine and, when a health
+// transition is detected, re-registers the endpoint in the registry.
+// Returns false always (reserved abort signal, kept for future use).
+func (s *CNIServer) applyPodLiveness(ctx context.Context, state *livenessState, pod *cniv1.CNIPod, healthy bool) bool {
+	key := pod.GetContainerId()
+	if _, ok := state.firstSeen[key]; !ok {
+		state.firstSeen[key] = time.Now()
+	}
+	_, servedBefore := state.sawHealthy[key]
+	if healthy {
+		state.sawHealthy[key] = struct{}{}
+	}
+
+	want := livenessWant(healthy)
+	eds := registry.HealthCheckModeFromAnnotations(pod.GetAnnotations()) == registryv1.ServiceEndpoint_HEALTH_CHECK_MODE_EDS
+
+	// Warm-up grace (active mode only): hosts start failed until their first
+	// passing check, so a 503 on a never-yet-serving pod inside the grace
+	// window is startup, not an app failure. EDS-mode pods need no grace —
+	// they are registered UNHEALTHY, so warm-up 503s are not transitions.
+	if !healthy && !eds && !servedBefore && time.Since(state.firstSeen[key]) < livenessWarmupGrace {
+		return false
+	}
+
+	// Absent prior state is seeded with the endpoint's registration health so
+	// only a real transition triggers a re-register: EDS-mode endpoints are
+	// registered UNHEALTHY (gated until this proxy vets the app — the first
+	// healthy observation here is the promotion), active-mode endpoints
+	// register HEALTHY.
+	prev := livenessPrev(state, key, eds)
+	if prev == want {
+		return false
+	}
+
+	serviceName, protocol, endpoint, err := registry.NewServiceEndpointFromCNIPod(s.clusterName, s.nodeName, s.nodeRegion, s.nodeZone, s.nodeIP, pod)
+	if err != nil {
+		s.log.DebugContext(ctx, "liveness: failed to build endpoint", "pod", pod.GetName(), "error", err)
+		return false
+	}
+	endpoint.Health = want
+
+	s.registerHealthTransition(ctx, state, pod, key, prev, want, servedBefore, serviceName, protocol, endpoint)
+	return false
+}
+
+// registerHealthTransition performs the guarded registry re-registration for a
+// pod whose health changed, tracing the operation and updating the state machine.
+func (s *CNIServer) registerHealthTransition(
+	ctx context.Context,
+	state *livenessState,
+	pod *cniv1.CNIPod,
+	key string,
+	prev, want registryv1.ServiceEndpoint_Health,
+	servedBefore bool,
+	serviceName string,
+	protocol registryv1.Service_Protocol,
+	endpoint *registryv1.ServiceEndpoint,
+) {
+	// Health transitions are rare and meaningful, so each gets its own trace
+	// (a per-tick span would be a 5s-interval no-op most of the time).
+	spanCtx, span := otel.Tracer(tracerName).Start(ctx, "agent.liveness.health_transition",
+		trace.WithAttributes(
+			telemetry.AttrPodName.String(pod.GetName()),
+			telemetry.AttrPodNamespace.String(pod.GetNamespace()),
+			attribute.String("aether.health.from", prev.String()),
+			attribute.String("aether.health.to", want.String()),
+		))
+
+	// Re-check the pod still exists in storage — and is not terminating —
+	// under lifecycleMu before re-registering: the pods slice is a snapshot
+	// from the start of this tick, and a concurrent RemovePod (which holds
+	// lifecycleMu across unregister + storage delete) or termination-watch
+	// deregistration may have unregistered the endpoint — re-registering
+	// then would resurrect a deleted endpoint in the registry permanently.
+	s.lifecycleMu.Lock()
+	if cur, getErr := s.storage.GetResource(spanCtx, types.ContainerID(pod.GetContainerId())); getErr != nil || cur.GetTerminating() {
+		s.lifecycleMu.Unlock()
+		span.End()
+		state.forget(key)
+		s.log.DebugContext(ctx, "liveness: pod gone or terminating; skipping health update", "pod", pod.GetName())
+		return
+	}
+	err := s.registry.RegisterEndpoint(spanCtx, serviceName, protocol, endpoint)
+	s.lifecycleMu.Unlock()
+	telemetry.EndSpan(span, err)
+	if err != nil {
+		s.log.ErrorContext(ctx, "liveness: failed to re-register endpoint health", "error", err, "pod", pod.GetName())
+		return
+	}
+	s.metrics.healthTransition(ctx, prev.String(), want.String())
+	// First-ever promotion to HEALTHY: record how long the pod waited between
+	// its gateway becoming observable and mesh routability (the gap that lets
+	// k8s rolls outpace mesh promotion when it grows).
+	if want == registryv1.ServiceEndpoint_HEALTH_HEALTHY && !servedBefore {
+		s.metrics.promotionDelayObserved(ctx, time.Since(state.firstSeen[key]).Seconds())
+	}
+	state.last[key] = want
+	s.log.DebugContext(ctx, "liveness: updated endpoint health", "pod", pod.GetName(), "health", want.String())
 }

--- a/agent/internal/proxy/hotrestart/coordination.go
+++ b/agent/internal/proxy/hotrestart/coordination.go
@@ -181,22 +181,7 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			if live {
 				everLive = true
 				holding = false
-				if launched, wasLive := s.epochProgress(); !wasLive {
-					// First LIVE confirmation for this epoch: the handoff (or
-					// initial start, epoch 0) completed.
-					s.metrics.handoffCompleted(time.Since(launched).Seconds())
-				}
-				s.markEpochLive()
-				s.writeState(epoch) // LIVE-gated heartbeat
-				// Hold readiness until the cross-pod handoff is fully complete (the
-				// predecessor has been terminated by this Envoy's parent-shutdown), so
-				// the DaemonSet doesn't delete the old pod while we still need it.
-				if !ready && !time.Now().Before(s.readyGateTime()) {
-					s.setReady()
-					ready = true
-					s.metrics.readyTransition(true)
-					s.log.InfoContext(ctx, "pod ready: envoy live at newest epoch", "epoch", epoch)
-				}
+				ready = s.onLiveEpoch(ctx, epoch, ready)
 				continue
 			}
 			// Hold readiness while this supervisor's Envoy is still the serving
@@ -211,38 +196,78 @@ func (s *Supervisor) watchLiveness(ctx context.Context) {
 			// coincided with pod churn (e2e 2026-06-11). The wedge watchdogs below
 			// still run: a successor stuck pre-LIVE or an unreachable admin ends
 			// the hold via container restart, and the child exiting ends it here.
-			hold := ready && reachable && s.childTracked(epoch)
-			if hold && !holding {
-				holding = true
-				s.log.InfoContext(ctx, "holding readiness: serving as hot-restart parent mid-handoff", "epoch", epoch)
-			}
-			if ready && !hold {
-				s.clearReady()
-				ready = false
-				holding = false
-				s.metrics.readyTransition(false)
-				s.log.InfoContext(ctx, "pod not ready: envoy not live at newest epoch", "epoch", epoch)
-			}
-
-			launched, wasLive := s.epochProgress()
-			if epoch > 0 && !wasLive && s.childTracked(epoch) && time.Since(launched) > s.handoffDeadline() {
-				s.metrics.wedged(wedgeHandoffTimeout)
-				s.fireWatchdog(fmt.Errorf(
-					"hot-restart handoff watchdog: epoch %d not LIVE within %s of launch (parent likely died mid-handoff)",
-					epoch, s.handoffDeadline(),
-				))
-				return
-			}
-			if everLive && !reachable && s.childTracked(epoch) && time.Since(unreachableSince) > s.adminUnresponsiveDeadline() {
-				s.metrics.wedged(wedgeAdminUnresponsive)
-				s.fireWatchdog(fmt.Errorf(
-					"admin watchdog: envoy admin %s unresponsive for %s with child alive at epoch %d",
-					s.cfg.AdminAddress, s.adminUnresponsiveDeadline(), epoch,
-				))
+			ready, holding = s.onNotLiveEpoch(ctx, epoch, ready, reachable, holding)
+			if s.checkWedgeWatchdogs(ctx, epoch, everLive, reachable, unreachableSince) {
 				return
 			}
 		}
 	}
+}
+
+// onLiveEpoch handles a tick where admin reports LIVE at the current epoch:
+// records handoff completion, publishes the heartbeat, and gates readiness.
+// Returns the updated ready state.
+func (s *Supervisor) onLiveEpoch(ctx context.Context, epoch int, ready bool) bool {
+	if launched, wasLive := s.epochProgress(); !wasLive {
+		// First LIVE confirmation for this epoch: the handoff (or
+		// initial start, epoch 0) completed.
+		s.metrics.handoffCompleted(time.Since(launched).Seconds())
+	}
+	s.markEpochLive()
+	s.writeState(epoch) // LIVE-gated heartbeat
+	// Hold readiness until the cross-pod handoff is fully complete (the
+	// predecessor has been terminated by this Envoy's parent-shutdown), so
+	// the DaemonSet doesn't delete the old pod while we still need it.
+	if !ready && !time.Now().Before(s.readyGateTime()) {
+		s.setReady()
+		ready = true
+		s.metrics.readyTransition(true)
+		s.log.InfoContext(ctx, "pod ready: envoy live at newest epoch", "epoch", epoch)
+	}
+	return ready
+}
+
+// onNotLiveEpoch handles a tick where admin does not report LIVE at the current
+// epoch: manages the readiness-hold logic for the mid-handoff parent state.
+// Returns the updated ready and holding states.
+func (s *Supervisor) onNotLiveEpoch(ctx context.Context, epoch int, ready, reachable, holding bool) (bool, bool) {
+	hold := ready && reachable && s.childTracked(epoch)
+	if hold && !holding {
+		holding = true
+		s.log.InfoContext(ctx, "holding readiness: serving as hot-restart parent mid-handoff", "epoch", epoch)
+	}
+	if ready && !hold {
+		s.clearReady()
+		ready = false
+		holding = false
+		s.metrics.readyTransition(false)
+		s.log.InfoContext(ctx, "pod not ready: envoy not live at newest epoch", "epoch", epoch)
+	}
+	return ready, holding
+}
+
+// checkWedgeWatchdogs fires the watchdog if the handoff or admin-unresponsive
+// watchdog thresholds are exceeded. Returns true if the caller should return
+// (watchdog fired).
+func (s *Supervisor) checkWedgeWatchdogs(ctx context.Context, epoch int, everLive, reachable bool, unreachableSince time.Time) bool {
+	launched, wasLive := s.epochProgress()
+	if epoch > 0 && !wasLive && s.childTracked(epoch) && time.Since(launched) > s.handoffDeadline() {
+		s.metrics.wedged(wedgeHandoffTimeout)
+		s.fireWatchdog(fmt.Errorf(
+			"hot-restart handoff watchdog: epoch %d not LIVE within %s of launch (parent likely died mid-handoff)",
+			epoch, s.handoffDeadline(),
+		))
+		return true
+	}
+	if everLive && !reachable && s.childTracked(epoch) && time.Since(unreachableSince) > s.adminUnresponsiveDeadline() {
+		s.metrics.wedged(wedgeAdminUnresponsive)
+		s.fireWatchdog(fmt.Errorf(
+			"admin watchdog: envoy admin %s unresponsive for %s with child alive at epoch %d",
+			s.cfg.AdminAddress, s.adminUnresponsiveDeadline(), epoch,
+		))
+		return true
+	}
+	return false
 }
 
 func (s *Supervisor) setReady() {

--- a/agent/internal/proxy/hotrestart/supervisor.go
+++ b/agent/internal/proxy/hotrestart/supervisor.go
@@ -235,168 +235,257 @@ func (s *Supervisor) Run(ctx context.Context) error {
 		return fmt.Errorf("starting initial envoy epoch: %w", err)
 	}
 
-	debounce := time.NewTimer(debounceDelay)
-	debounce.Stop()
-	var debounceC <-chan time.Time
-	bindRetries := 0
-	crashRetries := 0
-
-	arm := func(reason string) {
-		s.log.DebugContext(ctx, "hot restart armed", "reason", reason, "debounce", debounceDelay)
-		s.metrics.restartTriggered(reason)
-		debounce.Reset(debounceDelay)
-		debounceC = debounce.C
+	lp := &restartLoop{
+		s:       s,
+		ctx:     ctx,
+		debounce: time.NewTimer(debounceDelay),
 	}
+	lp.debounce.Stop()
+	return lp.run(sigCh, trigger)
+}
 
+// restartLoop holds the mutable state for the Run event loop, allowing the loop
+// body to be split into helpers without passing every variable as a parameter.
+type restartLoop struct {
+	s        *Supervisor
+	ctx      context.Context
+	debounce *time.Timer
+	debounceC   <-chan time.Time
+	bindRetries int
+	crashRetries int
+}
+
+// arm arms (or re-arms) the debounce timer for a hot-restart trigger.
+func (lp *restartLoop) arm(reason string) {
+	lp.s.log.DebugContext(lp.ctx, "hot restart armed", "reason", reason, "debounce", debounceDelay)
+	lp.s.metrics.restartTriggered(reason)
+	lp.debounce.Reset(debounceDelay)
+	lp.debounceC = lp.debounce.C
+}
+
+// run is the event loop for the hot-restart supervisor.
+func (lp *restartLoop) run(sigCh <-chan os.Signal, trigger <-chan struct{}) error {
 	for {
 		select {
-		case <-ctx.Done():
-			// If our Envoy no longer answers admin LIVE at our own epoch, its
-			// sockets have (very likely) been transferred to a surging successor
-			// that is still initializing — the DaemonSet deletes this pod the moment
-			// it turns NotReady, which is exactly that window. Do NOT signal Envoy
-			// (the successor still needs its hot-restart parent alive, even before
-			// reaching LIVE — killing it aborts the successor with errno 111): wait
-			// for the successor's parent-shutdown protocol to terminate it, with a
-			// deadline fallback. The check cannot rely on the successor having
-			// published its epoch, since it does so only once LIVE.
-			//
-			// StateDir is always set in production (the supervisor only runs in the
-			// cross-pod configuration); the guard keeps unit-test supervisors that
-			// run without coordination state on the plain shutdown path.
-			if s.cfg.StateDir != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
-				s.log.InfoContext(ctx, "termination requested mid-handoff; waiting for successor to terminate our envoy")
-				s.awaitProtocolTermination()
-				return nil
-			}
-			s.log.InfoContext(ctx, "termination requested, shutting down all envoy epochs")
-			s.shutdown()
-			return nil
+		case <-lp.ctx.Done():
+			return lp.s.handleShutdown(lp.ctx)
 
 		case sig := <-sigCh:
-			switch sig {
-			case syscall.SIGHUP:
-				arm("sighup")
-			case syscall.SIGUSR1:
-				s.forwardToCurrent(syscall.SIGUSR1)
-			}
+			lp.handleSignal(sig)
 
 		case <-trigger:
-			arm("config_change")
+			lp.arm("config_change")
 
-		case <-debounceC:
-			debounceC = nil
-			// Defer the restart while the current epoch is still initializing:
-			// forking epoch N+1 against a not-yet-LIVE N makes Envoy exit with
-			// "previous envoy process is still initializing", which the main loop
-			// treats as a fatal newest-epoch death (container restart, brief node
-			// data-plane gap). Re-arm and retry once N is LIVE. Skipped when no
-			// admin address is configured.
-			if s.cfg.AdminAddress != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
-				s.log.DebugContext(ctx, "current epoch not yet live; deferring hot restart", "epoch", s.currentEpoch())
-				arm("deferred_not_live")
-				continue
-			}
-			// Pre-validate the changed bootstrap ON THIS NODE before forking
-			// the new epoch. Every supervisor sees a ConfigMap change at the
-			// same time (fsnotify), so a config that fails at runtime takes
-			// down every node's data plane simultaneously, bypassing all
-			// rollout safety — observed 2026-06-11 (rev 64): a resource
-			// monitor that validated fine in docker was fatal in the
-			// privileged pod environment, and the fleet-wide simultaneous hot
-			// restart turned it into a 13-minute cluster outage. envoy
-			// --mode validate executes bootstrap initialization in the same
-			// environment as the real fork, so it catches exactly that
-			// class. On failure: keep the current epoch serving, count it,
-			// and wait for the next config change.
-			if err := s.validateConfig(ctx); err != nil {
-				s.metrics.configValidationFailed()
-				s.log.ErrorContext(ctx, "changed bootstrap config failed node-local validation; KEEPING current epoch (hot restart skipped)", "error", err)
-				continue
-			}
-			s.log.InfoContext(ctx, "performing hot restart")
-			if err := s.hotRestart(); err != nil {
-				s.log.ErrorContext(ctx, "hot restart failed; keeping current epoch", "error", err)
+		case <-lp.debounceC:
+			lp.debounceC = nil
+			if err := lp.handleDebounce(); err != nil {
+				return err
 			}
 
-		case err := <-s.watchdogFired:
+		case err := <-lp.s.watchdogFired:
 			// The newest Envoy is wedged (see watchLiveness): kill everything and
 			// exit non-zero. Kubernetes recreates the pod; the fresh supervisor
 			// re-probes the (now dead) predecessor and recovers at epoch 0.
-			s.log.ErrorContext(ctx, "liveness watchdog fired; terminating for container restart", "error", err)
-			s.shutdown()
+			lp.s.log.ErrorContext(lp.ctx, "liveness watchdog fired; terminating for container restart", "error", err)
+			lp.s.shutdown()
 			return err
 
-		case exit := <-s.childExited:
-			if exit.epoch == s.currentEpoch() {
-				if exit.err == nil {
-					s.metrics.childExited(exitSuccessorTerminated)
-					// Clean exit (status 0) of our newest epoch: that's the
-					// successor's hot-restart parent-shutdown protocol terminating us
-					// (a crash would be non-zero/signaled). The signal
-					// is deliberate process state, not the shared epoch file — the
-					// successor publishes its epoch only once LIVE, which may be
-					// after it terminates us. Don't exit (restartPolicy=Always would
-					// relaunch and collide): await deletion by the DaemonSet.
-					s.log.InfoContext(ctx, "newest epoch terminated cleanly by successor; awaiting pod deletion", "epoch", exit.epoch)
-					s.reap(exit.epoch)
-					<-ctx.Done()
-					return nil
-				}
-				// A fresh epoch that died non-LIVE within seconds: either a base-id
-				// bind collision (a predecessor still holds the domain socket; exits
-				// errno 98, no signal) or a genuine Envoy crash (a fatal SIGNAL).
-				// Retry epoch detection in-process — a predecessor keeps serving
-				// meanwhile — instead of exiting into CrashLoopBackOff. A crash gets
-				// a much smaller budget so a deterministically crashing Envoy
-				// surfaces fast instead of masquerading as a collision for minutes.
-				if s.quickNonLiveExit() {
-					crash := isCrashSignal(exit.err)
-					attempt, budget := bindRetries+1, maxBindCollisionRetries
-					if crash {
-						attempt, budget = crashRetries+1, maxCrashRetries
-					}
-					if attempt <= budget {
-						if crash {
-							crashRetries++
-						} else {
-							bindRetries++
-						}
-						s.metrics.childExited(exitBindCollision)
-						s.reap(exit.epoch)
-						kind := "suspected base-id bind collision with a live predecessor"
-						if crash {
-							kind = "envoy crashed on launch (fatal signal)"
-						}
-						s.log.InfoContext(ctx, kind+"; retrying epoch detection in-process",
-							"epoch", exit.epoch, "attempt", attempt, "budget", budget, "crashSignal", crash, "error", exit.err.Error())
-						select {
-						case <-ctx.Done():
-							s.shutdown()
-							return nil
-						case <-time.After(bindCollisionRetryPause):
-						}
-						s.resetEpochForRetry()
-						s.initStartEpoch(ctx)
-						s.gateReadinessIfSuccessor()
-						if err := s.hotRestart(); err != nil {
-							return fmt.Errorf("relaunching envoy after retry: %w", err)
-						}
-						continue
-					}
-				}
-				// The newest epoch died unexpectedly: nothing left serving traffic.
-				// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).
-				s.metrics.childExited(exitUnexpected)
-				s.reap(exit.epoch)
-				s.shutdown()
-				return fmt.Errorf("envoy epoch %d exited unexpectedly: %w", exit.epoch, exit.err)
+		case exit := <-lp.s.childExited:
+			retErr, done := lp.handleChildExit(exit)
+			if done {
+				return retErr
 			}
-			// An older epoch finished draining after a hot restart: expected. Reap it.
-			s.metrics.childExited(exitDrained)
-			s.reap(exit.epoch)
 		}
 	}
+}
+
+// handleSignal dispatches an OS signal received by Run.
+func (lp *restartLoop) handleSignal(sig os.Signal) {
+	switch sig {
+	case syscall.SIGHUP:
+		lp.arm("sighup")
+	case syscall.SIGUSR1:
+		lp.s.forwardToCurrent(syscall.SIGUSR1)
+	}
+}
+
+// handleDebounce is called when the debounce timer fires. It defers or performs
+// the hot restart, returning a non-nil error on fatal failure.
+func (lp *restartLoop) handleDebounce() error {
+	rearm, err := lp.s.handleDebounce(lp.ctx)
+	if err != nil {
+		return err
+	}
+	if rearm != "" {
+		lp.arm(rearm)
+	}
+	return nil
+}
+
+// handleChildExit is called when a child process exits. Returns (err, done=true)
+// when the supervisor should exit.
+func (lp *restartLoop) handleChildExit(exit childExit) (retErr error, done bool) {
+	retErr, done, rearm := lp.s.handleChildExit(lp.ctx, exit, &lp.bindRetries, &lp.crashRetries)
+	if rearm != "" {
+		lp.arm(rearm)
+	}
+	return retErr, done
+}
+
+// handleShutdown implements the ctx.Done case of the Run select: if this
+// supervisor is in the mid-handoff window (Envoy not LIVE at our epoch), it
+// waits for the successor's parent-shutdown protocol to terminate our Envoy
+// before returning; otherwise it signals all children and drains.
+func (s *Supervisor) handleShutdown(ctx context.Context) error {
+	// If our Envoy no longer answers admin LIVE at our own epoch, its
+	// sockets have (very likely) been transferred to a surging successor
+	// that is still initializing — the DaemonSet deletes this pod the moment
+	// it turns NotReady, which is exactly that window. Do NOT signal Envoy
+	// (the successor still needs its hot-restart parent alive, even before
+	// reaching LIVE — killing it aborts the successor with errno 111): wait
+	// for the successor's parent-shutdown protocol to terminate it, with a
+	// deadline fallback. The check cannot rely on the successor having
+	// published its epoch, since it does so only once LIVE.
+	//
+	// StateDir is always set in production (the supervisor only runs in the
+	// cross-pod configuration); the guard keeps unit-test supervisors that
+	// run without coordination state on the plain shutdown path.
+	if s.cfg.StateDir != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
+		s.log.InfoContext(ctx, "termination requested mid-handoff; waiting for successor to terminate our envoy")
+		s.awaitProtocolTermination()
+		return nil
+	}
+	s.log.InfoContext(ctx, "termination requested, shutting down all envoy epochs")
+	s.shutdown()
+	return nil
+}
+
+// handleDebounce implements the debounceC case of the Run select: defers the
+// restart if the current epoch is not yet LIVE, validates the config, then
+// performs the hot restart. Returns a non-empty rearm reason if the caller
+// should re-arm the debounce, or a non-nil error on fatal failure.
+func (s *Supervisor) handleDebounce(ctx context.Context) (rearmReason string, err error) {
+	// Defer the restart while the current epoch is still initializing:
+	// forking epoch N+1 against a not-yet-LIVE N makes Envoy exit with
+	// "previous envoy process is still initializing", which the main loop
+	// treats as a fatal newest-epoch death (container restart, brief node
+	// data-plane gap). Re-arm and retry once N is LIVE. Skipped when no
+	// admin address is configured.
+	if s.cfg.AdminAddress != "" && !s.adminLiveAtEpoch(ctx, s.currentEpoch()) {
+		s.log.DebugContext(ctx, "current epoch not yet live; deferring hot restart", "epoch", s.currentEpoch())
+		return "deferred_not_live", nil
+	}
+	// Pre-validate the changed bootstrap ON THIS NODE before forking
+	// the new epoch. Every supervisor sees a ConfigMap change at the
+	// same time (fsnotify), so a config that fails at runtime takes
+	// down every node's data plane simultaneously, bypassing all
+	// rollout safety — observed 2026-06-11 (rev 64): a resource
+	// monitor that validated fine in docker was fatal in the
+	// privileged pod environment, and the fleet-wide simultaneous hot
+	// restart turned it into a 13-minute cluster outage. envoy
+	// --mode validate executes bootstrap initialization in the same
+	// environment as the real fork, so it catches exactly that
+	// class. On failure: keep the current epoch serving, count it,
+	// and wait for the next config change.
+	if err := s.validateConfig(ctx); err != nil {
+		s.metrics.configValidationFailed()
+		s.log.ErrorContext(ctx, "changed bootstrap config failed node-local validation; KEEPING current epoch (hot restart skipped)", "error", err)
+		return "", nil
+	}
+	s.log.InfoContext(ctx, "performing hot restart")
+	if err := s.hotRestart(); err != nil {
+		s.log.ErrorContext(ctx, "hot restart failed; keeping current epoch", "error", err)
+	}
+	return "", nil
+}
+
+// handleChildExit implements the childExited case of the Run select loop.
+// It returns (err, done=true) when the supervisor should exit, or
+// (nil, false) to continue; rearmReason is non-empty if the arm function
+// should be called (bind-collision retry re-arms via continue, so the
+// caller must call arm before continuing the loop).
+func (s *Supervisor) handleChildExit(ctx context.Context, exit childExit, bindRetries, crashRetries *int) (retErr error, done bool, rearmReason string) {
+	if exit.epoch != s.currentEpoch() {
+		// An older epoch finished draining after a hot restart: expected. Reap it.
+		s.metrics.childExited(exitDrained)
+		s.reap(exit.epoch)
+		return nil, false, ""
+	}
+	if exit.err == nil {
+		s.metrics.childExited(exitSuccessorTerminated)
+		// Clean exit (status 0) of our newest epoch: that's the
+		// successor's hot-restart parent-shutdown protocol terminating us
+		// (a crash would be non-zero/signaled). The signal
+		// is deliberate process state, not the shared epoch file — the
+		// successor publishes its epoch only once LIVE, which may be
+		// after it terminates us. Don't exit (restartPolicy=Always would
+		// relaunch and collide): await deletion by the DaemonSet.
+		s.log.InfoContext(ctx, "newest epoch terminated cleanly by successor; awaiting pod deletion", "epoch", exit.epoch)
+		s.reap(exit.epoch)
+		<-ctx.Done()
+		return nil, true, ""
+	}
+	if retried, retErr, done := s.retryBindCollision(ctx, exit, bindRetries, crashRetries); retried {
+		return retErr, done, ""
+	}
+	// The newest epoch died unexpectedly: nothing left serving traffic.
+	// Bail non-zero so Kubernetes recreates the pod (SIGCHLD-fatal).
+	s.metrics.childExited(exitUnexpected)
+	s.reap(exit.epoch)
+	s.shutdown()
+	return fmt.Errorf("envoy epoch %d exited unexpectedly: %w", exit.epoch, exit.err), true, ""
+}
+
+// retryBindCollision handles the bind-collision / crash-on-launch retry logic
+// for a newest epoch that died non-LIVE within seconds of launch. Returns
+// (retried=true, err, done) when the case was handled (either retried or
+// budget exhausted non-retried), (false, nil, false) when this was not a
+// quick non-live exit and the caller should fall through.
+func (s *Supervisor) retryBindCollision(ctx context.Context, exit childExit, bindRetries, crashRetries *int) (retried bool, retErr error, done bool) {
+	// A fresh epoch that died non-LIVE within seconds: either a base-id
+	// bind collision (a predecessor still holds the domain socket; exits
+	// errno 98, no signal) or a genuine Envoy crash (a fatal SIGNAL).
+	// Retry epoch detection in-process — a predecessor keeps serving
+	// meanwhile — instead of exiting into CrashLoopBackOff. A crash gets
+	// a much smaller budget so a deterministically crashing Envoy
+	// surfaces fast instead of masquerading as a collision for minutes.
+	if !s.quickNonLiveExit() {
+		return false, nil, false
+	}
+	crash := isCrashSignal(exit.err)
+	attempt, budget := *bindRetries+1, maxBindCollisionRetries
+	if crash {
+		attempt, budget = *crashRetries+1, maxCrashRetries
+	}
+	if attempt > budget {
+		return false, nil, false
+	}
+	if crash {
+		*crashRetries++
+	} else {
+		*bindRetries++
+	}
+	s.metrics.childExited(exitBindCollision)
+	s.reap(exit.epoch)
+	kind := "suspected base-id bind collision with a live predecessor"
+	if crash {
+		kind = "envoy crashed on launch (fatal signal)"
+	}
+	s.log.InfoContext(ctx, kind+"; retrying epoch detection in-process",
+		"epoch", exit.epoch, "attempt", attempt, "budget", budget, "crashSignal", crash, "error", exit.err.Error())
+	select {
+	case <-ctx.Done():
+		s.shutdown()
+		return true, nil, true
+	case <-time.After(bindCollisionRetryPause):
+	}
+	s.resetEpochForRetry()
+	s.initStartEpoch(ctx)
+	s.gateReadinessIfSuccessor()
+	if err := s.hotRestart(); err != nil {
+		return true, fmt.Errorf("relaunching envoy after retry: %w", err), true
+	}
+	return true, nil, false
 }
 
 // hotRestart forks a new Envoy child at the next restart epoch and schedules

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -183,57 +183,37 @@ func (b *Bridge) Start(ctx context.Context) error {
 		go b.runNodeSVIDRefresh(ctx)
 	}
 
-	// Maintain the bundle subscription for the bridge's lifetime, re-subscribing
-	// with backoff when the stream ends (e.g. the SPIRE agent restarts) instead
-	// of failing the runnable — which would take down the whole agent for a
-	// transient disconnect. SPIRE sends the full bundle set as the first response
-	// on every new stream, so a plain re-subscribe fully resynchronizes; the
-	// cached bundle secrets keep serving while disconnected.
+	return b.runBundleSubscriptionLoop(ctx, client)
+}
+
+// runBundleSubscriptionLoop maintains the bundle subscription for the bridge's
+// lifetime, re-subscribing with backoff when the stream ends (e.g. the SPIRE
+// agent restarts) instead of failing the runnable — which would take down the
+// whole agent for a transient disconnect. SPIRE sends the full bundle set as
+// the first response on every new stream, so a plain re-subscribe fully
+// resynchronizes; the cached bundle secrets keep serving while disconnected.
+func (b *Bridge) runBundleSubscriptionLoop(ctx context.Context, client *Client) error {
 	backoff := b.backoffInitial
 	first := true
 	for {
 		bundleCh, subErr := client.SubscribeBundles(ctx)
 		if subErr != nil {
-			if ctx.Err() != nil {
-				b.log.InfoContext(ctx, "shutting down SPIRE bridge")
+			ok, newBackoff := b.handleBundleSubscribeError(ctx, subErr, backoff)
+			if !ok {
 				return nil
 			}
-			b.metrics.streamFailed(ctx, streamBundle)
-			wait := jitteredBackoff(backoff)
-			b.log.ErrorContext(ctx, "subscribing to X.509 bundles failed; retrying", "error", subErr, "backoff", wait)
-			if !sleepCtx(ctx, wait) {
-				b.log.InfoContext(ctx, "shutting down SPIRE bridge")
-				return nil
-			}
-			backoff = min(backoff*2, b.backoffMax)
+			backoff = newBackoff
 			first = false
 			continue
 		}
-		if first {
-			b.log.InfoContext(ctx, "subscribed to X.509 bundles")
-			first = false
-		} else {
-			b.metrics.streamReconnected(ctx, streamBundle)
-			b.log.InfoContext(ctx, "re-subscribed to X.509 bundles")
-		}
+		b.logBundleSubscribed(ctx, first)
+		first = false
 
-	receive:
-		for {
-			select {
-			case <-ctx.Done():
-				b.log.InfoContext(ctx, "shutting down SPIRE bridge")
-				return nil
-			case resp, ok := <-bundleCh:
-				if !ok {
-					break receive
-				}
-				// Receiving proves the stream is healthy; reset the backoff.
-				backoff = b.backoffInitial
-				if err := b.handleBundleUpdate(ctx, resp); err != nil {
-					b.log.ErrorContext(ctx, "handling bundle update", "error", err)
-				}
-			}
+		done, newBackoff := b.drainBundleStream(ctx, bundleCh, backoff)
+		if done {
+			return nil
 		}
+		backoff = newBackoff
 
 		b.metrics.streamFailed(ctx, streamBundle)
 		wait := jitteredBackoff(backoff)
@@ -243,6 +223,57 @@ func (b *Bridge) Start(ctx context.Context) error {
 			return nil
 		}
 		backoff = min(backoff*2, b.backoffMax)
+	}
+}
+
+// handleBundleSubscribeError handles a subscription error in runBundleSubscriptionLoop.
+// Returns (ok=false) if the context is cancelled and the loop should exit,
+// otherwise waits with backoff and returns (true, updatedBackoff).
+func (b *Bridge) handleBundleSubscribeError(ctx context.Context, subErr error, backoff time.Duration) (ok bool, newBackoff time.Duration) {
+	if ctx.Err() != nil {
+		b.log.InfoContext(ctx, "shutting down SPIRE bridge")
+		return false, backoff
+	}
+	b.metrics.streamFailed(ctx, streamBundle)
+	wait := jitteredBackoff(backoff)
+	b.log.ErrorContext(ctx, "subscribing to X.509 bundles failed; retrying", "error", subErr, "backoff", wait)
+	if !sleepCtx(ctx, wait) {
+		b.log.InfoContext(ctx, "shutting down SPIRE bridge")
+		return false, backoff
+	}
+	return true, min(backoff*2, b.backoffMax)
+}
+
+// logBundleSubscribed emits the appropriate log line for a successful bundle subscription.
+func (b *Bridge) logBundleSubscribed(ctx context.Context, first bool) {
+	if first {
+		b.log.InfoContext(ctx, "subscribed to X.509 bundles")
+	} else {
+		b.metrics.streamReconnected(ctx, streamBundle)
+		b.log.InfoContext(ctx, "re-subscribed to X.509 bundles")
+	}
+}
+
+// drainBundleStream reads from bundleCh until the channel is closed or the
+// context is cancelled. Returns (done=true) when the context is cancelled
+// (caller should return nil), and the updated backoff (reset to initial on
+// each successful receive).
+func (b *Bridge) drainBundleStream(ctx context.Context, bundleCh <-chan *delegatedidentityv1.SubscribeToX509BundlesResponse, backoff time.Duration) (done bool, newBackoff time.Duration) {
+	for {
+		select {
+		case <-ctx.Done():
+			b.log.InfoContext(ctx, "shutting down SPIRE bridge")
+			return true, backoff
+		case resp, ok := <-bundleCh:
+			if !ok {
+				return false, backoff
+			}
+			// Receiving proves the stream is healthy; reset the backoff.
+			backoff = b.backoffInitial
+			if err := b.handleBundleUpdate(ctx, resp); err != nil {
+				b.log.ErrorContext(ctx, "handling bundle update", "error", err)
+			}
+		}
 	}
 }
 
@@ -323,60 +354,85 @@ func (b *Bridge) SubscribePod(netns, spiffeID string, selectors []*apitypes.Sele
 
 	b.log.Info("subscribed to SVIDs", "spiffeID", spiffeID)
 
-	go func() {
-		ch := svidCh
-		backoff := b.backoffInitial
-		for {
-		receive:
-			for {
-				select {
-				case <-subCtx.Done():
-					return
-				case resp, ok := <-ch:
-					if !ok {
-						break receive
-					}
-					// Receiving proves the stream is healthy; reset the backoff.
-					backoff = b.backoffInitial
-					// Use subCtx (tied to the bridge/subscription lifetime), not the
-					// caller's request context: SubscribePod is called synchronously
-					// from CmdAdd, whose context is cancelled as soon as it returns —
-					// pushing the SVID into the snapshot must outlive that request.
-					if handleErr := b.handleSVIDUpdate(subCtx, resp); handleErr != nil {
-						b.log.Error("handling SVID update", "error", handleErr, "spiffeID", spiffeID)
-					}
-				}
-			}
-
-			// The stream ended while the pod is still subscribed (e.g. the SPIRE
-			// agent restarted): re-subscribe with backoff so rotations keep
-			// flowing — exiting here would silently freeze this pod's SVID until
-			// it expired. The cached SVID keeps serving meanwhile, and the first
-			// response on the new stream is the current SVID set, so a plain
-			// re-subscribe fully resynchronizes.
-			b.metrics.streamFailed(subCtx, streamSVID)
-			for {
-				wait := jitteredBackoff(backoff)
-				b.log.Info("SVID subscription stream closed; re-subscribing", "spiffeID", spiffeID, "backoff", wait)
-				if !sleepCtx(subCtx, wait) {
-					return
-				}
-				backoff = min(backoff*2, b.backoffMax)
-				newCh, subErr := b.client.SubscribeSVIDsBySelectors(subCtx, selectors)
-				if subErr != nil {
-					b.metrics.streamFailed(subCtx, streamSVID)
-					b.log.Error("re-subscribing to SVIDs failed; retrying", "error", subErr, "spiffeID", spiffeID)
-					continue
-				}
-				ch = newCh
-				b.metrics.streamReconnected(subCtx, streamSVID)
-				b.log.Info("re-subscribed to SVIDs", "spiffeID", spiffeID)
-				break
-			}
-		}
-	}()
+	go b.runSVIDSubscriptionLoop(subCtx, svidCh, spiffeID, selectors)
 
 	return nil
+}
+
+// runSVIDSubscriptionLoop is the goroutine that drives an SVID subscription for
+// one pod. It reads from the initial channel and re-subscribes with backoff
+// whenever the stream closes (e.g. the SPIRE agent restarts). It exits when
+// subCtx is cancelled.
+func (b *Bridge) runSVIDSubscriptionLoop(subCtx context.Context, svidCh <-chan *delegatedidentityv1.SubscribeToX509SVIDsResponse, spiffeID string, selectors []*apitypes.Selector) {
+	ch := svidCh
+	backoff := b.backoffInitial
+	for {
+		backoff = b.drainSVIDStream(subCtx, ch, spiffeID, backoff)
+		if subCtx.Err() != nil {
+			return
+		}
+
+		// The stream ended while the pod is still subscribed (e.g. the SPIRE
+		// agent restarted): re-subscribe with backoff so rotations keep
+		// flowing — exiting here would silently freeze this pod's SVID until
+		// it expired. The cached SVID keeps serving meanwhile, and the first
+		// response on the new stream is the current SVID set, so a plain
+		// re-subscribe fully resynchronizes.
+		b.metrics.streamFailed(subCtx, streamSVID)
+		newCh, ok := b.resubscribeSVIDs(subCtx, selectors, spiffeID, &backoff)
+		if !ok {
+			return
+		}
+		ch = newCh
+	}
+}
+
+// drainSVIDStream reads responses from ch until it is closed or subCtx is
+// cancelled. Resets backoff to initial on each successful receive. Returns the
+// updated backoff.
+func (b *Bridge) drainSVIDStream(subCtx context.Context, ch <-chan *delegatedidentityv1.SubscribeToX509SVIDsResponse, spiffeID string, backoff time.Duration) time.Duration {
+	for {
+		select {
+		case <-subCtx.Done():
+			return backoff
+		case resp, ok := <-ch:
+			if !ok {
+				return backoff
+			}
+			// Receiving proves the stream is healthy; reset the backoff.
+			backoff = b.backoffInitial
+			// Use subCtx (tied to the bridge/subscription lifetime), not the
+			// caller's request context: SubscribePod is called synchronously
+			// from CmdAdd, whose context is cancelled as soon as it returns —
+			// pushing the SVID into the snapshot must outlive that request.
+			if handleErr := b.handleSVIDUpdate(subCtx, resp); handleErr != nil {
+				b.log.Error("handling SVID update", "error", handleErr, "spiffeID", spiffeID)
+			}
+		}
+	}
+}
+
+// resubscribeSVIDs retries subscribing to SVIDs with backoff until it succeeds
+// or subCtx is cancelled. Returns (channel, true) on success, (nil, false) when
+// the context was cancelled.
+func (b *Bridge) resubscribeSVIDs(subCtx context.Context, selectors []*apitypes.Selector, spiffeID string, backoff *time.Duration) (<-chan *delegatedidentityv1.SubscribeToX509SVIDsResponse, bool) {
+	for {
+		wait := jitteredBackoff(*backoff)
+		b.log.Info("SVID subscription stream closed; re-subscribing", "spiffeID", spiffeID, "backoff", wait)
+		if !sleepCtx(subCtx, wait) {
+			return nil, false
+		}
+		*backoff = min(*backoff*2, b.backoffMax)
+		newCh, subErr := b.client.SubscribeSVIDsBySelectors(subCtx, selectors)
+		if subErr != nil {
+			b.metrics.streamFailed(subCtx, streamSVID)
+			b.log.Error("re-subscribing to SVIDs failed; retrying", "error", subErr, "spiffeID", spiffeID)
+			continue
+		}
+		b.metrics.streamReconnected(subCtx, streamSVID)
+		b.log.Info("re-subscribed to SVIDs", "spiffeID", spiffeID)
+		return newCh, true
+	}
 }
 
 // UnsubscribePod stops the SVID subscription for the pod in the given network


### PR DESCRIPTION
## Summary

Lane 3 of the cognitive-complexity reduction campaign (#556). Reduces all non-test functions in `agent/internal/cni/server/`, `agent/internal/proxy/hotrestart/`, and `agent/internal/spire/` to ≤15 via pure structural extraction — no behavior changes.

## Per-function extraction summary

| Function | Before | After | Technique |
|---|---|---|---|
| `(*CNIServer).sweepGhostEndpoints` | 75 | 9 | Extracted `listRegistryEndpoints`, `pruneStaleStoragePods`, `pruneOnePod`, `reportMissingStoragePods`, `classifyPods`, `deregisterGhostEndpoints`, `deregisterGhostEndpointsForService`, `registeredIPs`, `registerMissingEndpoints` |
| `(*Supervisor).Run` | 68 | 8 | Extracted `restartLoop` struct with `run`, `handleSignal`, `handleDebounce`, `handleChildExit` methods; extracted `handleShutdown`, `handleDebounce`, `handleChildExit`, `retryBindCollision` on `Supervisor` |
| `(*CNIServer).reconcileLiveness` | 39 | 10 | Extracted `applyPodLiveness`, `registerHealthTransition`, `livenessWant`, `livenessPrev` |
| `(*Supervisor).watchLiveness` | 36 | 12 | Extracted `onLiveEpoch`, `onNotLiveEpoch`, `checkWedgeWatchdogs` |
| `(*Bridge).Start` | 34 | 7 | Extracted `runBundleSubscriptionLoop`, `drainBundleStream`, `handleBundleSubscribeError`, `logBundleSubscribed` |
| `(*Bridge).SubscribePod` | 34 | 10 | Extracted `runSVIDSubscriptionLoop`, `drainSVIDStream`, `resubscribeSVIDs` |

## Verification

```
$ $BIN -over 15 agent/internal/cni/server/ agent/internal/proxy/hotrestart/ agent/internal/spire/
(no output — all functions ≤15)
```

```
$ bazel test --test_output=errors //agent/...
26 tests pass.
```

`make gazelle` — no BUILD changes needed.
`make format` — imports ordered; no additional changes.

## Notes

- `Supervisor.Run` (originally 68): the event loop is complex by nature. Introduced a `restartLoop` helper struct to carry loop state (debounce timer, retry counters) so the select cases can be delegated to named methods without large parameter lists. The select case ordering is unchanged.
- `watchLiveness` state transitions, channel ordering, and wedge watchdog sequence are preserved verbatim — only the dead-code blocks were moved to helpers.
- `sweepGhostEndpoints` decision order (list → lock → prune stale → report missing → classify → deregister ghosts → register missing) is unchanged.
- `Bridge.Start`/`SubscribePod` subscription/retry/cleanup ordering preserved exactly.

Part of #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR