### PR TITLE
build(mesh-dns): give the daemon its own slim image (#583 option B)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -61,8 +61,9 @@ jobs:
       - name: Build and load container images
         run: |
           retry() { for n in 1 2 3; do "$@" && return 0; echo "attempt $n failed; retrying in 20s"; sleep 20; done; return 1; }
-          for t in //agent/cmd/agent:image_load //cni/cmd/cni-install:image_load \
-                   //registrar/cmd/registrar:image_load //controller/cmd/controller:image_load; do
+          for t in //agent/cmd/agent:image_load //agent/cmd/mesh-dns:image_load \
+                   //cni/cmd/cni-install:image_load //registrar/cmd/registrar:image_load \
+                   //controller/cmd/controller:image_load; do
             retry bazel run --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} "$t"
           done
 
@@ -70,6 +71,7 @@ jobs:
         run: |
           docker save \
             "${IMAGE_REGISTRY}/agent:latest" \
+            "${IMAGE_REGISTRY}/mesh-dns:latest" \
             "${IMAGE_REGISTRY}/cni-install:latest" \
             "${IMAGE_REGISTRY}/registrar:latest" \
             "${IMAGE_REGISTRY}/controller:latest" \
@@ -116,7 +118,7 @@ jobs:
 
       - name: Load images into kind
         run: |
-          for img in agent:latest cni-install:latest registrar:latest controller:latest; do
+          for img in agent:latest mesh-dns:latest cni-install:latest registrar:latest controller:latest; do
             kind load docker-image "${IMAGE_REGISTRY}/${img}" --name "${KIND_CLUSTER}"
           done
 
@@ -167,6 +169,7 @@ jobs:
             --set edge.tls.enabled=true \
             --set edge.gateway.create=false \
             $(img agent agent) \
+            $(img agent.meshDnsDaemon mesh-dns) \
             $(img cniInstall cni-install) \
             $(img registrar registrar) \
             $(img controller controller) \
@@ -279,7 +282,7 @@ jobs:
 
       - name: Load images into kind
         run: |
-          for img in agent:latest cni-install:latest registrar:latest controller:latest; do
+          for img in agent:latest mesh-dns:latest cni-install:latest registrar:latest controller:latest; do
             kind load docker-image "${IMAGE_REGISTRY}/${img}" --name "${KIND_CLUSTER}"
           done
 
@@ -309,6 +312,7 @@ jobs:
             --set spire.enabled=false \
             --set agent.gamma=true \
             $(img agent agent) \
+            $(img agent.meshDnsDaemon mesh-dns) \
             $(img cniInstall cni-install) \
             $(img registrar registrar) \
             $(img controller controller) \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,9 +38,11 @@ jobs:
         run: |
           bazel build --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //...
       # `*.push` publishes each chart together with the images it references
-      # (aether.push -> agent + cni-install + registrar + controller images +
-      # the aether chart; crds.push -> the MeshConfig CRD chart; prober.push ->
-      # prober chart + image), so a single GHCR login covers images and charts.
+      # (aether.push -> agent + mesh-dns + cni-install + registrar + controller
+      # images + the aether chart; crds.push -> the MeshConfig CRD chart;
+      # prober.push -> prober chart + image), so a single GHCR login covers images
+      # and charts. Adding an image to a chart's `images` attr is all that is needed
+      # to get it published — no separate push step (mesh-dns, #583).
       - name: Push charts + images
         env:
           HELM_REGISTRY_USERNAME: ${{ github.actor }}

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,20 @@ load-agent-image:
 push-agent-image:
 	@bazel run //agent/cmd/agent:image_push
 
+# The slim mesh-DNS daemon (#583) — its own binary AND its own image, so the
+# aether-mesh-dns DaemonSet no longer ships the full agent.
+.PHONY: build-mesh-dns
+build-mesh-dns:
+	@bazel build //agent/cmd/mesh-dns/...
+
+.PHONY: load-mesh-dns-image
+load-mesh-dns-image:
+	@bazel run //agent/cmd/mesh-dns:image_load
+
+.PHONY: push-mesh-dns-image
+push-mesh-dns-image:
+	@bazel run //agent/cmd/mesh-dns:image_push
+
 .PHONY: build-cni-install
 build-cni-install:
 	@bazel build //cni/cmd/cni-install/...
@@ -75,10 +89,10 @@ push-registrar-image:
 	@bazel run //registrar/cmd/registrar:image_push
 
 .PHONY: load-all
-load-all: load-agent-image load-cni-install-image load-registrar-image
+load-all: load-agent-image load-mesh-dns-image load-cni-install-image load-registrar-image
 
 .PHONY: push-all
-push-all: push-agent-image push-cni-install-image push-registrar-image
+push-all: push-agent-image push-mesh-dns-image push-cni-install-image push-registrar-image
 
 # Publish everything in the order that works: image manifests FIRST, then the
 # charts (chart-only push targets). The combined `:*.push` targets race the

--- a/agent/cmd/agent/BUILD.bazel
+++ b/agent/cmd/agent/BUILD.bazel
@@ -25,11 +25,4 @@ go_multi_arch_image(
     name = "agent_image",
     binary = ":agent",
     repository = "bpalermo/aether/agent",
-    # Ship the slim standalone mesh-DNS binary in the same image (#583). The
-    # aether-mesh-dns DaemonSet runs /mesh-dns instead of re-execing the full /agent,
-    # so its (re-exec'd) readiness probe is cheap. One image carries both entrypoints;
-    # a separate mesh-dns image/publish pipeline is deferred (#583's other option).
-    tars_layer = {
-        "/mesh-dns": "//agent/cmd/mesh-dns:mesh-dns",
-    },
 )

--- a/agent/cmd/agent/testdata/container_test.yaml
+++ b/agent/cmd/agent/testdata/container_test.yaml
@@ -8,10 +8,10 @@ fileExistenceTests:
     shouldExist: true
     permissions: '-rwxr-xr-x'
     isExecutableBy: 'other'
-  # The slim standalone mesh-DNS binary ships in the same image (#583); the
-  # aether-mesh-dns DaemonSet runs /mesh-dns instead of re-execing the full /agent.
-  - name: 'mesh-dns'
+  # The slim mesh-DNS daemon now has its OWN image
+  # (//agent/cmd/mesh-dns:mesh-dns_image, #583 option B). It was only ever bundled
+  # here to avoid standing up a second publish pipeline; assert it is gone so the
+  # agent image can't silently re-acquire it.
+  - name: 'no mesh-dns binary'
     path: '/mesh-dns'
-    shouldExist: true
-    permissions: '-rwxr-xr-x'
-    isExecutableBy: 'other'
+    shouldExist: false

--- a/agent/cmd/mesh-dns/BUILD.bazel
+++ b/agent/cmd/mesh-dns/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//bazel/img:go_multi_arch_image.bzl", "go_multi_arch_image")
 
 go_library(
     name = "mesh-dns_lib",
@@ -24,9 +25,22 @@ go_binary(
     },
 )
 
+# Dedicated image for the aether-mesh-dns DaemonSet (#583, option B). The daemon
+# used to ship inside the agent image (one extra /mesh-dns layer) purely to avoid
+# standing up a second publish pipeline; that made every node pull
+# controller-runtime, xDS/go-control-plane, the CNI server and SPIRE for a process
+# that binds a host port and answers every managed pod's :53 DNAT and executes none
+# of it. This image carries the slim binary alone.
+go_multi_arch_image(
+    name = "mesh-dns_image",
+    binary = ":mesh-dns",
+    repository = "bpalermo/aether/mesh-dns",
+)
+
 go_test(
     name = "mesh-dns_test",
     srcs = ["main_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":mesh-dns_lib"],
     deps = [
         "//agent/internal/meshdns",

--- a/agent/cmd/mesh-dns/testdata/container_test.yaml
+++ b/agent/cmd/mesh-dns/testdata/container_test.yaml
@@ -1,0 +1,18 @@
+schemaVersion: 2.0.0
+metadataTest:
+  entrypoint: ["/mesh-dns"]
+  user: 65532 # nonroot
+fileExistenceTests:
+  # The slim standalone mesh-DNS binary (#583) — the ONLY thing in this image.
+  # The DaemonSet runs it as its command AND re-execs it for the readiness marker
+  # check, so it must be executable by the (non-root) runtime user.
+  - name: 'mesh-dns'
+    path: '/mesh-dns'
+    shouldExist: true
+    permissions: '-rwxr-xr-x'
+    isExecutableBy: 'other'
+  # Guard against the agent image's payload leaking back in: this image exists to
+  # NOT carry the full agent (#583 option B).
+  - name: 'no agent binary'
+    path: '/agent'
+    shouldExist: false

--- a/charts/aether/BUILD.bazel
+++ b/charts/aether/BUILD.bazel
@@ -19,6 +19,7 @@ helm_chart(
     chart = "Chart.yaml",
     images = [
         "//agent/cmd/agent:image_push",
+        "//agent/cmd/mesh-dns:image_push",
         "//cni/cmd/cni-install:image_push",
         "//registrar/cmd/registrar:image_push",
         "//controller/cmd/controller:image_push",

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.87.0"
+version: "0.88.0"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/mesh-dns-daemonset.yaml
+++ b/charts/aether/templates/mesh-dns-daemonset.yaml
@@ -44,8 +44,11 @@ spec:
           effect: NoSchedule
       containers:
         - name: mesh-dns
-          image: {{ include "aether.image" .Values.agent.image | quote }}
-          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          # Its own slim image (#583 option B) — NOT agent.image, which carries the
+          # full agent (controller-runtime, xDS, CNI server, SPIRE) this daemon never
+          # executes but would still pull onto every node and expose on a host port.
+          image: {{ include "aether.image" .Values.agent.meshDnsDaemon.image | quote }}
+          imagePullPolicy: {{ .Values.agent.meshDnsDaemon.image.pullPolicy }}
           command: ["/mesh-dns"]
           args:
             - "--debug={{ .Values.debug }}"

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -160,6 +160,17 @@ agent:
   # agent.meshDns is true. It mounts the agent's registry hostPath read-only and
   # serves HOST_IP:18054 from the snapshot the agent writes.
   meshDnsDaemon:
+    # Its OWN image (#583 option B), carrying ONLY the slim /mesh-dns binary — no
+    # controller-runtime, no xDS/go-control-plane, no CNI server, no SPIRE. The daemon
+    # briefly shipped as an extra layer inside agent.image (the interim #583 measure),
+    # which made every node pull the whole agent for a process that executes none of
+    # it. Same repository+digest convention as agent.image: mirror to a private
+    # registry by overriding `repository` alone; the digest is preserved.
+    image:
+      repository: "{@//agent/cmd/mesh-dns:image_push.repository}"
+      digest: "{@//agent/cmd/mesh-dns:image_push.digest}"
+      tag: ""
+      pullPolicy: Always
     # Issue #583: the readiness probe now re-execs the SLIM /mesh-dns binary (only the
     # resolver + snapshot reload + telemetry — no controller-runtime/xDS/CNI/SPIRE), not
     # the full /agent, so the re-exec CPU headroom that inflated these limits is gone.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -42,6 +42,7 @@ over Bazel).
 make build              # bazel build //...  (everything)
 
 make build-agent        # //agent/cmd/agent/...        (node agent + edge + supervisor)
+make build-mesh-dns     # //agent/cmd/mesh-dns/...     (slim standalone mesh-DNS daemon)
 make build-registrar    # //registrar/cmd/registrar/...
 make build-cni-install  # //cni/cmd/cni-install/...
 ```
@@ -109,13 +110,17 @@ make tidy               # bazel mod tidy
 
 ## 5. Container images
 
-In-repo images (agent, cni-install, registrar) build with `rules_img`:
+In-repo images (agent, mesh-dns, cni-install, registrar) build with `rules_img`:
 
 ```bash
-make load-all           # load agent + cni-install + registrar into local Docker
-make load-agent-image   # a single image (…-registrar-image, …-cni-install-image likewise)
+make load-all           # load agent + mesh-dns + cni-install + registrar into local Docker
+make load-agent-image   # a single image (…-mesh-dns-image, …-registrar-image, …-cni-install-image likewise)
 make push-all           # push all to the registry
 ```
+
+`mesh-dns` is its own image (#583): the `aether-mesh-dns` DaemonSet must NOT ship
+the full agent, so it gets the slim `/mesh-dns` binary alone (~7Mi vs the agent's
+~20Mi) and the chart pins it separately via `agent.meshDnsDaemon.image`.
 
 The `controller` image is not in `load-all`; load it with
 `bazel run //controller/cmd/controller:image_load`.

--- a/e2e/multicluster_config.sh
+++ b/e2e/multicluster_config.sh
@@ -33,7 +33,7 @@ REGION="local"
 NS="aether-system"
 GWAPI_VERSION="v1.5.1"
 MCS_VERSION="v0.5.0"
-IMAGES=(agent cni-install registrar controller)
+IMAGES=(agent mesh-dns cni-install registrar controller)
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 ok() { printf '\033[1;32m  ✓ %s\033[0m\n' "$*"; }
@@ -151,7 +151,7 @@ install_aether() {
 			--set "registrar.region=$REGION" \
 			--set "registrar.etcd.region=$REGION" \
 			--set "registrar.etcd.endpoints[0]=$etcd" \
-			$(img agent agent) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
+			$(img agent agent) $(img agent.meshDnsDaemon mesh-dns) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
 			--timeout 4m >/dev/null
 		kubectl --context "kind-$c" -n "$NS" rollout status deploy/aether-registrar --timeout=150s >/dev/null
 		ok "aether registrar up on '$c'"

--- a/e2e/multicluster_replicator.sh
+++ b/e2e/multicluster_replicator.sh
@@ -43,7 +43,7 @@ GWAPI_VERSION="v1.5.1"
 SPIRE_CHART_VERSION="${SPIRE_CHART_VERSION:-0.28.4}"
 SPIRE_CRDS_VERSION="${SPIRE_CRDS_VERSION:-0.5.0}"
 SPIRE_CLASS="spire-mgmt-spire" # spire-controller-manager class (namespace-release)
-IMAGES=(agent cni-install registrar controller)
+IMAGES=(agent mesh-dns cni-install registrar controller)
 # Origin-heartbeat lease TTL is 30s (replicator default); how long verify waits
 # for the mirror to expire after the origin dies (TTL + keepalive/gRPC slack).
 FAILOVER_TIMEOUT="${FAILOVER_TIMEOUT:-90}"
@@ -245,7 +245,7 @@ install_aether() {
 			--set "registrar.region=$(region_of "$c")" \
 			--set "registrar.etcd.endpoints[0]=http://$(etcd_ip "$c"):2379" \
 			--set "registrar.peerEtcd[0]=$(region_of "$peer")=http://$(etcd_ip "$peer"):2379" \
-			$(img agent agent) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
+			$(img agent agent) $(img agent.meshDnsDaemon mesh-dns) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
 			--timeout 5m >/dev/null || die "aether install failed on '$c'"
 		kubectl --context "kind-$c" -n "$NS" rollout status ds/aether-agent --timeout=180s >/dev/null || true
 		# client_code() resolves echo.<ns>.<mesh-domain>, and since #578 the AGENT no

--- a/e2e/multicluster_waypoint.sh
+++ b/e2e/multicluster_waypoint.sh
@@ -41,7 +41,7 @@ GWAPI_VERSION="v1.5.1"
 SPIRE_CHART_VERSION="${SPIRE_CHART_VERSION:-0.28.4}"
 SPIRE_CRDS_VERSION="${SPIRE_CRDS_VERSION:-0.5.0}"
 SPIRE_CLASS="spire-mgmt-spire" # spire-controller-manager class (namespace-release)
-IMAGES=(agent cni-install registrar controller)
+IMAGES=(agent mesh-dns cni-install registrar controller)
 
 log() { printf '\n\033[1;34m==> %s\033[0m\n' "$*"; }
 ok() { printf '\033[1;32m  ✓ %s\033[0m\n' "$*"; }
@@ -223,7 +223,7 @@ install_aether() {
 			--set "registrar.region=$REGION" \
 			--set "registrar.etcd.region=$REGION" \
 			--set "registrar.etcd.endpoints[0]=$etcd" \
-			$(img agent agent) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
+			$(img agent agent) $(img agent.meshDnsDaemon mesh-dns) $(img cniInstall cni-install) $(img registrar registrar) $(img controller controller) \
 			--timeout 5m >/dev/null || die "aether install failed on '$c'"
 		kubectl --context "kind-$c" -n "$NS" rollout status ds/aether-agent --timeout=180s >/dev/null || true
 		# The data-path assertion resolves echo.<ns>.<mesh-domain>, and since #578 the


### PR DESCRIPTION
Follows #583 — this is its deferred **option B**.

## Why

#583 built the slim standalone `/mesh-dns` binary (no controller-runtime, no xDS/go-control-plane, no CNI server, no SPIRE) and cut the daemon from ~51m→16m CPU and ~14→5Mi RSS. But to avoid standing up a new publish pipeline at the time, that binary shipped as an extra **layer inside the agent image**, with the DaemonSet running `command: ["/mesh-dns"]` out of `.Values.agent.image`.

So today every node pulls controller-runtime, xDS, the CNI server and SPIRE for a process that executes none of it — wasted pull bandwidth, and unnecessary attack surface for a component that binds a host port and is reached by every managed pod's `:53` DNAT.

## What

- **New image** `//agent/cmd/mesh-dns:mesh-dns_image` via the same `go_multi_arch_image` macro as every other image: distroless `nonroot`, amd64+arm64 `image_index`, `image_load` / `image_push` / `image_test`. Entrypoint `/mesh-dns`, repository `bpalermo/aether/mesh-dns`.
- **Agent image loses the interim layer** (`tars_layer` dropped). Nothing else referenced `/mesh-dns` — the `agent mesh-dns` cobra subcommand was already retired in #583.
- **Publish wiring: no new step.** `//charts/aether:aether.push` publishes the chart together with the images in its `images` attr, so adding `//agent/cmd/mesh-dns:image_push` there is the entire wiring. It also digest-pins the new `agent.meshDnsDaemon.image` placeholders at package time. Verified: `bazel query 'deps(//charts/aether:aether.push, 2)'` now lists `//agent/cmd/mesh-dns:image_push`.
- **Chart**: new `agent.meshDnsDaemon.image` (`repository` + `digest` + `tag` + `pullPolicy`), stamped exactly like `agent.image`, rendered through the `aether.image` helper. `command: ["/mesh-dns"]` and the exec readiness probe are unchanged. Chart `0.87.0` → `0.88.0`.
- **Container tests assert the split in both directions**: the new image has `/mesh-dns` and *not* `/agent`; the agent image now asserts `/mesh-dns` is **absent**, so it can't silently re-acquire the payload.
- **Harnesses**: `make load-all` / `push-all`, the three `e2e/multicluster_*.sh` scripts, and the e2e/conformance workflow jobs build, load and `--set agent.meshDnsDaemon.image.*` the new image — the daemon no longer inherits the agent's local kind override, so it would otherwise `ImagePullBackOff` in kind.

## Size

Single-manifest docker tarball (zstd layers), the pushed/pulled artifact:

| image | before | after |
|---|---|---|
| agent | 26.8 MiB | **20.4 MiB** (−23.8%) |
| mesh-dns DaemonSet pull | 26.8 MiB (the agent image) | **7.2 MiB** (−73.2%) |

Underlying binaries: `agent` 67.1 MB vs `mesh-dns` 16.9 MB.

## Slim dep graph re-proved

```
$ bazel query 'somepath(//agent/cmd/mesh-dns:mesh-dns, @io_k8s_sigs_controller_runtime//...)'
INFO: Empty results

$ bazel query 'somepath(//agent/cmd/mesh-dns:mesh-dns, @com_github_envoyproxy_go_control_plane//...)'
INFO: Empty results
```

## Verification

- `bazel build //...` — 283 targets, green
- `bazel test --test_tag_filters=-integration //...` — 74/74 pass (incl. both `image_test`s, `aether_lint_test`, `aether_template_test`)
- `bazel build --config=ci //...` — clean
- `bazel run //:format` + `make format-check` — clean
- `make gazelle` — no drift (it added `data = glob(["testdata/**"])` to `mesh-dns_test` for the new testdata dir; kept as generated)
- Packaged the chart with `--stamp` and confirmed `agent.meshDnsDaemon.image` resolves to `ghcr.io/bpalermo/aether/mesh-dns@sha256:…`
- Loaded the image and ran both entrypoint paths (`--help`, `--readiness-check`) incl. as uid 65532; confirmed `/mesh-dns` is gone from the agent image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR