### PR TITLE
feat(prober): add mesh_dns tier that resolves service names to close the DNS blind spot

### DIFF
--- a/charts/prober/templates/_helpers.tpl
+++ b/charts/prober/templates/_helpers.tpl
@@ -63,3 +63,23 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Upstream authorization list (config.aether.io/upstreams, proposal 004).
+
+Unions the reachability tier's echo service names with the mesh_dns tier's
+resolved authorities: a mesh_dns target dials a real ClusterIP, so its upstream
+cluster must be authorized too. Each mesh_dns FQDN is reduced to its host (the
+":port" is dropped) since authorization keys on the authority, not the port.
+Empty when neither tier is configured.
+*/}}
+{{- define "prober.upstreams" -}}
+{{- $u := list -}}
+{{- range .Values.probe.reachabilityTargets -}}
+{{- $u = append $u . -}}
+{{- end -}}
+{{- range .Values.probe.meshDNSTargets -}}
+{{- $u = append $u (splitList ":" . | first) -}}
+{{- end -}}
+{{- join "," $u -}}
+{{- end -}}

--- a/charts/prober/templates/daemonset.yaml
+++ b/charts/prober/templates/daemonset.yaml
@@ -16,10 +16,13 @@ spec:
         # Mesh injection: the CNI intercepts this pod and the agent plumbs the
         # per-pod egress listener at {{ .Values.probe.egress }}.
         aether.io/managed: "true"
-      {{- with .Values.probe.reachabilityTargets }}
+      {{- $upstreams := include "prober.upstreams" . }}
+      {{- with $upstreams }}
       annotations:
-        # Reachability tier only: authorize the echo upstream clusters (proposal 004).
-        config.aether.io/upstreams: {{ join "," . | quote }}
+        # Authorize the upstream clusters the reachability and mesh_dns tiers dial
+        # (proposal 004). The mesh_dns tier resolves a real ClusterIP, so its
+        # upstream must be authorized here too.
+        config.aether.io/upstreams: {{ . | quote }}
       {{- end }}
     spec:
       serviceAccountName: {{ include "prober.serviceAccountName" . }}
@@ -36,6 +39,12 @@ spec:
             - "--timeout={{ .Values.probe.timeout }}"
             {{- with .Values.probe.reachabilityTargets }}
             - "--reachability-targets={{ join "," . }}"
+            {{- end }}
+            {{- with .Values.probe.meshDNSTargets }}
+            # mesh_dns tier: these FQDNs are RESOLVED through the mesh DNS path (not
+            # Host-overridden), so a mesh-DNS outage surfaces as an alertable dns_*
+            # result — closing the blind spot behind issue #574.
+            - "--mesh-dns-targets={{ join "," . }}"
             {{- end }}
             {{- with .Values.telemetry.otlpEndpoint }}
             - "--otlp-endpoint={{ . }}"

--- a/charts/prober/values.yaml
+++ b/charts/prober/values.yaml
@@ -32,6 +32,14 @@ probe:
   # Optional reachability tier: echo upstream service names. When non-empty, the
   # pod gets config.aether.io/upstreams so the agent programs those clusters.
   reachabilityTargets: []
+  # Optional mesh_dns tier: namespace-qualified FQDN authorities (host[:port],
+  # default port 18081). Unlike liveness/reachability these are RESOLVED through the
+  # mesh DNS path (CNI :53 DNAT → agent resolver → ClusterIP) rather than being
+  # Host-overridden, so a real mesh-DNS outage becomes an alertable dns_* signal
+  # (closes the blind spot behind issue #574). Only works because this pod is
+  # mesh-managed. Each target's host is also added to config.aether.io/upstreams.
+  meshDNSTargets:
+    - "echo.aether-test.aether.internal:18081"
 
 # OTel: push the probe SLI to the collector (host:port, insecure). Empty disables
 # telemetry (the prober still runs but emits nothing).

--- a/prober/internal/cmd/root.go
+++ b/prober/internal/cmd/root.go
@@ -37,6 +37,7 @@ func GetCommand() *cobra.Command {
 	f.StringVar(&cfg.LivenessAuthority, "liveness-authority", cfg.LivenessAuthority, "reserved Host authority for the liveness probe (must not be a real service)")
 	f.StringVar(&cfg.MeshDomain, "mesh-domain", cfg.MeshDomain, "mesh authority suffix for reachability targets")
 	f.StringSliceVar(&cfg.ReachabilityTargets, "reachability-targets", cfg.ReachabilityTargets, "optional echo upstream service names for the reachability tier")
+	f.StringSliceVar(&cfg.MeshDNSTargets, "mesh-dns-targets", cfg.MeshDNSTargets, "optional namespace-qualified FQDN authorities (host[:port], default port 18081) for the mesh_dns tier; these are resolved through the mesh DNS path rather than Host-overridden")
 	f.Float64Var(&cfg.Rate, "rate", cfg.Rate, "probes per second per target")
 	f.DurationVar(&cfg.Timeout, "timeout", cfg.Timeout, "per-probe timeout")
 	f.IntVar(&cfg.MaxConcurrent, "max-concurrent", cfg.MaxConcurrent, "max in-flight probes per target")

--- a/prober/internal/prober/prober.go
+++ b/prober/internal/prober/prober.go
@@ -35,12 +35,23 @@ const (
 
 	tierLiveness     = "liveness"
 	tierReachability = "reachability"
+	tierMeshDNS      = "mesh_dns"
+
+	// defaultMeshDNSPort is appended to a mesh_dns target that omits a port so the
+	// probe still dials the local mesh egress listener after resolving the name.
+	defaultMeshDNSPort = "18081"
 
 	resultSuccess         = "success"
 	resultHTTPError       = "http_error"
 	resultConnectionError = "connection_error"
 	resultTimeout         = "timeout"
 	resultSaturated       = "saturated"
+	// resultDNSError and its refinements are emitted only by the mesh_dns tier: a
+	// name-resolution failure is an independently alertable signal, distinct from a
+	// post-resolution connect failure (which stays connection_error).
+	resultDNSError    = "dns_error"
+	resultDNSNXDomain = "dns_nxdomain"
+	resultDNSTimeout  = "dns_timeout"
 )
 
 // Config configures the prober.
@@ -50,6 +61,7 @@ type Config struct {
 	LivenessAuthority   string
 	MeshDomain          string
 	ReachabilityTargets []string
+	MeshDNSTargets      []string
 	Rate                float64
 	Timeout             time.Duration
 	MaxConcurrent       int
@@ -130,7 +142,32 @@ func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Pro
 			authority: svc + "." + cfg.MeshDomain,
 		})
 	}
+	// Mesh-DNS tier (optional): unlike the tiers above, the URL is the REAL
+	// namespace-qualified name and the authority is left empty, so the Go transport
+	// resolves the FQDN through the system resolver (CNI :53 DNAT → agent mesh-DNS
+	// resolver → ClusterIP) instead of dialing the fixed egress with a Host override.
+	// This is the whole point: it exercises the mesh-DNS path the other tiers bypass,
+	// closing the blind spot where a mesh-DNS outage is invisible.
+	for _, fqdn := range cfg.MeshDNSTargets {
+		p.targets = append(p.targets, target{
+			tier: tierMeshDNS,
+			name: fqdn,
+			url:  "http://" + withDefaultPort(fqdn, defaultMeshDNSPort) + "/",
+			// authority intentionally left empty: do NOT override the Host, so the
+			// transport actually resolves and connects to the real name.
+		})
+	}
 	return p, nil
+}
+
+// withDefaultPort returns authority unchanged when it already carries a port,
+// otherwise it appends ":port". It handles the no-port case only (mesh-DNS targets
+// are hostnames, never bracketed IPv6 literals).
+func withDefaultPort(authority, port string) string {
+	if _, _, err := net.SplitHostPort(authority); err == nil {
+		return authority
+	}
+	return authority + ":" + port
 }
 
 func newMeter(ctx context.Context, endpoint, version string) (metric.Meter, *sdkmetric.MeterProvider, error) {
@@ -224,7 +261,11 @@ func (p *Prober) probe(ctx context.Context, t target) {
 		p.record(t, resultConnectionError, 0)
 		return
 	}
-	req.Host = t.authority
+	// mesh_dns targets carry no authority: leaving req.Host unset preserves the
+	// FQDN so the transport resolves and dials the real name (the point of the tier).
+	if t.authority != "" {
+		req.Host = t.authority
+	}
 	// Mark the probe not-sampled so the mesh proxy's HCM doesn't create and export
 	// a span per probe. The proxy's tracing is parent-based: a request that already
 	// carries a trace context honors its sampled decision instead of rolling
@@ -264,10 +305,28 @@ func notSampledTraceparent() string {
 }
 
 // classifyErr maps a request error to a result. connection_error is the class the
-// proxy-emitted metric is blind to (no response produced / listener down).
+// proxy-emitted metric is blind to (no response produced / listener down). A
+// name-resolution failure is split out into the dns_* classes so a mesh-DNS
+// regression is an unambiguous, independently alertable signal — never folded into
+// connection_error. A connect failure AFTER successful resolution stays
+// connection_error.
 func classifyErr(ctx context.Context, err error) string {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
 		return resultTimeout
+	}
+	// A DNS failure is checked before the generic net.Error timeout branch: a
+	// *net.DNSError also satisfies net.Error, and a resolution timeout must surface
+	// as dns_timeout (not the transport timeout) so the mesh-DNS signal is distinct.
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		switch {
+		case dnsErr.IsNotFound:
+			return resultDNSNXDomain
+		case dnsErr.IsTimeout:
+			return resultDNSTimeout
+		default:
+			return resultDNSError
+		}
 	}
 	var ne net.Error
 	if errors.As(err, &ne) && ne.Timeout() {

--- a/prober/internal/prober/prober_test.go
+++ b/prober/internal/prober/prober_test.go
@@ -3,6 +3,7 @@ package prober
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"regexp"
 	"strings"
@@ -40,6 +41,63 @@ func TestClassifyErr(t *testing.T) {
 			t.Fatalf("got %q, want %q", got, resultTimeout)
 		}
 	})
+	t.Run("wrapped DNS not-found -> dns_nxdomain", func(t *testing.T) {
+		// Wrap the *net.DNSError so classifyErr must unwrap it via errors.As, mirroring
+		// how the http transport surfaces a resolution failure inside an *url.Error.
+		err := fmt.Errorf("dial: %w", &net.DNSError{Err: "no such host", Name: "bogus.aether.internal", IsNotFound: true})
+		if got := classifyErr(context.Background(), err); got != resultDNSNXDomain {
+			t.Fatalf("got %q, want %q", got, resultDNSNXDomain)
+		}
+	})
+	t.Run("wrapped DNS timeout -> dns_timeout", func(t *testing.T) {
+		err := fmt.Errorf("dial: %w", &net.DNSError{Err: "i/o timeout", Name: "slow.aether.internal", IsTimeout: true})
+		if got := classifyErr(context.Background(), err); got != resultDNSTimeout {
+			t.Fatalf("got %q, want %q", got, resultDNSTimeout)
+		}
+	})
+	t.Run("wrapped generic DNS error -> dns_error", func(t *testing.T) {
+		err := fmt.Errorf("dial: %w", &net.DNSError{Err: "server misbehaving", Name: "echo.aether.internal"})
+		if got := classifyErr(context.Background(), err); got != resultDNSError {
+			t.Fatalf("got %q, want %q", got, resultDNSError)
+		}
+	})
+	t.Run("post-resolution dial error stays connection_error", func(t *testing.T) {
+		// A dial failure with no *net.DNSError in the chain means the name resolved
+		// and the connect failed — this must remain connection_error, not a dns_* class.
+		err := fmt.Errorf("dial tcp 10.0.0.1:18081: %w", &net.OpError{Op: "dial", Err: errors.New("connection refused")})
+		if got := classifyErr(context.Background(), err); got != resultConnectionError {
+			t.Fatalf("got %q, want %q", got, resultConnectionError)
+		}
+	})
+}
+
+func TestNewMeshDNSTargets(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.MeshDNSTargets = []string{"echo.aether-test.aether.internal:18081", "echo.aether-test.aether.internal"}
+	p, err := New(context.Background(), cfg, logr.Discard(), "test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	// 1 liveness + 0 reachability + 2 mesh_dns.
+	if len(p.targets) != 3 {
+		t.Fatalf("want 3 targets (1 liveness + 2 mesh_dns), got %d", len(p.targets))
+	}
+	md := p.targets[1]
+	if md.tier != tierMeshDNS {
+		t.Fatalf("mesh_dns target tier = %q, want %q", md.tier, tierMeshDNS)
+	}
+	// The URL must be the REAL FQDN so the transport resolves it — not the fixed egress.
+	if want := "http://echo.aether-test.aether.internal:18081/"; md.url != want {
+		t.Fatalf("mesh_dns url = %q, want %q", md.url, want)
+	}
+	// authority MUST be empty: probe() must not override Host, or the name would never resolve.
+	if md.authority != "" {
+		t.Fatalf("mesh_dns authority = %q, want empty (no Host override)", md.authority)
+	}
+	// A target without an explicit port gets the default appended.
+	if want := "http://echo.aether-test.aether.internal:18081/"; p.targets[2].url != want {
+		t.Fatalf("mesh_dns default-port url = %q, want %q", p.targets[2].url, want)
+	}
 }
 
 func TestNewTargets(t *testing.T) {


### PR DESCRIPTION
## The blind spot

Every existing prober tier (`liveness`, `reachability`) dials the fixed local mesh egress `127.0.0.1:18081` with a `Host:` override. **No probe ever resolves a mesh DNS name**, so a real mesh-DNS outage is completely invisible to the prober SLI. This is exactly why an 8h soak "PASS" was able to coexist with apparent total DNS failure during **issue #574** (which turned out to be stale flat test names — the correct mesh name form is `<svc>.<ns>.aether.internal`). The same class of gap also hides a single-node DNAT miss after a node reboot: if one node's CNI :53 redirect never programs, only that node's DNS is dead and the fleet-collapsed liveness signal stays green.

## The new `mesh_dns` tier

- New tier `tierMeshDNS = "mesh_dns"`, config `MeshDNSTargets []string`, and cobra flag `--mesh-dns-targets` (comma-separated `host[:port]`, default port `18081`).
- Unlike the other tiers, a mesh_dns target's URL is the **real** namespace-qualified FQDN (`http://echo.aether-test.aether.internal:18081/`) and it deliberately leaves `req.Host`/authority **unset**. The Go transport then resolves the FQDN through the system resolver, which in a mesh-managed pod goes CNI `:53` DNAT → agent mesh-DNS resolver → ClusterIP. This exercises the exact DNS path every other tier bypasses.
- Everything else is unchanged: same `aether_probe_requests_total{tier,target,result}` counter, same rate/timeout/concurrency machinery, same OTLP wiring. Liveness/reachability behavior is untouched.

## The `dns_error` classification

`classifyErr` now unwraps the error chain with `errors.As` looking for `*net.DNSError` **before** the generic `net.Error` timeout branch (a `*net.DNSError` also satisfies `net.Error`, so ordering matters):

- `*net.DNSError.IsNotFound` → `dns_nxdomain`
- `*net.DNSError.IsTimeout` → `dns_timeout`
- otherwise → `dns_error`

A connect failure that happens **after** successful resolution has no `*net.DNSError` in its chain and stays `connection_error`. This separation is the point: a mesh-DNS regression becomes an unambiguous, independently alertable signal instead of being folded into `connection_error`.

## How it's validated

- Unit tests: `classifyErr` returns `dns_nxdomain`/`dns_timeout`/`dns_error` for wrapped `*net.DNSError` variants and still returns `connection_error` for a post-resolution dial error; `mesh_dns` target construction yields the FQDN URL with an empty authority (no Host override) and applies the default `:18081` port.
- `bazel test //prober/...` green.
- Chart renders: the `charts/prober` DaemonSet emits `--mesh-dns-targets=echo.aether-test.aether.internal:18081` and adds the resolved host to `config.aether.io/upstreams` (the mesh_dns tier dials a real ClusterIP, so its upstream must be authorized).

## Deploy

The prober DaemonSet lives in `charts/prober` and is **mesh-managed** (`aether.io/managed: "true"`), which is required — the DNS probe only works through the mesh `:53` DNAT.

## PromQL alert

```promql
sum(rate(aether_probe_requests_total{tier="mesh_dns",result=~"dns_.*"}[5m])) by (k8s_node_name) > 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR
