### PR TITLE
feat(mesh-dns): readiness gate so surge rolls are hitless

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -57,7 +57,10 @@ go_library(
 
 go_test(
     name = "cmd_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "meshdns_test.go",
+    ],
     embed = [":cmd"],
     deps = [
         "//agent/internal/cni/server",

--- a/agent/internal/cmd/meshdns.go
+++ b/agent/internal/cmd/meshdns.go
@@ -23,11 +23,13 @@ const meshDnsReloadDebounce = 200 * time.Millisecond
 // meshDnsCfg holds the flag-bound configuration for the mesh-dns subcommand
 // (issue #578: the standalone, surge-capable mesh-DNS resolver DaemonSet).
 var (
-	meshDnsSnapshotPath string
-	meshDnsMeshDomain   string
-	meshDnsUpstream     []string
-	meshDnsDebug        bool
-	meshDnsOTLPEndpoint string
+	meshDnsSnapshotPath   string
+	meshDnsMeshDomain     string
+	meshDnsUpstream       []string
+	meshDnsDebug          bool
+	meshDnsOTLPEndpoint   string
+	meshDnsReadyMarker    string
+	meshDnsReadinessCheck bool
 )
 
 var meshDnsCmd = &cobra.Command{
@@ -40,6 +42,17 @@ var meshDnsCmd = &cobra.Command{
 		"access — records come only from the file.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
+		// --readiness-check is the exec readiness probe: exit 0 iff this pod's
+		// pod-local ready marker is present (the distroless agent image has no shell
+		// or cat, so the probe re-execs this binary). The marker is written only once
+		// THIS process has bound its listeners, so the surge rollout keeps the
+		// predecessor until the successor truly serves.
+		if meshDnsReadinessCheck {
+			if _, err := os.Stat(meshDnsReadyMarker); err != nil {
+				return fmt.Errorf("not ready: %w", err)
+			}
+			return nil
+		}
 		return runMeshDNS(cmd.Context())
 	},
 }
@@ -67,6 +80,7 @@ func runMeshDNS(ctx context.Context) error {
 	server := meshdns.NewServerWithOptions(
 		meshDnsMeshDomain, addr, meshDnsSnapshotPath, log,
 		meshdns.WithReusePort(true),
+		meshdns.WithReadyMarker(meshDnsReadyMarker),
 	)
 	upstreams := meshDnsUpstream
 	if len(upstreams) == 0 {
@@ -172,6 +186,8 @@ func init() {
 	f.StringArrayVar(&meshDnsUpstream, "mesh-dns-upstream", nil, "Upstream resolver(s) (host[:port]) non-mesh queries are forwarded to; defaults to /etc/resolv.conf")
 	f.BoolVar(&meshDnsDebug, "debug", false, "Enable debug-level logging")
 	f.StringVar(&meshDnsOTLPEndpoint, "otlp-endpoint", "", "OTLP gRPC collector endpoint for mesh-DNS metrics push (e.g. collector:4317); empty disables telemetry")
+	f.StringVar(&meshDnsReadyMarker, "ready-marker", "/run/aether/mesh-dns.ready", "Pod-local path for the readiness marker written once the resolver's listeners are bound")
+	f.BoolVar(&meshDnsReadinessCheck, "readiness-check", false, "Exit 0 iff the --ready-marker file exists (exec readiness probe mode)")
 
 	rootCmd.AddCommand(meshDnsCmd)
 }

--- a/agent/internal/cmd/meshdns_test.go
+++ b/agent/internal/cmd/meshdns_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runReadinessCheck exercises the mesh-dns RunE in --readiness-check mode against
+// the given marker path, returning the error (nil == exit 0). It drives RunE
+// directly (not rootCmd.Execute) so it exercises only the probe branch, without
+// the agent root command's required node/cluster flags.
+func runReadinessCheck(t *testing.T, marker string) error {
+	t.Helper()
+	meshDnsReadinessCheck = true
+	meshDnsReadyMarker = marker
+	t.Cleanup(func() {
+		meshDnsReadinessCheck = false
+		meshDnsReadyMarker = ""
+	})
+	return meshDnsCmd.RunE(meshDnsCmd, nil)
+}
+
+// TestMeshDNSReadinessCheckMarkerPresent: the exec probe exits 0 when the marker exists.
+func TestMeshDNSReadinessCheckMarkerPresent(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "mesh-dns.ready")
+	require.NoError(t, os.WriteFile(marker, nil, 0o644))
+
+	assert.NoError(t, runReadinessCheck(t, marker), "marker present -> exit 0")
+}
+
+// TestMeshDNSReadinessCheckMarkerAbsent: the exec probe exits non-zero (returns an
+// error) when the marker is absent, so k8s holds the pod NotReady.
+func TestMeshDNSReadinessCheckMarkerAbsent(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "does-not-exist.ready")
+
+	assert.Error(t, runReadinessCheck(t, marker), "marker absent -> non-zero")
+}

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -47,6 +47,7 @@ type Server struct {
 	meshDomain   string
 	addr         string
 	snapshotPath string
+	readyMarker  string
 	reusePort    bool
 	log          *slog.Logger
 	client       *dns.Client
@@ -67,6 +68,18 @@ type Option func(*Server)
 // hitless: the successor pod binds :18054 while the predecessor still serves.
 func WithReusePort(v bool) Option {
 	return func(s *Server) { s.reusePort = v }
+}
+
+// WithReadyMarker makes Start write a pod-local ready-marker file at path once the
+// UDP+TCP listeners are bound (and remove it on shutdown). The exec readiness probe
+// (`agent mesh-dns --readiness-check`) stats this file, so the DaemonSet's
+// maxSurge:1/maxUnavailable:0 rollout keeps the predecessor pod until the successor
+// is TRULY bound — that overlap is what lets SO_REUSEPORT hand off with zero gap.
+// The marker is intentionally pod-local (each container's own fs): a network probe
+// to hostIP:18054 could be answered by the OTHER co-bound REUSEPORT socket and
+// falsely mark this process ready before it has bound. An empty path disables it.
+func WithReadyMarker(path string) Option {
+	return func(s *Server) { s.readyMarker = path }
 }
 
 // NewServer builds the resolver for meshDomain, listening on addr (host:port).
@@ -213,6 +226,11 @@ func (s *Server) Start(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Both listeners are bound now (buildServers pre-binds the sockets on the
+	// reusePort path and dns.Server binds them synchronously otherwise): report
+	// ready so a surge successor is only marked Ready once it can actually serve.
+	s.writeReadyMarker(ctx)
+	defer s.removeReadyMarker()
 	errc := make(chan error, 2)
 	if s.reusePort {
 		go func() { errc <- udp.ActivateAndServe() }()
@@ -229,6 +247,38 @@ func (s *Server) Start(ctx context.Context) error {
 		return nil
 	case err := <-errc:
 		return err
+	}
+}
+
+// writeReadyMarker creates (truncating) the pod-local ready-marker file. A
+// write error is logged but never fatal — the resolver's job is serving DNS, and
+// a missing marker only degrades the surge handoff (the probe stays not-ready),
+// it never breaks resolution. A no-op when no marker path is configured.
+func (s *Server) writeReadyMarker(ctx context.Context) {
+	if s.readyMarker == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(s.readyMarker), snapshotDirMode); err != nil {
+		s.log.WarnContext(ctx, "failed to create mesh-DNS ready-marker dir", "path", s.readyMarker, "error", err)
+		return
+	}
+	f, err := os.OpenFile(s.readyMarker, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, snapshotFileMode)
+	if err != nil {
+		s.log.WarnContext(ctx, "failed to write mesh-DNS ready-marker", "path", s.readyMarker, "error", err)
+		return
+	}
+	_ = f.Close()
+	s.log.InfoContext(ctx, "mesh-DNS ready-marker written", "path", s.readyMarker)
+}
+
+// removeReadyMarker best-effort deletes the ready-marker on shutdown so a
+// terminating pod stops reporting ready (its readiness probe then fails).
+func (s *Server) removeReadyMarker() {
+	if s.readyMarker == "" {
+		return
+	}
+	if err := os.Remove(s.readyMarker); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		s.log.Warn("failed to remove mesh-DNS ready-marker on shutdown", "path", s.readyMarker, "error", err)
 	}
 }
 

--- a/agent/internal/meshdns/server_test.go
+++ b/agent/internal/meshdns/server_test.go
@@ -176,6 +176,47 @@ func newReusePortServer(t *testing.T, addr string, records map[string]string) *S
 	return s
 }
 
+// TestReadyMarkerWrittenOnStartRemovedOnCancel: Start writes the pod-local ready
+// marker once the listeners are bound, and removes it when the context is cancelled.
+func TestReadyMarkerWrittenOnStartRemovedOnCancel(t *testing.T) {
+	addr := fmt.Sprintf("127.0.0.1:%d", freeUDPPort(t))
+	marker := filepath.Join(t.TempDir(), "sub", "mesh-dns.ready") // dir created by Start
+
+	s := NewServerWithOptions("aether.internal", addr, "", slog.New(slog.DiscardHandler),
+		WithReusePort(true), WithReadyMarker(marker))
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() { errc <- s.Start(ctx) }()
+
+	// Once the resolver answers over UDP its listeners are bound, so the marker
+	// (written right after buildServers) must exist.
+	waitForUDP(t, addr)
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(marker)
+		return err == nil
+	}, 2*time.Second, 20*time.Millisecond, "ready marker written after bind")
+
+	// Shutdown removes the marker so a terminating pod stops reporting ready.
+	cancel()
+	select {
+	case <-errc:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after cancel")
+	}
+	_, err := os.Stat(marker)
+	assert.ErrorIs(t, err, os.ErrNotExist, "ready marker removed on shutdown")
+}
+
+// TestReadyMarkerDisabledWhenUnset: with no marker path, Start writes nothing (and
+// does not fail). Guards the empty-path no-op branch.
+func TestReadyMarkerDisabledWhenUnset(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	// Both helpers must be safe no-ops when readyMarker is empty.
+	s.writeReadyMarker(context.Background())
+	s.removeReadyMarker()
+	assert.Empty(t, s.readyMarker)
+}
+
 // assertResolves sends a UDP A query to addr and asserts the answer IP.
 func assertResolves(t *testing.T, addr, name, want string) {
 	t.Helper()

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.83.0"
+version: "0.84.0"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/mesh-dns-daemonset.yaml
+++ b/charts/aether/templates/mesh-dns-daemonset.yaml
@@ -51,6 +51,7 @@ spec:
             - "mesh-dns"
             - "--debug={{ .Values.debug }}"
             - "--mesh-domain={{ .Values.meshDomain }}"
+            - "--ready-marker=/run/aether/mesh-dns.ready"
             {{- range .Values.agent.meshDnsUpstream }}
             - "--mesh-dns-upstream={{ . }}"
             {{- end }}
@@ -74,6 +75,25 @@ spec:
             # Stamped onto every OTel signal so metrics are filterable per node/pod.
             - name: OTEL_RESOURCE_ATTRIBUTES
               value: "k8s.node.name=$(HOST_IP),k8s.pod.name=$(POD_NAME),k8s.namespace.name=$(POD_NAMESPACE)"
+          # Pod-local readiness: passes only once THIS process has bound its
+          # UDP+TCP listeners (it writes the marker after the sockets are up). With
+          # maxSurge:1/maxUnavailable:0 this holds the predecessor pod until the
+          # successor is truly serving, so their SO_REUSEPORT sockets overlap and the
+          # handoff is zero-gap. It must be pod-local, not a network probe: a probe to
+          # hostIP:18054 could be answered by the OTHER co-bound REUSEPORT socket and
+          # falsely mark this pod ready before it has bound.
+          readinessProbe:
+            exec:
+              command:
+                - "/agent"
+                - "mesh-dns"
+                - "--readiness-check"
+                - "--ready-marker=/run/aether/mesh-dns.ready"
+            initialDelaySeconds: 0
+            periodSeconds: 2
+            timeoutSeconds: 1
+            failureThreshold: 2
+            successThreshold: 1
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
@@ -89,6 +109,9 @@ spec:
               mountPath: /host/var/lib/aether/registry
               readOnly: true
               mountPropagation: HostToContainer
+            # Writable scratch for the pod-local ready marker (root fs is read-only).
+            - name: run-aether
+              mountPath: /run/aether
           resources:
             {{- toYaml .Values.agent.meshDnsDaemon.resources | nindent 12 }}
       volumes:
@@ -96,4 +119,8 @@ spec:
           hostPath:
             path: /var/lib/aether/registry
             type: DirectoryOrCreate
+        # Pod-local (per-pod) emptyDir so each surge pod's marker proves ITS own
+        # process is serving — never shared across the predecessor/successor.
+        - name: run-aether
+          emptyDir: {}
 {{- end }}


### PR DESCRIPTION
Follows #578 / #579.

## Problem
#579 decoupled the `aether-mesh-dns` DaemonSet, but talos e2e showed its OWN rolls are not hitless (+130 failed `mesh_dns` probes). The DaemonSet has no readiness probe, so with `maxSurge:1/maxUnavailable:0` k8s marks the new pod Ready the instant its container is Running — before it binds `:18054` — and retires the old pod before the `SO_REUSEPORT` co-bind ever engages. Old and new never overlap, so the handoff gaps.

## Fix
Mirror the existing `proxy-supervisor` pattern: a pod-local ready-marker file + `--readiness-check` exec probe.

- **`meshdns.Server`**: new `WithReadyMarker(path)` option. `Start` writes the marker file AFTER `buildServers` binds the UDP+TCP listeners and BEFORE the serve loop; removes it on ctx-cancel shutdown. Best-effort (logged, never fails `Start`).
- **`agent mesh-dns`**: `--ready-marker` (default `/run/aether/mesh-dns.ready`) + `--readiness-check` (stats the marker, exits 0 iff present — the exec probe entrypoint, since the distroless image has no shell).
- **chart**: writable `/run/aether` `emptyDir`, `--ready-marker` arg, and an exec `readinessProbe` (`periodSeconds:2`, `failureThreshold:2`). `Chart.yaml` 0.83.0 → 0.84.0.

The marker is intentionally **pod-local** (per-pod `emptyDir`): a network/tcpSocket probe to `hostIP:18054` could be answered by the OTHER co-bound REUSEPORT socket and falsely mark the new pod ready before it has bound. A pod-local marker proves THIS process is serving, so the surge keeps the predecessor until the successor truly binds — then REUSEPORT gives a zero-gap handoff.

## Tests
- `Server` writes the marker after `Start` binds and removes it on ctx cancel; empty-path no-op.
- `--readiness-check` returns non-zero when the marker is absent, nil (exit 0) when present.
- Full `bazel test //agent/...` green; `--config=ci` (gocognit) clean; format-check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR