### PR TITLE
feat(agent): ghost-sweep prune circuit breaker + lost-ADD self-heal eviction (#566, #567)

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -35,6 +35,8 @@ go_library(
         "@build_buf_go_protovalidate//:protovalidate",
         "@com_github_grpc_ecosystem_go_grpc_middleware_v2//interceptors/protovalidate",
         "@io_k8s_api//core/v1:core",
+        "@io_k8s_api//policy/v1:policy",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/types",
         "@io_k8s_client_go//tools/cache",
         "@io_k8s_sigs_controller_runtime//pkg/cache",

--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Registry reconciliation (e2e findings, 2026-06-10).
@@ -38,6 +39,49 @@ import (
 // registering pod cannot be judged a ghost mid-flight.
 
 const ghostSweepInterval = 60 * time.Second
+
+// Prune circuit-breaker guards (#566, 2026-07-19 power-blip incident). A
+// transient netns-stat failure across the whole fleet must not be read as every
+// pod becoming a ghost at once.
+const (
+	// ghostNetnsFailThreshold is the number of CONSECUTIVE sweep passes a stored
+	// pod's netns check must fail before the pod is classified a stale-netns
+	// ghost. Hysteresis: a one-off (transient) stat failure resets on the next
+	// pass and never prunes. Orphan pruning (K8s pod authoritatively gone) is not
+	// gated by this — the API is ground truth.
+	ghostNetnsFailThreshold = 3
+
+	// pruneBreakerFraction is the fraction of stored pods a single pass may prune
+	// before the mass-delete breaker refuses the whole prune. Correlated
+	// netns-check failure (the incident) trips it; genuine churn does not (truly
+	// gone pods are gone from the API too and the API cross-check keeps a Running
+	// pod out of the prune set regardless of a netns stat failure).
+	pruneBreakerFraction = 0.30
+
+	// pruneBreakerMinPods is the absolute floor below which the fraction breaker
+	// does not apply — on a near-empty node pruning 1 of 2 pods is normal, not a
+	// mass event.
+	pruneBreakerMinPods = 2
+)
+
+// Lost-CNI-ADD self-heal guards (#567).
+const (
+	// lostAddEvictThreshold is the number of CONSECUTIVE sweep passes a live mesh
+	// pod must be observed missing from local storage before the agent evicts it
+	// to force sandbox recreation (a fresh CNI ADD). A single transient miss —
+	// e.g. a pod mid-ADD whose storage write lands just after the sweep read —
+	// never triggers eviction.
+	lostAddEvictThreshold = 3
+
+	// lostAddEvictPerPass caps evictions per sweep pass per node so a correlated
+	// loss can never evict the world in one tick — recovery stays gradual and
+	// PDB-bounded.
+	lostAddEvictPerPass = 2
+)
+
+// evictReason is the k8s Event reason recorded on a pod the agent evicts to
+// recover a lost CNI ADD.
+const evictReason = "AetherCNIAddLost"
 
 // sweptProtocols are the registry protocols the ghost sweep reconciles. Both
 // HTTP and TCP services are owned per node, so a missed deregistration of either
@@ -152,8 +196,9 @@ func (s *CNIServer) sweepGhostEndpoints(ctx context.Context) {
 	// empty list would nuke every entry), so that half is skipped this cycle.
 	nodePods, nodePodsOK := s.listNodePods(ctx)
 
-	pods, stalePruned, orphansPruned = s.pruneStaleStoragePods(ctx, pods, nodePods, nodePodsOK)
-	missingStorage = s.reportMissingStoragePods(ctx, pods, nodePods, nodePodsOK)
+	var breakerTripped bool
+	pods, stalePruned, orphansPruned, breakerTripped = s.pruneStaleStoragePods(ctx, pods, nodePods, nodePodsOK)
+	missingStorage = s.reportMissingStoragePods(ctx, pods, nodePods, nodePodsOK, breakerTripped)
 
 	live, terminating := s.classifyPods(pods)
 	ghostsRemoved = s.deregisterGhostEndpoints(ctx, all, live, terminating)
@@ -198,9 +243,10 @@ func (s *CNIServer) listRegistryEndpoints(ctx context.Context) (map[string][]*re
 }
 
 // pruneStaleStoragePods removes pods from storage whose network namespace is
-// gone or whose Kubernetes pod no longer exists. Returns the surviving pods
-// and the counts of stale and orphaned pods pruned.
-func (s *CNIServer) pruneStaleStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) ([]*cniv1.CNIPod, int, int) {
+// gone or whose Kubernetes pod no longer exists. Returns the surviving pods, the
+// counts of stale and orphaned pods pruned, and whether the mass-delete circuit
+// breaker refused the pass (#566, which the lost-ADD self-heal interlocks on).
+func (s *CNIServer) pruneStaleStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) ([]*cniv1.CNIPod, int, int, bool) {
 	// Prune storage entries that no longer correspond to a live pod: a missed CNI
 	// DEL left the file behind. Keeping it both re-registers a dead endpoint (the
 	// missing-direction loop would treat it as a live local pod) and makes Envoy
@@ -214,28 +260,153 @@ func (s *CNIServer) pruneStaleStoragePods(ctx context.Context, pods []*cniv1.CNI
 	// clusters (which carry the netns) — so the dead-netns cluster leaves the
 	// snapshot. The pruned pod's registry endpoints then fall through to ghost
 	// deregistration below.
+	//
+	// Circuit breaker (#566, 2026-07-19 power blip): a transient netns-stat
+	// failure hit every pod at once and the old logic pruned them all, wiping
+	// persistent storage with no self-recovery. Three guards now bound that:
+	// netns-only classification needs ghostNetnsFailThreshold consecutive failures
+	// (hysteresis), a pod the API still reports Running is never a ghost regardless
+	// of netns (cross-check), and a pass that would prune too large a fraction is
+	// refused wholesale (mass breaker).
+	candidates := s.classifyPruneCandidates(ctx, pods, nodePods, nodePodsOK)
+	if s.pruneBreakerTrips(ctx, len(pods), len(candidates)) {
+		// Refuse the whole pass. Keep every pod: truly-gone pods are also gone
+		// from the API, which the orphan cross-check catches once the correlated
+		// netns failure clears, so nothing is leaked permanently.
+		return pods, 0, 0, true
+	}
+	return s.applyPrune(ctx, pods, candidates)
+}
+
+// pruneCandidate marks a stored pod for pruning and why (orphaned = K8s pod gone,
+// which routes the log/metric and bypasses netns hysteresis).
+type pruneCandidate struct {
+	orphaned bool
+}
+
+// classifyPruneCandidates decides which stored pods this pass would prune,
+// applying the netns-failure hysteresis and the API cross-check. It returns the
+// prune set keyed by container ID and updates the per-pod netns-failure streaks
+// as a side effect (reset on a passing check or an API-confirmed live pod).
+func (s *CNIServer) classifyPruneCandidates(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) map[string]pruneCandidate {
+	if s.netnsFailStreaks == nil {
+		s.netnsFailStreaks = map[string]int{}
+	}
+	// Drop streaks for container IDs no longer in storage (removed pods) so the
+	// map can't grow unbounded across sweeps.
+	s.pruneVanishedNetnsStreaks(pods)
+	candidates := make(map[string]pruneCandidate)
+	for _, p := range pods {
+		id := p.GetContainerId()
+		netns := p.GetNetworkNamespace()
+		netnsGone := netns != "" && !netnsExists(netns)
+
+		// Orphaned = the K8s API no longer has this pod on this node. The API is
+		// ground truth, so this prunes immediately (no hysteresis).
+		if nodePodsOK && !podInNode(nodePods, p) {
+			delete(s.netnsFailStreaks, id)
+			candidates[id] = pruneCandidate{orphaned: true}
+			continue
+		}
+
+		if !netnsGone {
+			delete(s.netnsFailStreaks, id) // netns present: clear any streak
+			continue
+		}
+
+		// API cross-check (#566): a pod the API still reports Running with a live
+		// IP is NOT a ghost, whatever the netns stat says — the incident's exact
+		// false positive. Skip it and do not accrue a failure streak.
+		if nodePodsOK && podRunningWithIP(nodePods, p) {
+			delete(s.netnsFailStreaks, id)
+			s.log.WarnContext(ctx, "ghost sweep: netns check failed but pod is Running per the API; not pruning",
+				"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns)
+			continue
+		}
+
+		// Netns-gone hysteresis (#566): only classify as a ghost after N
+		// consecutive failed passes, so a transient stat failure never prunes.
+		s.netnsFailStreaks[id]++
+		if s.netnsFailStreaks[id] < ghostNetnsFailThreshold {
+			s.log.DebugContext(ctx, "ghost sweep: netns check failed; below prune threshold (hysteresis)",
+				"pod", p.GetName(), "namespace", p.GetNamespace(), "netns", netns,
+				"failures", s.netnsFailStreaks[id], "threshold", ghostNetnsFailThreshold)
+			continue
+		}
+		candidates[id] = pruneCandidate{orphaned: false}
+	}
+	return candidates
+}
+
+// pruneVanishedNetnsStreaks drops netns-failure streaks for container IDs no
+// longer present in storage, bounding the map to live pods.
+func (s *CNIServer) pruneVanishedNetnsStreaks(pods []*cniv1.CNIPod) {
+	if len(s.netnsFailStreaks) == 0 {
+		return
+	}
+	live := make(map[string]struct{}, len(pods))
+	for _, p := range pods {
+		live[p.GetContainerId()] = struct{}{}
+	}
+	for id := range s.netnsFailStreaks {
+		if _, ok := live[id]; !ok {
+			delete(s.netnsFailStreaks, id)
+		}
+	}
+}
+
+// pruneBreakerTrips reports whether pruning candidateCount of storedCount pods in
+// one pass exceeds the mass-delete circuit breaker (#566). It logs at ERROR and
+// increments a metric when it trips.
+func (s *CNIServer) pruneBreakerTrips(ctx context.Context, storedCount, candidateCount int) bool {
+	if candidateCount <= pruneBreakerMinPods {
+		return false
+	}
+	if float64(candidateCount) <= float64(storedCount)*pruneBreakerFraction {
+		return false
+	}
+	s.log.ErrorContext(ctx, "ghost sweep: prune circuit breaker TRIPPED; refusing to prune (correlated netns-check failure suspected — fix storage cause, not mass-delete)",
+		"would_prune", candidateCount, "stored", storedCount,
+		"fraction_limit", pruneBreakerFraction, "min_pods", pruneBreakerMinPods)
+	s.metrics.pruneBreakerTripped(ctx)
+	return true
+}
+
+// applyPrune removes the classified prune candidates from storage and drops
+// their listeners, returning the surviving pods and the stale/orphan counts.
+func (s *CNIServer) applyPrune(ctx context.Context, pods []*cniv1.CNIPod, candidates map[string]pruneCandidate) ([]*cniv1.CNIPod, int, int, bool) {
 	stalePruned, orphansPruned := 0, 0
 	fresh := pods[:0]
 	for _, p := range pods {
-		netns := p.GetNetworkNamespace()
-		netnsGone := netns != "" && !netnsExists(netns)
-		orphaned := nodePodsOK && !podInNode(nodePods, p)
-		if !netnsGone && !orphaned {
+		cand, isCandidate := candidates[p.GetContainerId()]
+		if !isCandidate {
 			fresh = append(fresh, p)
 			continue
 		}
-		kept, wasOrphaned := s.pruneOnePod(ctx, p, netns, orphaned)
+		kept, wasOrphaned := s.pruneOnePod(ctx, p, p.GetNetworkNamespace(), cand.orphaned)
 		if kept {
 			fresh = append(fresh, p)
 			continue
 		}
+		delete(s.netnsFailStreaks, p.GetContainerId())
 		if wasOrphaned {
 			orphansPruned++
 		} else {
 			stalePruned++
 		}
 	}
-	return fresh, stalePruned, orphansPruned
+	return fresh, stalePruned, orphansPruned, false
+}
+
+// podRunningWithIP reports whether the API's copy of a stored pod is Running,
+// not terminating, and has a pod IP — the state that makes a netns-stat failure a
+// false positive rather than a real missed CNI DEL (#566).
+func podRunningWithIP(nodePods map[string]*corev1.Pod, p *cniv1.CNIPod) bool {
+	kp, ok := nodePods[podKey(p.GetNamespace(), p.GetName())]
+	if !ok {
+		return false
+	}
+	return kp.Status.Phase == corev1.PodRunning && kp.DeletionTimestamp == nil && kp.Status.PodIP != ""
 }
 
 // pruneOnePod removes a single stale or orphaned pod from storage and drops its
@@ -261,41 +432,145 @@ func (s *CNIServer) pruneOnePod(ctx context.Context, p *cniv1.CNIPod, netns stri
 	return false, orphaned
 }
 
-// reportMissingStoragePods emits warnings for live mesh-managed K8s pods that
-// have no entry in local storage (a lost CNI ADD). Returns the count of such
-// pods found.
-func (s *CNIServer) reportMissingStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) int {
+// reportMissingStoragePods surfaces live mesh-managed K8s pods that have no
+// entry in local storage (a lost CNI ADD) and, after lostAddEvictThreshold
+// consecutive detections, evicts them to force a fresh CNI ADD (#567). Returns
+// the count of such pods found. breakerTripped skips eviction entirely (#566
+// interlock: mass loss means fix the storage cause, not evict the world).
+func (s *CNIServer) reportMissingStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool, breakerTripped bool) int {
 	// Surface live mesh-managed pods on this node that local storage has no entry
 	// for: a lost CNI ADD (talos worker-01, 2026-06-22: prober-k7vsm running with
 	// no listener). The agent has no CNI data (netns, IPs) to synthesize a
-	// listener, so it cannot self-heal — emit a metric + warning so the gap is
-	// visible (the pod must be rolled) instead of silently serving no listener.
+	// listener, so it cannot rebuild one in place — but CNI ADD reliably re-fires
+	// on sandbox recreation, so after a few confirming passes it evicts the pod
+	// (Eviction API, PDB-respecting, rate-limited) to trigger exactly that.
 	if !nodePodsOK {
+		// Without a trustworthy pod list we cannot tell missing from mid-ADD; drop
+		// all streaks so a list blip never accrues toward an eviction.
+		s.missingStorageStreaks = nil
 		return 0
 	}
-	missingStorage := 0
+	if s.missingStorageStreaks == nil {
+		s.missingStorageStreaks = map[string]int{}
+	}
 	stored := make(map[string]struct{}, len(pods))
 	for _, p := range pods {
 		stored[podKey(p.GetNamespace(), p.GetName())] = struct{}{}
 	}
+
+	missing := s.collectMissingStoragePods(stored, nodePods)
+	s.resetVanishedMissingStreaks(missing)
+
+	evictedThisPass := 0
+	for _, kp := range missing {
+		key := podKey(kp.GetNamespace(), kp.GetName())
+		s.missingStorageStreaks[key]++
+		streak := s.missingStorageStreaks[key]
+		s.log.WarnContext(ctx, "ghost sweep: live mesh pod missing from local storage (CNI ADD lost; pod has no listener)",
+			"pod", kp.GetName(), "namespace", kp.GetNamespace(), "podIP", kp.Status.PodIP,
+			"consecutive_sweeps", streak, "evict_threshold", lostAddEvictThreshold)
+
+		if breakerTripped {
+			continue // #566 interlock: never evict while the prune breaker tripped
+		}
+		if streak < lostAddEvictThreshold || evictedThisPass >= lostAddEvictPerPass {
+			continue
+		}
+		if s.evictLostAddPod(ctx, kp) {
+			evictedThisPass++
+			delete(s.missingStorageStreaks, key) // don't re-count until re-detected
+		}
+	}
+	return len(missing)
+}
+
+// collectMissingStoragePods returns this node's live mesh-managed pods (Running,
+// non-terminating, IP assigned) that local storage has no entry for — the lost
+// CNI ADD set. A Pending pod is mid-ADD and a terminating one mid-removal; both
+// have a legitimately transient gap and are excluded.
+func (s *CNIServer) collectMissingStoragePods(stored map[string]struct{}, nodePods map[string]*corev1.Pod) []*corev1.Pod {
+	var missing []*corev1.Pod
 	for key, kp := range nodePods {
 		if _, ok := stored[key]; ok {
 			continue
 		}
-		// Only a Running, non-terminating, mesh-managed pod is a genuine lost
-		// ADD; a Pending pod is mid-CNI-ADD and a terminating one is mid-removal
-		// — both have a legitimately transient storage gap.
 		if kp.Status.Phase != corev1.PodRunning || kp.DeletionTimestamp != nil {
 			continue
 		}
 		if !isMeshManagedK8sPod(kp) {
 			continue
 		}
-		missingStorage++
-		s.log.WarnContext(ctx, "ghost sweep: live mesh pod missing from local storage (CNI ADD lost; pod has no listener and must be rolled)",
-			"pod", kp.GetName(), "namespace", kp.GetNamespace(), "podIP", kp.Status.PodIP)
+		missing = append(missing, kp)
 	}
-	return missingStorage
+	return missing
+}
+
+// resetVanishedMissingStreaks drops streaks for pods no longer in the
+// missing set (they registered or disappeared) so a later recurrence starts
+// fresh from zero rather than instantly re-tripping the eviction threshold.
+func (s *CNIServer) resetVanishedMissingStreaks(missing []*corev1.Pod) {
+	stillMissing := make(map[string]struct{}, len(missing))
+	for _, kp := range missing {
+		stillMissing[podKey(kp.GetNamespace(), kp.GetName())] = struct{}{}
+	}
+	for key := range s.missingStorageStreaks {
+		if _, ok := stillMissing[key]; !ok {
+			delete(s.missingStorageStreaks, key)
+		}
+	}
+}
+
+// evictLostAddPod evicts a lost-CNI-ADD pod via the Eviction API to force
+// sandbox recreation (and a fresh CNI ADD), recording a k8s Event, a log line,
+// and a metric. Returns true if the eviction request was accepted.
+func (s *CNIServer) evictLostAddPod(ctx context.Context, kp *corev1.Pod) bool {
+	if s.evictPod == nil {
+		return false
+	}
+	if err := s.evictPod(ctx, kp.GetNamespace(), kp.GetName()); err != nil {
+		// A PDB block (429 TooManyRequests) is expected and benign — the pod stays
+		// in the missing set and eviction is retried on a later pass.
+		s.log.WarnContext(ctx, "ghost sweep: failed to evict lost-ADD pod; will retry",
+			"pod", kp.GetName(), "namespace", kp.GetNamespace(), "error", err)
+		return false
+	}
+	s.recordPodEvent(ctx, kp, evictReason,
+		"aether agent evicted this pod: CNI ADD was lost (no mesh listener); eviction forces sandbox recreation to re-run CNI ADD")
+	s.metrics.lostAddEvicted(ctx)
+	s.log.InfoContext(ctx, "ghost sweep: evicted lost-ADD pod to force CNI re-ADD",
+		"pod", kp.GetName(), "namespace", kp.GetNamespace(), "podIP", kp.Status.PodIP)
+	return true
+}
+
+// recordPodEvent writes a Warning Event on a pod (best-effort). The agent has no
+// EventRecorder wired, so it creates the corev1.Event directly via the client.
+func (s *CNIServer) recordPodEvent(ctx context.Context, kp *corev1.Pod, reason, message string) {
+	if s.k8sClient == nil {
+		return
+	}
+	now := metav1.Now()
+	ev := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: kp.GetName() + ".",
+			Namespace:    kp.GetNamespace(),
+		},
+		InvolvedObject: corev1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: kp.GetNamespace(),
+			Name:      kp.GetName(),
+			UID:       kp.GetUID(),
+		},
+		Reason:         reason,
+		Message:        message,
+		Type:           corev1.EventTypeWarning,
+		Source:         corev1.EventSource{Component: "aether-agent"},
+		FirstTimestamp: now,
+		LastTimestamp:  now,
+		Count:          1,
+	}
+	if err := s.k8sClient.Create(ctx, ev); err != nil {
+		s.log.DebugContext(ctx, "ghost sweep: failed to record eviction event", "pod", kp.GetName(), "error", err)
+	}
 }
 
 // classifyPods splits a slice of stored pods into a live-by-IP map and a

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -114,7 +115,9 @@ func TestSweepGhostEndpoints(t *testing.T) {
 
 // TestSweepPrunesStalePods: a stored pod whose network namespace no longer
 // exists (a missed CNI DEL) is removed from storage and its registry endpoint
-// deregistered; a live pod is untouched.
+// deregistered; a live pod is untouched. Since #566 a stale-netns pod is only
+// pruned after ghostNetnsFailThreshold consecutive failed passes (hysteresis),
+// so this drives the sweep to the threshold.
 func TestSweepPrunesStalePods(t *testing.T) {
 	ctx := context.Background()
 
@@ -140,6 +143,13 @@ func TestSweepPrunesStalePods(t *testing.T) {
 	}}
 	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
 
+	// Below the threshold the pod survives (hysteresis).
+	for i := 1; i < ghostNetnsFailThreshold; i++ {
+		s.sweepGhostEndpoints(ctx)
+		_, err := store.GetResource(ctx, types.ContainerID("container-stale"))
+		require.NoError(t, err, "stale pod kept below the netns-fail threshold (pass %d)", i)
+	}
+	// The threshold pass prunes it.
 	s.sweepGhostEndpoints(ctx)
 
 	_, err := store.GetResource(ctx, types.ContainerID("container-stale"))
@@ -284,4 +294,249 @@ func TestSweepPrefersAuthoritativeListing(t *testing.T) {
 
 	_, ok := reg.registered["default/default/10.0.0.1"]
 	require.True(t, ok, "sweep must re-register from the authoritative (empty) listing, not the stale cache")
+}
+
+// runningK8sPod returns a mesh-managed Kubernetes pod that is Running with an
+// assigned IP — the state the #566 API cross-check treats as "not a ghost".
+func runningK8sPod(name, namespace, ip string) *corev1.Pod {
+	p := validK8sPod(name, namespace)
+	p.Status.Phase = corev1.PodRunning
+	p.Status.PodIP = ip
+	return p
+}
+
+// TestSweepHysteresisTransientNetnsFailure (#566): a single (or below-threshold)
+// run of failed netns checks must NOT prune — only ghostNetnsFailThreshold
+// CONSECUTIVE failures do. A passing check in between resets the streak.
+func TestSweepHysteresisTransientNetnsFailure(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+
+	pod := validCNIPod("pod-a", "default", "container-a")
+	pod.NetworkNamespace = "/run/aether/netns/a"
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-a"), pod))
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	// No k8s client: the netns-only path (no orphan/cross-check) is exercised.
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	// Two failed passes: below threshold, pod kept.
+	netnsExists = func(string) bool { return false }
+	for i := 1; i < ghostNetnsFailThreshold; i++ {
+		s.sweepGhostEndpoints(ctx)
+		_, err := store.GetResource(ctx, types.ContainerID("container-a"))
+		require.NoError(t, err, "pod kept below threshold (pass %d)", i)
+	}
+
+	// A passing check resets the streak: the prior failures no longer count.
+	netnsExists = func(string) bool { return true }
+	s.sweepGhostEndpoints(ctx)
+	assert.NotContains(t, s.netnsFailStreaks, "container-a", "passing netns check resets the streak")
+
+	// One more failure after the reset is again below threshold -> still kept.
+	netnsExists = func(string) bool { return false }
+	s.sweepGhostEndpoints(ctx)
+	_, err := store.GetResource(ctx, types.ContainerID("container-a"))
+	require.NoError(t, err, "streak restarted after the reset; single failure never prunes")
+}
+
+// TestSweepAPICrossCheckVetoesPrune (#566): a pod whose netns check fails but
+// which the K8s API still reports Running with a live IP is NOT a ghost — it is
+// never pruned no matter how many passes fail, and never accrues a streak.
+func TestSweepAPICrossCheckVetoesPrune(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	netnsExists = func(string) bool { return false } // every netns check fails
+
+	pod := validCNIPod("pod-running", "default", "container-running")
+	pod.NetworkNamespace = "/run/aether/netns/running"
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-running"), pod))
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	// API says the pod is Running with an IP -> cross-check veto.
+	k8s := fake.NewClientBuilder().WithObjects(runningK8sPod("pod-running", "default", "10.0.0.1")).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	for i := 0; i < ghostNetnsFailThreshold+2; i++ {
+		s.sweepGhostEndpoints(ctx)
+	}
+
+	_, err := store.GetResource(ctx, types.ContainerID("container-running"))
+	require.NoError(t, err, "Running-per-API pod is never pruned despite netns stat failures")
+	assert.NotContains(t, s.netnsFailStreaks, "container-running", "cross-check veto never accrues a failure streak")
+}
+
+// TestSweepMassBreakerRefusesPrune (#566): a pass that would prune more than
+// pruneBreakerFraction of stored pods (and more than pruneBreakerMinPods
+// absolute) is refused wholesale — no pod is removed and the breaker metric
+// increments. Simulates the incident: every pod's netns check fails at once.
+func TestSweepMassBreakerRefusesPrune(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	netnsExists = func(string) bool { return false } // all netns checks fail (the blip)
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	const n = 10
+	for i := 0; i < n; i++ {
+		id := "container-" + string(rune('a'+i))
+		p := validCNIPod("pod-"+string(rune('a'+i)), "default", id)
+		p.NetworkNamespace = "/run/aether/netns/" + id
+		p.Ips = []string{"10.0.1." + string(rune('0'+i))}
+		require.NoError(t, store.AddResource(ctx, types.ContainerID(id), p))
+	}
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	// No k8s client: nothing vetoes, so all n pods are candidates once past
+	// hysteresis — exactly the correlated-failure case the breaker guards.
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	// Drive past the hysteresis threshold; the breaker must refuse every pass.
+	for i := 0; i < ghostNetnsFailThreshold+1; i++ {
+		s.sweepGhostEndpoints(ctx)
+	}
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, n, "mass-delete breaker refused the prune; every pod kept")
+}
+
+// TestSweepMassBreakerMetricAndInterlock (#566 + #567): when the mass breaker
+// trips, the breaker metric increments and lost-ADD eviction is skipped in the
+// same pass (interlock).
+func TestSweepMassBreakerMetricAndInterlock(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	netnsExists = func(string) bool { return false }
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	const n = 10
+	objs := make([]client.Object, 0, n)
+	for i := 0; i < n; i++ {
+		id := "container-" + string(rune('a'+i))
+		name := "pod-" + string(rune('a'+i))
+		p := validCNIPod(name, "default", id)
+		p.NetworkNamespace = "/run/aether/netns/" + id
+		p.Ips = []string{"10.0.2." + string(rune('0'+i))}
+		require.NoError(t, store.AddResource(ctx, types.ContainerID(id), p))
+		// The API still reports every pod Running WITHOUT an IP so the cross-check
+		// does not veto (podRunningWithIP requires an IP) — the pods remain prune
+		// candidates and the breaker must trip.
+		kp := runningK8sPod(name, "default", "")
+		objs = append(objs, kp)
+	}
+	// One extra live mesh pod that is missing from storage -> a lost-ADD that
+	// WOULD be a candidate for eviction if the breaker had not tripped.
+	objs = append(objs, runningK8sPod("pod-missing", "default", "10.9.9.9"))
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	k8s := fake.NewClientBuilder().WithObjects(objs...).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	m, reader := newTestCNIMetrics(t)
+	s.metrics = m
+
+	evictions := 0
+	s.evictPod = func(context.Context, string, string) error { evictions++; return nil }
+
+	for i := 0; i < ghostNetnsFailThreshold+lostAddEvictThreshold+2; i++ {
+		s.sweepGhostEndpoints(ctx)
+	}
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, n, "breaker refused prune; every stored pod kept")
+	assert.Zero(t, evictions, "eviction is interlocked off while the breaker trips")
+
+	tripped, found := metricSum(t, reader, "aether.agent.ghost_sweep.prune_breaker_tripped")
+	require.True(t, found, "breaker metric recorded")
+	assert.Positive(t, tripped, "breaker tripped at least once")
+}
+
+// TestSweepEvictsLostAddPodAfterThreshold (#567): a live mesh pod missing from
+// local storage is evicted only after lostAddEvictThreshold consecutive sweeps,
+// via the Eviction API, and its streak resets after eviction.
+func TestSweepEvictsLostAddPodAfterThreshold(t *testing.T) {
+	ctx := context.Background()
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]() // storage empty: the ADD was lost
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	k8s := fake.NewClientBuilder().WithObjects(runningK8sPod("pod-lost", "default", "10.0.0.7")).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	var evicted []string
+	s.evictPod = func(_ context.Context, ns, name string) error {
+		evicted = append(evicted, ns+"/"+name)
+		return nil
+	}
+
+	// Below the threshold: warned, not evicted.
+	for i := 1; i < lostAddEvictThreshold; i++ {
+		s.sweepGhostEndpoints(ctx)
+		assert.Empty(t, evicted, "not evicted below threshold (pass %d)", i)
+	}
+	// Threshold pass: evicted once.
+	s.sweepGhostEndpoints(ctx)
+	assert.Equal(t, []string{"default/pod-lost"}, evicted, "evicted at the threshold")
+	assert.NotContains(t, s.missingStorageStreaks, podKey("default", "pod-lost"), "streak reset after eviction")
+}
+
+// TestSweepLostAddEvictionRateLimited (#567): at most lostAddEvictPerPass pods
+// are evicted in a single sweep pass even when many are eligible.
+func TestSweepLostAddEvictionRateLimited(t *testing.T) {
+	ctx := context.Background()
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]() // all ADDs lost
+	objs := make([]client.Object, 0, 5)
+	for i := 0; i < 5; i++ {
+		objs = append(objs, runningK8sPod("pod-"+string(rune('a'+i)), "default", "10.0.3."+string(rune('0'+i))))
+	}
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	k8s := fake.NewClientBuilder().WithObjects(objs...).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	evictionsPerPass := 0
+	maxPerPass := 0
+	s.evictPod = func(context.Context, string, string) error { evictionsPerPass++; return nil }
+
+	for i := 0; i < lostAddEvictThreshold+3; i++ {
+		evictionsPerPass = 0
+		s.sweepGhostEndpoints(ctx)
+		if evictionsPerPass > maxPerPass {
+			maxPerPass = evictionsPerPass
+		}
+	}
+	assert.LessOrEqual(t, maxPerPass, lostAddEvictPerPass, "evictions are rate-limited per pass")
+	assert.Positive(t, maxPerPass, "some eviction happened once the threshold was crossed")
+}
+
+// TestSweepLostAddStreakResetsOnRecovery (#567): once a missing pod appears in
+// storage (CNI ADD re-ran) its streak resets, so a later recurrence must again
+// clear the full threshold before another eviction.
+func TestSweepLostAddStreakResetsOnRecovery(t *testing.T) {
+	ctx := context.Background()
+
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	k8s := fake.NewClientBuilder().WithObjects(runningK8sPod("pod-x", "default", "10.0.0.1")).Build()
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+
+	evictions := 0
+	s.evictPod = func(context.Context, string, string) error { evictions++; return nil }
+
+	// One below-threshold miss, then the pod registers (ADD lands): streak clears.
+	s.sweepGhostEndpoints(ctx)
+	require.Equal(t, 1, s.missingStorageStreaks[podKey("default", "pod-x")])
+	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-x"), validCNIPod("pod-x", "default", "container-x")))
+	s.sweepGhostEndpoints(ctx)
+	assert.NotContains(t, s.missingStorageStreaks, podKey("default", "pod-x"), "streak reset once the pod registered")
+	assert.Zero(t, evictions, "no eviction after recovery")
 }

--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -30,6 +30,8 @@ type cniMetrics struct {
 	orphansPruned     metric.Int64Counter
 	missingStorage    metric.Int64Counter
 	sweepErrors       metric.Int64Counter
+	pruneBreaker      metric.Int64Counter
+	lostAddEvictions  metric.Int64Counter
 	storagePods       metric.Int64Gauge
 	healthTransitions metric.Int64Counter
 	promotionDelay    metric.Float64Histogram
@@ -63,6 +65,14 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 	if m.sweepErrors, err = meter.Int64Counter("aether.agent.ghost_sweep.errors",
 		metric.WithDescription("Ghost sweep cycles that failed before reconciling")); err != nil {
 		return nil, fmt.Errorf("sweep errors: %w", err)
+	}
+	if m.pruneBreaker, err = meter.Int64Counter("aether.agent.ghost_sweep.prune_breaker_tripped",
+		metric.WithDescription("Ghost sweep passes whose mass-delete circuit breaker refused to prune (correlated netns-check failure suspected)")); err != nil {
+		return nil, fmt.Errorf("prune breaker: %w", err)
+	}
+	if m.lostAddEvictions, err = meter.Int64Counter("aether.agent.ghost_sweep.lost_add_evictions",
+		metric.WithDescription("Pods evicted by the ghost sweep to force a fresh CNI ADD after a lost one left them with no mesh listener")); err != nil {
+		return nil, fmt.Errorf("lost add evictions: %w", err)
 	}
 	if m.storagePods, err = meter.Int64Gauge("aether.agent.storage.pods",
 		metric.WithDescription("Pods currently tracked in the agent's local file storage")); err != nil {
@@ -105,6 +115,23 @@ func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingR
 		m.missingStorage.Add(ctx, int64(missingStorage))
 	}
 	m.storagePods.Record(ctx, int64(storedPods))
+}
+
+// pruneBreakerTripped records a sweep pass whose mass-delete circuit breaker
+// refused to prune (#566).
+func (m *cniMetrics) pruneBreakerTripped(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.pruneBreaker.Add(ctx, 1)
+}
+
+// lostAddEvicted records a pod evicted to force a fresh CNI ADD (#567).
+func (m *cniMetrics) lostAddEvicted(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.lostAddEvictions.Add(ctx, 1)
 }
 
 func (m *cniMetrics) healthTransition(ctx context.Context, from, to string) {

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -22,6 +22,8 @@ import (
 	"go.opentelemetry.io/otel"
 	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -83,6 +85,27 @@ type CNIServer struct {
 	// drainPoolCloseDelay separates the two drain phases (see
 	// schedulePoolClose); overridable in tests.
 	drainPoolCloseDelay time.Duration
+
+	// netnsFailStreaks counts, per container ID, consecutive ghost-sweep passes
+	// whose netns-liveness check failed. A stored pod is classified a
+	// stale-netns ghost only after ghostNetnsFailThreshold consecutive failures
+	// (hysteresis), so a transient fleet-wide stat failure — the 2026-07-19
+	// power-blip signature — cannot mass-prune live pods (#566). Reset the moment
+	// a netns check passes or the pod leaves storage. Accessed only under
+	// lifecycleMu (the sweep holds it across the prune).
+	netnsFailStreaks map[string]int
+
+	// missingStorageStreaks counts, per namespace/name, consecutive ghost-sweep
+	// passes a live mesh pod was found missing from local storage (a lost CNI
+	// ADD). After lostAddEvictThreshold passes the agent evicts the pod to force
+	// sandbox recreation and a fresh CNI ADD (#567). Reset when the pod registers
+	// or disappears. Accessed only under lifecycleMu.
+	missingStorageStreaks map[string]int
+
+	// evictPod evicts a pod via the Kubernetes Eviction API (policy/v1,
+	// PDB-respecting). Overridable in tests (the fake client has no eviction
+	// subresource). Nil disables self-heal eviction.
+	evictPod func(ctx context.Context, namespace, name string) error
 }
 
 var _ xds.ServerCallback = (*CNIServer)(nil)
@@ -123,6 +146,15 @@ func NewCNIServer(clusterName string, nodeName string, trustDomain string, local
 		ackTracker:          ackTracker,
 		spireBridge:         spireBridge,
 		healthClient:        newHealthGatewayClient(cfg.ProxyHealthSocketPath),
+	}
+	// Self-heal lost-CNI-ADD pods via the Eviction API (#567): PDB-respecting, so
+	// a real deploy's disruption budget still applies. Nil client => no eviction.
+	if k8sClient != nil {
+		cniSrv.evictPod = func(ctx context.Context, namespace, name string) error {
+			return k8sClient.SubResource("eviction").Create(ctx,
+				&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}},
+				&policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}})
+		}
 	}
 
 	cniSrv.AddCallback(cniSrv)

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.79.0-{GIT_COMMIT}"
+version: "0.80.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.78.0-{GIT_COMMIT}"
+version: "0.79.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -8,6 +8,17 @@ rules:
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["list", "get", "watch"]
+  # Self-heal lost CNI ADDs (#567): evict a live mesh pod that has no local
+  # storage entry (no mesh listener) so sandbox recreation re-runs CNI ADD. The
+  # Eviction API is PDB-respecting; the ghost sweep rate-limits and interlocks it
+  # behind the prune circuit breaker.
+  - apiGroups: ["policy"]
+    resources: ["pods/eviction"]
+    verbs: ["create"]
+  # Record a Warning Event on a pod when the agent evicts it for a lost CNI ADD.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create"]
   - apiGroups: [""]
     resources: ["nodes"]
     # patch: remove the aether.io/agent-not-ready startup taint once CNI is serving.


### PR DESCRIPTION
## Summary

Hardens the CNI ghost sweep against the 2026-07-19 power-blip incident, where a transient fleet-wide netns-check failure made the prune classify **every** stored pod as a ghost and wipe persistent storage on all nodes — a total mesh egress outage with no self-recovery (container restarts never re-run CNI ADD).

Fixes #566 — prune circuit breaker (root cause).
Fixes #567 — self-heal lost-CNI-ADD pods.

Extends the small phase-helper structure introduced in #561.

### #566 — prune circuit breaker
- **Hysteresis**: a netns-gone pod is only classified a ghost after `ghostNetnsFailThreshold = 3` **consecutive** failed sweep passes. A passing check (or an API-confirmed-live pod) resets the per-container streak. Orphan pruning (K8s pod authoritatively gone) is *not* gated — the API is ground truth.
- **API cross-check**: before pruning on a netns failure, if the pod list the sweep already fetches reports the pod `Running` with a live IP, it is *not* a ghost — skipped and logged. This vetoes the incident's exact false positive.
- **Mass-delete breaker**: a pass that would prune more than `pruneBreakerFraction = 0.30` of stored pods **and** more than `pruneBreakerMinPods = 2` absolute is refused wholesale — logged at ERROR with the would-be count and a `prune_breaker_tripped` metric. Every pod is kept. Manual recovery is unaffected: truly-gone pods are gone from the API too, which the orphan cross-check prunes once the correlated failure clears.

### #567 — lost-ADD self-heal
- A live mesh pod missing from local storage (lost CNI ADD) is evicted via the **Eviction API** (`policy/v1`, PDB-respecting) after `lostAddEvictThreshold = 3` consecutive detections, forcing sandbox recreation and a fresh CNI ADD.
- Rate-limited to `lostAddEvictPerPass = 2` evictions per sweep per node. Emits a `AetherCNIAddLost` Warning Event on the pod + log + `lost_add_evictions` metric. Streaks reset when the pod registers or disappears.
- **Interlock**: eviction is skipped entirely in any pass where the #566 mass breaker tripped (mass loss = fix the storage cause, not evict the world).
- **RBAC**: agent ClusterRole gains `policy/pods/eviction` create and `events` create. Chart base version bumped `0.78.0 → 0.79.0`.

## Incident replay under the new logic
1. Power blip: netns stat fails for all N pods simultaneously; sandboxes survive; API still reports every pod `Running` with its IP.
2. **API cross-check** vetoes every pod immediately — Running-per-API ⇒ not a ghost. Zero prune candidates, zero streaks accrued. (Even absent the API, hysteresis would hold them for 3 passes, and the mass breaker would refuse the pass on pass 3.)
3. Storage is untouched; listeners stay; mesh egress continues. No outage.
4. If instead a pod genuinely lost its ADD, it accrues a missing-storage streak and, after 3 passes (breaker not tripped), is evicted — the sandbox is recreated and CNI ADD re-registers it. Self-healed with no manual roll.

## Tests
Table-driven, using the package's existing fakes: hysteresis (below-threshold kept, threshold prunes, passing-check reset), API-cross-check veto, mass-breaker trip + metric + eviction interlock, eviction after M sweeps, per-pass rate limit, streak reset on recovery. Existing `TestSweepPrunesStalePods` adapted to drive past the hysteresis threshold (intent preserved). Full `//agent/...` suite green (non-race; `TestHandlePodTerminatingPoolClosePhase` is the known #554 -race flake, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR
