### PR TITLE
fix(mesh-dns): close the agent-roll cold window (warm-start + authoritative)

### DIFF
--- a/agent/constants/constants.go
+++ b/agent/constants/constants.go
@@ -12,6 +12,15 @@ const (
 	// here (the node hostPath doesn't exist in the edge pod).
 	DefaultEdgeRegistryDir = constants.CNIDefaultRegistryPath
 
+	// DefaultMeshDNSSnapshotPath is the default host-persistent file the in-process
+	// mesh-DNS resolver persists its last-known record table to (and warm-loads at
+	// boot). It lives in a dedicated SUBDIRECTORY under the CNI registry hostPath so
+	// it survives a rolling agent restart (a new pod) yet stays out of the CNI pod
+	// store's top-level *.json scan (setupStorage/loadAll unmarshals every top-level
+	// .json there as a CNIPod — a subdir is skipped), closing the mesh_dns cold
+	// window (Fix 1).
+	DefaultMeshDNSSnapshotPath = DefaultHostCNIRegistryDir + "/mesh-dns/records.json"
+
 	// DefaultXdsSocketPath is the default Unix domain socket path for the xDS server
 	DefaultXdsSocketPath = "/run/aether/xds.sock"
 	// DefaultCNISocketPath is the default Unix domain socket path for the CNI server

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -139,6 +139,12 @@ type AgentConfig struct {
 	// MeshDNSUpstream is the upstream resolver(s) (host[:port]) the mesh-DNS filter
 	// forwards non-mesh queries to — the cluster kube-dns.
 	MeshDNSUpstream []string
+	// MeshDNSSnapshotPath is the host-persistent file the mesh-DNS resolver writes
+	// its last-known record table to on every reconcile and warm-loads at boot, so a
+	// rolling agent restart answers mesh names from last-known ClusterIPs within ms
+	// of process start (before the informer cache syncs the first reconcile). Lives
+	// under the CNI registry hostPath so it survives the pod (a restart = a new pod).
+	MeshDNSSnapshotPath string
 	// GatewayClassName is the GatewayClass whose Gateways this edge serves.
 	GatewayClassName string
 
@@ -171,6 +177,7 @@ func NewAgentConfig() *AgentConfig {
 		GatewayClassName:        "aether",
 		CNIServerConfig:         cniServer.NewCNIServerConfig(),
 		MountedLocalStorageDir:  constants.DefaultHostCNIRegistryDir,
+		MeshDNSSnapshotPath:     constants.DefaultMeshDNSSnapshotPath,
 		RegistrarAddress:        "aether-registrar.aether-system.svc:443",
 		MeshDomain:              meshconst.DefaultMeshDomain,
 		SpireEnabled:            true,

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -128,6 +128,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.EastWestWaypoint, "east-west-waypoint", false, "Enable the split-horizon east/west waypoint (proposal 019): dial cross-cluster endpoints at their node's routable IP + the fixed tunnel port (18009) instead of their pod IP, and SNI-forward to the local pod. Intra-cluster stays direct pod-to-pod. Needs cross-cluster endpoint visibility (shared etcd) and a shared SPIRE trust domain.")
 	rootCmd.Flags().BoolVar(&cfg.MeshDNS, "mesh-dns", false, "Enable per-pod mesh DNS: answer <svc>.<mesh-domain> from the generated mesh Services and forward the rest to --mesh-dns-upstream (proposal 018, mesh-global FQDN)")
 	rootCmd.Flags().StringSliceVar(&cfg.MeshDNSUpstream, "mesh-dns-upstream", cfg.MeshDNSUpstream, "Upstream resolver(s) (host[:port]) the mesh-DNS filter forwards non-mesh queries to (the cluster kube-dns)")
+	rootCmd.Flags().StringVar(&cfg.MeshDNSSnapshotPath, "mesh-dns-snapshot-path", cfg.MeshDNSSnapshotPath, "Host-persistent file the in-process mesh-DNS resolver persists its last-known record table to and warm-loads at boot, closing the agent-roll cold window (proposal 018, mesh-global FQDN). Defaults under the CNI registry hostPath so it survives a rolling restart; empty disables persistence")
 }
 
 // registerSharedFlags registers the flags common to the node agent (root) and
@@ -376,6 +377,13 @@ func configureSnapshotCache(ctx context.Context, m ctrl.Manager) (*cache.Snapsho
 
 // wireMeshDNS starts the in-process mesh-DNS resolver and connects it to the
 // snapshot cache when --mesh-dns is enabled. It is a no-op when disabled.
+//
+// The resolver binds EARLY — directly in a goroutine, NOT via m.Add — so its UDP+TCP
+// sockets are open the moment the agent process starts, before controller-runtime's
+// cache-gated Runnable group waits on informer sync. On an agent roll that closes the
+// "bind gap" where DNAT'd :53 packets hit a closed port and clients time out (Fix 1).
+// Combined with the warm-start snapshot loaded in NewServer, the fresh agent answers
+// mesh names from last-known ClusterIPs within ms of boot.
 func wireMeshDNS(ctx context.Context, m ctrl.Manager, snapshotCache *cache.SnapshotCache) error {
 	if !cfg.MeshDNS {
 		return nil
@@ -386,7 +394,7 @@ func wireMeshDNS(ctx context.Context, m ctrl.Manager, snapshotCache *cache.Snaps
 	// no setns, no privilege increase).
 	hostIP := os.Getenv("HOST_IP")
 	resolverPort := uint32(meshconst.ProxyDNSResolverPort)
-	dnsServer := meshdns.NewServer(cfg.MeshDomain, fmt.Sprintf("%s:%d", hostIP, resolverPort), l)
+	dnsServer := meshdns.NewServer(cfg.MeshDomain, fmt.Sprintf("%s:%d", hostIP, resolverPort), cfg.MeshDNSSnapshotPath, l)
 	// Default the forward upstream to the agent's own resolv.conf (kube-dns, via
 	// ClusterFirstWithHostNet) when --mesh-dns-upstream is unset, so mesh DNS is
 	// safe to enable by default without per-cluster configuration.
@@ -396,9 +404,15 @@ func wireMeshDNS(ctx context.Context, m ctrl.Manager, snapshotCache *cache.Snaps
 		l.Info("mesh-DNS upstream defaulted from /etc/resolv.conf", "upstreams", upstreams)
 	}
 	dnsServer.SetUpstreams(upstreams)
-	if err := m.Add(dnsServer); err != nil {
-		return fmt.Errorf("failed to add mesh-DNS resolver: %w", err)
-	}
+	// Bind now, off the cache-gated Runnable group. Start honours ctx.Done for
+	// graceful miekg/dns Shutdown; a bind error is fatal (a wedged resolver silently
+	// breaks every pod's DNS), so crash so the DaemonSet restarts us.
+	go func() {
+		if err := dnsServer.Start(ctx); err != nil {
+			l.ErrorContext(ctx, "mesh-DNS resolver failed", "error", err)
+			os.Exit(1)
+		}
+	}()
 	snapshotCache.SetMeshDNSServer(dnsServer)
 	return nil
 }

--- a/agent/internal/meshdns/BUILD.bazel
+++ b/agent/internal/meshdns/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/bpalermo/aether/agent/internal/meshdns",
     visibility = ["//agent:__subpackages__"],
     deps = [
+        "//common/file",
         "//common/log",
         "//common/serviceref",
         "@com_github_miekg_dns//:dns",
@@ -27,6 +28,7 @@ go_test(
     ],
     embed = [":meshdns"],
     deps = [
+        "@com_github_miekg_dns//:dns",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/agent/internal/meshdns/metrics.go
+++ b/agent/internal/meshdns/metrics.go
@@ -19,7 +19,7 @@ type metrics struct {
 func newMetrics() *metrics {
 	q, err := otel.Meter("aether/mesh-dns").Int64Counter(
 		"aether.mesh_dns.queries",
-		metric.WithDescription("Mesh-DNS queries handled by the in-agent resolver, by result (answered=mesh hit, forwarded=relayed to upstream, forward_error=upstream failed)"),
+		metric.WithDescription("Mesh-DNS queries handled by the in-agent resolver, by result (answered=mesh hit, forwarded=relayed to upstream, forward_error=upstream failed, nxdomain=authoritative mesh miss, cold=SERVFAIL for a mesh name before records were ever populated)"),
 	)
 	if err != nil {
 		return nil
@@ -38,4 +38,11 @@ const (
 	resultAnswered     = "answered"
 	resultForwarded    = "forwarded"
 	resultForwardError = "forward_error"
+	// resultNXDomain is an authoritative miss: a name under the mesh domain that
+	// is not in the record table, answered NXDOMAIN once records are populated.
+	resultNXDomain = "nxdomain"
+	// resultCold is a mesh-domain query received before the record table was ever
+	// populated (warm-start snapshot empty + no reconcile yet); answered SERVFAIL
+	// so the client retries instead of caching a negative answer.
+	resultCold = "cold"
 )

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -13,11 +13,17 @@ package meshdns
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"io/fs"
 	"log/slog"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
+	"github.com/bpalermo/aether/common/file"
 	"github.com/bpalermo/aether/common/serviceref"
 
 	commonlog "github.com/bpalermo/aether/common/log"
@@ -26,37 +32,109 @@ import (
 
 const answerTTL = 30
 
+// snapshotFileMode is the permission for the persisted records snapshot.
+const snapshotFileMode = 0o644
+
+// snapshotDirMode is the permission for the snapshot's parent directory.
+const snapshotDirMode = 0o755
+
 // Server answers mesh A records and forwards the rest. Safe for concurrent use, and a
 // controller-runtime Runnable (Start serves until the context is cancelled).
 type Server struct {
-	meshDomain string
-	addr       string
-	log        *slog.Logger
-	client     *dns.Client
-	metrics    *metrics
+	meshDomain   string
+	addr         string
+	snapshotPath string
+	log          *slog.Logger
+	client       *dns.Client
+	metrics      *metrics
 
 	mu        sync.RWMutex
-	records   map[string]string // bare service -> A-record IP
+	records   map[string]string // "<ns>/<svc>" -> A-record IP
+	ready     bool              // records have been populated at least once
 	upstreams []string
 }
 
 // NewServer builds the resolver for meshDomain, listening on addr (host:port).
-func NewServer(meshDomain, addr string, log *slog.Logger) *Server {
-	return &Server{
-		meshDomain: meshDomain,
-		addr:       addr,
-		log:        commonlog.Named(log, "mesh-dns"),
-		client:     &dns.Client{Net: "udp"},
-		metrics:    newMetrics(),
-		records:    map[string]string{},
+// snapshotPath, when non-empty, is a host-persistent file the last-known record
+// table is written to on every SetRecords and warm-loaded from at boot (Fix 1):
+// a freshly-restarted agent answers mesh names from last-known ClusterIPs within
+// ms of process start, before the informer cache has synced the first reconcile.
+func NewServer(meshDomain, addr, snapshotPath string, log *slog.Logger) *Server {
+	s := &Server{
+		meshDomain:   meshDomain,
+		addr:         addr,
+		snapshotPath: snapshotPath,
+		log:          commonlog.Named(log, "mesh-dns"),
+		client:       &dns.Client{Net: "udp"},
+		metrics:      newMetrics(),
+		records:      map[string]string{},
 	}
+	s.loadSnapshot()
+	return s
 }
 
-// SetRecords replaces the service->IP answer table.
+// loadSnapshot warm-starts the record table from the on-disk snapshot, if present.
+// A missing/unreadable/corrupt snapshot is not fatal (the resolver simply starts
+// cold and forwards nothing for mesh names until the first reconcile — see
+// ServeDNS). A successful non-empty load flips ready true so mesh misses answer
+// NXDOMAIN authoritatively from the very first query rather than SERVFAIL.
+func (s *Server) loadSnapshot() {
+	if s.snapshotPath == "" {
+		return
+	}
+	data, err := os.ReadFile(s.snapshotPath)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			s.log.Warn("failed to read mesh-DNS snapshot; starting cold", "path", s.snapshotPath, "error", err)
+		}
+		return
+	}
+	var records map[string]string
+	if err := json.Unmarshal(data, &records); err != nil {
+		s.log.Warn("failed to parse mesh-DNS snapshot; starting cold", "path", s.snapshotPath, "error", err)
+		return
+	}
+	s.mu.Lock()
+	s.records = records
+	if len(records) > 0 {
+		s.ready = true
+	}
+	s.mu.Unlock()
+	s.log.Info("warm-started mesh-DNS records from snapshot", "path", s.snapshotPath, "records", len(records))
+}
+
+// SetRecords replaces the service->IP answer table, flips the ready flag (so a
+// subsequent mesh miss answers NXDOMAIN, not SERVFAIL), and persists the table to
+// the host-persistent snapshot so a future agent restart warm-starts from it.
 func (s *Server) SetRecords(records map[string]string) {
 	s.mu.Lock()
 	s.records = records
+	s.ready = true
 	s.mu.Unlock()
+	s.persistSnapshot(records)
+}
+
+// persistSnapshot atomically writes the record table to the snapshot file. Errors
+// are logged, never fatal: a failed persist only means the NEXT restart starts
+// cold, and serving continues normally.
+func (s *Server) persistSnapshot(records map[string]string) {
+	if s.snapshotPath == "" {
+		return
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		s.log.Warn("failed to marshal mesh-DNS snapshot", "error", err)
+		return
+	}
+	// The snapshot lives in a dedicated subdir under the host-persistent registry
+	// volume; create it (host mount is DirectoryOrCreate, the subdir is ours).
+	if err := os.MkdirAll(filepath.Dir(s.snapshotPath), snapshotDirMode); err != nil {
+		s.log.Warn("failed to create mesh-DNS snapshot dir", "path", s.snapshotPath, "error", err)
+		return
+	}
+	if err := file.AtomicWrite(s.snapshotPath, data, snapshotFileMode); err != nil {
+		s.log.Warn("failed to persist mesh-DNS snapshot", "path", s.snapshotPath, "error", err)
+	}
 }
 
 // SetUpstreams sets the resolver(s) non-mesh queries are forwarded to (host[:port]).
@@ -87,54 +165,113 @@ func (s *Server) Start(ctx context.Context) error {
 // ServeDNS answers a known mesh name authoritatively for EVERY query type — A
 // returns the record, anything else (AAAA, etc.) returns NODATA (NOERROR, empty) so
 // the name consistently EXISTS. Forwarding the AAAA would yield NXDOMAIN upstream, and
-// c-ares (curl/Alpine) then concludes the whole name is gone. Unknown names (incl.
-// cluster.local and external) are forwarded to the upstream resolver.
+// c-ares (curl/Alpine) then concludes the whole name is gone.
+//
+// The resolver is AUTHORITATIVE for the mesh domain: a name under .meshDomain that
+// is not in the record table is NEVER forwarded to kube-dns (which has no mesh
+// zone and would answer SERVFAIL/NXDOMAIN, surfacing as roll-correlated failures).
+// Instead the miss is answered locally — NXDOMAIN once records have ever been
+// populated (a real miss), or SERVFAIL while still cold (never populated, so the
+// name may simply not have been reconciled yet — retryable). Only genuinely
+// non-mesh names (cluster.local, external) are forwarded upstream.
 func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	if len(r.Question) == 1 {
 		q := r.Question[0]
-		if ip := s.lookup(q.Name); ip != "" {
-			m := new(dns.Msg)
-			m.SetReply(r)
-			m.Authoritative = true
-			// Echo the client's EDNS0 OPT (UDP size + DO); c-ares rejects an answer
-			// that omits the OPT it asked with (getaddrinfo/dig are lenient).
-			if opt := r.IsEdns0(); opt != nil {
-				m.SetEdns0(opt.UDPSize(), opt.Do())
-			}
-			if q.Qtype == dns.TypeA {
-				if v4 := net.ParseIP(ip).To4(); v4 != nil {
-					m.Answer = []dns.RR{&dns.A{
-						Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: answerTTL},
-						A:   v4,
-					}}
-				}
-			}
-			// Non-A (incl. AAAA): NODATA — empty answer, NOERROR, authoritative.
-			_ = w.WriteMsg(m)
-			s.metrics.record(resultAnswered)
+		if s.isMeshName(q.Name) {
+			s.serveMesh(w, r, q)
 			return
 		}
 	}
 	s.forward(w, r)
 }
 
-// lookup maps <svc>.<ns>.<meshDomain> -> its A-record IP, or "" if not a known
-// mesh name (proposal 020 Part 1; records are keyed by the "<ns>/<svc>" key).
-func (s *Server) lookup(qname string) string {
+// serveMesh answers a mesh-domain query authoritatively: a hit returns the A record
+// (NODATA for non-A), a miss returns NXDOMAIN when ready or SERVFAIL when still cold.
+func (s *Server) serveMesh(w dns.ResponseWriter, r *dns.Msg, q dns.Question) {
+	ip, ready := s.lookup(q.Name)
+	if ip == "" {
+		if !ready {
+			// Never populated: the name may simply not be reconciled yet. SERVFAIL is
+			// retryable and not negatively cached, unlike NXDOMAIN.
+			s.writeRcode(w, r, dns.RcodeServerFailure, resultCold)
+			return
+		}
+		// Authoritative miss: the mesh has records but not this name.
+		s.writeRcode(w, r, dns.RcodeNameError, resultNXDomain)
+		return
+	}
+
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Authoritative = true
+	// Echo the client's EDNS0 OPT (UDP size + DO); c-ares rejects an answer
+	// that omits the OPT it asked with (getaddrinfo/dig are lenient).
+	if opt := r.IsEdns0(); opt != nil {
+		m.SetEdns0(opt.UDPSize(), opt.Do())
+	}
+	if q.Qtype == dns.TypeA {
+		if v4 := net.ParseIP(ip).To4(); v4 != nil {
+			m.Answer = []dns.RR{&dns.A{
+				Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: answerTTL},
+				A:   v4,
+			}}
+		}
+	}
+	// Non-A (incl. AAAA): NODATA — empty answer, NOERROR, authoritative.
+	_ = w.WriteMsg(m)
+	s.metrics.record(resultAnswered)
+}
+
+// writeRcode replies with an authoritative bare rcode (no answer) and records the metric.
+func (s *Server) writeRcode(w dns.ResponseWriter, r *dns.Msg, rcode int, result string) {
+	m := new(dns.Msg)
+	m.SetRcode(r, rcode)
+	m.Authoritative = true
+	_ = w.WriteMsg(m)
+	s.metrics.record(result)
+}
+
+// isMeshName reports whether qname is a well-formed name under the mesh domain
+// ("<svc>.<ns>.<meshDomain>", exactly two labels before the suffix). Names under
+// the mesh domain that are answered authoritatively (hit, NXDOMAIN, or cold
+// SERVFAIL) — never forwarded. A malformed name under the mesh domain (wrong label
+// count) is NOT a mesh name and falls through to forwarding, matching the previous
+// lookup()=="" behaviour for those spellings.
+func (s *Server) isMeshName(qname string) bool {
+	_, _, ok := s.parseMeshName(qname)
+	return ok
+}
+
+// parseMeshName splits <svc>.<ns>.<meshDomain> into (ns, svc). ok is false when the
+// name is not a well-formed two-label mesh name.
+func (s *Server) parseMeshName(qname string) (ns, svc string, ok bool) {
 	name := strings.TrimSuffix(strings.ToLower(qname), ".")
 	suffix := "." + s.meshDomain
 	if !strings.HasSuffix(name, suffix) {
-		return ""
+		return "", "", false
 	}
 	// "<svc>.<ns>" — exactly two labels (service name, then namespace).
 	svc, ns, found := strings.Cut(strings.TrimSuffix(name, suffix), ".")
 	if !found || svc == "" || ns == "" || strings.Contains(ns, ".") {
-		return ""
+		return "", "", false
+	}
+	return ns, svc, true
+}
+
+// lookup maps <svc>.<ns>.<meshDomain> -> its A-record IP (proposal 020 Part 1;
+// records are keyed by the "<ns>/<svc>" key). ready reports whether the record
+// table has ever been populated (warm-start snapshot or a reconcile), so the
+// caller can pick SERVFAIL (cold) vs NXDOMAIN (real miss) for an empty result.
+func (s *Server) lookup(qname string) (ip string, ready bool) {
+	ns, svc, ok := s.parseMeshName(qname)
+	if !ok {
+		return "", false
 	}
 	s.mu.RLock()
-	ip := s.records[serviceref.New(ns, svc).Key()]
+	ip = s.records[serviceref.New(ns, svc).Key()]
+	ready = s.ready
 	s.mu.RUnlock()
-	return ip
+	return ip, ready
 }
 
 func (s *Server) forward(w dns.ResponseWriter, r *dns.Msg) {

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -167,13 +167,14 @@ func (s *Server) Start(ctx context.Context) error {
 // the name consistently EXISTS. Forwarding the AAAA would yield NXDOMAIN upstream, and
 // c-ares (curl/Alpine) then concludes the whole name is gone.
 //
-// The resolver is AUTHORITATIVE for the mesh domain: a name under .meshDomain that
-// is not in the record table is NEVER forwarded to kube-dns (which has no mesh
-// zone and would answer SERVFAIL/NXDOMAIN, surfacing as roll-correlated failures).
-// Instead the miss is answered locally — NXDOMAIN once records have ever been
-// populated (a real miss), or SERVFAIL while still cold (never populated, so the
-// name may simply not have been reconciled yet — retryable). Only genuinely
-// non-mesh names (cluster.local, external) are forwarded upstream.
+// The resolver is AUTHORITATIVE for the ENTIRE mesh domain: ANY name under
+// .meshDomain is answered locally and NEVER forwarded to kube-dns (which has no mesh
+// zone and would answer SERVFAIL/NXDOMAIN or a slow upstream round-trip, surfacing as
+// roll-correlated failures). A well-formed "<svc>.<ns>" miss is NXDOMAIN once records
+// have ever been populated (a real miss) or SERVFAIL while still cold (never
+// populated, so the name may simply not have been reconciled yet — retryable); a
+// malformed spelling under the zone is always NXDOMAIN. Only genuinely non-mesh names
+// (cluster.local, external) are forwarded upstream.
 func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	if len(r.Question) == 1 {
 		q := r.Question[0]
@@ -185,9 +186,17 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	s.forward(w, r)
 }
 
-// serveMesh answers a mesh-domain query authoritatively: a hit returns the A record
-// (NODATA for non-A), a miss returns NXDOMAIN when ready or SERVFAIL when still cold.
+// serveMesh answers a mesh-domain query authoritatively: a well-formed "<svc>.<ns>"
+// hit returns the A record (NODATA for non-A) and a miss returns NXDOMAIN when ready
+// or SERVFAIL when still cold; a malformed name under the zone (wrong label count)
+// is always NXDOMAIN — it can never exist, so retrying can't help.
 func (s *Server) serveMesh(w dns.ResponseWriter, r *dns.Msg, q dns.Question) {
+	if _, _, ok := s.parseMeshName(q.Name); !ok {
+		// Under the mesh domain but not a well-formed "<svc>.<ns>" name. Structurally
+		// invalid regardless of readiness: authoritative NXDOMAIN, never forwarded.
+		s.writeRcode(w, r, dns.RcodeNameError, resultNXDomain)
+		return
+	}
 	ip, ready := s.lookup(q.Name)
 	if ip == "" {
 		if !ready {
@@ -231,15 +240,17 @@ func (s *Server) writeRcode(w dns.ResponseWriter, r *dns.Msg, rcode int, result 
 	s.metrics.record(result)
 }
 
-// isMeshName reports whether qname is a well-formed name under the mesh domain
-// ("<svc>.<ns>.<meshDomain>", exactly two labels before the suffix). Names under
-// the mesh domain that are answered authoritatively (hit, NXDOMAIN, or cold
-// SERVFAIL) — never forwarded. A malformed name under the mesh domain (wrong label
-// count) is NOT a mesh name and falls through to forwarding, matching the previous
-// lookup()=="" behaviour for those spellings.
+// isMeshName reports whether qname is any name UNDER the mesh domain (has at least
+// one label before ".<meshDomain>"). The resolver owns the whole zone, so every such
+// name is answered authoritatively and NEVER forwarded — a well-formed "<svc>.<ns>"
+// resolves (hit / NXDOMAIN / cold SERVFAIL in serveMesh), and a malformed spelling
+// (wrong label count, e.g. the flat "<svc>.<meshDomain>") is an authoritative
+// NXDOMAIN rather than a wasted, slow round-trip to kube-dns (which has no mesh zone).
+// The bare apex "<meshDomain>" has no leading label and is not matched (it falls
+// through to forwarding — harmless, nobody resolves it as a service).
 func (s *Server) isMeshName(qname string) bool {
-	_, _, ok := s.parseMeshName(qname)
-	return ok
+	name := strings.TrimSuffix(strings.ToLower(qname), ".")
+	return strings.HasSuffix(name, "."+s.meshDomain)
 }
 
 // parseMeshName splits <svc>.<ns>.<meshDomain> into (ns, svc). ok is false when the

--- a/agent/internal/meshdns/server_test.go
+++ b/agent/internal/meshdns/server_test.go
@@ -28,11 +28,15 @@ func TestLookup(t *testing.T) {
 	assertMeshMiss(t, s, "unknown.team-a.aether.internal.")
 	assertMeshMiss(t, s, "svc-1.aether-test.aether.internal.", "wrong namespace")
 
-	// Not mesh names at all -> forwarded (isMeshName false).
+	// The resolver owns the WHOLE zone: any name under .meshDomain is a mesh name
+	// (answered authoritatively, never forwarded) even when malformed.
+	assert.True(t, s.isMeshName("svc-1.aether.internal."), "single label under the zone is still ours")
+	assert.True(t, s.isMeshName("a.b.c.aether.internal."), "three labels under the zone are still ours")
+
+	// Not under the mesh domain -> forwarded (isMeshName false). The bare apex has no
+	// leading label and is not matched (harmless: nobody resolves it as a service).
 	assert.False(t, s.isMeshName("svc-1.aether-test.svc.cluster.local."), "cluster.local is not a mesh name")
-	assert.False(t, s.isMeshName("svc-1.aether.internal."), "single label (no namespace) is not a mesh name")
-	assert.False(t, s.isMeshName("a.b.c.aether.internal."), "three labels under the mesh domain")
-	assert.False(t, s.isMeshName("aether.internal."), "the bare mesh domain")
+	assert.False(t, s.isMeshName("aether.internal."), "the bare mesh domain apex")
 	assert.False(t, s.isMeshName("google.com."), "external name")
 }
 
@@ -142,6 +146,26 @@ func TestServeMeshMissReadyIsNXDomain(t *testing.T) {
 	assert.Equal(t, dns.RcodeNameError, resp.Rcode, "ready mesh miss -> NXDOMAIN")
 	assert.True(t, resp.Authoritative)
 	assert.Empty(t, resp.Answer)
+}
+
+// TestServeMalformedUnderZoneIsNXDomain: a name under the mesh domain that is NOT a
+// well-formed "<svc>.<ns>" (wrong label count, e.g. the flat "<svc>.<meshDomain>" or a
+// three-label spelling) is answered authoritative NXDOMAIN and NEVER forwarded — even
+// while cold, since a structurally invalid name can never become valid.
+func TestServeMalformedUnderZoneIsNXDomain(t *testing.T) {
+	// Cold server (never populated) + a black-hole upstream: if a malformed mesh name
+	// were ever forwarded, forward() would answer NON-authoritative; we assert the
+	// opposite, so forwarding is ruled out.
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetUpstreams([]string{"127.0.0.1:1"})
+
+	for _, name := range []string{"svc-1.aether.internal", "a.b.c.aether.internal"} {
+		resp := serve(s, query(name, dns.TypeA))
+		require.NotNil(t, resp, name)
+		assert.Equal(t, dns.RcodeNameError, resp.Rcode, "%s -> NXDOMAIN", name)
+		assert.True(t, resp.Authoritative, "%s answered authoritatively, not forwarded", name)
+		assert.Empty(t, resp.Answer, name)
+	}
 }
 
 // TestServeMeshHitAnswersWithEDNS0: a mesh hit answers the A record and echoes the

--- a/agent/internal/meshdns/server_test.go
+++ b/agent/internal/meshdns/server_test.go
@@ -1,27 +1,192 @@
 package meshdns
 
 import (
+	"encoding/json"
 	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLookup(t *testing.T) {
-	s := NewServer("aether.internal", "127.0.0.1:18054", slog.New(slog.DiscardHandler))
+	s := NewServer("aether.internal", "127.0.0.1:18054", "", slog.New(slog.DiscardHandler))
 	// 020 Part 1: records keyed by "<ns>/<svc>".
 	s.SetRecords(map[string]string{"team-a/svc-1": "10.111.0.5", "default/echo": "10.111.0.6"})
 
 	// <svc>.<ns>.<meshDomain> -> its record; case-insensitive; trailing dot tolerated.
-	assert.Equal(t, "10.111.0.5", s.lookup("svc-1.team-a.aether.internal."))
-	assert.Equal(t, "10.111.0.5", s.lookup("SVC-1.TEAM-A.AETHER.INTERNAL"))
-	assert.Equal(t, "10.111.0.6", s.lookup("echo.default.aether.internal."))
+	assertHit(t, s, "svc-1.team-a.aether.internal.", "10.111.0.5")
+	assertHit(t, s, "SVC-1.TEAM-A.AETHER.INTERNAL", "10.111.0.5")
+	assertHit(t, s, "echo.default.aether.internal.", "10.111.0.6")
 
-	// not answered -> forwarded (lookup returns ""):
-	assert.Empty(t, s.lookup("svc-1.aether-test.svc.cluster.local."), "cluster.local is not a mesh name")
-	assert.Empty(t, s.lookup("unknown.team-a.aether.internal."), "not in the record table")
-	assert.Empty(t, s.lookup("svc-1.aether.internal."), "single label (no namespace) is not a mesh name now")
-	assert.Empty(t, s.lookup("a.b.c.aether.internal."), "three labels under the mesh domain")
-	assert.Empty(t, s.lookup("aether.internal."), "the bare mesh domain")
-	assert.Empty(t, s.lookup("google.com."), "external name")
+	// Mesh names that miss the record table are authoritative (NOT forwarded);
+	// lookup returns "" but the name still parses as a mesh name.
+	assertMeshMiss(t, s, "unknown.team-a.aether.internal.")
+	assertMeshMiss(t, s, "svc-1.aether-test.aether.internal.", "wrong namespace")
+
+	// Not mesh names at all -> forwarded (isMeshName false).
+	assert.False(t, s.isMeshName("svc-1.aether-test.svc.cluster.local."), "cluster.local is not a mesh name")
+	assert.False(t, s.isMeshName("svc-1.aether.internal."), "single label (no namespace) is not a mesh name")
+	assert.False(t, s.isMeshName("a.b.c.aether.internal."), "three labels under the mesh domain")
+	assert.False(t, s.isMeshName("aether.internal."), "the bare mesh domain")
+	assert.False(t, s.isMeshName("google.com."), "external name")
+}
+
+func assertHit(t *testing.T, s *Server, qname, want string) {
+	t.Helper()
+	assert.True(t, s.isMeshName(qname), "%s should be a mesh name", qname)
+	ip, ready := s.lookup(qname)
+	assert.Equal(t, want, ip)
+	assert.True(t, ready, "records populated -> ready")
+}
+
+func assertMeshMiss(t *testing.T, s *Server, qname string, msg ...string) {
+	t.Helper()
+	assert.True(t, s.isMeshName(qname), "%s should be a mesh name", qname)
+	ip, _ := s.lookup(qname)
+	assert.Empty(t, ip, msg)
+}
+
+// TestWarmStartLoadsSnapshot: a NewServer with an existing snapshot file warm-starts
+// its record table (and flips ready) before any SetRecords/reconcile.
+func TestWarmStartLoadsSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "records.json")
+	data, err := json.Marshal(map[string]string{"team-a/svc-1": "10.111.0.5"})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+
+	s := NewServer("aether.internal", "127.0.0.1:0", path, slog.New(slog.DiscardHandler))
+
+	ip, ready := s.lookup("svc-1.team-a.aether.internal.")
+	assert.Equal(t, "10.111.0.5", ip, "warm-started from snapshot")
+	assert.True(t, ready, "a non-empty warm load flips ready")
+}
+
+// TestWarmStartMissingSnapshotIsCold: no snapshot file -> cold (not ready), empty records.
+func TestWarmStartMissingSnapshotIsCold(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "does-not-exist.json")
+	s := NewServer("aether.internal", "127.0.0.1:0", path, slog.New(slog.DiscardHandler))
+
+	ip, ready := s.lookup("svc-1.team-a.aether.internal.")
+	assert.Empty(t, ip)
+	assert.False(t, ready, "no snapshot -> cold")
+}
+
+// TestSetRecordsPersistsSnapshot: SetRecords writes the table to disk so a subsequent
+// process can warm-start from it.
+func TestSetRecordsPersistsSnapshot(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "records.json")
+	s := NewServer("aether.internal", "127.0.0.1:0", path, slog.New(slog.DiscardHandler))
+	s.SetRecords(map[string]string{"default/echo": "10.111.0.6"})
+
+	raw, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(raw, &got))
+	assert.Equal(t, map[string]string{"default/echo": "10.111.0.6"}, got)
+
+	// A second server warm-starts from what the first persisted.
+	s2 := NewServer("aether.internal", "127.0.0.1:0", path, slog.New(slog.DiscardHandler))
+	ip, ready := s2.lookup("echo.default.aether.internal.")
+	assert.Equal(t, "10.111.0.6", ip)
+	assert.True(t, ready)
+}
+
+// fakeResponseWriter captures the reply message ServeDNS writes.
+type fakeResponseWriter struct {
+	dns.ResponseWriter
+	msg *dns.Msg
+}
+
+func (f *fakeResponseWriter) WriteMsg(m *dns.Msg) error { f.msg = m; return nil }
+func (f *fakeResponseWriter) LocalAddr() net.Addr       { return &net.UDPAddr{} }
+func (f *fakeResponseWriter) RemoteAddr() net.Addr      { return &net.UDPAddr{} }
+
+func query(name string, qtype uint16) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(name), qtype)
+	return m
+}
+
+func serve(s *Server, r *dns.Msg) *dns.Msg {
+	w := &fakeResponseWriter{}
+	s.ServeDNS(w, r)
+	return w.msg
+}
+
+// TestServeMeshMissColdIsServfail: a mesh miss BEFORE records are ever populated is
+// SERVFAIL (retryable), and it is never forwarded upstream.
+func TestServeMeshMissColdIsServfail(t *testing.T) {
+	// No upstreams configured: if the code ever forwarded a mesh name, forward()
+	// would fall through to its own SERVFAIL path — but we assert authoritative,
+	// which forward() never sets, so the two are distinguishable.
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	resp := serve(s, query("svc-1.team-a.aether.internal", dns.TypeA))
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeServerFailure, resp.Rcode, "cold mesh miss -> SERVFAIL")
+	assert.True(t, resp.Authoritative, "answered authoritatively, not forwarded")
+	assert.Empty(t, resp.Answer)
+}
+
+// TestServeMeshMissReadyIsNXDomain: once records are populated, an unknown mesh name
+// is answered NXDOMAIN authoritatively, never forwarded.
+func TestServeMeshMissReadyIsNXDomain(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetRecords(map[string]string{"default/echo": "10.111.0.6"})
+	resp := serve(s, query("nope.default.aether.internal", dns.TypeA))
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeNameError, resp.Rcode, "ready mesh miss -> NXDOMAIN")
+	assert.True(t, resp.Authoritative)
+	assert.Empty(t, resp.Answer)
+}
+
+// TestServeMeshHitAnswersWithEDNS0: a mesh hit answers the A record and echoes the
+// client's EDNS0 OPT.
+func TestServeMeshHitAnswersWithEDNS0(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetRecords(map[string]string{"default/echo": "10.111.0.6"})
+
+	r := query("echo.default.aether.internal", dns.TypeA)
+	r.SetEdns0(4096, true)
+	resp := serve(s, r)
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	assert.True(t, resp.Authoritative)
+	require.Len(t, resp.Answer, 1)
+	a, ok := resp.Answer[0].(*dns.A)
+	require.True(t, ok)
+	assert.Equal(t, "10.111.0.6", a.A.String())
+	assert.NotNil(t, resp.IsEdns0(), "client EDNS0 OPT echoed back")
+}
+
+// TestServeMeshHitNonAIsNODATA: a non-A query for a known mesh name is NODATA
+// (NOERROR, empty answer, authoritative) so the name consistently EXISTS.
+func TestServeMeshHitNonAIsNODATA(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetRecords(map[string]string{"default/echo": "10.111.0.6"})
+
+	resp := serve(s, query("echo.default.aether.internal", dns.TypeAAAA))
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "NODATA, not NXDOMAIN")
+	assert.True(t, resp.Authoritative)
+	assert.Empty(t, resp.Answer)
+}
+
+// TestServeNonMeshForwards: a genuinely non-mesh name IS forwarded to the upstream
+// resolver. With no reachable upstream, forward() answers SERVFAIL and, crucially,
+// does NOT set Authoritative (the distinguishing marker from the mesh cold path).
+func TestServeNonMeshForwards(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	// Point the upstream at a black hole so Exchange fails fast and forward() falls
+	// through to its non-authoritative SERVFAIL.
+	s.SetUpstreams([]string{"127.0.0.1:1"})
+
+	resp := serve(s, query("google.com", dns.TypeA))
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeServerFailure, resp.Rcode)
+	assert.False(t, resp.Authoritative, "forwarded (upstream failed), not an authoritative mesh answer")
 }


### PR DESCRIPTION
## Problem

The soak's `mesh_dns` prober tier caught a **0.509% roll-correlated failure** (timeout dominant, plus `dns_error`/`dns_nxdomain`) on the node agent's in-process mesh DNS resolver. Two windows open on every agent restart:

1. **Bind gap → timeout (dominant):** controller-runtime starts plain Runnables only *after* informer caches sync, so `ListenAndServe` on `HOST_IP:18054` was delayed until cache sync. Per-pod nftables `:53` DNAT'd packets hit a closed port → client timeout.
2. **Empty-records-forward → dns_error/nxdomain:** the record table starts `{}`; until the first reconcile a real mesh name missed and was *forwarded* to kube-dns, which has no `aether.internal` zone → SERVFAIL/NXDOMAIN. Forwarding a mesh-domain name is never correct — the resolver is authoritative for the mesh domain.

## Fix 1 — warm-start from a disk snapshot + bind early

- Persist the `records` table to a **host-persistent** snapshot (atomic write via `common/file`) on every `SetRecords`, and warm-load it in `NewServer` **before binding**, so a fresh agent answers mesh names from last-known ClusterIPs within ms of process start.
- Snapshot lives in a **dedicated subdir** (`.../registry/mesh-dns/records.json`) under the already-mounted CNI registry hostPath: survives a rolling pod restart, and stays out of the CNI pod store's top-level `*.json` scan (`setupStorage`/`loadAll` unmarshals every top-level `.json` there as a `CNIPod`; a subdir is skipped). New `--mesh-dns-snapshot-path` flag, defaulted there.
- **Bind early:** start the resolver directly in a goroutine (not `m.Add`), off the cache-gated Runnable group, so its UDP+TCP sockets open at process start. `Start` still honors `ctx.Done` for graceful miekg/dns `Shutdown`; a bind error crashes the agent so the DaemonSet restarts it.

## Fix 2 — never forward the mesh domain; authoritative answer + readiness gate

- A name under `.meshDomain` that misses the record table is **never forwarded**. Answered locally: **NXDOMAIN** once records have ever been populated (a real miss), **SERVFAIL** (retryable) while still cold (never populated). Only genuinely non-mesh names still forward upstream.
- EDNS0 echo + NODATA-for-non-A behavior for hits is unchanged.
- New metric result labels on `aether.mesh_dns.queries`: `nxdomain` (authoritative mesh miss) and `cold` (SERVFAIL before records populated), nil-safe.

Serving stale is safe: ClusterIPs are stable for a Service's lifetime; worst case a since-deleted service resolves to a dead VIP for one reconcile (fast self-healing connection error), strictly better than timeout/NXDOMAIN.

## Testing

- `bazel test //agent/...` — all 26 targets pass (new meshdns cases: warm-start load, missing-snapshot cold, SetRecords persist round-trip, cold→SERVFAIL vs ready→NXDOMAIN, mesh names never forwarded, non-mesh still forwarded, hit answers with EDNS0, non-A NODATA).
- `make format-check` clean; `--config=ci` lint (gocognit ≤15 gate) green on touched packages.

## Chart

No template change needed — the snapshot subdir lives under the already-unconditionally-mounted `cni-registry-dir` hostPath, so no Chart.yaml bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR