### PR TITLE
fix(e2e): wait for aether-mesh-dns in the multi-cluster harnesses

### DIFF
--- a/e2e/multicluster_replicator.sh
+++ b/e2e/multicluster_replicator.sh
@@ -55,6 +55,21 @@ die() {
 	exit 1
 }
 
+# client_code() dials a MESH DNS NAME, so a bare "curl 000" is ambiguous: it could be
+# routing, or nothing may have resolved the name at all. Dump the resolver's state on
+# failure so the next red run says which, instead of costing a bisect (this suite sat
+# red for three nights over exactly this).
+dump_mesh_dns() {
+	local c
+	for c in "$@"; do
+		printf '\033[1;33m  -- mesh-dns state on %s --\033[0m\n' "$c" >&2
+		kubectl --context "kind-$c" -n "$NS" get pods -l app.kubernetes.io/component=mesh-dns \
+			-o wide 2>&1 | sed 's/^/    /' >&2 || true
+		kubectl --context "kind-$c" -n "$NS" logs -l app.kubernetes.io/component=mesh-dns \
+			--tail=15 --prefix 2>&1 | sed 's/^/    /' >&2 || true
+	done
+}
+
 etcd_name() { echo "aether-etcd-region-$1"; }
 region_of() { echo "region-$1"; }
 
@@ -233,6 +248,11 @@ install_aether() {
 			$(img agent agent) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
 			--timeout 5m >/dev/null || die "aether install failed on '$c'"
 		kubectl --context "kind-$c" -n "$NS" rollout status ds/aether-agent --timeout=180s >/dev/null || true
+		# client_code() resolves echo.<ns>.<mesh-domain>, and since #578 the AGENT no
+		# longer answers that -- the aether-mesh-dns DaemonSet does. Waiting only on
+		# the agent stopped implying "DNS is serving", which is what made this suite
+		# fail with an unexplained curl 000.
+		kubectl --context "kind-$c" -n "$NS" rollout status ds/aether-mesh-dns --timeout=180s >/dev/null || true
 		ok "aether up on '$c'"
 	done
 	rm -rf "$(dirname "$charts")"
@@ -328,7 +348,10 @@ verify() {
 		[ "$code" = "200" ] && break
 		sleep 6
 	done
-	[ "$code" = "200" ] || die "cross-region call returned $code (expected 200)"
+	if [ "$code" != "200" ]; then
+		dump_mesh_dns "$CLUSTER_A" "$CLUSTER_B"
+		die "cross-region call returned $code (expected 200) — the target is a MESH DNS NAME, so rule out resolution using the mesh-dns state above before digging into cross-region routing"
+	fi
 	ok "cross-region call succeeded (HTTP 200) over mirror + waypoint"
 
 	log "3/4 failover: kill region $region_b's registrar (replicator leader) -> its mirror in etcd-a must EXPIRE at the lease TTL"

--- a/e2e/multicluster_waypoint.sh
+++ b/e2e/multicluster_waypoint.sh
@@ -50,6 +50,21 @@ die() {
 	exit 1
 }
 
+# The data-path assertion dials a MESH DNS NAME, so a bare "curl 000" is ambiguous:
+# it could be routing, or it could be that nothing resolved the name at all. Dump the
+# resolver's state on failure so the next red run says which, instead of costing a
+# bisect (this suite sat red for three nights over exactly this).
+dump_mesh_dns() {
+	local c
+	for c in "$@"; do
+		printf '\033[1;33m  -- mesh-dns state on %s --\033[0m\n' "$c" >&2
+		kubectl --context "kind-$c" -n "$NS" get pods -l app.kubernetes.io/component=mesh-dns \
+			-o wide 2>&1 | sed 's/^/    /' >&2 || true
+		kubectl --context "kind-$c" -n "$NS" logs -l app.kubernetes.io/component=mesh-dns \
+			--tail=15 --prefix 2>&1 | sed 's/^/    /' >&2 || true
+	done
+}
+
 raise_inotify() {
 	if sudo -n true 2>/dev/null; then
 		sudo sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288 >/dev/null 2>&1 &&
@@ -211,6 +226,11 @@ install_aether() {
 			$(img agent agent) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
 			--timeout 5m >/dev/null || die "aether install failed on '$c'"
 		kubectl --context "kind-$c" -n "$NS" rollout status ds/aether-agent --timeout=180s >/dev/null || true
+		# The data-path assertion resolves echo.<ns>.<mesh-domain>, and since #578 the
+		# AGENT no longer answers that -- the aether-mesh-dns DaemonSet does. Waiting
+		# only on the agent stopped implying "DNS is serving", which is what made this
+		# suite fail with an unexplained curl 000.
+		kubectl --context "kind-$c" -n "$NS" rollout status ds/aether-mesh-dns --timeout=180s >/dev/null || true
 		ok "aether up on '$c'"
 	done
 	rm -rf "$(dirname "$charts")"
@@ -295,7 +315,8 @@ verify() {
 	if [ "$code" = "200" ]; then
 		ok "cross-cluster call succeeded (HTTP 200) — waypoint data path works: client(a) -> b-node:$TUNNEL_PORT -> echo pod(b), mTLS end-to-end"
 	else
-		die "cross-cluster call returned $code (expected 200) — inspect a's EDS for echo (should be b-node-ip:$TUNNEL_PORT) and b's ew_tunnel listener"
+		dump_mesh_dns "$CLUSTER_A" "$CLUSTER_B"
+		die "cross-cluster call returned $code (expected 200) — the target is a MESH DNS NAME, so first rule out resolution using the mesh-dns state above; if DNS is healthy, inspect a's EDS for echo (should be b-node-ip:$TUNNEL_PORT) and b's ew_tunnel listener"
 	fi
 }
 


### PR DESCRIPTION
The nightly `e2e` workflow has been red since 07-22 (`waypoint` + `replicator`, both `curl 000`). The regression window contains **exactly** the three mesh-DNS decoupling commits (#579/#580/#581).

Both suites assert on a **mesh DNS name** (`echo.<ns>.<mesh-domain>`) but gated readiness only on `ds/aether-agent`. Before #578 that was sufficient — the agent *was* the resolver. After the decoupling it no longer implies DNS is serving, so the harness races a cold `aether-mesh-dns` DaemonSet and fails with an unexplained `000`.

## Changes
- Wait for `ds/aether-mesh-dns` alongside the agent in both harnesses.
- `dump_mesh_dns()` on assertion failure (pod state + recent logs, both clusters). A bare `000` is ambiguous between *didn't route* and *didn't resolve* — that ambiguity is what made this a bisect instead of a self-evident failure.

## Caveat
The missing wait is definitively a defect but is **not proven** to be the whole cause: the daemon's readiness probe re-execs a binary and is CPU-sensitive (#581), and CI runners are exactly that environment. The diagnostics exist so the next run settles it conclusively.

Not a data-plane regression — talos runs the decoupled resolver hitless (soak-validated: agent-roll +1, daemon-roll +0).

Refs #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)