### PR TITLE
test(cni): fix the data race under -race in the drain pool-close test

### DIFF
--- a/agent/internal/cni/server/termination_test.go
+++ b/agent/internal/cni/server/termination_test.go
@@ -197,15 +197,26 @@ func TestHandlePodTerminatingPoolClosePhase(t *testing.T) {
 		return reg.LastHealth() == registryv1.ServiceEndpoint_HEALTH_UNHEALTHY
 	}, 2*time.Second, 10*time.Millisecond, "phase 2: unhealthy re-registration after drain delay")
 
-	// Resurrection guard: pod removed (CNI DEL) before phase 2 fires.
+	// Resurrection guard: pod removed (CNI DEL) before phase 2 fires. The drain
+	// delay is widened first so the interleaving under test — DEL wins the race —
+	// is the one actually exercised rather than whichever the scheduler picks.
+	s.drainPoolCloseDelay = 200 * time.Millisecond
 	pod2 := validCNIPod("pod-2q", "default", "container-2q")
 	require.NoError(t, store.AddResource(ctx, types.ContainerID("container-2q"), pod2))
 	s.handlePodTerminating(ctx, terminatingK8sPod("pod-2q", "default", "test-node"))
 	registeredBefore := reg.Registered()
-	require.NoError(t, store.RemoveResource(ctx, types.ContainerID("container-2q")))
 
-	time.Sleep(100 * time.Millisecond) // > test drain delay
-	assert.Equal(t, registeredBefore, reg.Registered(), "phase 2 must not re-register a removed pod")
+	// RemovePod deletes from storage under lifecycleMu; do the same here so the
+	// removal cannot land inside schedulePoolClose's critical section (between
+	// its existence check and the re-registration), which no real CNI DEL can do.
+	s.lifecycleMu.Lock()
+	require.NoError(t, store.RemoveResource(ctx, types.ContainerID("container-2q")))
+	s.lifecycleMu.Unlock()
+
+	// Poll past the drain deadline: phase 2 fires, finds no pod, closes nothing.
+	assert.Never(t, func() bool {
+		return reg.Registered() != registeredBefore
+	}, 500*time.Millisecond, 10*time.Millisecond, "phase 2 must not re-register a removed pod")
 }
 
 // TestDrainDelayForPod: phase 2 scales with the workload's sleep preStop

--- a/agent/storage/mock.go
+++ b/agent/storage/mock.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/bpalermo/aether/agent/types"
 	"google.golang.org/protobuf/proto"
@@ -13,6 +14,13 @@ import (
 // method, types in other packages cannot implement the interface directly;
 // MockStorage bridges that gap by living in package storage while exposing
 // configurable behaviour via exported function fields.
+//
+// Like LocalStorage — the implementation it stands in for — MockStorage is safe
+// for concurrent use. Production callers (the CNI server's liveness loop, ghost
+// sweep and drain timers) read and write storage from several goroutines, so a
+// double without that guarantee turns any test of those paths into a data race
+// on the backing map rather than a test of the code under test. The configurable
+// function fields are NOT guarded: set them before the storage is shared.
 type MockStorage[T proto.Message] struct {
 	// GetAllFunc is called by GetAll. If nil, GetAll iterates the resources map.
 	GetAllFunc func(ctx context.Context) ([]T, error)
@@ -26,6 +34,9 @@ type MockStorage[T proto.Message] struct {
 
 	// RemoveResourceFunc is called by RemoveResource. If nil, the resource is deleted from the map.
 	RemoveResourceFunc func(ctx context.Context, key types.ContainerID) error
+
+	// mu guards resources.
+	mu sync.RWMutex
 
 	// resources holds items added via AddResource when no AddResourceFunc is set.
 	resources map[types.ContainerID]T
@@ -59,6 +70,8 @@ func (m *MockStorage[T]) AddResource(ctx context.Context, key types.ContainerID,
 	if m.AddResourceFunc != nil {
 		return m.AddResourceFunc(ctx, key, resource)
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.resources[key] = resource
 	return nil
 }
@@ -67,6 +80,8 @@ func (m *MockStorage[T]) RemoveResource(ctx context.Context, key types.Container
 	if m.RemoveResourceFunc != nil {
 		return m.RemoveResourceFunc(ctx, key)
 	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	delete(m.resources, key)
 	return nil
 }
@@ -75,6 +90,8 @@ func (m *MockStorage[T]) GetResource(ctx context.Context, key types.ContainerID)
 	if m.GetResourceFunc != nil {
 		return m.GetResourceFunc(ctx, key)
 	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	r, ok := m.resources[key]
 	if !ok {
 		var zero T
@@ -87,6 +104,8 @@ func (m *MockStorage[T]) GetAll(ctx context.Context) ([]T, error) {
 	if m.GetAllFunc != nil {
 		return m.GetAllFunc(ctx)
 	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
 	result := make([]T, 0, len(m.resources))
 	for _, v := range m.resources {
 		result = append(result, v)


### PR DESCRIPTION
## Triage

`bazel test --@rules_go//go/config:race=true //agent/internal/cni/server:server_test` fails **deterministically** (not intermittently) on `TestHandlePodTerminatingPoolClosePhase`:

```
WARNING: DATA RACE
Read at 0x00c0008282a0 by goroutine 65:
  runtime.mapaccess2_faststr()
  github.com/bpalermo/aether/agent/storage.(*MockStorage[...]).GetResource()
      agent/storage/mock.go:78
  github.com/bpalermo/aether/agent/internal/cni/server.(*CNIServer).schedulePoolClose()
      agent/internal/cni/server/termination.go:208
  ...handlePodTerminating.gowrap2()
      agent/internal/cni/server/termination.go:145

Previous write at 0x00c0008282a0 by goroutine 59:
  runtime.mapdelete_faststr()
  github.com/bpalermo/aether/agent/storage.(*MockStorage[...]).RemoveResource()
      agent/storage/mock.go:70
  ...server.TestHandlePodTerminatingPoolClosePhase()
      agent/internal/cni/server/termination_test.go:205
  testing.tRunner()
```

**Verdict: racy test synchronisation — not a production data race.**

The read side is production code, but it is correctly synchronised: `schedulePoolClose` takes `lifecycleMu` before `GetResource` (termination.go:206-208), exactly as its comment promises, and every production mutation of that storage (`RemovePod`, the liveness loop, the ghost sweep) holds the same mutex. The write side is *test scaffolding*: the test body calls `MockStorage.RemoveResource` directly at termination_test.go:205 to simulate a CNI DEL, outside `lifecycleMu`. The racing memory is the mock's backing map, not any production state.

Two defects behind it:

1. **The double doesn't match the contract it doubles.** `LocalStorage` is documented "safe for concurrent access using RWMutex"; `MockStorage` had a bare map. Any test that drives a production path with background goroutines (liveness loop, ghost sweep, drain timers) therefore races on the map rather than testing the code under test. The sibling double in this same file (`unregisterRecordingRegistry`) *is* mutex-guarded — the storage one was simply missed.
2. **The test modelled a CNI DEL that cannot happen.** An unlocked storage delete can land *inside* `schedulePoolClose`'s critical section, between its existence check and the re-registration — an interleaving a real DEL (which removes storage under `lifecycleMu`) can never produce. It also had only a ~10ms margin over the drain timer, so the ordering it claims to test was whatever the scheduler picked.

## Fix

- `agent/storage/mock.go`: guard `resources` with a `sync.RWMutex`, matching `LocalStorage`'s concurrency contract. The configurable `*Func` hooks are invoked outside the lock so a hook may re-enter the mock.
- `termination_test.go`: perform the simulated DEL under `lifecycleMu` (as `RemovePod` does), widen the drain delay so "DEL wins" is actually the interleaving exercised, and replace the bare `time.Sleep` + `assert.Equal` with a polling `assert.Never` that spans the drain deadline.

No production code changed. No sleeps added, nothing skipped or short-gated.

## Verification

- `--runs_per_test=20` with `--@rules_go//go/config:race=true`: **20/20 PASSED** (max 15.2s, min 14.5s, avg 14.9s).
- All of `//agent/...` under `-race`: **27/27 pass** — this was the only race blocker in the tree.
- Normal mode `bazel test //agent/...`: 27/27 pass.
- `bazel run //:format` clean, `bazel build --config=ci //agent/...` (lint) green, `make gazelle` produced no BUILD changes.

## Follow-up recommendation (not in this PR)

The repo already has `test:race --@rules_go//go/config:race` in `.bazelrc`, and `//agent/...` is now fully green under it — so a race leg would pass today. Recommendation: add a **nightly** (or `e2e.yaml`-style scheduled) `bazel test --config=race //...` job rather than a per-PR leg. A per-PR leg would double the compile+cache footprint of the impacted-target legs (race builds a separate configuration, so it shares no cache with the normal build) and inflate every PR's critical path for a class of bug that is usually latent rather than newly introduced; a nightly catches it within a day, when it is still cheap to attribute. Without *something*, this class stays invisible — which is exactly why #554 sat parked.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR