### PR TITLE
fix(mesh-dns): readiness probe timeout + CPU headroom (unblock surge rollout)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.84.0"
+version: "0.85.0"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/mesh-dns-daemonset.yaml
+++ b/charts/aether/templates/mesh-dns-daemonset.yaml
@@ -83,16 +83,21 @@ spec:
           # hostIP:18054 could be answered by the OTHER co-bound REUSEPORT socket and
           # falsely mark this pod ready before it has bound.
           readinessProbe:
+            # The check re-execs the full /agent binary (distroless image, no shell),
+            # whose cold start under the daemon's small CPU request exceeds the 1s
+            # default probe timeout — so give it headroom (timeout 5s) and a longer
+            # period to bound the exec churn. Readiness only gates surge handoffs, so
+            # a 5s period is ample; the old pod keeps serving until the new one passes.
             exec:
               command:
                 - "/agent"
                 - "mesh-dns"
                 - "--readiness-check"
                 - "--ready-marker=/run/aether/mesh-dns.ready"
-            initialDelaySeconds: 0
-            periodSeconds: 2
-            timeoutSeconds: 1
-            failureThreshold: 2
+            initialDelaySeconds: 1
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
             successThreshold: 1
           securityContext:
             readOnlyRootFilesystem: true

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -160,13 +160,17 @@ agent:
   # agent.meshDns is true. It mounts the agent's registry hostPath read-only and
   # serves HOST_IP:18054 from the snapshot the agent writes.
   meshDnsDaemon:
+    # The readiness probe re-execs the full /agent binary every few seconds, which
+    # transiently spawns a second process — so the daemon needs CPU burst headroom
+    # (else the cold-start exec throttles past the probe timeout) and memory headroom
+    # (two /agent processes momentarily) beyond what the tiny resident resolver uses.
     resources:
       requests:
-        cpu: 50m
-        memory: 32Mi
-      limits:
         cpu: 100m
-        memory: 64Mi
+        memory: 48Mi
+      limits:
+        cpu: 300m
+        memory: 128Mi
   # Image as repository + digest (digest-pinned for immutability). Mirror to a
   # private registry by overriding `repository` alone; the digest is preserved.
   image:


### PR DESCRIPTION
The mesh-dns daemon readiness probe (added in #580) re-execs the **full `/agent` binary** (distroless image, no shell), whose cold start under the daemon's 50m CPU request exceeds the **1s default probe timeout**. On talos e2e the surge pod bound and wrote its ready-marker but the probe kept timing out (`command timed out after 1s`, x136), so it never reported Ready and `maxUnavailable:0` wedged the DaemonSet rollout (old pods kept serving — no DNS outage, but the roll stalled).

The `proxy-supervisor` uses the same exec-marker pattern at the 1s default only because `/opt/aether/supervisor` is a *small* binary; the full agent needs headroom.

## Fix (chart-only)
- readinessProbe: `timeoutSeconds 1→5`, `periodSeconds 2→5`, `failureThreshold 2→3`, `initialDelaySeconds 0→1`.
- `meshDnsDaemon.resources`: CPU limit `100m→300m` (burst for the cold-start exec) + request `50m→100m`; memory `64Mi→128Mi` limit / `48Mi` request (the probe transiently spawns a second `/agent`).
- Chart `0.84.0 → 0.85.0`.

Marker semantics and REUSEPORT logic unchanged. Follows #578/#579/#580.