### PR TITLE
fix(rbac): pods/eviction under core apiGroup, not policy (#567 self-heal was 403ing)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.81.0-{GIT_COMMIT}"
+version: "0.82.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-rbac.yaml
+++ b/charts/aether/templates/agent-rbac.yaml
@@ -12,7 +12,10 @@ rules:
   # storage entry (no mesh listener) so sandbox recreation re-runs CNI ADD. The
   # Eviction API is PDB-respecting; the ghost sweep rate-limits and interlocks it
   # behind the prune circuit breaker.
-  - apiGroups: ["policy"]
+  # NOTE: the pods/eviction subresource create is authorized under the CORE ("")
+  # apiGroup, NOT "policy" — despite the Eviction object being policy/v1. Using
+  # "policy" here silently 403s every eviction (found via a node-reboot G1 test).
+  - apiGroups: [""]
     resources: ["pods/eviction"]
     verbs: ["create"]
   # Record a Warning Event on a pod when the agent evicts it for a lost CNI ADD.


### PR DESCRIPTION
## The bug
#572's agent ClusterRole granted `pods/eviction` create under `apiGroups: ["policy"]`. But Kubernetes authorizes the eviction **subresource** create under the **core (`""`) apiGroup** — the Eviction object is `policy/v1`, but the RBAC check is against `pods/eviction` in group `""`. So every ghost-sweep self-heal eviction silently 403'd, making the #567 lost-CNI-ADD self-heal **non-functional as shipped**.

## How it was found
A node-reboot G1 validation (rebooted main-worker-05): a prober pod came back with its CNI ADD lost (no mesh listener), the self-heal correctly detected it (`consecutive_sweeps:7 > threshold:3`) and tried to evict it — and got `pods "prober-r26fl" is forbidden: ... cannot create resource "pods/eviction" in ... namespace "aether-test"`. The pod stayed mesh-broken (5/s prober connection_error) until manually rolled — i.e. the exact power-blip failure mode #567 was meant to auto-heal.

One-line fix: `apiGroups: ["policy"]` → `apiGroups: [""]`. Chart 0.82.0. (The taint-lifecycle half of the same reboot test passed cleanly — guard re-armed at +30s, agent removed it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR