### PR TITLE
fix(capture): preserve downstream protocol on the non-mesh passthrough upstream (#568)

### DIFF
--- a/agent/internal/xds/config/http.go
+++ b/agent/internal/xds/config/http.go
@@ -53,3 +53,33 @@ func Http2ProtocolOptions() *httpv3.HttpProtocolOptions {
 		},
 	}
 }
+
+// UseDownstreamProtocolOptions creates HTTP protocol options that make the
+// upstream connection MIRROR the downstream protocol (Envoy's
+// USE_DOWNSTREAM_PROTOCOL semantics): an HTTP/1.1 downstream dials HTTP/1.1
+// upstream, an HTTP/2 (incl. h2c) downstream dials h2c upstream.
+//
+// This is required for the redirect-all capture passthrough (proposal 022):
+// non-mesh traffic sniffed as cleartext HTTP by http_inspector transits the
+// cap_http HCM and is forwarded to the ORIGINAL_DST passthrough cluster. Without
+// these options the passthrough defaults to HTTP/1.1 upstream, so an h2c gRPC
+// client to a non-mesh h2-only server (e.g. an OTLP otel-collector on :4317)
+// gets "reset reason: protocol error" — the HCM dialed HTTP/1.1 to an h2-only
+// upstream (issue #568). Mirroring the downstream protocol keeps both cleartext
+// HTTP/1.1 and h2c non-mesh egress working through the passthrough.
+//
+// Both Http1 and Http2 option messages are populated so Envoy has the concrete
+// codec config for whichever protocol the downstream turns out to be.
+func UseDownstreamProtocolOptions() *httpv3.HttpProtocolOptions {
+	return &httpv3.HttpProtocolOptions{
+		CommonHttpProtocolOptions: &corev3.HttpProtocolOptions{
+			IdleTimeout: durationpb.New(UpstreamIdleTimeout),
+		},
+		UpstreamProtocolOptions: &httpv3.HttpProtocolOptions_UseDownstreamProtocolConfig{
+			UseDownstreamProtocolConfig: &httpv3.HttpProtocolOptions_UseDownstreamHttpConfig{
+				HttpProtocolOptions:  &corev3.Http1ProtocolOptions{},
+				Http2ProtocolOptions: &corev3.Http2ProtocolOptions{},
+			},
+		},
+	}
+}

--- a/agent/internal/xds/config/http_test.go
+++ b/agent/internal/xds/config/http_test.go
@@ -74,15 +74,50 @@ func TestHttp2ProtocolOptions(t *testing.T) {
 	}
 }
 
-// TestUpstreamIdleTimeoutSet verifies both protocol-options helpers carry the
+// TestUseDownstreamProtocolOptions verifies the passthrough helper (issue #568)
+// selects Envoy's USE_DOWNSTREAM_PROTOCOL mode and populates BOTH the HTTP/1 and
+// HTTP/2 codec configs, so an h2c downstream (non-mesh OTLP gRPC through the
+// redirect-all capture passthrough) dials h2c upstream instead of the
+// ORIGINAL_DST default HTTP/1.1 that resets an h2-only server.
+func TestUseDownstreamProtocolOptions(t *testing.T) {
+	got := UseDownstreamProtocolOptions()
+	if got == nil {
+		t.Fatal("expected non-nil HttpProtocolOptions")
+	}
+
+	// Must be the use-downstream-protocol oneof, NOT an explicit http1/http2 config.
+	// (An explicit config would pin the upstream protocol and reintroduce #568 for
+	// whichever protocol it did not pin.)
+	useDownstream, ok := got.UpstreamProtocolOptions.(*httpv3.HttpProtocolOptions_UseDownstreamProtocolConfig)
+	if !ok {
+		t.Fatalf("expected UseDownstreamProtocolConfig, got %T", got.UpstreamProtocolOptions)
+	}
+
+	cfg := useDownstream.UseDownstreamProtocolConfig
+	if cfg == nil {
+		t.Fatal("expected non-nil UseDownstreamHttpConfig")
+	}
+	// Both codecs must be present so Envoy has concrete config for whichever
+	// protocol the sniffed downstream turns out to be: h1 (http/1.1 egress) and
+	// h2c (the gRPC case #568 regresses on).
+	if cfg.GetHttpProtocolOptions() == nil {
+		t.Fatal("expected non-nil Http1ProtocolOptions (http/1.1 downstream must map to h1 upstream)")
+	}
+	if cfg.GetHttp2ProtocolOptions() == nil {
+		t.Fatal("expected non-nil Http2ProtocolOptions (h2c downstream must map to h2c upstream — the #568 fix)")
+	}
+}
+
+// TestUpstreamIdleTimeoutSet verifies the protocol-options helpers carry the
 // 30s idle timeout. Service clusters pool per downstream connection for
 // per-source mTLS; an orphaned pool's upstream connection is reclaimed ONLY by
 // this timeout (Envoy default 1h leaked ~41k mTLS conns / 3.2 GiB per proxy
 // under non-keepalive downstream traffic on talos-main, 2026-06-11).
 func TestUpstreamIdleTimeoutSet(t *testing.T) {
 	for name, opts := range map[string]*httpv3.HttpProtocolOptions{
-		"http1": Http1ProtocolOptions(),
-		"http2": Http2ProtocolOptions(),
+		"http1":          Http1ProtocolOptions(),
+		"http2":          Http2ProtocolOptions(),
+		"use_downstream": UseDownstreamProtocolOptions(),
 	} {
 		idle := opts.GetCommonHttpProtocolOptions().GetIdleTimeout()
 		if idle == nil {

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -162,6 +162,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/matching/common_inputs/transport_socket/v3:transport_socket",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/quic/v3:quic",
         "@com_github_envoyproxy_go_control_plane_envoy//extensions/transport_sockets/tls/v3:tls",
+        "@com_github_envoyproxy_go_control_plane_envoy//extensions/upstreams/http/v3:http",
         "@com_github_envoyproxy_go_control_plane_envoy//type/matcher/v3:matcher",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",

--- a/agent/internal/xds/proxy/capture_test.go
+++ b/agent/internal/xds/proxy/capture_test.go
@@ -5,6 +5,7 @@ import (
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 
+	"github.com/bpalermo/aether/agent/internal/xds/config"
 	cniv1 "github.com/bpalermo/aether/api/aether/cni/v1"
 	meshconst "github.com/bpalermo/aether/common/constants/mesh"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -12,6 +13,7 @@ import (
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp_proxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	httpv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -186,8 +188,24 @@ func TestNewPassthroughOriginalDstCluster(t *testing.T) {
 	assert.Equal(t, clusterv3.Cluster_CLUSTER_PROVIDED, cl.GetLbPolicy())
 	// No transport socket — passthrough is plaintext.
 	assert.Nil(t, cl.GetTransportSocket())
-	// No upstream HTTP protocol options — raw TCP.
-	assert.Empty(t, cl.GetTypedExtensionProtocolOptions())
+
+	// USE_DOWNSTREAM_PROTOCOL upstream options (issue #568): sniffed cleartext HTTP
+	// (h2c OR http/1.1) transits the cap_http HCM to this cluster; the upstream dial
+	// MUST mirror the downstream protocol or an h2c gRPC client to a non-mesh
+	// h2-only server resets ("protocol error"). Assert the cluster carries the
+	// use-downstream config with BOTH codecs populated.
+	tepo := cl.GetTypedExtensionProtocolOptions()
+	require.Contains(t, tepo, config.UpstreamHTTPProtocolOptionsKey,
+		"passthrough must carry upstream HTTP protocol options to preserve h2c (#568)")
+	var protoOpts httpv3.HttpProtocolOptions
+	require.NoError(t, tepo[config.UpstreamHTTPProtocolOptionsKey].UnmarshalTo(&protoOpts))
+	useDownstream, ok := protoOpts.GetUpstreamProtocolOptions().(*httpv3.HttpProtocolOptions_UseDownstreamProtocolConfig)
+	require.True(t, ok, "expected UseDownstreamProtocolConfig, got %T", protoOpts.GetUpstreamProtocolOptions())
+	require.NotNil(t, useDownstream.UseDownstreamProtocolConfig)
+	assert.NotNil(t, useDownstream.UseDownstreamProtocolConfig.GetHttpProtocolOptions(),
+		"http/1.1 downstream must map to h1 upstream")
+	assert.NotNil(t, useDownstream.UseDownstreamProtocolConfig.GetHttp2ProtocolOptions(),
+		"h2c downstream must map to h2c upstream (the #568 fix)")
 
 	// SO_MARK on the upstream sockets (proposal 022 M2-default): the CNI
 	// redirect-all rule RETURNs this mark so the proxy's own forwarded egress is

--- a/agent/internal/xds/proxy/cluster.go
+++ b/agent/internal/xds/proxy/cluster.go
@@ -270,9 +270,21 @@ func NewPassthroughOriginalDstCluster() *clusterv3.Cluster {
 				State:       corev3.SocketOption_STATE_PREBIND,
 			}},
 		},
-		// No TypedExtensionProtocolOptions: passthrough is plain TCP.
+		// Mirror the downstream protocol on the upstream dial (issue #568). Non-mesh
+		// egress that http_inspector sniffed as cleartext HTTP (h2c OR http/1.1)
+		// transits the cap_http HCM and lands here via the redirect-all catch-all's
+		// passthrough fallthrough. The HCM speaks HTTP to this cluster, so an h2c
+		// downstream (e.g. OTLP gRPC to a non-mesh otel-collector on :4317) MUST dial
+		// h2c upstream — the ORIGINAL_DST default of HTTP/1.1 resets an h2-only server
+		// ("reset reason: protocol error"). USE_DOWNSTREAM_PROTOCOL keeps h1→h1 and
+		// h2c→h2c. This only affects connections the HCM forwards (sniffed HTTP);
+		// raw-TCP and TLS passthrough hit the L4 cap_passthrough default chain via
+		// tcp_proxy, which ignores these HTTP-codec options entirely.
 		// No TransportSocket: plaintext — mesh mTLS does NOT apply here.
 		// No LbSubsetConfig / OutlierDetection: single-connection, no pool.
+		TypedExtensionProtocolOptions: map[string]*anypb.Any{
+			config.UpstreamHTTPProtocolOptionsKey: config.TypedConfig(config.UseDownstreamProtocolOptions()),
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes #568

## Problem

A mesh pod under `captureRedirectAllDefault: true` sending OTLP gRPC (h2c) to a **non-mesh** ClusterIP (e.g. `otel-collector:4317`, a plain h2c-only gRPC server) got:

```
upstream connect error or disconnect/reset before headers. reset reason: protocol error
```

## Root cause — which chain/cluster carried the broken traffic

1. CNI redirect-all sends the h2c connection to the per-pod capture listener.
2. Listener filters run: `original_dst` recovers the ClusterIP; `http_inspector` sniffs the stream as **h2c** (cleartext HTTP/2).
3. Chain matching: no per-ClusterIP TCP floor chain matches (the collector is not a mesh service), and the L4 `cap_passthrough` DefaultFilterChain only catches TLS + non-HTTP raw TCP. The **`cap_http` HCM chain** matches — its `FilterChainMatch` is `{transport_protocol: raw_buffer, application_protocols: [http/1.0, http/1.1, h2c]}`, and **h2c is in that list**.
4. Inside `cap_http`, the authority `otel-collector:4317` is not a mesh authority and not a known target, so it hits the redirect-all catch-all's **passthrough fallthrough** → routes to the **`passthrough_original_dst` ORIGINAL_DST cluster**.
5. That cluster had **no `TypedExtensionProtocolOptions`**, so Envoy defaulted the upstream dial to **HTTP/1.1**. The HCM spoke HTTP/1.1 to an h2-only server → reset before headers → the Envoy-injected `protocol error` gRPC status.

So: the broken traffic transited the **`cap_http` HCM chain** (not the L4 default chain) and terminated on the **`passthrough_original_dst`** cluster, which defaulted to HTTP/1.1 upstream.

## Fix — option (a): preserve downstream protocol on the passthrough

Chosen **option (a)** (USE_DOWNSTREAM_PROTOCOL on the passthrough cluster). Rationale: the h2c connection is *already inside* the HCM because `http_inspector` legitimately detected it as HTTP; the HCM speaks HTTP to its upstream, so the upstream must mirror the downstream protocol. Option (b) — diverting non-mesh traffic off the HCM onto the TCP floor — is structurally wrong here: to bypass the HCM you'd have to stop matching h2c into `cap_http`, which would also break legitimate non-mesh cleartext **HTTP/1.1** egress that correctly transits the HCM today.

- New `config.UseDownstreamProtocolOptions()` builds `HttpProtocolOptions` with `use_downstream_protocol_config` and both HTTP/1 and HTTP/2 codec messages populated (so Envoy has concrete config for whichever protocol the downstream turns out to be).
- `NewPassthroughOriginalDstCluster()` now carries it via `TypedExtensionProtocolOptions`. Result: h1 downstream → h1 upstream, h2c downstream → h2c upstream.

Mesh traffic handling (per-source mTLS, SNI demux, ODCDS, TCP floor) is **byte-identical** — only the non-mesh passthrough upstream protocol changes. Raw-TCP and TLS passthrough still hit the L4 `cap_passthrough` default chain via `tcp_proxy`, which ignores these HTTP-codec options.

## Validation

- **Unit** `//agent/internal/xds/config:config_test` — asserts the helper selects `UseDownstreamProtocolConfig` with both codecs + the 30s idle timeout.
- **Unit** `//agent/internal/xds/proxy:proxy_test` — `TestNewPassthroughOriginalDstCluster` now asserts the passthrough cluster carries the use-downstream config with both h1 and h2c populated (h1 traffic unaffected).
- **Bootstrap validation** `//test/envoy_validate:envoy_validate_test` — passes. Its capture bootstrap already builds `NewPassthroughOriginalDstCluster()`, so `envoy --mode validate` now confirms Envoy **accepts** an ORIGINAL_DST cluster carrying HTTP protocol options.
- Full `//agent/...` (`-integration`) + `//test/envoy_validate/...`: 25/25 pass.

## Follow-up (not in this PR)

- **e2e case**: sending gRPC through redirect-all capture to a non-mesh h2c server needs new infra (an h2c echo-server image loaded into the kind cluster). Skipped tonight to avoid destabilizing the existing e2e jobs; should be added alongside upstreaming the `capture.aether.io/exclude-outbound-ports: "4317"` mitigation into the soak/test manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR