### PR TITLE
ci(lint): gocognit threshold to 15, production code only

### DIFF
--- a/agent/internal/xds/server/refresh.go
+++ b/agent/internal/xds/server/refresh.go
@@ -131,62 +131,16 @@ func (r *RegistryRefresher) Start(ctx context.Context) error {
 
 	r.log.DebugContext(ctx, "watching registry for endpoint changes")
 
-	// arm (re)arms the debounce window. Stop+drain before Reset so a prior
-	// expiry doesn't leave a stale tick queued. Stop reporting true means the
-	// timer was already armed — this signal coalesced.
-	arm := func() {
-		if timer.Stop() {
-			if r.coalesced != nil {
-				r.coalesced.Add(ctx, 1)
-			}
-		} else {
-			select {
-			case <-timer.C:
-			default:
-			}
-		}
-		timer.Reset(r.debounce)
-	}
-
-	// reload rebuilds the scoped snapshot now (shared by the debounce expiry
-	// and the dependency-change leading edge).
-	var lastReload time.Time
-	reload := func() {
-		lastReload = time.Now()
-		// Re-assert the watch filter from the current dependency set
-		// before reloading: a grown set must reach the registrar so the
-		// watch cache receives the newly in-scope services (no-op when
-		// unchanged; the resulting watch events trigger the next reload).
-		AssertWatchFilter(r.cache, r.registry)
-		if err := r.cache.LoadClustersFromRegistry(ctx, r.clusterName, r.nodeName, r.registry); err != nil {
-			r.log.ErrorContext(ctx, "failed to refresh clusters from registry", "error", err)
-			if r.refreshErrors != nil {
-				r.refreshErrors.Add(ctx, 1)
-			}
-			return
-		}
-		r.log.DebugContext(ctx, "refreshed clusters from registry")
-	}
+	loop := &refreshLoop{r: r, timer: timer}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-changes:
-			arm()
+			loop.arm(ctx)
 		case <-depChanges:
-			// The node dependency set changed (pod add/remove, changed
-			// declared upstreams, or an ODCDS observation). Unlike registry
-			// event bursts, this is a single latency-critical event — an
-			// ODCDS observation has a PAUSED REQUEST behind it — so it fires
-			// the reload immediately on the leading edge; only when reloads
-			// are already hot (within one debounce window) does it fall back
-			// to the trailing debounce to coalesce storms.
-			if time.Since(lastReload) >= r.debounce {
-				reload()
-			} else {
-				arm()
-			}
+			loop.onDependencyChange(ctx)
 		case <-pruneTicker.C:
 			// Each signals a dependency change (handled above) when anything
 			// expired: observed (ODCDS) entries past their idle TTL, and
@@ -196,7 +150,66 @@ func (r *RegistryRefresher) Start(ctx context.Context) error {
 			r.cache.PruneObservedDependencies()
 			r.cache.SignalIfRetentionExpired()
 		case <-timer.C:
-			reload()
+			loop.reload(ctx)
 		}
+	}
+}
+
+// refreshLoop carries the debounce state shared between Start's select loop
+// and its helpers.
+type refreshLoop struct {
+	r          *RegistryRefresher
+	timer      *time.Timer
+	lastReload time.Time
+}
+
+// arm (re)arms the debounce window. Stop+drain before Reset so a prior
+// expiry doesn't leave a stale tick queued. Stop reporting true means the
+// timer was already armed — this signal coalesced.
+func (l *refreshLoop) arm(ctx context.Context) {
+	if l.timer.Stop() {
+		if l.r.coalesced != nil {
+			l.r.coalesced.Add(ctx, 1)
+		}
+	} else {
+		select {
+		case <-l.timer.C:
+		default:
+		}
+	}
+	l.timer.Reset(l.r.debounce)
+}
+
+// reload rebuilds the scoped snapshot now (shared by the debounce expiry
+// and the dependency-change leading edge).
+func (l *refreshLoop) reload(ctx context.Context) {
+	l.lastReload = time.Now()
+	// Re-assert the watch filter from the current dependency set
+	// before reloading: a grown set must reach the registrar so the
+	// watch cache receives the newly in-scope services (no-op when
+	// unchanged; the resulting watch events trigger the next reload).
+	AssertWatchFilter(l.r.cache, l.r.registry)
+	if err := l.r.cache.LoadClustersFromRegistry(ctx, l.r.clusterName, l.r.nodeName, l.r.registry); err != nil {
+		l.r.log.ErrorContext(ctx, "failed to refresh clusters from registry", "error", err)
+		if l.r.refreshErrors != nil {
+			l.r.refreshErrors.Add(ctx, 1)
+		}
+		return
+	}
+	l.r.log.DebugContext(ctx, "refreshed clusters from registry")
+}
+
+// onDependencyChange handles a node dependency-set change (pod add/remove,
+// changed declared upstreams, or an ODCDS observation). Unlike registry
+// event bursts, this is a single latency-critical event — an ODCDS
+// observation has a PAUSED REQUEST behind it — so it fires the reload
+// immediately on the leading edge; only when reloads are already hot (within
+// one debounce window) does it fall back to the trailing debounce to
+// coalesce storms.
+func (l *refreshLoop) onDependencyChange(ctx context.Context) {
+	if time.Since(l.lastReload) >= l.r.debounce {
+		l.reload(ctx)
+	} else {
+		l.arm(ctx)
 	}
 }

--- a/bazel/lint/gocognit.bzl
+++ b/bazel/lint/gocognit.bzl
@@ -1,8 +1,8 @@
 """API for declaring a gocognit cognitive-complexity lint aspect.
 
 gocognit (https://github.com/uudashr/gocognit) reports Go functions whose
-cognitive complexity exceeds a threshold. This aspect visits Go rules
-(go_library / go_binary / go_test), filters out generated sources, and runs
+cognitive complexity exceeds a threshold. This aspect visits production Go
+rules (go_library / go_binary), filters out generated sources, and runs
 gocognit with `-over <threshold>`.
 
 Typical usage in `bazel/lint/linters.bzl`:
@@ -12,24 +12,19 @@ load("//bazel/lint:gocognit.bzl", "lint_gocognit_aspect")
 
 gocognit = lint_gocognit_aspect(
     binary = Label("@com_github_uudashr_gocognit//cmd/gocognit"),
-    threshold = 109,
+    threshold = 15,
 )
 
 gocognit_test = lint_test(aspect = gocognit)
 ```
 
-## Threshold / ratchet policy
+## Threshold / scope policy
 
-The ideal cognitive-complexity target is **20** (gocognit's documented
-recommendation). At the time this aspect was introduced the repo had 49
-functions over 20 (worst case: `buildVirtualHost` at 109), which is far more
-than the 5-function budget the team is willing to refactor in one change. So
-the threshold is set to the smallest value >= 20 that yields ZERO current
-violations (a ratchet): `-over 109`. Lower it as complexity is paid down — the
-eventual goal is `-over 20`. What blocks 20 today is the backlog of
-already-complex functions (see the PR that introduced this aspect for the full
-list); those must be refactored (out of scope for that change) before the
-ratchet can tighten.
+The threshold is **15**: the aspect was introduced at a ratchet of 109 (the
+then-smallest zero-violation value), and the #556 campaign refactored all 65
+production functions over 15, so the gate now sits at the target. Test code
+(go_test rules) is deliberately NOT visited: complexity gating on validated
+e2e/conformance harnesses adds churn risk for no production value.
 
 ## Contract
 
@@ -226,7 +221,7 @@ def _gocognit_aspect_impl(target, ctx):
     _run_gocognit(ctx, srcs, outputs.machine_out, outputs.machine_exit_code)
     return [info]
 
-def lint_gocognit_aspect(binary, threshold, rule_kinds = ["go_library", "go_binary", "go_test"]):
+def lint_gocognit_aspect(binary, threshold, rule_kinds = ["go_library", "go_binary"]):
     """A factory function to create the gocognit linter aspect.
 
     Args:

--- a/bazel/lint/linters.bzl
+++ b/bazel/lint/linters.bzl
@@ -26,11 +26,11 @@ shellcheck = lint_shellcheck_aspect(
 shellcheck_test = lint_test(aspect = shellcheck)
 
 # gocognit reports Go functions over a cognitive-complexity threshold.
-# Threshold is a ratchet: the smallest value >= 20 with zero current
-# violations. See bazel/lint/gocognit.bzl for the ratchet rationale.
+# 15 is the target (reached via the #556 campaign, PRs #558-#563); the
+# aspect lints production code only. See bazel/lint/gocognit.bzl.
 gocognit = lint_gocognit_aspect(
     binary = Label("@com_github_uudashr_gocognit//cmd/gocognit"),
-    threshold = 109,
+    threshold = 15,
 )
 
 gocognit_test = lint_test(aspect = gocognit)


### PR DESCRIPTION
Flips the gocognit ratchet 109→15 now that the #556 campaign (PRs #558–#563) refactored all 65 production offenders. Scopes the aspect to production rules (go_library/go_binary) — test harnesses are deliberately not complexity-gated. Includes the one function the lane partition missed (`RegistryRefresher.Start`, 23→≤15, extracted `refreshLoop` helpers, debounce/leading-edge semantics byte-identical).

Validated: `bazel build --config=lint --@aspect_rules_lint//lint:fail_on_violation //...` green; `//agent/internal/xds/...` tests pass.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR