### PR TITLE
feat(prober): probe the mesh-DNS forward path + add mesh-DNS alerting rules

### DIFF
--- a/charts/prober/Chart.yaml
+++ b/charts/prober/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   is structurally blind to during hot restarts.
 type: application
 # Stamped at package time when built with `--stamp` (see registrar Chart.yaml).
-version: "0.1.0-{GIT_COMMIT}"
+version: "0.2.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/prober/values.yaml
+++ b/charts/prober/values.yaml
@@ -38,8 +38,17 @@ probe:
   # Host-overridden, so a real mesh-DNS outage becomes an alertable dns_* signal
   # (closes the blind spot behind issue #574). Only works because this pod is
   # mesh-managed. Each target's host is also added to config.aether.io/upstreams.
+  #
+  # Two targets on purpose — they exercise DIFFERENT resolver paths, and the
+  # `target` label keeps them separable:
+  #   *.aether.internal      -> answered authoritatively from the record snapshot
+  #   *.svc.cluster.local    -> NOT a mesh name, so it is FORWARDED to kube-dns
+  # Without the second, the forward path is unprobed: it carries the majority of a
+  # real workload's lookups, yet organic forward traffic here is near zero, so a
+  # kube-dns or upstream-failover regression would be invisible.
   meshDNSTargets:
     - "echo.aether-test.aether.internal:18081"
+    - "echo.aether-test.svc.cluster.local:18081"
 
 # OTel: push the probe SLI to the collector (host:port, insecure). Empty disables
 # telemetry (the prober still runs but emits nothing).

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,75 @@
+# Observability: alerting rules
+
+## mesh-DNS (`mesh-dns-alerts.yml`)
+
+Covers the `aether-mesh-dns` DaemonSet, which is on the critical path for **every**
+managed pod's DNS (the CNI DNATs all UDP+TCP `:53` to `HOST_IP:18054`).
+
+Since #578 the resolver runs in its own process and answers from a snapshot file the
+node **agent** writes. That cross-process dependency is the reason most of these rules
+exist — and why the external prober alone is not sufficient.
+
+| Alert | Severity | Catches |
+|---|---|---|
+| `MeshDNSSnapshotStale` | critical | agent stopped writing → daemon serves frozen records |
+| `MeshDNSNoRecords` | critical | empty snapshot → every mesh name NXDOMAINs |
+| `MeshDNSNoUpstreams` | critical | no forward upstream → all non-mesh DNS fails |
+| `MeshDNSWatcherInactive` | warning | fsnotify watcher died → updates silently stop |
+| `MeshDNSReloadFailing` | warning | corrupt/unreadable snapshot |
+| `MeshDNSResolutionFailing` | critical | external prober can't resolve (per path) |
+| `MeshDNSMetricsAbsent` | critical | daemons down fleet-wide, or the OTLP path is broken |
+
+### Why staleness is the important one
+
+If the agent dies, no fsnotify event ever fires, so the daemon keeps serving its **last
+known table indefinitely**. Because `ready` is true, misses are answered as
+*authoritative* NXDOMAINs, which clients negatively cache. New services never resolve;
+re-IP'd services resolve to dead ClusterIPs.
+
+**The external prober stays 100% green through all of it** — its long-lived target keeps
+resolving from the stale snapshot. `MeshDNSSnapshotStale` is the only signal for a
+failure that is silently *wrong* rather than loudly *broken*.
+
+The agent re-stamps the snapshot every 60s (`capture.MeshDNSHeartbeat`) even when
+records are unchanged, precisely so that age is meaningful on a quiet cluster.
+`snapshot_generation` advances only on a real content change, so the two are
+distinguishable.
+
+### Probe targets cover different paths
+
+The `mesh_dns` prober tier carries two targets, separable by the `target` label:
+
+- `*.aether.internal` → answered authoritatively from the snapshot
+- `*.svc.cluster.local` → **forwarded** to kube-dns
+
+Both matter: the forward path carries the majority of a real workload's lookups but
+almost no organic traffic here, so without the second target a kube-dns or
+upstream-failover regression would be invisible.
+
+## Installing
+
+There is **no Prometheus operator** on `talos-main` (no `PrometheusRule` CRD) and the
+Grafana install has **no alerting sidecar** — only dashboard and datasource sidecars.
+So these rules are delivered through the Prometheus helm values:
+
+```yaml
+# prometheus helm values
+serverFiles:
+  alerting_rules.yml:
+    groups:
+      # contents of mesh-dns-alerts.yml
+```
+
+Then `helm upgrade` the Prometheus release. Verify with:
+
+```bash
+kubectl get cm prometheus-server -n prometheus \
+  -o go-template='{{index .data "alerting_rules.yml"}}' | head
+```
+
+Rules appear under **Alerts** in the Prometheus UI once loaded.
+
+> **Note — no notification delivery.** There is currently no Alertmanager deployed, so
+> firing alerts are visible in the Prometheus UI but are **not routed anywhere**.
+> Deploying Alertmanager (or moving these to Grafana-managed alert rules with a contact
+> point) is required before they page anyone.

--- a/docs/observability/mesh-dns-alerts.yml
+++ b/docs/observability/mesh-dns-alerts.yml
@@ -1,0 +1,126 @@
+# Prometheus alerting rules for the mesh-DNS resolver (issue #586 follow-up).
+#
+# The resolver is on the critical path for EVERY managed pod's DNS: the CNI DNATs
+# all UDP+TCP :53 to HOST_IP:18054. It runs as its own DaemonSet (aether-mesh-dns)
+# and answers from a snapshot file the node AGENT writes -- a cross-process
+# dependency that most of these rules exist to watch.
+#
+# Install: merge into the Prometheus helm values under
+#   serverFiles:
+#     alerting_rules.yml:
+#       groups: [...]
+# See README.md in this directory.
+
+groups:
+  - name: aether-mesh-dns
+    rules:
+      # ---------------------------------------------------------------- P1
+      # The failure mode that is SILENTLY WRONG rather than loudly broken, and
+      # the one the external prober cannot see: it keeps resolving its long-lived
+      # target from the frozen snapshot and stays green the whole time.
+      - alert: MeshDNSSnapshotStale
+        expr: max by (node) (aether_mesh_dns_snapshot_age_seconds) > 300
+        for: 5m
+        labels:
+          severity: critical
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS records are stale on {{ $labels.node }}"
+          description: >-
+            The agent re-stamps the snapshot every 60s; age is now {{ $value | humanize }}s.
+            The agent has stopped writing (crash, RBAC loss, or a wedged capture
+            reconciler). The daemon keeps serving the frozen table as AUTHORITATIVE
+            NXDOMAINs, which clients negatively cache: new services never resolve and
+            re-IP'd services resolve to dead ClusterIPs. The external prober will NOT
+            catch this.
+
+      # An empty snapshot makes every mesh name an authoritative NXDOMAIN.
+      - alert: MeshDNSNoRecords
+        expr: min by (node) (aether_mesh_dns_records) == 0
+        for: 5m
+        labels:
+          severity: critical
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS is serving zero records on {{ $labels.node }}"
+          description: >-
+            The resolver has no A records, so every <svc>.<ns>.aether.internal lookup
+            returns an authoritative NXDOMAIN for every pod on this node.
+
+      # With no upstream, EVERY non-mesh name fails - cluster.local and external
+      # included, because all :53 traffic is DNAT'd here. Root cause is usually an
+      # unreadable /etc/resolv.conf at daemon start.
+      - alert: MeshDNSNoUpstreams
+        expr: min by (node) (aether_mesh_dns_upstreams_configured) == 0
+        for: 5m
+        labels:
+          severity: critical
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS has no forward upstream on {{ $labels.node }}"
+          description: >-
+            Non-mesh resolution (cluster.local and external) is failing for every pod
+            on this node. Check the daemon log for the ERROR emitted at startup when
+            /etc/resolv.conf yields no nameservers.
+
+      # ---------------------------------------------------------------- P2
+      # A dead watcher means reloads stop silently; records then freeze and
+      # MeshDNSSnapshotStale follows. This fires first and is the better signal.
+      - alert: MeshDNSWatcherInactive
+        expr: min by (node) (aether_mesh_dns_watch_active) == 0
+        for: 10m
+        labels:
+          severity: warning
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS snapshot watcher is inactive on {{ $labels.node }}"
+          description: >-
+            The fsnotify watcher failed to start or died, so record updates are no
+            longer picked up. Restart the aether-mesh-dns pod on this node.
+
+      - alert: MeshDNSReloadFailing
+        expr: sum by (node) (rate(aether_mesh_dns_snapshot_reloads_total{result!="success"}[10m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS snapshot reloads are failing on {{ $labels.node }}"
+          description: >-
+            Reloads are erroring ({{ $labels.result }}); the daemon keeps the last good
+            table. A parse_error usually means a truncated or corrupt snapshot file.
+
+      # External SLI. Deliberately EXCLUDES http_error: that is the cross-node drain
+      # path (a different failure domain), and including it would fire on every proxy
+      # roll. Generic `timeout` IS included -- a hung resolver surfaces as a context
+      # deadline, not as dns_timeout.
+      - alert: MeshDNSResolutionFailing
+        expr: |
+          sum by (node, target) (
+            rate(aether_probe_requests_total{tier="mesh_dns",result=~"dns_error|dns_nxdomain|dns_timeout|timeout"}[5m])
+          ) > 0
+        for: 10m
+        labels:
+          severity: critical
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS resolution failing on {{ $labels.node }} for {{ $labels.target }}"
+          description: >-
+            The external prober cannot resolve {{ $labels.target }}. A *.aether.internal
+            target implicates the resolver's authoritative path; a *.svc.cluster.local
+            target implicates the FORWARD path (kube-dns or upstream failover).
+
+      # Catch-all: every daemon stopped reporting. Push-based OTLP means a dead
+      # daemon simply stops producing series rather than going to 0.
+      - alert: MeshDNSMetricsAbsent
+        expr: absent(aether_mesh_dns_ready)
+        for: 10m
+        labels:
+          severity: critical
+          component: mesh-dns
+        annotations:
+          summary: "mesh-DNS is reporting no metrics fleet-wide"
+          description: >-
+            No aether_mesh_dns_* series for 10m. Either every daemon is down (DNS is
+            broken cluster-wide) or the OTLP metrics path is broken (check the
+            otel-collector for memory saturation, which sheds exports silently).


### PR DESCRIPTION
Closes the two observability follow-ups deferred from #586.

## 1. Probe the forward path (`charts/prober/values.yaml`)

The `mesh_dns` tier only resolved `*.aether.internal` — which the resolver answers **authoritatively from its snapshot and never forwards**. So the forward path (kube-dns reachability, upstream failover, the empty-upstreams mode) had **zero probe coverage**, despite all pod `:53` traffic being DNAT'd through it.

Live counters showed the blind spot plainly: **~6 forwarded queries per node vs ~380,000 answered** — unexercised *and* unwatched.

Adds `echo.aether-test.svc.cluster.local:18081`, which is not a mesh name and therefore takes the `forward()` path. Values-only:
- the `target` label keeps the paths separable (verified: the metric carries the full FQDN);
- `prober.upstreams` already folds each target host into `config.aether.io/upstreams` (verified in rendered output).

## 2. Alerting rules (`docs/observability/`)

**Nothing alerted on mesh DNS at all** — the metrics were consumed by nobody. Seven rules, expressions validated against live Prometheus:

| Alert | Sev | Catches |
|---|---|---|
| `MeshDNSSnapshotStale` | critical | agent stopped writing → frozen records |
| `MeshDNSNoRecords` | critical | empty snapshot → every mesh name NXDOMAINs |
| `MeshDNSNoUpstreams` | critical | no upstream → all non-mesh DNS fails |
| `MeshDNSWatcherInactive` | warning | fsnotify died → updates silently stop |
| `MeshDNSReloadFailing` | warning | corrupt/unreadable snapshot |
| `MeshDNSResolutionFailing` | critical | prober can't resolve (per path) |
| `MeshDNSMetricsAbsent` | critical | daemons down, or the OTLP path broke |

Two deliberate choices: `MeshDNSResolutionFailing` **excludes** `http_error` (the cross-node drain path — a different failure domain that would fire on every proxy roll) but **includes** generic `timeout`, since a hung resolver surfaces as a context deadline rather than `dns_timeout`.

### Delivery is documented, not automated
There is **no Prometheus operator** (no `PrometheusRule` CRD) and the Grafana install has **no alerting sidecar** (dashboards/datasources only), so the rules go into the Prometheus helm values — see `docs/observability/README.md`. And there is **no Alertmanager deployed**, so firing alerts will be visible in the Prometheus UI but **not routed anywhere** until one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)