### PR TITLE
feat(node): re-arm the agent-not-ready taint across reboots and agent outages

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -265,18 +265,20 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	// Remove the aether startup taint from this node once the CNI server is
-	// serving, so workload pods (which don't tolerate it) can schedule here. The
-	// operator registers the taint via the kubelet; this closes the cold-start
-	// window where a pod's CNI ADD would arrive before the agent is ready.
-	// Unconditional (proposal 031): a no-op when the taint isn't registered.
-	if err = m.Add(&node.TaintRemover{
+	// Remove the aether startup taint from this node whenever it is present and
+	// the CNI server is serving, so workload pods (which don't tolerate it) can
+	// schedule here. This is a reconciler on this agent's own Node, so it also
+	// drops the taint the controller's node-taint guard re-applies after a reboot
+	// or agent outage (issue #569, gaps G1/G2), not just the one the kubelet
+	// registered at boot. Unconditional (proposal 031): a no-op when the taint
+	// isn't present. Best-effort: NeedLeaderElection=false, never fails startup.
+	if err = (&node.TaintRemover{
 		Client:     m.GetClient(),
 		NodeName:   cfg.NodeName,
 		SocketPath: cfg.CNIServerConfig.SocketPath,
 		Log:        l,
-	}); err != nil {
-		return fmt.Errorf("failed to add startup-taint remover: %w", err)
+	}).SetupWithManager(m); err != nil {
+		return fmt.Errorf("failed to set up startup-taint remover: %w", err)
 	}
 
 	// Rebuild the cluster/endpoint/route snapshot when the registry reports

--- a/agent/internal/node/taint.go
+++ b/agent/internal/node/taint.go
@@ -12,14 +12,17 @@ import (
 	aetherlabels "github.com/bpalermo/aether/common/constants/labels"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	socketPollInterval = 200 * time.Millisecond
-	patchRetries       = 5
-	patchRetryDelay    = time.Second
-)
+// socketRequeue is how long to wait before re-reconciling when the taint is
+// present but the CNI socket isn't serving yet — the reconciler can't watch a
+// Unix socket, so it polls the node until the CNI comes up.
+const socketRequeue = time.Second
 
 // removeTaint removes every taint with the given key from the node's spec,
 // returning whether any were removed. Pure (no API calls), unit-testable.
@@ -36,11 +39,26 @@ func removeTaint(node *corev1.Node, key string) (changed bool) {
 	return changed
 }
 
-// TaintRemover is a manager Runnable that removes the aether startup taint
-// (aetherlabels.TaintAgentNotReady) from this agent's OWN node once the CNI server
-// is serving — signalled by its Unix socket existing, which means a pod's CNI
-// ADD can now be handled. Workload pods don't tolerate the taint, so they wait
-// until this runs. Best-effort: it never fails agent startup.
+// hasTaint reports whether the node carries a taint with the given key.
+func hasTaint(node *corev1.Node, key string) bool {
+	for _, t := range node.Spec.Taints {
+		if t.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// TaintRemover is a controller-runtime reconciler that removes the aether
+// startup taint (aetherlabels.TaintAgentNotReady) from this agent's OWN node
+// whenever the taint is present AND the CNI server is serving — signalled by its
+// Unix socket existing, which means a pod's CNI ADD can now be handled. Workload
+// pods don't tolerate the taint, so they wait until this runs.
+//
+// Unlike the original one-shot remover, it reconciles: the controller's node-taint
+// guard can (re-)apply the taint to a running node after a reboot or an agent
+// outage (issue #569, gaps G1/G2), and this remover drops it again once CNI is
+// serving. Best-effort: it never fails agent startup.
 type TaintRemover struct {
 	Client     client.Client
 	NodeName   string
@@ -52,61 +70,60 @@ type TaintRemover struct {
 // leader.
 func (r *TaintRemover) NeedLeaderElection() bool { return false }
 
-// Start waits for the CNI server to be serving, then removes the startup taint.
-func (r *TaintRemover) Start(ctx context.Context) error {
-	if err := r.waitForCNIReady(ctx); err != nil {
-		r.Log.WarnContext(ctx, "CNI server not ready; skipping startup-taint removal", "error", err)
-		return nil // best-effort; never block/fail the manager
-	}
-	if err := r.removeFromNode(ctx); err != nil {
-		r.Log.ErrorContext(ctx, "failed to remove startup taint (best-effort)", "node", r.NodeName, "error", err)
-	}
-	return nil
+// SetupWithManager registers the remover to watch ONLY this agent's own Node
+// object (filtered by node name), so every agent reconciles its own node and no
+// other. A change that (re-)adds the taint re-triggers removal.
+func (r *TaintRemover) SetupWithManager(mgr ctrl.Manager) error {
+	ownNode := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == r.NodeName
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}, builder.WithPredicates(ownNode)).
+		Named("agent-taint-remover").
+		Complete(r)
 }
 
-// waitForCNIReady blocks until the CNI server's Unix socket exists (it's serving)
-// or the context is cancelled.
-func (r *TaintRemover) waitForCNIReady(ctx context.Context) error {
-	ticker := time.NewTicker(socketPollInterval)
-	defer ticker.Stop()
-	for {
-		if _, err := os.Stat(r.SocketPath); err == nil {
-			return nil
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
+// Reconcile removes the startup taint from this agent's node when it is present
+// and the CNI socket is serving. When the taint is present but CNI isn't up yet,
+// it requeues (the reconciler can't watch a Unix socket) rather than blocking a
+// worker. Best-effort: a patch failure is retried by controller-runtime, never
+// surfaced as a startup failure.
+func (r *TaintRemover) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	if req.Name != r.NodeName {
+		return reconcile.Result{}, nil
 	}
+
+	node := &corev1.Node{}
+	if err := r.Client.Get(ctx, types.NamespacedName{Name: r.NodeName}, node); err != nil {
+		// Node gone/transient: let controller-runtime retry with backoff.
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !hasTaint(node, aetherlabels.TaintAgentNotReady) {
+		return reconcile.Result{}, nil // nothing to do
+	}
+
+	if !r.cniServing() {
+		// The taint is present but CNI isn't serving yet — don't remove it (that's
+		// the whole point of the gate). Requeue to re-check once CNI comes up.
+		r.Log.DebugContext(ctx, "startup taint present but CNI not serving; requeueing", "node", r.NodeName)
+		return reconcile.Result{RequeueAfter: socketRequeue}, nil
+	}
+
+	base := node.DeepCopy()
+	if !removeTaint(node, aetherlabels.TaintAgentNotReady) {
+		return reconcile.Result{}, nil
+	}
+	if err := r.Client.Patch(ctx, node, client.MergeFrom(base)); err != nil {
+		r.Log.ErrorContext(ctx, "failed to remove startup taint (best-effort, will retry)", "node", r.NodeName, "error", err)
+		return reconcile.Result{}, err
+	}
+	r.Log.InfoContext(ctx, "removed startup taint", "node", r.NodeName, "taint", aetherlabels.TaintAgentNotReady)
+	return reconcile.Result{}, nil
 }
 
-// removeFromNode patches this agent's node to drop the startup taint, retrying a
-// few times on conflict/transient errors. A no-op if the taint is already absent.
-func (r *TaintRemover) removeFromNode(ctx context.Context) error {
-	var lastErr error
-	for i := 0; i < patchRetries; i++ {
-		node := &corev1.Node{}
-		if err := r.Client.Get(ctx, types.NamespacedName{Name: r.NodeName}, node); err != nil {
-			lastErr = err
-		} else {
-			base := node.DeepCopy()
-			if !removeTaint(node, aetherlabels.TaintAgentNotReady) {
-				r.Log.DebugContext(ctx, "startup taint already absent", "node", r.NodeName)
-				return nil
-			}
-			if err := r.Client.Patch(ctx, node, client.MergeFrom(base)); err != nil {
-				lastErr = err
-			} else {
-				r.Log.InfoContext(ctx, "removed startup taint", "node", r.NodeName, "taint", aetherlabels.TaintAgentNotReady)
-				return nil
-			}
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-time.After(patchRetryDelay):
-		}
-	}
-	return lastErr
+// cniServing reports whether the CNI server's Unix socket exists (it's serving).
+func (r *TaintRemover) cniServing() bool {
+	_, err := os.Stat(r.SocketPath)
+	return err == nil
 }

--- a/agent/internal/node/taint_test.go
+++ b/agent/internal/node/taint_test.go
@@ -1,10 +1,23 @@
 package node
 
 import (
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
+	aetherlabels "github.com/bpalermo/aether/common/constants/labels"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 func TestRemoveTaint(t *testing.T) {
@@ -34,5 +47,108 @@ func TestRemoveTaint(t *testing.T) {
 		node := &corev1.Node{}
 		assert.False(t, removeTaint(node, key))
 		assert.Empty(t, node.Spec.Taints)
+	})
+}
+
+const testNode = "node-a"
+
+func nodeWithTaint(name string, tainted bool) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if tainted {
+		n.Spec.Taints = []corev1.Taint{{
+			Key:    aetherlabels.TaintAgentNotReady,
+			Value:  "true",
+			Effect: corev1.TaintEffectNoSchedule,
+		}}
+	}
+	return n
+}
+
+func newRemover(t *testing.T, socketPath string, objs ...client.Object) (*TaintRemover, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &TaintRemover{
+		Client:     c,
+		NodeName:   testNode,
+		SocketPath: socketPath,
+		Log:        slog.New(slog.DiscardHandler),
+	}, c
+}
+
+// touchSocket creates a file to stand in for the CNI Unix socket (cniServing
+// only stats the path).
+func touchSocket(t *testing.T) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cni.sock")
+	require.NoError(t, os.WriteFile(p, nil, 0o600))
+	return p
+}
+
+func nodeTaintPresent(t *testing.T, c client.Client) bool {
+	t.Helper()
+	n := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNode}, n))
+	return hasTaint(n, aetherlabels.TaintAgentNotReady)
+}
+
+func reconcileNode(t *testing.T, r *TaintRemover) reconcile.Result {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: testNode},
+	})
+	require.NoError(t, err)
+	return res
+}
+
+func TestReconcile(t *testing.T) {
+	t.Run("taint present + socket serving -> removed", func(t *testing.T) {
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, true))
+		reconcileNode(t, r)
+		assert.False(t, nodeTaintPresent(t, c), "taint should be removed once CNI is serving")
+	})
+
+	t.Run("taint re-added later is removed once socket present", func(t *testing.T) {
+		// Start with an untainted node (already removed once) + serving socket.
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, false))
+		reconcileNode(t, r) // no-op
+		assert.False(t, nodeTaintPresent(t, c))
+
+		// The controller re-applies the taint (reboot / agent outage). Re-reconcile.
+		n := &corev1.Node{}
+		require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testNode}, n))
+		n.Spec.Taints = []corev1.Taint{{
+			Key: aetherlabels.TaintAgentNotReady, Value: "true", Effect: corev1.TaintEffectNoSchedule,
+		}}
+		require.NoError(t, c.Update(context.Background(), n))
+
+		reconcileNode(t, r)
+		assert.False(t, nodeTaintPresent(t, c), "re-added taint should be removed again (G2)")
+	})
+
+	t.Run("socket absent -> taint kept, requeued", func(t *testing.T) {
+		// A socket path that does not exist -> CNI not serving.
+		missing := filepath.Join(t.TempDir(), "absent.sock")
+		r, c := newRemover(t, missing, nodeWithTaint(testNode, true))
+		res := reconcileNode(t, r)
+		assert.True(t, nodeTaintPresent(t, c), "taint must NOT be removed while CNI is down")
+		assert.Positive(t, res.RequeueAfter, "should requeue to re-check once CNI comes up")
+	})
+
+	t.Run("no taint -> no-op", func(t *testing.T) {
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, false))
+		res := reconcileNode(t, r)
+		assert.False(t, nodeTaintPresent(t, c))
+		assert.Zero(t, res.RequeueAfter)
+	})
+
+	t.Run("request for a different node -> ignored", func(t *testing.T) {
+		r, _ := newRemover(t, touchSocket(t), nodeWithTaint(testNode, true))
+		res, err := r.Reconcile(context.Background(), reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: "some-other-node"},
+		})
+		require.NoError(t, err)
+		assert.Zero(t, res.RequeueAfter)
 	})
 }

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.78.0-{GIT_COMMIT}"
+version: "0.79.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-rbac.yaml
+++ b/charts/aether/templates/controller-rbac.yaml
@@ -5,6 +5,16 @@ metadata:
   labels:
     {{- include "aether.controller.labels" . | nindent 4 }}
 rules:
+  # Node-taint guard (issue #569 / proposal 033): watch Nodes + agent DS pods and
+  # re-arm the aether.io/agent-not-ready:NoSchedule taint on a node whose agent
+  # pod is missing/not-Ready past a grace period. patch: add the taint (never
+  # removes — the agent owns removal). Pods are read to find each node's agent.
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
   # Watch and report on the cluster-scoped MeshConfig CRs.
   - apiGroups: ["config.aether.io"]
     resources: ["meshconfigs"]

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -8,15 +8,20 @@
 # (via the MeshConfig CR); everything else is deterministic deploy-time config.
 # See docs/proposals/015_mesh-config.md.
 #
-# Startup taint (cold-start CNI gate, issue #261): this chart ships the
-# aether.io/agent-not-ready toleration (agent + proxy DaemonSets only), the
-# nodes/patch RBAC, and the agent-side taint removal (it drops the taint once its
-# CNI socket is serving). You MUST register nodes WITH the taint yourself so
-# workload pods wait for a ready agent — the chart cannot taint nodes. Examples:
+# Startup taint (cold-start CNI gate, issue #261; lifecycle #569): this chart
+# ships the aether.io/agent-not-ready toleration (all aether components — agent +
+# proxy DaemonSets, controller/registrar/edge Deployments), the nodes/patch RBAC,
+# the agent-side taint removal (it drops the taint once its CNI socket is serving),
+# AND the controller-side node-taint guard (it RE-ARMS the taint on a node whose
+# agent pod is missing/not-Ready past a ~30s grace, e.g. after a reboot or an agent
+# outage). You SHOULD still register nodes WITH the taint so a brand-new node is
+# gated before its agent's first reconcile:
 #   kubelet:  --register-with-taints=aether.io/agent-not-ready=true:NoSchedule
 #   Talos:    machine.kubelet.extraArgs."register-with-taints" (machineconfig)
-# The agent removes the taint unconditionally (needs the chart's nodes/patch
-# RBAC); removal is a no-op on nodes registered without it.
+# The agent removes the taint whenever it is present and CNI is serving (needs the
+# chart's nodes/patch RBAC); the guard only ever adds it, never removes it.
+# NOTE: the external SPIRE agent DaemonSet must also tolerate this taint — set it in
+# your spire helm values (spire-agent.tolerations), NOT here.
 
 # Override the chart name / fully-qualified resource name.
 nameOverride: ""

--- a/controller/internal/cmd/BUILD.bazel
+++ b/controller/internal/cmd/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//controller/internal/gatewayapi",
         "//controller/internal/httpfilter",
         "//controller/internal/meshconfig",
+        "//controller/internal/nodetaint",
         "//controller/internal/podmutate",
         "//controller/internal/webhook",
         "@com_github_spf13_cobra//:cobra",

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bpalermo/aether/controller/internal/gatewayapi"
 	"github.com/bpalermo/aether/controller/internal/httpfilter"
 	"github.com/bpalermo/aether/controller/internal/meshconfig"
+	"github.com/bpalermo/aether/controller/internal/nodetaint"
 	"github.com/bpalermo/aether/controller/internal/podmutate"
 	cwebhook "github.com/bpalermo/aether/controller/internal/webhook"
 	"github.com/spf13/cobra"
@@ -130,6 +131,10 @@ func runController(ctx context.Context) (retErr error) {
 		return fmt.Errorf("failed to set up MeshConfig reconciler: %w", err)
 	}
 
+	if err = wireNodeTaintGuard(m, fallbackNamespace); err != nil {
+		return err
+	}
+
 	// All validation is served on one /validate endpoint, dispatched by Kind. The
 	// HTTPRoute validator uses the API reader for a cluster-wide hostname-conflict
 	// list (uncached, correct regardless of the manager cache scope).
@@ -199,6 +204,24 @@ func buildControllerBootstrapOpts(ctx context.Context) (*spire.Source, []func(*c
 	})
 	l.InfoContext(ctx, "webhook serving with SPIRE SVID", "socket", cfg.SpireWorkloadSocketPath)
 	return src, bootstrapOpts, nil
+}
+
+// wireNodeTaintGuard registers the leader-elected node-taint guard, which
+// re-arms the aether startup taint on a node whose agent pod is missing/not-Ready
+// past a grace period (issue #569: reboots don't re-apply register-with-taints,
+// and the old one-shot remover never re-armed). The agent DaemonSet runs in the
+// controller's own (fallback) namespace, so the guard selects agent pods there.
+// The guard never removes the taint — the per-node agent owns removal.
+func wireNodeTaintGuard(m ctrl.Manager, agentNamespace string) error {
+	guard := &nodetaint.Guard{
+		Client:         m.GetClient(),
+		AgentNamespace: agentNamespace,
+		Log:            l,
+	}
+	if err := guard.SetupWithManager(m); err != nil {
+		return fmt.Errorf("failed to set up node-taint guard: %w", err)
+	}
+	return nil
 }
 
 // wireCABundleInjector registers the CA bundle injector when SPIRE is enabled.

--- a/controller/internal/nodetaint/BUILD.bazel
+++ b/controller/internal/nodetaint/BUILD.bazel
@@ -1,26 +1,26 @@
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
-    name = "node",
-    srcs = ["taint.go"],
-    importpath = "github.com/bpalermo/aether/agent/internal/node",
-    visibility = ["//agent:__subpackages__"],
+    name = "nodetaint",
+    srcs = ["guard.go"],
+    importpath = "github.com/bpalermo/aether/controller/internal/nodetaint",
+    visibility = ["//controller:__subpackages__"],
     deps = [
         "//common/constants/labels",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/types",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
-        "@io_k8s_sigs_controller_runtime//pkg/builder",
         "@io_k8s_sigs_controller_runtime//pkg/client",
-        "@io_k8s_sigs_controller_runtime//pkg/predicate",
+        "@io_k8s_sigs_controller_runtime//pkg/handler",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile",
     ],
 )
 
 go_test(
-    name = "node_test",
-    srcs = ["taint_test.go"],
-    embed = [":node"],
+    name = "nodetaint_test",
+    srcs = ["guard_test.go"],
+    embed = [":nodetaint"],
     deps = [
         "//common/constants/labels",
         "@com_github_stretchr_testify//assert",

--- a/controller/internal/nodetaint/guard.go
+++ b/controller/internal/nodetaint/guard.go
@@ -1,0 +1,202 @@
+// Package nodetaint holds the controller's node-taint guard: a leader-elected
+// reconciler that RE-ARMS the aether startup taint (aetherlabels.TaintAgentNotReady)
+// on a node whose agent pod is missing or not-Ready past a grace period, so a node
+// that rebooted (kubelet never re-applies register-with-taints, gap G1) or whose
+// agent crashed (gap G2) stops scheduling workload pods until an agent is serving
+// again. It NEVER removes the taint — the per-node agent (agent/internal/node) owns
+// removal, gated on its CNI socket. See issue #569 / proposal 033.
+package nodetaint
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	aetherlabels "github.com/bpalermo/aether/common/constants/labels"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// grace is how long a node may have no Ready agent pod before the guard
+	// re-arms the taint. A routine agent roll replaces the pod well within this
+	// window, so it does not flap the taint (debounced). Constant, not a flag —
+	// proposal 031: no new flags.
+	grace = 30 * time.Second
+
+	// agentNameLabel identifies the aether-agent DaemonSet pods. It matches the
+	// chart's `aether.agent.selectorLabels` (charts/aether/templates/_helpers.tpl).
+	agentNameLabel = "app.kubernetes.io/name"
+	agentNameValue = "aether-agent"
+	fieldOwner     = "aether-controller"
+	taintValue     = "true"
+)
+
+// Guard re-arms the startup taint on nodes without a Ready agent pod. It watches
+// Nodes and the agent DaemonSet's pods (in AgentNamespace). It is leader-elected
+// (one writer mesh-wide) and never removes the taint.
+type Guard struct {
+	Client client.Client
+	// AgentNamespace is the namespace the agent DaemonSet runs in (aether-system).
+	AgentNamespace string
+	Log            *slog.Logger
+
+	// missingSince debounces re-arming: it records when a node was first observed
+	// without a Ready agent pod, so a pod replaced within the grace window doesn't
+	// taint. Cleared as soon as a Ready agent pod is seen again.
+	mu           sync.Mutex
+	missingSince map[string]time.Time
+}
+
+// NeedLeaderElection makes the guard run only on the elected controller — the
+// taint is a single-writer, mesh-wide decision.
+func (g *Guard) NeedLeaderElection() bool { return true }
+
+// SetupWithManager registers the guard: it reconciles Nodes and maps every
+// agent-pod change back to that pod's node, so a pod going NotReady / being
+// deleted re-triggers the node's evaluation.
+func (g *Guard) SetupWithManager(mgr ctrl.Manager) error {
+	g.missingSince = make(map[string]time.Time)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Node{}).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(g.podToNode)).
+		Named("node-taint-guard").
+		Complete(g)
+}
+
+// podToNode maps an agent-pod event to a reconcile request for the node the pod
+// runs on. Non-agent pods (or pods not yet scheduled) enqueue nothing.
+func (g *Guard) podToNode(_ context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod.Namespace != g.AgentNamespace {
+		return nil
+	}
+	if pod.Labels[agentNameLabel] != agentNameValue || pod.Spec.NodeName == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: pod.Spec.NodeName}}}
+}
+
+// Reconcile re-arms the taint on a node that has had no Ready agent pod for the
+// grace period. When a Ready agent pod exists it clears the debounce (and never
+// touches the taint — removal is the agent's job).
+func (g *Guard) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	node := &corev1.Node{}
+	if err := g.Client.Get(ctx, req.NamespacedName, node); err != nil {
+		if apierrors.IsNotFound(err) {
+			g.forget(req.Name)
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	ready, err := g.hasReadyAgent(ctx, req.Name)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	if ready {
+		// A serving agent is present. Clear the debounce; the agent removes the
+		// taint itself once its CNI socket is up — the guard never removes it.
+		g.forget(req.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// No Ready agent pod. If the taint is already armed, we're done (idempotent).
+	if hasTaint(node, aetherlabels.TaintAgentNotReady) {
+		g.forget(req.Name)
+		return reconcile.Result{}, nil
+	}
+
+	// Debounce: wait out the grace period before re-arming, so a routine agent
+	// roll (pod replaced within grace) never taints the node.
+	if wait := g.remainingGrace(req.Name); wait > 0 {
+		return reconcile.Result{RequeueAfter: wait}, nil
+	}
+
+	if err := g.armTaint(ctx, node); err != nil {
+		return reconcile.Result{}, err
+	}
+	g.forget(req.Name)
+	g.Log.WarnContext(ctx, "re-armed agent-not-ready taint: node had no Ready agent pod past grace",
+		"node", req.Name, "grace", grace)
+	return reconcile.Result{}, nil
+}
+
+// hasReadyAgent reports whether a Ready agent pod is running on the given node.
+func (g *Guard) hasReadyAgent(ctx context.Context, nodeName string) (bool, error) {
+	var pods corev1.PodList
+	if err := g.Client.List(
+		ctx, &pods,
+		client.InNamespace(g.AgentNamespace),
+		client.MatchingLabels{agentNameLabel: agentNameValue},
+	); err != nil {
+		return false, err
+	}
+	for i := range pods.Items {
+		p := &pods.Items[i]
+		if p.Spec.NodeName == nodeName && p.DeletionTimestamp == nil && podReady(p) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// remainingGrace returns how long is left in the grace window for a node observed
+// without a Ready agent, starting the clock on first observation. Returns 0 (or
+// less) once the window has elapsed — i.e. re-arm now.
+func (g *Guard) remainingGrace(nodeName string) time.Duration {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	first, seen := g.missingSince[nodeName]
+	now := time.Now()
+	if !seen {
+		g.missingSince[nodeName] = now
+		return grace
+	}
+	return grace - now.Sub(first)
+}
+
+// forget clears the debounce entry for a node (agent is Ready again, taint is
+// already armed, or the node is gone).
+func (g *Guard) forget(nodeName string) {
+	g.mu.Lock()
+	delete(g.missingSince, nodeName)
+	g.mu.Unlock()
+}
+
+// armTaint adds the startup taint to the node (a no-op patch if already present).
+func (g *Guard) armTaint(ctx context.Context, node *corev1.Node) error {
+	base := node.DeepCopy()
+	node.Spec.Taints = append(node.Spec.Taints, corev1.Taint{
+		Key:    aetherlabels.TaintAgentNotReady,
+		Value:  taintValue,
+		Effect: corev1.TaintEffectNoSchedule,
+	})
+	return g.Client.Patch(ctx, node, client.MergeFrom(base), client.FieldOwner(fieldOwner))
+}
+
+// hasTaint reports whether the node carries a taint with the given key.
+func hasTaint(node *corev1.Node, key string) bool {
+	for _, t := range node.Spec.Taints {
+		if t.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// podReady reports whether a pod's Ready condition is True.
+func podReady(pod *corev1.Pod) bool {
+	for _, c := range pod.Status.Conditions {
+		if c.Type == corev1.PodReady {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/controller/internal/nodetaint/guard_test.go
+++ b/controller/internal/nodetaint/guard_test.go
@@ -1,0 +1,204 @@
+package nodetaint
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	aetherlabels "github.com/bpalermo/aether/common/constants/labels"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	agentNS  = "aether-system"
+	nodeName = "node-a"
+)
+
+func node(name string, tainted bool) *corev1.Node {
+	n := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	if tainted {
+		n.Spec.Taints = []corev1.Taint{{
+			Key: aetherlabels.TaintAgentNotReady, Value: taintValue, Effect: corev1.TaintEffectNoSchedule,
+		}}
+	}
+	return n
+}
+
+func agentPod(name, node string, ready bool) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: agentNS,
+			Labels:    map[string]string{agentNameLabel: agentNameValue},
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+	}
+	status := corev1.ConditionFalse
+	if ready {
+		status = corev1.ConditionTrue
+	}
+	p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: status}}
+	return p
+}
+
+func newGuard(t *testing.T, objs ...client.Object) (*Guard, client.Client) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+	return &Guard{
+		Client:         c,
+		AgentNamespace: agentNS,
+		Log:            slog.New(slog.DiscardHandler),
+		missingSince:   make(map[string]time.Time),
+	}, c
+}
+
+func reconcileNode(t *testing.T, g *Guard) reconcile.Result {
+	t.Helper()
+	res, err := g.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: nodeName},
+	})
+	require.NoError(t, err)
+	return res
+}
+
+func tainted(t *testing.T, c client.Client) bool {
+	t.Helper()
+	n := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: nodeName}, n))
+	return hasTaint(n, aetherlabels.TaintAgentNotReady)
+}
+
+// TestReadyAgent: a Ready agent pod keeps the node untainted and clears any
+// debounce; the guard never removes an existing taint.
+func TestReadyAgent(t *testing.T) {
+	t.Run("ready agent -> node stays untainted", func(t *testing.T) {
+		g, c := newGuard(t, node(nodeName, false), agentPod("a", nodeName, true))
+		res := reconcileNode(t, g)
+		assert.False(t, tainted(t, c))
+		assert.Zero(t, res.RequeueAfter)
+	})
+
+	t.Run("guard never removes an existing taint", func(t *testing.T) {
+		// Even with a Ready agent, an already-present taint is left alone (the agent
+		// owns removal).
+		g, c := newGuard(t, node(nodeName, true), agentPod("a", nodeName, true))
+		reconcileNode(t, g)
+		assert.True(t, tainted(t, c), "guard must never remove the taint")
+	})
+}
+
+// TestMissingAgentArmsAfterGrace: no Ready agent pod -> taint armed only after
+// the grace window elapses (first reconcile debounces).
+func TestMissingAgentArmsAfterGrace(t *testing.T) {
+	g, c := newGuard(t, node(nodeName, false)) // no agent pods at all
+
+	// First observation: debounce, do NOT taint yet.
+	res := reconcileNode(t, g)
+	assert.False(t, tainted(t, c), "must not taint on first observation (debounce)")
+	assert.Positive(t, res.RequeueAfter)
+
+	// Simulate the grace window elapsing by backdating the first-seen timestamp.
+	g.mu.Lock()
+	g.missingSince[nodeName] = time.Now().Add(-2 * grace)
+	g.mu.Unlock()
+
+	reconcileNode(t, g)
+	assert.True(t, tainted(t, c), "must re-arm the taint once grace elapses with no Ready agent")
+}
+
+// TestFlapWithinGrace: a not-Ready agent pod that becomes Ready before the grace
+// elapses must NOT cause a taint (routine agent roll).
+func TestFlapWithinGrace(t *testing.T) {
+	g, c := newGuard(t, node(nodeName, false), agentPod("a", nodeName, false))
+
+	// Agent pod exists but is not Ready yet -> debounce.
+	res := reconcileNode(t, g)
+	assert.False(t, tainted(t, c))
+	assert.Positive(t, res.RequeueAfter)
+
+	// Within the grace window the pod becomes Ready (roll completes).
+	p := &corev1.Pod{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: agentNS, Name: "a"}, p))
+	p.Status.Conditions = []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}
+	require.NoError(t, c.Status().Update(context.Background(), p))
+
+	reconcileNode(t, g)
+	assert.False(t, tainted(t, c), "a pod that goes Ready within grace must not taint the node")
+
+	// Debounce must be cleared so a later miss starts a fresh window.
+	g.mu.Lock()
+	_, still := g.missingSince[nodeName]
+	g.mu.Unlock()
+	assert.False(t, still, "debounce entry should be cleared once an agent is Ready")
+}
+
+// TestIdempotentWhenAlreadyTainted: no Ready agent + taint already present -> no
+// duplicate taint, no error.
+func TestIdempotentWhenAlreadyTainted(t *testing.T) {
+	g, c := newGuard(t, node(nodeName, true)) // already tainted, no agent
+	reconcileNode(t, g)
+
+	n := &corev1.Node{}
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: nodeName}, n))
+	count := 0
+	for _, tt := range n.Spec.Taints {
+		if tt.Key == aetherlabels.TaintAgentNotReady {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "taint must not be duplicated")
+}
+
+// TestOtherNodeAgentIgnored: a Ready agent pod on a DIFFERENT node does not count
+// for this node.
+func TestOtherNodeAgentIgnored(t *testing.T) {
+	g, c := newGuard(t, node(nodeName, false), agentPod("b", "node-b", true))
+
+	res := reconcileNode(t, g)
+	assert.False(t, tainted(t, c), "still debouncing on first observation")
+	assert.Positive(t, res.RequeueAfter)
+
+	g.mu.Lock()
+	g.missingSince[nodeName] = time.Now().Add(-2 * grace)
+	g.mu.Unlock()
+
+	reconcileNode(t, g)
+	assert.True(t, tainted(t, c), "an agent on another node must not satisfy this node")
+}
+
+// TestPodToNode maps agent-pod events to their node, and ignores non-agent /
+// unscheduled / wrong-namespace pods.
+func TestPodToNode(t *testing.T) {
+	g, _ := newGuard(t)
+
+	reqs := g.podToNode(context.Background(), agentPod("a", nodeName, true))
+	require.Len(t, reqs, 1)
+	assert.Equal(t, nodeName, reqs[0].Name)
+
+	// Non-agent pod (missing label).
+	other := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: agentNS},
+		Spec:       corev1.PodSpec{NodeName: nodeName},
+	}
+	assert.Empty(t, g.podToNode(context.Background(), other))
+
+	// Wrong namespace.
+	wrongNS := agentPod("a", nodeName, true)
+	wrongNS.Namespace = "default"
+	assert.Empty(t, g.podToNode(context.Background(), wrongNS))
+
+	// Unscheduled agent pod (no NodeName).
+	assert.Empty(t, g.podToNode(context.Background(), agentPod("a", "", true)))
+}

--- a/docs/proposals/033_node-taint-lifecycle.md
+++ b/docs/proposals/033_node-taint-lifecycle.md
@@ -1,0 +1,141 @@
+# Proposal: Node-taint lifecycle — re-arm the agent-not-ready taint across reboots and agent outages
+
+**Status:** Accepted — 2026-07-19
+**Relates:** issue #263 / #261 (the startup taint + one-shot removal), proposal 031
+(agent flag-surface reduction — the "no new flags" philosophy this follows).
+**Fixes:** #569. **Non-goal:** container-restart waves on a re-armed node (#567).
+
+## Problem
+
+Aether gates a not-yet-ready node with the `aether.io/agent-not-ready:NoSchedule`
+startup taint (#263): the operator registers nodes with it
+(`kubelet --register-with-taints`), workload pods do **not** tolerate it, and the
+agent removes it once its CNI socket is serving — so a pod's fail-closed CNI ADD
+never arrives before the agent can handle it. That mechanism only ever fires
+**once, at node registration**. The 2026-07-19 incident review found three gaps
+where a node ends up schedulable while the agent is *not* serving:
+
+- **G1 — reboot leaves no taint.** The kubelet applies `register-with-taints`
+  only when it first creates the Node object, never again for an existing one.
+  After a reboot the on-disk CNI config keeps the kubelet reporting `Ready`, so
+  the node is schedulable **before** the agent process comes back up. Pods land
+  and sit in `ContainerCreating` on fail-closed CNI ADDs.
+- **G2 — removal is one-shot.** The old `TaintRemover` was a run-once manager
+  `Runnable`: it waited for the CNI socket, removed the taint, and returned. A
+  taint (re-)applied to an already-running node — by anything, including this
+  proposal's own guard — was **never** removed again.
+- **G3 — k8s's own taints don't cover this window.** `node.kubernetes.io/not-ready`
+  and `unreachable` track kubelet `NotReady`, not the aether-specific
+  "kubelet Ready but agent not serving" window. They can't gate on CNI readiness.
+
+## Design
+
+Two cooperating controllers, split by who is allowed to write which direction of
+the taint. No new flags (proposal 031): the grace period is a compiled constant.
+
+### Agent — reconciling remover (removes only)
+
+`agent/internal/node.TaintRemover` becomes a controller-runtime reconciler on the
+agent's **own** Node (filtered by node name via a predicate, so each agent watches
+exactly one node). On every Node event it removes the taint **iff** the taint is
+present **and** the CNI Unix socket is serving (the existing socket gate is kept;
+when the taint is present but CNI is down it requeues rather than blocking a
+worker — a reconciler can't watch a socket). `NeedLeaderElection=false` (per-node),
+best-effort (never fails agent startup). This closes **G2**: a taint the guard
+re-arms is dropped again as soon as the agent is serving. The pure `removeTaint`
+helper and its unit tests are preserved; the exported `TaintRemover` name is stable
+(only its wiring changes from `m.Add(...)` to `.SetupWithManager(m)`).
+
+### Controller — node-taint guard (adds only)
+
+New `controller/internal/nodetaint.Guard`, leader-elected (one writer mesh-wide).
+It watches **Nodes** and the **agent DaemonSet pods** (label selector
+`app.kubernetes.io/name=aether-agent` in the controller's own — aether-system —
+namespace; each pod event maps back to its node). When a node has **no Ready agent
+pod** it starts a grace timer; if the node is still without a Ready agent when the
+grace elapses, it **adds** the taint. It **never removes** it. This closes **G1**
+(a rebooted node with no serving agent gets re-tainted) and, with the agent's
+reconciling remover, **G2** end to end.
+
+- **Grace = 30s, a constant (not a flag).** Long enough that a routine agent roll —
+  pod deleted, replacement Ready — completes inside the window, so the taint does
+  **not** flap on every DaemonSet update (debounced via a per-node first-seen-missing
+  timestamp, cleared the moment a Ready agent is seen again).
+- **Idempotent.** If the taint is already present the guard does nothing.
+- **Control-plane nodes: data-driven, not skipped by assumption.** The guard does
+  not special-case control-plane nodes. It re-arms a node **only if** that node has
+  no Ready agent pod — and a node has an agent pod only where the agent DaemonSet
+  schedules. Since the agent DS carries **no** control-plane toleration and **no**
+  nodeSelector (charts/aether/templates/agent-daemonset.yaml), it does not run on
+  tainted control-plane nodes, so the guard's pod-presence check naturally skips
+  them. If an operator *does* run the agent on control-plane nodes, the guard
+  governs them correctly with no code change.
+
+### Effect stays NoSchedule
+
+Kept `NoSchedule`; see rejected alternatives.
+
+## Toleration audit
+
+The taint gates *workload* pods; every aether component must tolerate it (they *are*
+the thing that makes a node ready, or must run regardless).
+
+| workload | tolerates? | note |
+|---|---|---|
+| agent DaemonSet | yes (existing) | removes the taint; `cni-install` is its initContainer, covered |
+| aether-proxy DaemonSet | yes (existing) | runs on every node |
+| controller / registrar / edge Deployments | yes (existing) | must run to serve the mesh |
+| **workload / test / conformance manifests** | **no** (verified) | grep across the repo: only the aether components tolerate it |
+
+No workload or test manifest tolerates the taint (verified by repo-wide grep). The
+`cni-install` init container needs no separate toleration — it runs inside the agent
+DaemonSet, which already tolerates.
+
+### SPIRE agent DaemonSet — external chart, documented only
+
+When SPIRE is enabled, the SPIRE **agent** DaemonSet (from the external
+`spiffe/spire` helm chart, **not** this repo) delivers the SVIDs the aether agent
+needs, so it too must tolerate the taint or it will never schedule onto a freshly
+re-armed node — deadlocking startup. This chart cannot touch the external
+DaemonSet; the toleration must be set in the **spire helm values** under:
+
+```yaml
+spire-agent:
+  tolerations:
+    - key: aether.io/agent-not-ready
+      operator: Exists
+      effect: NoSchedule
+```
+
+(`spire-agent` is the sub-chart of `spiffe/spire` that renders the agent DaemonSet;
+this repo's `values.yaml` header calls this out.)
+
+## RBAC
+
+The controller Deployment's ClusterRole gains `nodes: [get,list,watch,patch]` and
+`pods: [get,list,watch]` (the agent already has nodes/patch). `patch` on nodes is
+add-only in practice — the guard only ever appends the taint.
+
+## Rejected alternatives
+
+- **NoExecute instead of NoSchedule.** `NoExecute` would **evict** every
+  non-tolerating pod already running on the node the instant the taint is
+  (re-)applied — i.e. on **every** agent roll or transient agent restart, the guard
+  would drain the node's mesh workloads. That is catastrophically more disruptive
+  than the problem it solves (a re-armed node keeps its running pods; only *new*
+  scheduling is blocked until the agent is serving). Rejected. `NoSchedule` gates
+  new pods without touching running ones.
+- **Agent re-applies its own taint on restart.** An agent can't taint the node it's
+  gating *before* it's running (the reboot/crash window is exactly when it is
+  absent), and making every agent a node-taint writer multiplies the write path and
+  races. A single leader-elected controller writer is simpler and covers the "agent
+  process entirely gone" case the agent itself can't.
+- **A flag for the grace period.** Proposal 031 retired the agent's flag surface;
+  30s is a well-understood roll-completion window. A constant keeps the operator
+  contract flat. If tuning is ever needed it can move to MeshConfig, not a flag.
+- **Rely on kubelet `register-with-taints` re-applying.** It doesn't (G1); the
+  kubelet applies register-taints once per Node object creation. Nothing external
+  re-arms on reboot — which is the entire motivation.
+- **A DaemonSet-only remover keyed on kubelet readiness.** k8s's not-ready taints
+  (G3) track kubelet Ready, not CNI-serving, so they'd remove the gate too early.
+```


### PR DESCRIPTION
Fixes #569.

## Problem

The `aether.io/agent-not-ready:NoSchedule` startup taint (#263) only ever fired at node registration, and its remover was one-shot at agent startup. The 2026-07-19 incident review found three gaps that leave a node schedulable while the agent is *not* serving:

- **G1** — a reboot never re-applies `register-with-taints`; the on-disk CNI config keeps the kubelet `Ready`, so the node schedules pods before the agent is back → `ContainerCreating` on fail-closed CNI ADDs.
- **G2** — removal was one-shot; a taint (re-)applied to a running node was never removed.
- **G3** — k8s's own not-ready taints track kubelet `NotReady`, not the aether "Ready but agent not serving" window.

## Design

Two cooperating controllers, split by write direction. No new flags (proposal 031); the grace period is a compiled constant.

- **Agent** (`agent/internal/node.TaintRemover`) — now a reconciler on its **own** Node (predicate-filtered by node name). Removes the taint whenever it is present **and** the CNI socket is serving (socket gate kept; requeues while CNI is down). `NeedLeaderElection=false`, best-effort. Closes **G2**. The pure `removeTaint` helper + its unit tests are preserved; `TaintRemover` stays exported (only wiring changed to `.SetupWithManager`).
- **Controller** (`controller/internal/nodetaint.Guard`) — new leader-elected guard. Watches Nodes + agent DS pods (`app.kubernetes.io/name=aether-agent`) and **adds** the taint on a node with no Ready agent pod past a **30s** grace, debounced so routine agent rolls don't flap it. **Never removes.** Closes **G1**. Control-plane nodes are handled data-driven: the guard only re-arms a node that has no Ready agent pod, and the agent DS has no control-plane toleration/nodeSelector, so control-plane nodes are naturally skipped.
- **Effect stays `NoSchedule`** — `NoExecute` rejected (it would evict mesh pods on every agent roll).

## Chart / RBAC

- Controller ClusterRole += `nodes [get,list,watch,patch]`, `pods [get,list,watch]`.
- Bumped aether chart `0.78.0` → `0.79.0`.

## Toleration audit

| workload | tolerates? |
|---|---|
| agent DS (incl. `cni-install` initContainer) | yes (existing) |
| aether-proxy DS | yes (existing) |
| controller / registrar / edge Deployments | yes (existing) |
| workload / test / conformance manifests | **no** (verified by repo-wide grep) |

The **external** SPIRE agent DaemonSet must also tolerate the taint — set it in the spire helm values under `spire-agent.tolerations` (documented in `values.yaml` and the proposal; this chart can't touch the external DS).

## Tests

`bazel test //agent/... //controller/...` — 33/33 pass. New unit tests: guard (missing agent → taint after grace; flap within grace → no taint; already-tainted → idempotent; never removes; other-node agent ignored; pod→node mapping) and reconciling remover (re-added taint → removed once socket present; socket absent → kept + requeued).

Proposal: `docs/proposals/033_node-taint-lifecycle.md`. Non-goal: container-restart waves (#567).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR