### PR TITLE
fix(mesh-dns): detect a wedged resolver and forward TCP queries over TCP

### DIFF
--- a/agent/internal/meshdns/BUILD.bazel
+++ b/agent/internal/meshdns/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "metrics.go",
         "resolvconf.go",
+        "selfcheck.go",
         "server.go",
         "telemetry.go",
     ],
@@ -34,6 +35,7 @@ go_test(
     name = "meshdns_test",
     srcs = [
         "resolvconf_test.go",
+        "selfcheck_test.go",
         "server_test.go",
     ],
     embed = [":meshdns"],

--- a/agent/internal/meshdns/metrics.go
+++ b/agent/internal/meshdns/metrics.go
@@ -32,14 +32,19 @@ type resolverState struct {
 	ready       bool
 	watchActive bool
 	upstreams   int64
+	// lastAnswered is the unix second of the last query the resolver actually answered
+	// (real traffic or a self-check); zero until it has answered anything at all.
+	lastAnswered int64
 }
 
 // metrics holds the resolver's OTel instruments. nil-safe: every record method is a
 // no-op when the meter failed to initialize.
 type metrics struct {
-	queries  metric.Int64Counter
-	duration metric.Float64Histogram
-	reloads  metric.Int64Counter
+	queries    metric.Int64Counter
+	duration   metric.Float64Histogram
+	reloads    metric.Int64Counter
+	selfChecks metric.Int64Counter
+	truncated  metric.Int64Counter
 }
 
 // newMetrics builds the resolver metrics on the global MeterProvider (a no-op meter
@@ -50,7 +55,11 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 	b := &meterBuilder{meter: otel.Meter(meterName)}
 
 	queries := b.counter("aether.mesh_dns.queries",
-		"Mesh-DNS queries handled by the resolver, by result (answered=mesh hit, forwarded=relayed to upstream, forward_error=upstream failed, nxdomain=authoritative mesh miss, cold=SERVFAIL for a mesh name before records were ever populated)")
+		"Mesh-DNS queries handled by the resolver, by result (answered=mesh hit, forwarded=relayed to upstream, forward_error=upstream failed, nxdomain=authoritative mesh miss, cold=SERVFAIL for a mesh name before records were ever populated) and by the transport the query arrived on (proto=udp|tcp; the CNI DNATs both)")
+	selfChecks := b.counter("aether.mesh_dns.self_check_total",
+		"In-process handler self-checks run by the wedge watchdog, by result (ok, fail). Consecutive failures remove the pod-local ready marker so the readiness probe flips the pod NotReady")
+	truncated := b.counter("aether.mesh_dns.responses_truncated_total",
+		"Upstream replies that came back truncated (TC=1) over UDP and were re-fetched over TCP")
 	reloads := b.counter("aether.mesh_dns.snapshot_reloads_total",
 		"Attempts to read the record snapshot the agent writes, by result (success, missing=file absent, parse_error=corrupt, read_error=I/O failure)")
 	duration := b.histogram("aether.mesh_dns.query.duration",
@@ -70,6 +79,8 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 		"Number of forward upstreams. Zero means every non-mesh query (cluster.local and external) fails")
 	ready := b.intGauge("aether.mesh_dns.ready",
 		"1 once records have ever been populated (mesh misses answer NXDOMAIN), 0 while cold (mesh misses answer SERVFAIL)")
+	lastAnswered := b.floatGauge("aether.mesh_dns.last_answered_timestamp_seconds",
+		"Unix timestamp of the last query the resolver actually answered — real traffic or the self-check watchdog. It stops advancing on a resolver that is bound but blind, which the ready marker alone cannot show")
 
 	if b.err != nil {
 		log.Warn("mesh-DNS metrics disabled: failed to create instruments", "error", b.err)
@@ -87,14 +98,23 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 		o.ObserveInt64(watchActive, boolGauge(st.watchActive))
 		o.ObserveInt64(upstreams, st.upstreams)
 		o.ObserveInt64(ready, boolGauge(st.ready))
+		if st.lastAnswered > 0 {
+			o.ObserveFloat64(lastAnswered, float64(st.lastAnswered))
+		}
 		return nil
 	}
-	if _, err := b.meter.RegisterCallback(observe, age, writtenAt, records, generation, watchActive, upstreams, ready); err != nil {
+	if _, err := b.meter.RegisterCallback(observe, age, writtenAt, records, generation, watchActive, upstreams, ready, lastAnswered); err != nil {
 		log.Warn("mesh-DNS metrics disabled: failed to register the gauge callback", "error", err)
 		return nil
 	}
 
-	return &metrics{queries: queries, duration: duration, reloads: reloads}
+	return &metrics{
+		queries:    queries,
+		duration:   duration,
+		reloads:    reloads,
+		selfChecks: selfChecks,
+		truncated:  truncated,
+	}
 }
 
 // meterBuilder creates instruments while latching the first error, so newMetrics
@@ -146,14 +166,38 @@ func boolGauge(v bool) int64 {
 	return 0
 }
 
-// observeQuery counts a handled query and records how long handling took.
-func (m *metrics) observeQuery(result string, d time.Duration) {
+// observeQuery counts a handled query (by result AND by the transport it arrived on)
+// and records how long handling took. The duration histogram keeps the result
+// dimension only: splitting 15 buckets by transport as well would double its series
+// count for a split whose latency profile is already carried by result.
+func (m *metrics) observeQuery(result, proto string, d time.Duration) {
 	if m == nil {
 		return
 	}
-	attrs := metric.WithAttributes(attribute.String("result", result))
-	m.queries.Add(context.Background(), 1, attrs)
-	m.duration.Record(context.Background(), d.Seconds(), attrs)
+	m.queries.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("result", result),
+		attribute.String("proto", proto),
+	))
+	m.duration.Record(context.Background(), d.Seconds(), metric.WithAttributes(
+		attribute.String("result", result),
+	))
+}
+
+// recordSelfCheck counts one watchdog self-check by outcome (ok / fail).
+func (m *metrics) recordSelfCheck(result string) {
+	if m == nil {
+		return
+	}
+	m.selfChecks.Add(context.Background(), 1, metric.WithAttributes(attribute.String("result", result)))
+}
+
+// recordTruncated counts an upstream reply that came back truncated over UDP and had
+// to be re-fetched over TCP.
+func (m *metrics) recordTruncated() {
+	if m == nil {
+		return
+	}
+	m.truncated.Add(context.Background(), 1)
 }
 
 // recordReload counts a snapshot read attempt by outcome.
@@ -175,6 +219,22 @@ const (
 	// populated (warm-start snapshot empty + no reconcile yet); answered SERVFAIL
 	// so the client retries instead of caching a negative answer.
 	resultCold = "cold"
+)
+
+const (
+	// protoUDP / protoTCP are the transports a query can arrive on — the CNI DNATs
+	// pod :53 for both — and double as the miekg/dns Client.Net values the forward
+	// path relays over.
+	protoUDP = "udp"
+	protoTCP = "tcp"
+)
+
+const (
+	// selfCheckOK is a watchdog check whose synthetic query got a sane reply.
+	selfCheckOK = "ok"
+	// selfCheckFail is a watchdog check that timed out or got an unusable reply —
+	// the resolver is bound but not answering.
+	selfCheckFail = "fail"
 )
 
 const (

--- a/agent/internal/meshdns/selfcheck.go
+++ b/agent/internal/meshdns/selfcheck.go
@@ -1,0 +1,251 @@
+package meshdns
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// selfCheckInterval is how often the wedge watchdog exercises the handler. The pod-local
+// readiness probe runs every 15s, so a 30s cadence reaches a NotReady verdict (3 failed
+// checks) inside ~90s without adding measurable load to a node-critical daemon.
+const selfCheckInterval = 30 * time.Second
+
+// selfCheckTimeout bounds ONE self-check. A wedged handler never returns, so the check
+// is run on its own goroutine and awaited: without a bound, the watchdog would wedge
+// alongside the thing it is watching and never reach a verdict.
+const selfCheckTimeout = 5 * time.Second
+
+// selfCheckFailureThreshold is how many CONSECUTIVE failed checks remove the ready
+// marker. More than one, so a single slow check (a scheduling stall on a saturated
+// node) cannot flap the pod NotReady; small enough that a real wedge is demoted fast.
+const selfCheckFailureThreshold = 3
+
+// selfCheckLabels is the reserved two-label prefix of the watchdog's probe name; the
+// mesh domain is appended to it. See selfCheckQName for why it looks like this.
+const selfCheckLabels = "_selfcheck._aether"
+
+// errSelfCheck marks a failed self-check so callers can match it with errors.Is.
+var errSelfCheck = errors.New("mesh-DNS self-check")
+
+// selfCheckQName builds the watchdog's probe name — "_selfcheck._aether.<meshDomain>."
+//
+// The name is chosen so the check proves THIS process answers, and nothing else:
+//
+//   - It is under the mesh domain, so it always takes the AUTHORITATIVE path and is
+//     never forwarded. The check therefore cannot fail merely because kube-dns is down:
+//     a wedge alarm that fires on an unrelated upstream outage is worse than none.
+//   - It is never sent over the network. The daemon binds HOST_IP:18054 with
+//     SO_REUSEPORT so a surge successor can co-bind, which means a query to that address
+//     may be answered by the PEER pod — the exact false-ready trap #580 rejected a
+//     tcpSocket probe over. The watchdog calls ServeDNS in-process instead, so only this
+//     process can satisfy it.
+//   - Both labels begin with "_", which is not a legal DNS-1123 Kubernetes namespace or
+//     Service name. The record table therefore can NEVER hold this key, so the answer is
+//     deterministic on a cluster with zero mesh services: NXDOMAIN once records are
+//     populated, SERVFAIL while still cold. Requiring a real record to exist would have
+//     made the check unusable exactly when the mesh is empty.
+//
+// Both accepted answers are authoritative and both prove the handler ran end to end —
+// name parse, record-table lock, reply write — which is what a wedge takes out.
+func (s *Server) selfCheckQName() string {
+	return selfCheckLabels + "." + dns.Fqdn(s.meshDomain)
+}
+
+// selfChecker is the wedge watchdog: it periodically exercises the handler in-process
+// and gates the pod-local ready marker on the verdict, so a resolver that is bound but
+// blind stops reporting Ready and the DaemonSet's surge/rollout machinery can react.
+// Its counters are owned by the single run goroutine and need no locking.
+type selfChecker struct {
+	s         *Server
+	interval  time.Duration
+	timeout   time.Duration
+	threshold int
+
+	fails   int
+	demoted bool // this watchdog removed the ready marker
+}
+
+// newSelfChecker builds the watchdog with the production intervals.
+func newSelfChecker(s *Server) *selfChecker {
+	return &selfChecker{
+		s:         s,
+		interval:  selfCheckInterval,
+		timeout:   selfCheckTimeout,
+		threshold: selfCheckFailureThreshold,
+	}
+}
+
+// run ticks the watchdog until the context is cancelled (Start returns).
+func (c *selfChecker) run(ctx context.Context) {
+	t := time.NewTicker(c.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			c.tick(ctx)
+		}
+	}
+}
+
+// tick runs one self-check and applies the verdict to the ready marker.
+func (c *selfChecker) tick(ctx context.Context) {
+	if err := c.s.selfCheck(c.timeout); err != nil {
+		c.fail(ctx, err)
+		return
+	}
+	c.pass(ctx)
+}
+
+// fail counts a failed check and, once the consecutive-failure threshold is reached,
+// removes the pod-local ready marker so the exec readiness probe flips the pod NotReady.
+func (c *selfChecker) fail(ctx context.Context, err error) {
+	c.s.metrics.recordSelfCheck(selfCheckFail)
+	c.fails++
+	if c.fails < c.threshold || c.demoted {
+		c.s.log.ErrorContext(ctx, "mesh-DNS self-check failed",
+			"error", err, "consecutiveFailures", c.fails, "threshold", c.threshold)
+		return
+	}
+	c.s.log.ErrorContext(ctx, "mesh-DNS self-check failed repeatedly; removing the ready marker so this pod reports NotReady",
+		"error", err, "consecutiveFailures", c.fails, "threshold", c.threshold)
+	c.s.removeReadyMarker()
+	c.demoted = true
+}
+
+// pass resets the failure run, stamps last-answered (so a quiet node never looks idle),
+// and restores a marker this watchdog previously removed.
+func (c *selfChecker) pass(ctx context.Context) {
+	c.s.metrics.recordSelfCheck(selfCheckOK)
+	c.s.markAnswered()
+	c.fails = 0
+	if !c.demoted {
+		return
+	}
+	c.s.log.InfoContext(ctx, "mesh-DNS self-check recovered; restoring the ready marker")
+	c.s.writeReadyMarker(ctx)
+	c.demoted = false
+}
+
+// selfCheck exercises the DNS handler ONCE, in-process, and reports why it is unhealthy.
+//
+// The handler call runs on its own goroutine and is awaited with a timeout: a wedged
+// handler (a stuck lock, a forward that never returns) never completes, and blocking the
+// watchdog on it would defeat the entire point. On timeout that goroutine is abandoned —
+// the process is wedged regardless and the pod is on its way to NotReady.
+//
+// The check goes through the real ServeDNS, so its queries also land in
+// aether.mesh_dns.queries (two per minute per node, negligible): exercising the exact
+// path real traffic takes is the point.
+func (s *Server) selfCheck(timeout time.Duration) error {
+	req := new(dns.Msg)
+	req.SetQuestion(s.selfCheckQName(), dns.TypeA)
+	w := newMemResponseWriter(nil)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.ServeDNS(w, req)
+	}()
+
+	select {
+	case <-done:
+		return validateSelfCheckReply(req, w.Msg())
+	case <-time.After(timeout):
+		return fmt.Errorf("%w: the handler did not reply within %s", errSelfCheck, timeout)
+	}
+}
+
+// validateSelfCheckReply asserts the synthetic query got a sane authoritative reply.
+// The reserved probe name can never be in the record table, so exactly two rcodes are
+// healthy: NXDOMAIN (records populated) and SERVFAIL (still cold — a fresh node whose
+// agent has not written a snapshot yet, which must NOT be called a wedge or the daemon
+// would flap NotReady on every fresh cluster).
+func validateSelfCheckReply(req, resp *dns.Msg) error {
+	switch {
+	case resp == nil:
+		return fmt.Errorf("%w: the handler wrote no reply", errSelfCheck)
+	case resp.Id != req.Id:
+		return fmt.Errorf("%w: reply id %d does not match query id %d", errSelfCheck, resp.Id, req.Id)
+	case !resp.Response:
+		return fmt.Errorf("%w: reply is not flagged as a response", errSelfCheck)
+	case !resp.Authoritative:
+		return fmt.Errorf("%w: reply is not authoritative, so the probe left the mesh zone", errSelfCheck)
+	case resp.Rcode != dns.RcodeNameError && resp.Rcode != dns.RcodeServerFailure:
+		return fmt.Errorf("%w: unexpected rcode %s for the reserved probe name", errSelfCheck, dns.RcodeToString[resp.Rcode])
+	}
+	return nil
+}
+
+// memResponseWriter is an in-memory dns.ResponseWriter: it captures the reply the
+// handler writes instead of putting it on a socket. The watchdog uses it to drive
+// ServeDNS in-process (see selfCheckQName for why the check must never leave the
+// process), and the tests use it to drive the handler directly — one implementation,
+// not two.
+type memResponseWriter struct {
+	local  net.Addr
+	remote net.Addr
+
+	mu  sync.Mutex
+	msg *dns.Msg
+}
+
+// selfCheckLocalAddr is the plausible server-side address the in-memory writer reports.
+// Nothing is ever dialled through it; it exists because handlers are entitled to ask.
+var selfCheckLocalAddr = &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53}
+
+// selfCheckRemoteAddr is the plausible client-side address. It is a *net.UDPAddr, so
+// queryProto classifies the self-check as UDP — the transport that needs no special
+// forward handling.
+var selfCheckRemoteAddr = &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 40404}
+
+// newMemResponseWriter builds an in-memory writer presenting remote as the client. A nil
+// remote defaults to a loopback UDP client.
+func newMemResponseWriter(remote net.Addr) *memResponseWriter {
+	if remote == nil {
+		remote = selfCheckRemoteAddr
+	}
+	return &memResponseWriter{local: selfCheckLocalAddr, remote: remote}
+}
+
+// Msg returns the reply the handler wrote, or nil if it wrote none.
+func (w *memResponseWriter) Msg() *dns.Msg {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.msg
+}
+
+func (w *memResponseWriter) LocalAddr() net.Addr  { return w.local }
+func (w *memResponseWriter) RemoteAddr() net.Addr { return w.remote }
+
+func (w *memResponseWriter) WriteMsg(m *dns.Msg) error {
+	w.mu.Lock()
+	w.msg = m
+	w.mu.Unlock()
+	return nil
+}
+
+// Write accepts a pre-packed reply. This resolver only ever calls WriteMsg, but the
+// interface allows either, so the raw form is unpacked rather than dropped.
+func (w *memResponseWriter) Write(b []byte) (int, error) {
+	m := new(dns.Msg)
+	if err := m.Unpack(b); err != nil {
+		return 0, err
+	}
+	if err := w.WriteMsg(m); err != nil {
+		return 0, err
+	}
+	return len(b), nil
+}
+
+func (w *memResponseWriter) Close() error        { return nil }
+func (w *memResponseWriter) TsigStatus() error   { return nil }
+func (w *memResponseWriter) TsigTimersOnly(bool) {}
+func (w *memResponseWriter) Hijack()             {}

--- a/agent/internal/meshdns/selfcheck_test.go
+++ b/agent/internal/meshdns/selfcheck_test.go
@@ -1,0 +1,197 @@
+package meshdns
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSelfCheckQNameIsUnderTheMeshZone: the probe name is a mesh name (so it takes the
+// authoritative path and is never forwarded) whose labels can never be a real
+// Kubernetes namespace/Service, so no record can ever satisfy it.
+func TestSelfCheckQNameIsUnderTheMeshZone(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+
+	name := s.selfCheckQName()
+	assert.Equal(t, "_selfcheck._aether.aether.internal.", name)
+	assert.True(t, s.isMeshName(name), "the probe is under the mesh zone, so it is never forwarded")
+
+	ns, svc, ok := s.parseMeshName(name)
+	require.True(t, ok, "the probe is a well-formed <svc>.<ns> name, so it exercises the record-table lookup")
+	assert.Equal(t, "_aether", ns)
+	assert.Equal(t, "_selfcheck", svc)
+	// Underscore labels are not legal DNS-1123 names, so this key cannot be projected.
+	assert.NotContains(t, s.records, "_aether/_selfcheck")
+}
+
+// TestSelfCheckPassesOnHealthyServer: a healthy resolver passes, both once records are
+// populated (NXDOMAIN for the reserved name) and while still cold (SERVFAIL) — a fresh
+// node whose agent has not written a snapshot yet must not be called a wedge.
+func TestSelfCheckPassesOnHealthyServer(t *testing.T) {
+	cold := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	assert.NoError(t, cold.selfCheck(time.Second), "a cold resolver is healthy, just not populated")
+
+	ready := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	ready.SetRecords(map[string]string{"default/echo": "10.111.0.6"})
+	assert.NoError(t, ready.selfCheck(time.Second))
+
+	// A pass stamps last-answered, so a quiet node never looks blind.
+	newSelfChecker(ready).pass(context.Background())
+	assert.Positive(t, ready.observedState().lastAnswered)
+}
+
+// TestSelfCheckDetectsWedgedHandler: a handler that cannot make progress (here: the
+// record-table lock is held, exactly what a stuck reconcile or forward would do) fails
+// the check instead of hanging the watchdog with it.
+func TestSelfCheckDetectsWedgedHandler(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+
+	s.mu.Lock() // wedge: every lookup now blocks
+	err := s.selfCheck(50 * time.Millisecond)
+	s.mu.Unlock()
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errSelfCheck)
+	assert.Contains(t, err.Error(), "did not reply")
+}
+
+// TestValidateSelfCheckReply: only an authoritative NXDOMAIN/SERVFAIL for the reserved
+// name counts as healthy — a missing reply, a mismatched id, or a non-authoritative
+// answer (i.e. the probe escaped to the forward path) is a failure.
+func TestValidateSelfCheckReply(t *testing.T) {
+	req := query("_selfcheck._aether.aether.internal", dns.TypeA)
+
+	authoritative := func(rcode int) *dns.Msg {
+		m := new(dns.Msg)
+		m.SetRcode(req, rcode)
+		m.Authoritative = true
+		return m
+	}
+
+	assert.NoError(t, validateSelfCheckReply(req, authoritative(dns.RcodeNameError)))
+	assert.NoError(t, validateSelfCheckReply(req, authoritative(dns.RcodeServerFailure)))
+
+	assert.ErrorIs(t, validateSelfCheckReply(req, nil), errSelfCheck)
+
+	forwarded := authoritative(dns.RcodeNameError)
+	forwarded.Authoritative = false
+	assert.ErrorIs(t, validateSelfCheckReply(req, forwarded), errSelfCheck)
+
+	// NOERROR means something answered the reserved name, which cannot happen.
+	assert.ErrorIs(t, validateSelfCheckReply(req, authoritative(dns.RcodeSuccess)), errSelfCheck)
+
+	wrongID := authoritative(dns.RcodeNameError)
+	wrongID.Id = req.Id + 1
+	assert.ErrorIs(t, validateSelfCheckReply(req, wrongID), errSelfCheck)
+
+	notAResponse := authoritative(dns.RcodeNameError)
+	notAResponse.Response = false
+	assert.ErrorIs(t, validateSelfCheckReply(req, notAResponse), errSelfCheck)
+}
+
+// TestWatchdogRemovesReadyMarkerAfterConsecutiveFailures: the ready marker survives
+// isolated failures and is removed only once the consecutive-failure threshold is
+// reached (so a single slow check cannot flap the pod), then restored on recovery.
+func TestWatchdogRemovesReadyMarkerAfterConsecutiveFailures(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "mesh-dns.ready")
+	s := NewServerWithOptions("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler),
+		WithReadyMarker(marker))
+	s.writeReadyMarker(context.Background()) // Start writes it once the listeners bind
+	require.FileExists(t, marker)
+
+	c := newSelfChecker(s)
+	c.timeout = 50 * time.Millisecond
+	require.Equal(t, 3, c.threshold)
+
+	ctx := context.Background()
+	s.mu.Lock() // wedge the handler for the whole failure run
+	for i := 1; i < c.threshold; i++ {
+		c.tick(ctx)
+		assert.FileExists(t, marker, "still Ready after %d of %d failures", i, c.threshold)
+	}
+	c.tick(ctx)
+	s.mu.Unlock()
+
+	assert.NoFileExists(t, marker, "the marker is removed once the threshold is reached")
+	assert.True(t, c.demoted)
+
+	// A single healthy check restores it: the readiness probe flips the pod back Ready.
+	c.tick(ctx)
+	assert.FileExists(t, marker, "the marker is restored on recovery")
+	assert.False(t, c.demoted)
+	assert.Zero(t, c.fails)
+}
+
+// TestWatchdogRunStopsWithContext: the watchdog goroutine Start launches exits when
+// Start's context is cancelled.
+func TestWatchdogRunStopsWithContext(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	c := newSelfChecker(s)
+	c.interval = 10 * time.Millisecond
+	c.timeout = time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); c.run(ctx) }()
+
+	// Let at least one tick land, then stop.
+	require.Eventually(t, func() bool { return s.observedState().lastAnswered > 0 },
+		2*time.Second, 10*time.Millisecond, "the watchdog stamps last-answered on a quiet resolver")
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the watchdog did not stop with its context")
+	}
+}
+
+// TestWatchdogWithoutMarkerIsHarmless: the in-agent resolver runs with no ready marker
+// (the DaemonSet is the only user), so a failing check must be a safe no-op there.
+func TestWatchdogWithoutMarkerIsHarmless(t *testing.T) {
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	c := newSelfChecker(s)
+	c.timeout = 20 * time.Millisecond
+
+	ctx := context.Background()
+	s.mu.Lock()
+	for range c.threshold {
+		c.tick(ctx)
+	}
+	s.mu.Unlock()
+	assert.True(t, c.demoted, "the verdict is still reached and logged")
+
+	c.tick(ctx)
+	assert.False(t, c.demoted)
+}
+
+// TestMemResponseWriterWrite: the shared in-memory writer also accepts a pre-packed
+// reply, so it satisfies dns.ResponseWriter faithfully rather than approximately.
+func TestMemResponseWriterWrite(t *testing.T) {
+	m := new(dns.Msg)
+	m.SetRcode(query("echo.default.aether.internal", dns.TypeA), dns.RcodeNameError)
+	packed, err := m.Pack()
+	require.NoError(t, err)
+
+	w := newMemResponseWriter(nil)
+	n, err := w.Write(packed)
+	require.NoError(t, err)
+	assert.Equal(t, len(packed), n)
+	require.NotNil(t, w.Msg())
+	assert.Equal(t, dns.RcodeNameError, w.Msg().Rcode)
+
+	_, err = w.Write([]byte{0x01})
+	assert.Error(t, err, "a malformed buffer is rejected, not silently captured")
+
+	assert.NoError(t, w.Close())
+	assert.NoError(t, w.TsigStatus())
+	w.TsigTimersOnly(true)
+	w.Hijack()
+	assert.NotNil(t, w.LocalAddr())
+	assert.NotNil(t, w.RemoteAddr())
+}

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -35,6 +36,16 @@ import (
 )
 
 const answerTTL = 30
+
+// forwardTimeout bounds EVERY stage of an upstream exchange (dial, write, read).
+//
+// miekg/dns already applies an implicit 2s default (its unexported dnsTimeout) when a
+// Client leaves DialTimeout/ReadTimeout/WriteTimeout at zero, so this pins the same
+// value — behaviour is unchanged, the bound is simply visible here and can no longer
+// move silently under a dependency bump. It matters: the CNI DNATs every managed pod's
+// :53 here, so a forward that outlives its deadline pins a serve goroutine, and enough
+// of those is exactly the bound-but-blind wedge the self-check watchdog exists to catch.
+const forwardTimeout = 2 * time.Second
 
 // snapshotFileMode is the permission for the persisted records snapshot.
 const snapshotFileMode = 0o644
@@ -95,8 +106,20 @@ type Server struct {
 	readyMarker  string
 	reusePort    bool
 	log          *slog.Logger
-	client       *dns.Client
 	metrics      *metrics
+
+	// Separate forward clients per transport. A query that arrived over TCP must be
+	// relayed over TCP (the client already expects a large answer), and a UDP relay
+	// that comes back truncated is retried over TCP — see forward. They are kept as
+	// two clients rather than one whose Net is mutated, which would race across the
+	// concurrent serve goroutines.
+	udpClient *dns.Client
+	tcpClient *dns.Client
+
+	// lastAnswered is the unix second of the most recent query the resolver actually
+	// answered, stamped from the hot path with a single atomic store (no lock) and
+	// exported as aether.mesh_dns.last_answered_timestamp_seconds.
+	lastAnswered atomic.Int64
 
 	mu          sync.RWMutex
 	records     map[string]string // "<ns>/<svc>" -> A-record IP
@@ -146,7 +169,8 @@ func NewServerWithOptions(meshDomain, addr, snapshotPath string, log *slog.Logge
 		addr:         addr,
 		snapshotPath: snapshotPath,
 		log:          commonlog.Named(log, "mesh-dns"),
-		client:       &dns.Client{Net: "udp"},
+		udpClient:    newForwardClient(protoUDP),
+		tcpClient:    newForwardClient(protoTCP),
 		records:      map[string]string{},
 	}
 	for _, o := range opts {
@@ -159,6 +183,17 @@ func NewServerWithOptions(meshDomain, addr, snapshotPath string, log *slog.Logge
 	return s
 }
 
+// newForwardClient builds the upstream client for one transport ("udp" or "tcp") with
+// every timeout stated explicitly (see forwardTimeout).
+func newForwardClient(proto string) *dns.Client {
+	return &dns.Client{
+		Net:          proto,
+		DialTimeout:  forwardTimeout,
+		ReadTimeout:  forwardTimeout,
+		WriteTimeout: forwardTimeout,
+	}
+}
+
 // observedState snapshots the resolver state the observable gauges export. It takes
 // the Server's RWMutex only to copy a handful of scalars and releases it before
 // returning, so the OTel collect callback never holds the lock across an export (and
@@ -167,13 +202,23 @@ func (s *Server) observedState() resolverState {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return resolverState{
-		records:     int64(len(s.records)),
-		writtenAt:   s.writtenAt,
-		generation:  s.generation,
-		ready:       s.ready,
-		watchActive: s.watchActive,
-		upstreams:   int64(len(s.upstreams)),
+		records:      int64(len(s.records)),
+		writtenAt:    s.writtenAt,
+		generation:   s.generation,
+		ready:        s.ready,
+		watchActive:  s.watchActive,
+		upstreams:    int64(len(s.upstreams)),
+		lastAnswered: s.lastAnswered.Load(),
 	}
+}
+
+// markAnswered stamps the wall clock of the most recent query the resolver actually
+// answered. It backs aether.mesh_dns.last_answered_timestamp_seconds, the only signal
+// that separates a resolver serving nothing because the node is quiet from one that is
+// bound but blind. Real traffic stamps it on the hot path (one atomic store) so a busy
+// resolver never looks idle, and the self-check watchdog stamps it on a quiet node.
+func (s *Server) markAnswered() {
+	s.lastAnswered.Store(time.Now().Unix())
 }
 
 // SetWatchActive records whether the daemon's fsnotify snapshot watcher is running.
@@ -382,6 +427,12 @@ func (s *Server) Start(ctx context.Context) error {
 	// ready so a surge successor is only marked Ready once it can actually serve.
 	s.writeReadyMarker(ctx)
 	defer s.removeReadyMarker()
+	// Only NOW — bound, and with the marker already written — does the wedge watchdog
+	// start. It can therefore only ever take away a readiness the bind already earned,
+	// so it cannot flap the pod during startup. It stops when Start returns.
+	watchdogCtx, stopWatchdog := context.WithCancel(ctx)
+	defer stopWatchdog()
+	go newSelfChecker(s).run(watchdogCtx)
 	errc := make(chan error, 2)
 	if s.reusePort {
 		go func() { errc <- udp.ActivateAndServe() }()
@@ -488,7 +539,29 @@ func reusePortControl(_, _ string, c syscall.RawConn) error {
 func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	start := time.Now()
 	result := s.serve(w, r)
-	s.metrics.observeQuery(result, time.Since(start))
+	if answeredResult(result) {
+		s.markAnswered()
+	}
+	s.metrics.observeQuery(result, queryProto(w), time.Since(start))
+}
+
+// answeredResult reports whether a result means the resolver produced a real answer,
+// which is what last_answered records. A cold SERVFAIL and a forward_error are
+// excluded: they are replies, but they are the resolver reporting that it CANNOT
+// answer, and a resolver stuck emitting them is not healthy.
+func answeredResult(result string) bool {
+	return result == resultAnswered || result == resultNXDomain || result == resultForwarded
+}
+
+// queryProto reports the transport a query ARRIVED on, read from the writer's remote
+// address: miekg/dns hands a *net.TCPAddr for the TCP listener and a *net.UDPAddr for
+// the UDP one. Anything else (including a nil addr) is reported as UDP, the
+// conservative default — UDP is the transport that needs no special forward handling.
+func queryProto(w dns.ResponseWriter) string {
+	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
+		return protoTCP
+	}
+	return protoUDP
 }
 
 // serve dispatches a query to the mesh or forward path and returns the metric result
@@ -600,16 +673,27 @@ func (s *Server) lookup(qname string) (ip string, ready bool) {
 	return ip, ready
 }
 
+// forward relays a non-mesh query (cluster.local, external) to the first upstream that
+// answers, and SERVFAILs — non-authoritatively, which is how the mesh cold path stays
+// distinguishable — when none does.
+//
+// The transport is not incidental. The CNI DNATs pod :53 for BOTH udp and tcp, so a
+// query can genuinely arrive over TCP, and a client that asked over TCP has already
+// decided it wants an answer too big for a datagram (usually after its own TC=1 retry).
+// Relaying that over UDP could return TC=1 again, which the old single-UDP-client code
+// recorded as a clean "forwarded" while the client looped or gave up. So: TCP in, TCP
+// out; and a UDP relay that comes back truncated is retried over TCP (see exchange).
 func (s *Server) forward(w dns.ResponseWriter, r *dns.Msg) string {
 	s.mu.RLock()
 	ups := s.upstreams
 	s.mu.RUnlock()
+	viaTCP := queryProto(w) == protoTCP
 	for _, up := range ups {
 		addr := up
 		if !strings.Contains(addr, ":") {
 			addr += ":53"
 		}
-		if resp, _, err := s.client.Exchange(r, addr); err == nil && resp != nil {
+		if resp := s.exchange(r, addr, viaTCP); resp != nil {
 			_ = w.WriteMsg(resp)
 			return resultForwarded
 		}
@@ -618,4 +702,50 @@ func (s *Server) forward(w dns.ResponseWriter, r *dns.Msg) string {
 	m.SetRcode(r, dns.RcodeServerFailure)
 	_ = w.WriteMsg(m)
 	return resultForwardError
+}
+
+// exchange relays r to ONE upstream over the transport the client used, returning nil
+// when that upstream failed (the caller then tries the next). A truncated UDP reply is
+// re-fetched over TCP, the standard recursive-resolver escalation.
+func (s *Server) exchange(r *dns.Msg, addr string, viaTCP bool) *dns.Msg {
+	if viaTCP {
+		return s.exchangeWith(s.tcpClient, r, addr)
+	}
+	resp := s.exchangeWith(s.udpClient, r, addr)
+	if resp == nil || !resp.Truncated {
+		return resp
+	}
+	// TC=1: the answer does not fit in a datagram. Re-ask over TCP. If that fails we
+	// still hand back the truncated reply — a TC=1 answer is a valid signal the client
+	// can act on (retry over TCP, which the CNI also DNATs here), and it beats SERVFAIL.
+	s.metrics.recordTruncated()
+	full := s.exchangeWith(s.tcpClient, r, addr)
+	if full == nil {
+		return resp
+	}
+	// The client asked over UDP and cannot receive more than it advertised, so pack the
+	// full answer back down to that size; Truncate re-sets TC=1 only if it still does
+	// not fit, and then the client's own TCP retry lands on the TCP path above.
+	full.Truncate(udpSizeFor(r))
+	return full
+}
+
+// exchangeWith runs one upstream exchange, mapping any failure to a nil reply.
+func (s *Server) exchangeWith(c *dns.Client, r *dns.Msg, addr string) *dns.Msg {
+	resp, _, err := c.Exchange(r, addr)
+	if err != nil {
+		return nil
+	}
+	return resp
+}
+
+// udpSizeFor is the largest UDP reply the client will accept: the EDNS0 buffer it
+// advertised, or RFC 1035's 512-byte floor when it asked without EDNS0.
+func udpSizeFor(r *dns.Msg) int {
+	if opt := r.IsEdns0(); opt != nil {
+		if size := int(opt.UDPSize()); size > dns.MinMsgSize {
+			return size
+		}
+	}
+	return dns.MinMsgSize
 }

--- a/agent/internal/meshdns/server_test.go
+++ b/agent/internal/meshdns/server_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
@@ -389,26 +390,24 @@ func waitForUDP(t *testing.T, addr string) {
 	t.Fatalf("resolver did not bind %s in time", addr)
 }
 
-// fakeResponseWriter captures the reply message ServeDNS writes.
-type fakeResponseWriter struct {
-	dns.ResponseWriter
-	msg *dns.Msg
-}
-
-func (f *fakeResponseWriter) WriteMsg(m *dns.Msg) error { f.msg = m; return nil }
-func (f *fakeResponseWriter) LocalAddr() net.Addr       { return &net.UDPAddr{} }
-func (f *fakeResponseWriter) RemoteAddr() net.Addr      { return &net.UDPAddr{} }
-
 func query(name string, qtype uint16) *dns.Msg {
 	m := new(dns.Msg)
 	m.SetQuestion(dns.Fqdn(name), qtype)
 	return m
 }
 
+// serve drives the handler in-process over the production in-memory ResponseWriter
+// (memResponseWriter, shared with the self-check watchdog) presenting a UDP client.
 func serve(s *Server, r *dns.Msg) *dns.Msg {
-	w := &fakeResponseWriter{}
+	return serveFrom(s, r, nil)
+}
+
+// serveFrom drives the handler with a specific client address, so a test can present a
+// TCP-originated query (the forward path branches on it).
+func serveFrom(s *Server, r *dns.Msg, remote net.Addr) *dns.Msg {
+	w := newMemResponseWriter(remote)
 	s.ServeDNS(w, r)
-	return w.msg
+	return w.Msg()
 }
 
 // TestServeMeshMissColdIsServfail: a mesh miss BEFORE records are ever populated is
@@ -502,6 +501,195 @@ func TestServeNonMeshForwards(t *testing.T) {
 	require.NotNil(t, resp)
 	assert.Equal(t, dns.RcodeServerFailure, resp.Rcode)
 	assert.False(t, resp.Authoritative, "forwarded (upstream failed), not an authoritative mesh answer")
+}
+
+// TestQueryProto: the transport a query arrived on is read off the writer's remote
+// address. Anything that is not a TCP address (including a nil one) is UDP.
+func TestQueryProto(t *testing.T) {
+	assert.Equal(t, protoUDP, queryProto(newMemResponseWriter(nil)))
+	assert.Equal(t, protoUDP, queryProto(newMemResponseWriter(&net.UDPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 1234})))
+	assert.Equal(t, protoTCP, queryProto(newMemResponseWriter(&net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 1234})))
+	assert.Equal(t, protoUDP, queryProto(newMemResponseWriter(nilAddr{})), "an unknown addr type is treated as UDP")
+}
+
+// nilAddr is an addr of neither UDP nor TCP type.
+type nilAddr struct{}
+
+func (nilAddr) Network() string { return "unix" }
+func (nilAddr) String() string  { return "@" }
+
+// TestForwardTCPQueryUsesTCP: a query that arrived over TCP is forwarded over TCP. The
+// CNI DNATs pod :53 for TCP too, and such a client has already decided it wants an
+// answer that does not fit a datagram — relaying it over UDP is what could hand it a
+// truncated reply we would then record as a clean "forwarded".
+func TestForwardTCPQueryUsesTCP(t *testing.T) {
+	seen := &protoRecorder{}
+	addr := startUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		seen.add(upstreamProto(w))
+		m := new(dns.Msg)
+		m.SetReply(r)
+		_ = w.WriteMsg(m)
+	})
+
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetUpstreams([]string{addr})
+
+	resp := serveFrom(s, query("google.com", dns.TypeA), &net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 5555})
+	require.NotNil(t, resp)
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	assert.Equal(t, []string{protoTCP}, seen.all(), "a TCP-originated query is forwarded over TCP")
+
+	// A UDP-originated query still goes out over UDP (the cheap common path).
+	resp = serve(s, query("google.com", dns.TypeA))
+	require.NotNil(t, resp)
+	assert.Equal(t, []string{protoTCP, protoUDP}, seen.all())
+}
+
+// TestForwardTruncatedUDPReplyRetriesOverTCP: when the upstream truncates the UDP reply
+// (TC=1) the resolver re-asks over TCP and returns the full answer, instead of passing a
+// truncated reply back as a clean "forwarded" while the client loops.
+func TestForwardTruncatedUDPReplyRetriesOverTCP(t *testing.T) {
+	seen := &protoRecorder{}
+	addr := startUpstream(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		proto := upstreamProto(w)
+		seen.add(proto)
+		m := new(dns.Msg)
+		m.SetReply(r)
+		if proto == protoUDP {
+			// Too big for a datagram: answer TC=1 with nothing, as a real upstream does.
+			m.Truncated = true
+			_ = w.WriteMsg(m)
+			return
+		}
+		m.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+			A:   net.IPv4(93, 184, 216, 34),
+		}}
+		_ = w.WriteMsg(m)
+	})
+
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetUpstreams([]string{addr})
+
+	resp := serve(s, query("big.example.com", dns.TypeA))
+	require.NotNil(t, resp)
+	assert.Equal(t, []string{protoUDP, protoTCP}, seen.all(), "UDP first, then the TCP retry")
+	assert.False(t, resp.Truncated, "the full TCP answer fits the client's buffer")
+	require.Len(t, resp.Answer, 1, "the client gets the answer, not an empty TC=1 reply")
+	a, ok := resp.Answer[0].(*dns.A)
+	require.True(t, ok)
+	assert.Equal(t, "93.184.216.34", a.A.String())
+}
+
+// TestForwardTruncatedRetryFailureKeepsTruncatedReply: if the TCP retry itself fails,
+// the client still gets the upstream's TC=1 reply — a signal it can act on (retry over
+// TCP, which the CNI also DNATs here) — rather than a SERVFAIL.
+func TestForwardTruncatedRetryFailureKeepsTruncatedReply(t *testing.T) {
+	addr := startUpstreamUDPOnly(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Truncated = true
+		_ = w.WriteMsg(m)
+	})
+
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	s.SetUpstreams([]string{addr})
+
+	resp := serve(s, query("big.example.com", dns.TypeA))
+	require.NotNil(t, resp)
+	assert.True(t, resp.Truncated, "the truncated reply is passed through when TCP is unreachable")
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "not a SERVFAIL")
+}
+
+// TestUDPSizeFor: the re-truncation ceiling is the client's advertised EDNS0 buffer,
+// with RFC 1035's 512-byte floor when it asked without EDNS0 (or advertised less).
+func TestUDPSizeFor(t *testing.T) {
+	assert.Equal(t, dns.MinMsgSize, udpSizeFor(query("google.com", dns.TypeA)))
+
+	big := query("google.com", dns.TypeA)
+	big.SetEdns0(4096, false)
+	assert.Equal(t, 4096, udpSizeFor(big))
+
+	small := query("google.com", dns.TypeA)
+	small.SetEdns0(200, false)
+	assert.Equal(t, dns.MinMsgSize, udpSizeFor(small), "never below the 512-byte floor")
+}
+
+// protoRecorder collects, in order, the transports an upstream saw.
+type protoRecorder struct {
+	mu     sync.Mutex
+	protos []string
+}
+
+func (p *protoRecorder) add(proto string) {
+	p.mu.Lock()
+	p.protos = append(p.protos, proto)
+	p.mu.Unlock()
+}
+
+func (p *protoRecorder) all() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.protos...)
+}
+
+// upstreamProto reports which transport a query reached the TEST upstream over.
+func upstreamProto(w dns.ResponseWriter) string {
+	if _, ok := w.RemoteAddr().(*net.TCPAddr); ok {
+		return protoTCP
+	}
+	return protoUDP
+}
+
+// startUpstream runs a test resolver on ONE host:port over BOTH udp and tcp (what a
+// real upstream looks like) and returns its address.
+func startUpstream(t *testing.T, h dns.HandlerFunc) string {
+	t.Helper()
+	addr := fmt.Sprintf("127.0.0.1:%d", freeDNSPort(t))
+	startUpstreamOn(t, addr, "udp", h)
+	startUpstreamOn(t, addr, "tcp", h)
+	return addr
+}
+
+// startUpstreamUDPOnly runs a test resolver that answers over udp only, so a TCP retry
+// against it fails.
+func startUpstreamUDPOnly(t *testing.T, h dns.HandlerFunc) string {
+	t.Helper()
+	addr := fmt.Sprintf("127.0.0.1:%d", freeDNSPort(t))
+	startUpstreamOn(t, addr, "udp", h)
+	return addr
+}
+
+// startUpstreamOn binds one transport of the test upstream and waits for it to serve.
+func startUpstreamOn(t *testing.T, addr, network string, h dns.HandlerFunc) {
+	t.Helper()
+	started := make(chan struct{})
+	srv := &dns.Server{Addr: addr, Net: network, Handler: h}
+	srv.NotifyStartedFunc = func() { close(started) }
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() { _ = srv.Shutdown() })
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("test upstream did not bind %s/%s in time", addr, network)
+	}
+}
+
+// freeDNSPort finds a port free on BOTH udp and tcp: the forward path dials one
+// host:port over either transport, so the test upstream must own both.
+func freeDNSPort(t *testing.T) int {
+	t.Helper()
+	for range 20 {
+		port := freeUDPPort(t)
+		ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+		if err != nil {
+			continue
+		}
+		require.NoError(t, ln.Close())
+		return port
+	}
+	t.Fatal("no port was free on both udp and tcp")
+	return 0
 }
 
 // TestEnsureSnapshotDir: the agent pre-creates the snapshot's parent so the resolver


### PR DESCRIPTION
Two of the follow-ups explicitly deferred by #586, in one PR because both live in the resolver's `server.go`.

## Fix 1 — wedge detection

The readiness gate wrote its pod-local marker once, right after the listeners bound (`Start` → `writeReadyMarker`), and never re-verified that queries were actually being answered. A resolver whose serve path wedged stayed **Ready forever** while the CNI kept DNAT-ing every managed pod's `:53` at something that answered nothing.

A watchdog (`agent/internal/meshdns/selfcheck.go`) now exercises the handler every 30s by calling `ServeDNS` **in-process** over an in-memory `dns.ResponseWriter`.

**Why not a network self-query:** the daemon binds `HOST_IP:18054` with `SO_REUSEPORT` so a surge successor can co-bind, which means a query to that address can be answered by the **peer** pod — the exact false-ready trap #580 rejected a `tcpSocket` probe over. Only an in-process call can prove *this* process answers.

**Why this probe name** (`_selfcheck._aether.<meshDomain>.`):

- under the mesh domain, so it always takes the authoritative path and is **never forwarded** — the check cannot fail merely because kube-dns is down;
- both labels start with `_`, which is not a legal DNS-1123 Kubernetes namespace or Service name, so the record table can **never** hold this key. The answer is therefore deterministic on a cluster with zero mesh services: NXDOMAIN once records are populated, SERVFAIL while still cold. Both are authoritative and both prove the handler ran end to end (name parse → record-table lock → reply write);
- it is a well-formed `<svc>.<ns>` name, so it goes through the record-table lookup — a wedge that is a stuck `s.mu` is caught, not skipped.

Each check runs on its own goroutine and is awaited with a 5s timeout: a wedged handler never returns, and blocking the watchdog on it would defeat the point. **Three consecutive** failures remove the ready marker so the exec readiness probe flips the pod NotReady and the surge/rollout machinery can react; a single pass restores it. The watchdog starts only *after* the bind has already written the marker, so it can never flap a starting pod.

## Fix 2 — UDP-only forward client truncating TCP-originated queries

`forward()` used a single `&dns.Client{Net: "udp"}`. Since the CNI DNATs TCP `:53` as well, a query that arrived over **TCP** — from a client that had already decided it wants an answer too big for a datagram — was relayed over **UDP** and could come back with `TC=1`, which we recorded as a clean `forwarded` while the client looped or failed.

- inbound protocol is read off the `ResponseWriter`'s `RemoteAddr()` (`*net.TCPAddr` vs `*net.UDPAddr`);
- TCP in → TCP out;
- a truncated UDP reply is retried over TCP and the full answer returned, re-packed to the client's advertised EDNS0 size (512-byte floor). If the TCP retry itself fails, the upstream's `TC=1` reply is passed through rather than a SERVFAIL;
- two clients (udp/tcp) rather than one whose `Net` is mutated under concurrent serve goroutines;
- `DialTimeout`/`ReadTimeout`/`WriteTimeout` are now **explicit**. miekg/dns was already applying an implicit 2s (its unexported `dnsTimeout`) to each; this pins the same value so the bound is visible and cannot move under a dependency bump.

## Metrics

| instrument | notes |
|---|---|
| `aether.mesh_dns.self_check_total{result=ok\|fail}` | counter |
| `aether.mesh_dns.last_answered_timestamp_seconds` | Float64ObservableGauge; stamped by **real traffic** on the hot path (one atomic store) as well as by the watchdog, so a busy resolver never looks idle and a bound-but-blind one stops advancing |
| `aether.mesh_dns.responses_truncated_total` | replies that arrived `TC=1` and required the TCP retry |
| `aether.mesh_dns.queries{result,proto}` | new `proto=udp\|tcp` attribute (the duration histogram keeps `result` only, to avoid doubling 15 buckets) |

## Notes

- No semantic change to EDNS0 OPT echo, NODATA-for-non-A, the never-forward-the-mesh-zone rule, SO_REUSEPORT, marker-after-bind, or the snapshot envelope/heartbeat.
- No `charts/` change: the existing exec readiness probe already stats the marker, which is exactly the lever the watchdog pulls.
- The test-only `fakeResponseWriter` is retired in favour of the production `memResponseWriter` the watchdog uses — one implementation, not two.
- Slim dep graph re-proven: `somepath(//agent/cmd/mesh-dns:mesh-dns, @io_k8s_sigs_controller_runtime//...)` and the `@com_github_envoyproxy_go_control_plane//...` equivalent are both **empty**.

Follows #586.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR