### PR TITLE
fix(soak): start a fresh churn log instead of appending to the last run's

### DIFF
--- a/e2e/soak/churn.sh
+++ b/e2e/soak/churn.sh
@@ -13,6 +13,14 @@ BUILD_LABEL="${1:-unspecified-build}"
 LOG="${SOAK_CHURN_LOG:-/tmp/soak-churn.log}"
 T0=$(date +%s)
 
+# Start a FRESH log, archiving any previous run alongside it. Without this the driver
+# appends to the last soak's file, and `grep -c ROLLED` -- which teardown uses to confirm
+# 30 rolls -- silently double-counts, so a run looks complete when it is not.
+if [ -s "$LOG" ]; then
+	mv -f "$LOG" "$LOG.$(date -u +%Y%m%dT%H%M%SZ).prev"
+fi
+: >"$LOG"
+
 log() { echo "$(date -u +%FT%TZ) $*" >>"$LOG"; }
 
 # Sleep until T0 + $1 minutes.


### PR DESCRIPTION
Caught live during tonight's soak kickoff.

`churn.sh` appended to `/tmp/soak-churn.log`, so a second run inherited the previous soak's lines. Teardown uses `grep -c ROLLED` to confirm 30 rolls — that silently double-counts. Tonight's run read **31 ROLLED before its first roll had even fired**, and would have ended at ~61, making an incomplete run look finished (or a complete one look wrong).

My ad-hoc invocations used to truncate the log in the shell before launching; that step was lost when the harness was committed in #585, and nothing in the script replaced it.

## Fix
Rotate any existing log to `<log>.<utc>.prev` and start clean. Verified: stale content is archived, the new log starts with only the current run's start line, and an already-running driver appending to the same inode is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)