### PR TITLE
ci(e2e): auto-file an issue when the nightly run fails

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -504,3 +504,53 @@ jobs:
       - name: Tear down
         if: always()
         run: ./e2e/multicluster_replicator.sh down || true
+
+  # --- Auto-file when the NIGHTLY run fails.
+  #
+  # This suite sat red for three consecutive nights (07-23..07-25) before anyone
+  # noticed: a scheduled run that fails notifies nobody and leaves no artifact, so
+  # a real regression (the mesh-DNS decoupling breaking the multi-cluster harness,
+  # #589) stayed invisible. This job turns that into a tracked issue.
+  #
+  # Deliberately scoped to `schedule`: PR runs already surface failures in the PR,
+  # so auto-filing those would be pure noise. And it updates ONE rolling issue
+  # rather than filing per night — three duplicate issues is how people learn to
+  # ignore them, which is the very failure mode this exists to prevent.
+  report-failure:
+    needs: [build, gateway-http, mesh-http, waypoint, replicator]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the nightly-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RESULTS: |
+            build=${{ needs.build.result }}
+            gateway-http=${{ needs.gateway-http.result }}
+            mesh-http=${{ needs.mesh-http.result }}
+            waypoint=${{ needs.waypoint.result }}
+            replicator=${{ needs.replicator.result }}
+        run: |
+          set -euo pipefail
+          title="Nightly e2e failing"
+          failed=$(echo "$RESULTS" | awk -F= '$2=="failure"{printf "`%s` ", $1}')
+          [ -n "$failed" ] || failed="(no job reported failure — check the run)"
+
+          body=$(printf '%s\n\n%s\n\n%s\n' \
+            "Failed jobs: ${failed}" \
+            "Run: ${RUN_URL}" \
+            "_Filed automatically by the \`report-failure\` job; this issue is reused for consecutive failures._")
+
+          # Dedupe on an OPEN issue with this exact title. Title-based (not label-based)
+          # so the job never depends on a label existing in the repo.
+          num=$(gh issue list --state open --search "in:title \"${title}\"" -L 1 --json number -q '.[0].number // empty')
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --body "$body"
+            echo "commented on #$num"
+          else
+            gh issue create --title "$title" --body "$body"
+          fi


### PR DESCRIPTION
The nightly e2e sat red for **three consecutive nights** (07-23..07-25) before it was noticed. A scheduled run that fails notifies nobody and leaves no artifact, so a genuine regression — the mesh-DNS decoupling breaking the multi-cluster harnesses (#589) — stayed invisible until found by chance. That silence is a bigger problem than the bug itself.

## Change
A `report-failure` job that opens (or comments on) a single rolling issue naming the failed jobs and linking the run.

## Design choices
- **Scoped to `schedule`.** PR runs already surface failures in the PR; auto-filing those would be pure noise.
- **One rolling issue, not one per night.** Three duplicate issues is precisely how people learn to ignore them — the failure mode this exists to prevent.
- **Dedupe by title, not label**, so the job never depends on a repo label existing (and can't fail on label creation).
- **`issues: write` scoped to this job**, rather than widening the workflow's top-level `contents: read`.

Verified locally: the awk extraction of failed jobs from the `needs.*.result` context, and the `gh issue list --search 'in:title ...'` dedupe query (returns empty cleanly via `// empty`). YAML parses and the job graph is correct.

Refs #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)