### PR TITLE
fix(mesh-dns): don't wedge when the snapshot dir doesn't exist yet

### DIFF
--- a/agent/cmd/mesh-dns/BUILD.bazel
+++ b/agent/cmd/mesh-dns/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":mesh-dns_lib"],
     deps = [
+        "//agent/internal/meshdns",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/agent/cmd/mesh-dns/main.go
+++ b/agent/cmd/mesh-dns/main.go
@@ -40,6 +40,12 @@ var Version = "dev"
 // ops back-to-back) into a single snapshot reload.
 const reloadDebounce = 200 * time.Millisecond
 
+// watchRetryInterval is how often we re-attempt an fsnotify watch that could not be
+// established (usually: the agent has not yet created the snapshot dir), and how often
+// we poll ReloadFromSnapshot while blind. Short enough that a fresh cluster converges
+// quickly, long enough to be free at steady state.
+const watchRetryInterval = 10 * time.Second
+
 // resolvConfPath is the node resolv.conf the default forward upstream is read from.
 // The DaemonSet runs ClusterFirstWithHostNet, so this points at the cluster kube-dns.
 const resolvConfPath = "/etc/resolv.conf"
@@ -169,18 +175,36 @@ func resolveUpstreams(l *slog.Logger, resolvConf string) []string {
 // atomic-rename the agent uses to update records is caught — fsnotify loses the watch
 // on the replaced inode, exactly as agent/storage handles it. Events on the snapshot
 // file are debounced and coalesced into a single ReloadFromSnapshot.
+// It RETRIES establishing the watch instead of giving up for the process lifetime.
+// The snapshot dir is created by the AGENT (this daemon mounts the volume read-only),
+// so on a fresh cluster the dir legitimately does not exist yet — treating that as
+// permanent left the daemon Ready but record-less forever (#589). While the watch is
+// down we still poll ReloadFromSnapshot, so records land even if fsnotify never works.
 func watchSnapshot(ctx context.Context, server *meshdns.Server, path string, l *slog.Logger) {
-	w := newSnapshotWatcher(path, l)
-	if w == nil {
-		// aether.mesh_dns.watch_active stays 0: records are frozen until restart.
-		return
+	for ctx.Err() == nil {
+		if w := newSnapshotWatcher(path, l); w != nil {
+			server.SetWatchActive(true)
+			// The agent may have written between our last reload and the watch being
+			// established; reload once so that window is never missed.
+			server.ReloadFromSnapshot()
+			runWatchLoop(ctx, w, server, path, l)
+			server.SetWatchActive(false)
+			_ = w.Close()
+		} else {
+			// Not watching yet: pick up records by polling until the dir appears.
+			server.ReloadFromSnapshot()
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(watchRetryInterval):
+		}
 	}
-	server.SetWatchActive(true)
-	defer func() {
-		server.SetWatchActive(false)
-		_ = w.Close()
-	}()
+}
 
+// runWatchLoop services one established watcher until the context ends or the watcher
+// closes its channels (after which watchSnapshot re-establishes it).
+func runWatchLoop(ctx context.Context, w *fsnotify.Watcher, server *meshdns.Server, path string, l *slog.Logger) {
 	deb := &debouncer{delay: reloadDebounce}
 	for {
 		select {
@@ -205,18 +229,21 @@ func watchSnapshot(ctx context.Context, server *meshdns.Server, path string, l *
 	}
 }
 
-// newSnapshotWatcher creates an fsnotify watcher on the snapshot file's parent dir,
-// or nil (logged) when the watcher can't be set up — records then only load at start.
+// newSnapshotWatcher creates an fsnotify watcher on the snapshot file's parent dir, or
+// nil (logged) when it can't be set up yet. The caller RETRIES: a missing dir just
+// means the agent has not written its first snapshot, which is normal on a fresh
+// cluster, so this is warned rather than errored.
 func newSnapshotWatcher(path string, l *slog.Logger) *fsnotify.Watcher {
 	w, err := fsnotify.NewWatcher()
 	if err != nil {
-		l.Error("mesh-DNS snapshot watcher disabled; records will not reload until restart", "error", err)
+		l.Warn("mesh-DNS snapshot watcher unavailable; retrying", "error", err, "retryIn", watchRetryInterval)
 		return nil
 	}
 	dir := filepath.Dir(path)
 	if err := w.Add(dir); err != nil {
 		_ = w.Close()
-		l.Error("failed to watch mesh-DNS snapshot dir; records will not reload until restart", "error", err, "dir", dir)
+		l.Warn("mesh-DNS snapshot dir not watchable yet (the agent creates it on its first write); retrying",
+			"error", err, "dir", dir, "retryIn", watchRetryInterval)
 		return nil
 	}
 	l.Info("watching mesh-DNS snapshot for changes", "dir", dir, "path", path)

--- a/agent/cmd/mesh-dns/main_test.go
+++ b/agent/cmd/mesh-dns/main_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/bpalermo/aether/agent/internal/meshdns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +83,21 @@ func TestResolveUpstreamsEmptyIsLoud(t *testing.T) {
 				"an empty upstream set is a node-wide DNS outage and must be loud")
 		})
 	}
+}
+
+// TestSnapshotWatcherRecoversWhenDirAppears: a missing snapshot dir is NOT terminal.
+// The agent creates it on startup/first write, so the daemon may legitimately start
+// first; treating that as permanent left it Ready but record-less forever (#589).
+func TestSnapshotWatcherRecoversWhenDirAppears(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mesh-dns", "records.json")
+	l := slog.New(slog.DiscardHandler)
+
+	// Dir absent: no watcher yet, and crucially the caller retries rather than exiting.
+	assert.Nil(t, newSnapshotWatcher(path, l), "no watcher while the dir is missing")
+
+	// Once the agent creates it, the very next attempt succeeds.
+	require.NoError(t, meshdns.EnsureSnapshotDir(path))
+	w := newSnapshotWatcher(path, l)
+	require.NotNil(t, w, "watcher established after the dir appears")
+	_ = w.Close()
 }

--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//agent/internal/edge/secret",
         "//agent/internal/gamma",
         "//agent/internal/l4route",
+        "//agent/internal/meshdns",
         "//agent/internal/node",
         "//agent/internal/proxy/hotrestart",
         "//agent/internal/spire",

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -34,6 +34,7 @@ import (
 	"github.com/bpalermo/aether/agent/internal/configimport"
 	"github.com/bpalermo/aether/agent/internal/gamma"
 	"github.com/bpalermo/aether/agent/internal/l4route"
+	"github.com/bpalermo/aether/agent/internal/meshdns"
 	"github.com/bpalermo/aether/agent/internal/node"
 	"github.com/bpalermo/aether/agent/internal/spire"
 	"github.com/bpalermo/aether/agent/internal/xds/ack"
@@ -388,6 +389,13 @@ func configureSnapshotCache(ctx context.Context, m ctrl.Manager) (*cache.Snapsho
 func wireMeshDNS(m ctrl.Manager, snapshotCache *cache.SnapshotCache) error {
 	if !cfg.MeshDNS {
 		return nil
+	}
+	// Create the snapshot dir NOW rather than lazily on the first write. The resolver
+	// daemon mounts this volume read-only, so it cannot create the dir itself; if it
+	// starts before our first projection it finds nothing to watch. Non-fatal: mesh
+	// DNS is not worth failing the agent over, and the first write retries anyway.
+	if err := meshdns.EnsureSnapshotDir(cfg.MeshDNSSnapshotPath); err != nil {
+		l.Error("failed to pre-create the mesh-DNS snapshot dir", "path", cfg.MeshDNSSnapshotPath, "error", err)
 	}
 	snapshotCache.SetMeshDNSSnapshotPath(cfg.MeshDNSSnapshotPath)
 	if err := m.Add(&capture.MeshDNSHeartbeat{Rewriter: snapshotCache, Log: l}); err != nil {

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -42,6 +42,23 @@ const snapshotFileMode = 0o644
 // snapshotDirMode is the permission for the snapshot's parent directory.
 const snapshotDirMode = 0o755
 
+// EnsureSnapshotDir creates the snapshot's parent directory (a dedicated subdir under
+// the host-persistent registry volume; the host mount is DirectoryOrCreate, the subdir
+// is ours).
+//
+// The AGENT must call this at startup, not merely on its first write: the resolver
+// daemon mounts the volume READ-ONLY and so cannot create the directory itself. If the
+// daemon starts first and finds no directory, its fsnotify watch has nothing to attach
+// to — on a fresh cluster that left the daemon Ready but permanently record-less,
+// which is what broke the multi-cluster e2e (#589).
+func EnsureSnapshotDir(path string) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, snapshotDirMode); err != nil {
+		return fmt.Errorf("create mesh-DNS snapshot dir %s: %w", dir, err)
+	}
+	return nil
+}
+
 // ErrSnapshotParse marks a snapshot that exists and was readable but could not be
 // decoded, so a caller (and the reload metric) can tell a corrupt file apart from an
 // I/O failure or a missing file (fs.ErrNotExist).
@@ -334,10 +351,8 @@ func WriteSnapshot(path string, records map[string]string, generation uint64) er
 	if err != nil {
 		return fmt.Errorf("marshal mesh-DNS snapshot: %w", err)
 	}
-	// The snapshot lives in a dedicated subdir under the host-persistent registry
-	// volume; create it (host mount is DirectoryOrCreate, the subdir is ours).
-	if err := os.MkdirAll(filepath.Dir(path), snapshotDirMode); err != nil {
-		return fmt.Errorf("create mesh-DNS snapshot dir %s: %w", filepath.Dir(path), err)
+	if err := EnsureSnapshotDir(path); err != nil {
+		return err
 	}
 	if err := file.AtomicWrite(path, data, snapshotFileMode); err != nil {
 		return fmt.Errorf("write mesh-DNS snapshot %s: %w", path, err)

--- a/agent/internal/meshdns/server_test.go
+++ b/agent/internal/meshdns/server_test.go
@@ -503,3 +503,18 @@ func TestServeNonMeshForwards(t *testing.T) {
 	assert.Equal(t, dns.RcodeServerFailure, resp.Rcode)
 	assert.False(t, resp.Authoritative, "forwarded (upstream failed), not an authoritative mesh answer")
 }
+
+// TestEnsureSnapshotDir: the agent pre-creates the snapshot's parent so the resolver
+// daemon -- which mounts the volume READ-ONLY and cannot create it -- always has a
+// directory to watch. Without this the daemon came up Ready but permanently
+// record-less on a fresh cluster (#589).
+func TestEnsureSnapshotDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mesh-dns", "records.json")
+	require.NoDirExists(t, filepath.Dir(path))
+
+	require.NoError(t, EnsureSnapshotDir(path))
+	assert.DirExists(t, filepath.Dir(path), "parent dir created")
+
+	// Idempotent: the agent calls it at startup AND on every write.
+	assert.NoError(t, EnsureSnapshotDir(path))
+}


### PR DESCRIPTION
Root cause of the multi-cluster e2e failing since 07-22 (#589), found via the diagnostics added in #590.

## The bug
Every mesh-dns pod in both kind clusters logged:

```
ERROR "failed to watch mesh-DNS snapshot dir; records will not reload until restart"
      error: "no such file or directory"
      dir:   "/host/var/lib/aether/registry/mesh-dns"
```

The chain:
1. The `mesh-dns/` subdir is created **lazily by the agent**, on its first `WriteSnapshot`.
2. The daemon mounts that volume **`readOnly: true`** — it cannot create the dir itself.
3. On a fresh cluster the daemon wins the race, finds no dir, and its fsnotify watch fails **permanently**.
4. It still reports **Ready 1/1** — the ready-marker is written after *bind*, not after records load. Kubernetes sees a healthy pod that can answer nothing, so every mesh name fails.

**This is a production bug, not a kind artifact.** It's invisible on any established cluster (on talos the dir has existed since #577), and only bites a **fresh install** — which is what every kind e2e run is. No amount of soaking on an existing cluster could have caught it.

## The fix — one per side of the race
- **Agent:** `EnsureSnapshotDir` at startup instead of on first write, so the dir exists before the daemon looks. Non-fatal.
- **Daemon:** retry establishing the watch rather than giving up for the process lifetime, and poll `ReloadFromSnapshot` while blind so records land even if fsnotify never works. A missing dir is now WARN, not ERROR.

The daemon half is the one that matters: it fixes the *class*, surviving any startup ordering, agent restart, or volume remount.

## Verification
`bazel test //agent/...` 27/27 · `--config=ci` (gocognit) clean · format clean · slim dep graph re-proven (**0** paths to controller-runtime *and* go-control-plane). New tests cover `EnsureSnapshotDir` and watcher recovery once the dir appears.

e2e verification to follow on this branch.

Refs #589.

🤖 Generated with [Claude Code](https://claude.com/claude-code)