### PR TITLE
fix(controller): node-taint guard skips nodes with no agent pod object

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.80.0-{GIT_COMMIT}"
+version: "0.81.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/controller/internal/nodetaint/guard.go
+++ b/controller/internal/nodetaint/guard.go
@@ -96,9 +96,18 @@ func (g *Guard) Reconcile(ctx context.Context, req reconcile.Request) (reconcile
 		return reconcile.Result{}, err
 	}
 
-	ready, err := g.hasReadyAgent(ctx, req.Name)
+	exists, ready, err := g.agentPodState(ctx, req.Name)
 	if err != nil {
 		return reconcile.Result{}, err
+	}
+	if !exists {
+		// No agent pod OBJECT for this node at all: the DaemonSet controller
+		// does not consider the node eligible (control-plane taint without a
+		// toleration, cordon+drain, ...). The guard must not manage such nodes —
+		// no agent will ever remove the taint there, and tainting a node the
+		// mesh doesn't cover is not this controller's call.
+		g.forget(req.Name)
+		return reconcile.Result{}, nil
 	}
 	if ready {
 		// A serving agent is present. Clear the debounce; the agent removes the
@@ -128,23 +137,29 @@ func (g *Guard) Reconcile(ctx context.Context, req reconcile.Request) (reconcile
 	return reconcile.Result{}, nil
 }
 
-// hasReadyAgent reports whether a Ready agent pod is running on the given node.
-func (g *Guard) hasReadyAgent(ctx context.Context, nodeName string) (bool, error) {
+// agentPodState reports whether any agent pod object is assigned to the given
+// node (regardless of phase — the DaemonSet controller creates the pod for every
+// eligible node), and whether a non-terminating Ready one is among them.
+func (g *Guard) agentPodState(ctx context.Context, nodeName string) (exists, ready bool, err error) {
 	var pods corev1.PodList
 	if err := g.Client.List(
 		ctx, &pods,
 		client.InNamespace(g.AgentNamespace),
 		client.MatchingLabels{agentNameLabel: agentNameValue},
 	); err != nil {
-		return false, err
+		return false, false, err
 	}
 	for i := range pods.Items {
 		p := &pods.Items[i]
-		if p.Spec.NodeName == nodeName && p.DeletionTimestamp == nil && podReady(p) {
-			return true, nil
+		if p.Spec.NodeName != nodeName {
+			continue
+		}
+		exists = true
+		if p.DeletionTimestamp == nil && podReady(p) {
+			return true, true, nil
 		}
 	}
-	return false, nil
+	return exists, false, nil
 }
 
 // remainingGrace returns how long is left in the grace window for a node observed

--- a/controller/internal/nodetaint/guard_test.go
+++ b/controller/internal/nodetaint/guard_test.go
@@ -99,10 +99,11 @@ func TestReadyAgent(t *testing.T) {
 	})
 }
 
-// TestMissingAgentArmsAfterGrace: no Ready agent pod -> taint armed only after
-// the grace window elapses (first reconcile debounces).
+// TestMissingAgentArmsAfterGrace: an agent pod that exists but is not Ready (the
+// rebooted-node reality — the DaemonSet pod object persists) -> taint armed only
+// after the grace window elapses (first reconcile debounces).
 func TestMissingAgentArmsAfterGrace(t *testing.T) {
-	g, c := newGuard(t, node(nodeName, false)) // no agent pods at all
+	g, c := newGuard(t, node(nodeName, false), agentPod("a", nodeName, false))
 
 	// First observation: debounce, do NOT taint yet.
 	res := reconcileNode(t, g)
@@ -162,9 +163,9 @@ func TestIdempotentWhenAlreadyTainted(t *testing.T) {
 }
 
 // TestOtherNodeAgentIgnored: a Ready agent pod on a DIFFERENT node does not count
-// for this node.
+// for this node (which has its own not-Ready agent pod).
 func TestOtherNodeAgentIgnored(t *testing.T) {
-	g, c := newGuard(t, node(nodeName, false), agentPod("b", "node-b", true))
+	g, c := newGuard(t, node(nodeName, false), agentPod("a", nodeName, false), agentPod("b", "node-b", true))
 
 	res := reconcileNode(t, g)
 	assert.False(t, tainted(t, c), "still debouncing on first observation")
@@ -176,6 +177,26 @@ func TestOtherNodeAgentIgnored(t *testing.T) {
 
 	reconcileNode(t, g)
 	assert.True(t, tainted(t, c), "an agent on another node must not satisfy this node")
+}
+
+// TestIneligibleNodeNeverTainted: a node with NO agent pod object at all (the
+// DaemonSet does not consider it eligible — control-plane taint without a
+// toleration, cordon+drain) must never be tainted: no agent would ever remove
+// the taint there. Regression test for the guard tainting main-cp-01.
+func TestIneligibleNodeNeverTainted(t *testing.T) {
+	g, c := newGuard(t, node(nodeName, false)) // no agent pod object for this node
+
+	res := reconcileNode(t, g)
+	assert.False(t, tainted(t, c))
+	assert.Zero(t, res.RequeueAfter, "ineligible nodes are not requeued")
+
+	// Even with a long-elapsed debounce window the guard must not arm.
+	g.mu.Lock()
+	g.missingSince[nodeName] = time.Now().Add(-2 * grace)
+	g.mu.Unlock()
+
+	reconcileNode(t, g)
+	assert.False(t, tainted(t, c), "a node the agent DS does not cover must never be tainted")
 }
 
 // TestPodToNode maps agent-pod events to their node, and ignores non-agent /


### PR DESCRIPTION
Found on talos immediately after deploying #571: the guard tainted `main-cp-01` (no agent DS pod there → 'no Ready agent' forever → permanent foreign taint that re-arms on every reconcile). Eligibility now keys on the existence of an agent pod OBJECT for the node — the DS controller creates one for every eligible node and it persists across reboots, so G1 coverage is unchanged. Regression test added; the missing-agent tests now model the rebooted-node reality (pod exists, not Ready). Chart 0.81.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR