### PR TITLE
test(soak): commit the 8h soak harness to the repo

### DIFF
--- a/e2e/soak/README.md
+++ b/e2e/soak/README.md
@@ -1,0 +1,78 @@
+# 8-hour soak harness
+
+Validates a deployed build against sustained mesh load plus continuous rollout churn.
+Used on the `talos-main` cluster before promoting a release.
+
+Three components run together:
+
+| Component | What it proves |
+|---|---|
+| **External prober** (`//prober`, DaemonSet, already deployed) | the availability SLI — **authoritative for PASS/FAIL** |
+| **k6 runners** (`k6-runner.yaml`) | mesh load by NAME (~300/s) so DNS + cross-node paths are exercised |
+| **Churn driver** (`churn.sh`) | 30 rolling restarts incl. mesh-dns/agent/proxy/edge + a concurrent triple |
+
+The prober is external **on purpose**: the mesh's own self-reported metrics are blind to
+the very churn being tested. Never grade a soak on mesh self-SLI alone.
+
+## Run
+
+```bash
+# 1. Load the k6 script as a ConfigMap (source of truth is the .js file here).
+kubectl create configmap k6-soak-script -n aether-test \
+  --from-file=test.js=e2e/soak/k6-mesh-soak.js \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# 2. Pre-flight: every component Ready, 0 restarts, prober SLI live at 25/s with 0 errors.
+kubectl get pods -n aether-system
+# prober baseline (Grafana/Prometheus):
+#   sum by (tier) (rate(aether_probe_requests_total{result="success"}[3m]))   -> ~25/s
+#   sum by (tier) (rate(aether_probe_requests_total{result!="success"}[5m]))  -> 0
+
+# 3. Start load, then churn (detached — churn sleeps ~7h15m).
+kubectl apply -f e2e/soak/k6-runner.yaml
+bash e2e/soak/churn.sh "rev183/0.86.0" &
+
+# 4. Teardown at T0+8h.
+kubectl delete -f e2e/soak/k6-runner.yaml
+grep -c ROLLED /tmp/soak-churn.log      # expect 30
+```
+
+## Grading
+
+Compute prober deltas over the churn window and compare against the last known-good run:
+
+```promql
+sum by (tier, result) (increase(aether_probe_requests_total[8h]))
+```
+
+- **liveness** tier (local, no DNS) — data-path SLI. Target **0.000%**.
+- **mesh_dns** tier (resolves a real FQDN) — DNS + cross-node SLI. Target: `dns_error`,
+  `dns_nxdomain`, `dns_timeout` **all zero**. A residual `http_error` (~0.02%) is the
+  known cross-node drain path, tracked separately.
+
+## Hard-won gotchas
+
+Each of these invalidated a real run:
+
+1. **Runner pods MUST carry `aether.io/managed: "true"`.** Without it there's no ndots
+   injection and no per-pod CNI `:53` DNAT, so mesh DNS never resolves — 100% failure
+   that looks like a mesh outage but is a harness bug.
+2. **Mesh DNS names are namespace-qualified: `<svc>.<ns>.aether.internal`.** The flat
+   `<svc>.aether.internal` form **never** resolves and returns NXDOMAIN.
+3. **Never restart the otel-collector mid-soak.** It causes Prometheus series churn that
+   makes the prober's cumulative counters non-monotonic — they become unusable for
+   grading. If the SLI breaks mid-run, grade from the clean window *before* the break
+   plus `kubectl` evidence; do **not** trust `increase[8h]` spanning a gap.
+4. **Watch collector memory.** If the collector saturates it silently sheds prober
+   exports and blinds the SLI (it is the same collector the mesh exports to). Sample
+   `kubectl top pods -n o11y` alongside the prober rate.
+5. **Never `helm --reuse-values`** on aether charts — it silently pins a stale image
+   digest. Use `helm get values <rel> -n <ns> -o yaml > /tmp/v.yaml` then `-f /tmp/v.yaml`.
+6. **k6 needs 1Gi.** At 256Mi runners OOM-restart ~3-5h into the 7h40m run, fragmenting
+   the summary.
+
+## Files
+
+- `k6-mesh-soak.js` — load script (constant-arrival-rate, qualified mesh names, no OTLP).
+- `k6-runner.yaml` — the 5-node runner DaemonSet.
+- `churn.sh` — the 30-roll churn driver; takes a build label for the log header.

--- a/e2e/soak/churn.sh
+++ b/e2e/soak/churn.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# 8-hour soak churn driver: 30 rolling restarts on a ~15-minute cadence, including
+# three aether-mesh-dns DaemonSet rolls (surge + SO_REUSEPORT handoff) and one
+# CONCURRENT triple (agent + proxy + svc at the same instant) as the stress peak.
+#
+# Run detached — it sleeps between rolls for ~7h15m:
+#   bash e2e/soak/churn.sh "rev183/0.86.0" &
+#
+# Progress is appended to $LOG with UTC timestamps; grep ROLLED to count.
+set -uo pipefail
+
+BUILD_LABEL="${1:-unspecified-build}"
+LOG="${SOAK_CHURN_LOG:-/tmp/soak-churn.log}"
+T0=$(date +%s)
+
+log() { echo "$(date -u +%FT%TZ) $*" >>"$LOG"; }
+
+# Sleep until T0 + $1 minutes.
+waituntil() {
+	local target now delta
+	target=$((T0 + $1 * 60))
+	now=$(date +%s)
+	delta=$((target - now))
+	if [ "$delta" -gt 0 ]; then sleep "$delta"; fi
+}
+
+roll() {
+	if kubectl rollout restart "$2" -n "$1" >>"$LOG" 2>&1; then
+		log "ROLLED $1/$2"
+	else
+		log "FAILED $1/$2"
+	fi
+}
+
+log "churn driver start T0=$(date -u +%FT%TZ) build=$BUILD_LABEL"
+
+# "<offset-minutes> <kind> [name]"
+SCHED=(
+	"15 svc svc-1" "30 svc svc-2" "45 proxy" "60 svc svc-3" "75 meshdns"
+	"90 agent" "105 svc svc-5" "120 proxy" "135 svc svc-1" "150 edge"
+	"165 svc svc-2" "180 meshdns" "195 svc svc-3" "210 svc svc-4" "225 svc svc-5"
+	"240 svc svc-1" "255 edge" "270 proxy" "285 svc svc-2" "300 TRIPLE"
+	"315 svc svc-4" "330 proxy" "345 meshdns" "360 svc svc-1" "375 svc svc-2"
+	"390 svc svc-3" "405 svc svc-4" "420 proxy" "435 svc svc-1"
+)
+
+for entry in "${SCHED[@]}"; do
+	read -r off kind name <<<"$entry"
+	waituntil "$off"
+	case "$kind" in
+	svc) roll aether-test "deployment/$name" ;;
+	proxy) roll aether-system daemonset/aether-proxy ;;
+	agent) roll aether-system daemonset/aether-agent ;;
+	meshdns) roll aether-system daemonset/aether-mesh-dns ;;
+	edge) roll aether-ingress deployment/aether-edge ;;
+	TRIPLE)
+		log "CONCURRENT triple begin"
+		roll aether-system daemonset/aether-agent &
+		roll aether-system daemonset/aether-proxy &
+		roll aether-test deployment/svc-3 &
+		wait
+		log "CONCURRENT triple done"
+		;;
+	*) log "UNKNOWN kind $kind" ;;
+	esac
+done
+
+log "churn driver complete (30 rolls: 5 proxy, 2 agent incl triple, 2 edge, 3 meshdns, 18 svc)"

--- a/e2e/soak/k6-mesh-soak.js
+++ b/e2e/soak/k6-mesh-soak.js
@@ -1,0 +1,31 @@
+import http from 'k6/http';
+import { check } from 'k6';
+
+export const options = {
+  scenarios: {
+    mesh_soak: {
+      executor: 'constant-arrival-rate',
+      rate: 60, timeUnit: '1s',
+      duration: '7h40m',
+      preAllocatedVUs: 60, maxVUs: 180,
+    },
+  },
+  thresholds: {
+    http_req_failed: ['rate<0.01'],
+    checks: ['rate>0.99'],
+  },
+};
+
+const targets = [
+  'http://svc-1.aether-test.aether.internal:18081/',
+  'http://svc-2.aether-test.aether.internal:18081/',
+  'http://svc-3.aether-test.aether.internal:18081/',
+  'http://svc-4.aether-test.aether.internal:18081/',
+  'http://echo.aether-test.aether.internal:18081/',
+];
+
+export default function () {
+  const url = targets[Math.floor(Math.random() * targets.length)];
+  const res = http.get(url, { tags: { endpoint: url } });
+  check(res, { 'status is 200': (r) => r.status === 200 });
+}

--- a/e2e/soak/k6-runner.yaml
+++ b/e2e/soak/k6-runner.yaml
@@ -1,0 +1,72 @@
+# Distributed k6 mesh load for the 8h soak: one runner per worker node, each at
+# 60 iters/s (constant-arrival-rate) against mesh services by NAME, so the run
+# exercises mesh DNS + the cross-node data path under churn.
+#
+# The ConfigMap this mounts is built from k6-mesh-soak.js — see README.md.
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k6-soak-loader
+  namespace: aether-test
+  labels:
+    app.kubernetes.io/name: k6-soak-loader
+    app.kubernetes.io/component: load-generator
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: k6-soak-loader
+  template:
+    metadata:
+      labels:
+        # REQUIRED: without this label the pod gets no ndots injection and no
+        # per-pod CNI :53 DNAT, so mesh DNS never resolves and the whole run is
+        # invalid (this silently wasted the 2026-07-19 soak).
+        aether.io/managed: "true"
+        app.kubernetes.io/name: k6-soak-loader
+        app.kubernetes.io/component: load-generator
+      annotations:
+        # Pre-warm ODCDS clusters so the first requests aren't cold-service misses.
+        config.aether.io/upstreams: "echo,svc-1,svc-2,svc-3,svc-4,svc-5"
+        capture.aether.io/exclude-outbound-ports: "6565"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: k6
+          image: grafana/k6:latest
+          args:
+            - run
+            - --no-usage-report
+            - /soak/test.js
+          volumeMounts:
+            - name: soak-script
+              mountPath: /soak
+          resources:
+            # k6 accumulates metric samples in memory for the end-of-run summary, so
+            # a 7h40m run outgrows a small limit: at 256Mi every runner OOM-restarted
+            # ~3-5h in (07-23 and 07-24 soaks), fragmenting the run and losing the
+            # http_req_failed summary. 1Gi comfortably covers the full 8h.
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 400m
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            runAsUser: 12345
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+        - name: soak-script
+          configMap:
+            name: k6-soak-script
+      restartPolicy: Always


### PR DESCRIPTION
The soak harness lived only in `/tmp` — and the k6 script only as an in-cluster ConfigMap — so it was one cleanup away from being lost, and had no review surface. That's precisely how the two harness bugs that **invalidated real soak runs** got in:

- runner pods missing `aether.io/managed: "true"` → no ndots injection, no per-pod CNI `:53` DNAT → mesh DNS never resolved (looked like a mesh outage; was a harness bug)
- flat `<svc>.aether.internal` targets, which never resolve (names are namespace-qualified)

## Adds `e2e/soak/`
- `k6-mesh-soak.js` — load script (constant-arrival-rate, qualified mesh names, no OTLP), recovered from the cluster ConfigMap.
- `k6-runner.yaml` — 5-node runner DaemonSet. **1Gi** memory: at 256Mi every runner OOM-restarted ~3–5h into the 7h40m run and lost the `http_req_failed` summary.
- `churn.sh` — 30-roll churn driver incl. 3 `aether-mesh-dns` rolls and the concurrent triple; build label is now a parameter instead of a stale hardcoded string.
- `README.md` — run + grading procedure, and the gotchas that each cost a run, notably **never restart the otel-collector mid-soak** (Prometheus series churn makes the prober's cumulative counters non-monotonic → ungradeable) and **never `helm --reuse-values`**.

Docs/test assets only — no production code, no chart changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)