### PR TITLE
feat(mesh-dns): split nodata from answered and bucket the query type

### DIFF
--- a/agent/internal/meshdns/BUILD.bazel
+++ b/agent/internal/meshdns/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
 go_test(
     name = "meshdns_test",
     srcs = [
+        "metrics_test.go",
         "resolvconf_test.go",
         "selfcheck_test.go",
         "server_test.go",
@@ -43,5 +44,9 @@ go_test(
         "@com_github_miekg_dns//:dns",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel//attribute",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk_metric//metricdata",
     ],
 )

--- a/agent/internal/meshdns/metrics.go
+++ b/agent/internal/meshdns/metrics.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/miekg/dns"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -55,7 +56,7 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 	b := &meterBuilder{meter: otel.Meter(meterName)}
 
 	queries := b.counter("aether.mesh_dns.queries",
-		"Mesh-DNS queries handled by the resolver, by result (answered=mesh hit, forwarded=relayed to upstream, forward_error=upstream failed, nxdomain=authoritative mesh miss, cold=SERVFAIL for a mesh name before records were ever populated) and by the transport the query arrived on (proto=udp|tcp; the CNI DNATs both)")
+		"Mesh-DNS queries handled by the resolver, by result (answered=mesh hit with an A record, nodata=known mesh name asked for a non-A type, forwarded=relayed to upstream, forward_error=upstream failed, nxdomain=authoritative mesh miss, cold=SERVFAIL for a mesh name before records were ever populated), by the transport the query arrived on (proto=udp|tcp; the CNI DNATs both), and by bucketed query type (qtype=a|aaaa|https|srv|ptr|txt|cname|other)")
 	selfChecks := b.counter("aether.mesh_dns.self_check_total",
 		"In-process handler self-checks run by the wedge watchdog, by result (ok, fail). Consecutive failures remove the pod-local ready marker so the readiness probe flips the pod NotReady")
 	truncated := b.counter("aether.mesh_dns.responses_truncated_total",
@@ -166,17 +167,24 @@ func boolGauge(v bool) int64 {
 	return 0
 }
 
-// observeQuery counts a handled query (by result AND by the transport it arrived on)
-// and records how long handling took. The duration histogram keeps the result
-// dimension only: splitting 15 buckets by transport as well would double its series
-// count for a split whose latency profile is already carried by result.
-func (m *metrics) observeQuery(result, proto string, d time.Duration) {
+// observeQuery counts a handled query (by result, by the transport it arrived on AND by
+// bucketed query type) and records how long handling took.
+//
+// The duration histogram deliberately keeps the result dimension ONLY. Its 15 explicit
+// buckets make every extra attribute expensive — proto would double the series count and
+// qtype would multiply it by eight — and neither buys anything: latency here is decided
+// by the PATH taken, which result already names. A mesh hit and an AAAA NODATA do the
+// same map lookup under the same lock, and a forwarded SRV costs the same kube-dns round
+// trip as a forwarded A. qtype and proto answer "what is being asked, over what", which
+// is a counter question; result answers "how long did it take", which is the histogram's.
+func (m *metrics) observeQuery(result, proto, qtype string, d time.Duration) {
 	if m == nil {
 		return
 	}
 	m.queries.Add(context.Background(), 1, metric.WithAttributes(
 		attribute.String("result", result),
 		attribute.String("proto", proto),
+		attribute.String("qtype", qtype),
 	))
 	m.duration.Record(context.Background(), d.Seconds(), metric.WithAttributes(
 		attribute.String("result", result),
@@ -209,7 +217,16 @@ func (m *metrics) recordReload(result string) {
 }
 
 const (
-	resultAnswered     = "answered"
+	// resultAnswered is a mesh hit that produced a real A record.
+	resultAnswered = "answered"
+	// resultNoData is a KNOWN mesh name asked for a type the resolver has no record
+	// for (AAAA and friends): NOERROR with an empty answer section, so the name
+	// consistently exists — see serveMesh. It is split out from resultAnswered
+	// because the two are operationally different: a healthy mesh shows a steady
+	// nodata trickle from the AAAA half of every dual-stack lookup, whereas nodata
+	// RISING against answered means clients are failing over to IPv6 or the record
+	// table has stopped producing usable A records. Conflated, that is invisible.
+	resultNoData       = "nodata"
 	resultForwarded    = "forwarded"
 	resultForwardError = "forward_error"
 	// resultNXDomain is an authoritative miss: a name under the mesh domain that
@@ -228,6 +245,68 @@ const (
 	protoUDP = "udp"
 	protoTCP = "tcp"
 )
+
+// qtype attribute values. This set is CLOSED, and that is the point: DNS defines ~90
+// query types, the CNI DNATs every managed pod's :53 straight here, and a buggy or
+// hostile client can therefore ask this resolver for arbitrary types. Emitting the raw
+// qtype would let any pod on the node inflate the counter's series count at will, so
+// queryQType maps to these buckets and EVERYTHING unrecognised collapses to qtypeOther.
+//
+// The named buckets are what a mesh resolver realistically sees and would act on:
+//
+//   - a: the only type the mesh record table can answer — the hit path itself.
+//   - aaaa: every dual-stack-capable resolver (glibc getaddrinfo, c-ares, Go) fires it
+//     alongside A, so it is essentially the whole nodata trickle. Watching it rise
+//     against a is the IPv6-failover signal the nodata split exists for.
+//   - https: curl 8.x, browsers and systemd-resolved query the HTTPS RR (type 65) next
+//     to A+AAAA. It is high volume and utterly routine, so leaving it in other would
+//     bury the genuinely exotic queries other is meant to expose.
+//   - srv: headless Services and gRPC/SIP-style discovery. Always forwarded (kube-dns
+//     owns _svc._proto), so it is the forward path's main non-address type.
+//   - ptr: reverse lookups from tooling and logging stacks; forwarded, and a burst of
+//     them is a classic accidental source of upstream latency.
+//   - txt: forwarded, normally near zero, and both a health-probe and an exfil channel —
+//     cheap to keep separable.
+//   - cname: what debugging tools (dig CNAME) and some client libraries ask directly,
+//     which distinguishes an operator/tool pattern from real workload traffic.
+//
+// Worst case is therefore 8 qtype x 6 result x 2 proto = 96 series per node, bounded no
+// matter what is asked; in practice only a handful are ever non-zero.
+const (
+	qtypeA     = "a"
+	qtypeAAAA  = "aaaa"
+	qtypeHTTPS = "https"
+	qtypeSRV   = "srv"
+	qtypePTR   = "ptr"
+	qtypeTXT   = "txt"
+	qtypeCNAME = "cname"
+	qtypeOther = "other"
+)
+
+// qtypeBuckets is the recognised-type lookup behind queryQType. A miss is qtypeOther,
+// which is what keeps the attribute's value set closed and its cardinality bounded.
+var qtypeBuckets = map[uint16]string{
+	dns.TypeA:     qtypeA,
+	dns.TypeAAAA:  qtypeAAAA,
+	dns.TypeHTTPS: qtypeHTTPS,
+	dns.TypeSRV:   qtypeSRV,
+	dns.TypePTR:   qtypePTR,
+	dns.TypeTXT:   qtypeTXT,
+	dns.TypeCNAME: qtypeCNAME,
+}
+
+// queryQType buckets the query's type for the qtype attribute (see qtypeBuckets). A
+// message without exactly one question is reported as qtypeOther: it is never a mesh
+// query (serve requires a single question) and has no single meaningful type.
+func queryQType(r *dns.Msg) string {
+	if r == nil || len(r.Question) != 1 {
+		return qtypeOther
+	}
+	if bucket, ok := qtypeBuckets[r.Question[0].Qtype]; ok {
+		return bucket
+	}
+	return qtypeOther
+}
 
 const (
 	// selfCheckOK is a watchdog check whose synthetic query got a sane reply.

--- a/agent/internal/meshdns/metrics_test.go
+++ b/agent/internal/meshdns/metrics_test.go
@@ -1,0 +1,186 @@
+package meshdns
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// queriesMetric is the counter every attribute assertion below reads.
+const queriesMetric = "aether.mesh_dns.queries"
+
+// meteredServer builds a resolver whose instruments are backed by a manual reader, so a
+// test can assert on the ATTRIBUTES actually exported rather than on an internal return
+// value. The global MeterProvider is swapped for the duration of the test (newMetrics
+// reads it at construction time) and restored afterwards.
+func meteredServer(t *testing.T, records map[string]string) (*Server, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	s := NewServer("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler))
+	if records != nil {
+		s.SetRecords(records)
+	}
+	return s, reader
+}
+
+// queryCounts collects the aether.mesh_dns.queries data points as
+// "result/proto/qtype" -> value, which is the whole attribute set the counter carries.
+func queryCounts(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+
+	counts := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != queriesMetric {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "%s should be an int64 sum", queriesMetric)
+			for _, dp := range sum.DataPoints {
+				counts[attrKey(t, dp.Attributes)] += dp.Value
+			}
+		}
+	}
+	return counts
+}
+
+// attrKey renders a data point's attributes as "result/proto/qtype".
+func attrKey(t *testing.T, set attribute.Set) string {
+	t.Helper()
+	get := func(k string) string {
+		v, ok := set.Value(attribute.Key(k))
+		require.True(t, ok, "data point is missing the %q attribute", k)
+		return v.Emit()
+	}
+	return get("result") + "/" + get("proto") + "/" + get("qtype")
+}
+
+// TestQueryMetricSplitsAnsweredFromNoData: an A hit is counted answered/a, while an AAAA
+// query for the SAME known name — the NODATA reply that keeps the name existing for
+// c-ares — is counted nodata/aaaa. Conflated (the pre-split behaviour) an IPv6 failover
+// would be indistinguishable from healthy traffic.
+func TestQueryMetricSplitsAnsweredFromNoData(t *testing.T) {
+	s, reader := meteredServer(t, map[string]string{"default/echo": "10.111.0.6"})
+
+	hit := serve(s, query("echo.default.aether.internal", dns.TypeA))
+	require.NotNil(t, hit)
+	require.Len(t, hit.Answer, 1, "the A query is a real hit")
+
+	nodata := serve(s, query("echo.default.aether.internal", dns.TypeAAAA))
+	require.NotNil(t, nodata)
+	require.Equal(t, dns.RcodeSuccess, nodata.Rcode, "NODATA, not NXDOMAIN")
+	require.Empty(t, nodata.Answer)
+
+	assert.Equal(t, map[string]int64{
+		"answered/udp/a":  1,
+		"nodata/udp/aaaa": 1,
+	}, queryCounts(t, reader))
+}
+
+// TestQueryMetricNoDataOnUnparseableRecord: an A query whose stored record is not a
+// usable IPv4 produces an empty answer, and is counted nodata — a record-table defect
+// showing up as nodata on qtype=a rather than hiding inside answered.
+func TestQueryMetricNoDataOnUnparseableRecord(t *testing.T) {
+	s, reader := meteredServer(t, map[string]string{"default/echo": "not-an-ip"})
+
+	resp := serve(s, query("echo.default.aether.internal", dns.TypeA))
+	require.NotNil(t, resp)
+	require.Empty(t, resp.Answer)
+
+	assert.Equal(t, map[string]int64{"nodata/udp/a": 1}, queryCounts(t, reader))
+}
+
+// TestQueryMetricBucketsExoticQType: an unrecognised query type collapses to "other".
+// The CNI DNATs every managed pod's :53 here, so an arbitrary client can ask for any of
+// DNS's ~90 types; the closed bucket set is what stops that inflating the series count.
+func TestQueryMetricBucketsExoticQType(t *testing.T) {
+	s, reader := meteredServer(t, map[string]string{"default/echo": "10.111.0.6"})
+
+	for _, qtype := range []uint16{dns.TypeNAPTR, dns.TypeANY, dns.TypeCAA, 61234} {
+		require.NotNil(t, serve(s, query("echo.default.aether.internal", qtype)))
+	}
+
+	assert.Equal(t, map[string]int64{"nodata/udp/other": 4},
+		queryCounts(t, reader), "every exotic type collapses into one series")
+}
+
+// TestQueryMetricProtoStillSplits: the proto attribute keeps reporting the transport the
+// query arrived on now that qtype sits beside it.
+func TestQueryMetricProtoStillSplits(t *testing.T) {
+	s, reader := meteredServer(t, map[string]string{"default/echo": "10.111.0.6"})
+
+	require.NotNil(t, serve(s, query("echo.default.aether.internal", dns.TypeA)))
+	require.NotNil(t, serveFrom(s, query("echo.default.aether.internal", dns.TypeA),
+		&net.TCPAddr{IP: net.IPv4(10, 0, 0, 1), Port: 5555}))
+
+	assert.Equal(t, map[string]int64{
+		"answered/udp/a": 1,
+		"answered/tcp/a": 1,
+	}, queryCounts(t, reader))
+}
+
+// TestQueryMetricMissAndColdKeepQType: the qtype attribute is recorded on every result,
+// not just on hits — an AAAA storm against names that do not exist is exactly the
+// pattern worth seeing before it becomes a latency complaint.
+func TestQueryMetricMissAndColdKeepQType(t *testing.T) {
+	s, reader := meteredServer(t, nil)
+
+	require.NotNil(t, serve(s, query("nope.default.aether.internal", dns.TypeAAAA)), "cold: SERVFAIL")
+	s.SetRecords(map[string]string{"default/echo": "10.111.0.6"})
+	require.NotNil(t, serve(s, query("nope.default.aether.internal", dns.TypeAAAA)), "ready: NXDOMAIN")
+
+	assert.Equal(t, map[string]int64{
+		"cold/udp/aaaa":     1,
+		"nxdomain/udp/aaaa": 1,
+	}, queryCounts(t, reader))
+}
+
+// TestQueryQTypeBuckets pins the closed bucket set: every recognised type maps to its own
+// value and everything else — including a malformed multi-question message — is "other".
+func TestQueryQTypeBuckets(t *testing.T) {
+	for qtype, want := range map[uint16]string{
+		dns.TypeA:     qtypeA,
+		dns.TypeAAAA:  qtypeAAAA,
+		dns.TypeHTTPS: qtypeHTTPS,
+		dns.TypeSRV:   qtypeSRV,
+		dns.TypePTR:   qtypePTR,
+		dns.TypeTXT:   qtypeTXT,
+		dns.TypeCNAME: qtypeCNAME,
+		dns.TypeSOA:   qtypeOther,
+		dns.TypeMX:    qtypeOther,
+		dns.TypeANY:   qtypeOther,
+		65535:         qtypeOther,
+	} {
+		assert.Equal(t, want, queryQType(query("echo.default.aether.internal", qtype)),
+			"qtype %d", qtype)
+	}
+
+	assert.Equal(t, qtypeOther, queryQType(nil), "a nil message is never a mesh query")
+	assert.Equal(t, qtypeOther, queryQType(new(dns.Msg)), "no question section")
+
+	multi := query("echo.default.aether.internal", dns.TypeA)
+	multi.Question = append(multi.Question, multi.Question[0])
+	assert.Equal(t, qtypeOther, queryQType(multi), "more than one question has no single type")
+}
+
+// TestObserveQueryNilMetricsIsNoOp: metrics are optional (newMetrics returns nil when the
+// instruments fail), and the resolver must keep serving regardless.
+func TestObserveQueryNilMetricsIsNoOp(t *testing.T) {
+	var m *metrics
+	assert.NotPanics(t, func() { m.observeQuery(resultNoData, protoUDP, qtypeAAAA, 0) })
+}

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -542,15 +542,17 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	if answeredResult(result) {
 		s.markAnswered()
 	}
-	s.metrics.observeQuery(result, queryProto(w), time.Since(start))
+	s.metrics.observeQuery(result, queryProto(w), queryQType(r), time.Since(start))
 }
 
 // answeredResult reports whether a result means the resolver produced a real answer,
-// which is what last_answered records. A cold SERVFAIL and a forward_error are
-// excluded: they are replies, but they are the resolver reporting that it CANNOT
-// answer, and a resolver stuck emitting them is not healthy.
+// which is what last_answered records. NODATA counts: it is an authoritative reply
+// derived from the record table, and the handler ran end to end to produce it. A cold
+// SERVFAIL and a forward_error are excluded: they are replies, but they are the resolver
+// reporting that it CANNOT answer, and a resolver stuck emitting them is not healthy.
 func answeredResult(result string) bool {
-	return result == resultAnswered || result == resultNXDomain || result == resultForwarded
+	return result == resultAnswered || result == resultNoData ||
+		result == resultNXDomain || result == resultForwarded
 }
 
 // queryProto reports the transport a query ARRIVED on, read from the writer's remote
@@ -577,9 +579,9 @@ func (s *Server) serve(w dns.ResponseWriter, r *dns.Msg) string {
 }
 
 // serveMesh answers a mesh-domain query authoritatively: a well-formed "<svc>.<ns>"
-// hit returns the A record (NODATA for non-A) and a miss returns NXDOMAIN when ready
-// or SERVFAIL when still cold; a malformed name under the zone (wrong label count)
-// is always NXDOMAIN — it can never exist, so retrying can't help.
+// hit returns the A record (NODATA, counted apart, for non-A) and a miss returns
+// NXDOMAIN when ready or SERVFAIL when still cold; a malformed name under the zone
+// (wrong label count) is always NXDOMAIN — it can never exist, so retrying can't help.
 func (s *Server) serveMesh(w dns.ResponseWriter, r *dns.Msg, q dns.Question) string {
 	if _, _, ok := s.parseMeshName(q.Name); !ok {
 		// Under the mesh domain but not a well-formed "<svc>.<ns>" name. Structurally
@@ -613,8 +615,16 @@ func (s *Server) serveMesh(w dns.ResponseWriter, r *dns.Msg, q dns.Question) str
 			}}
 		}
 	}
-	// Non-A (incl. AAAA): NODATA — empty answer, NOERROR, authoritative.
+	// Non-A (incl. AAAA): NODATA — empty answer, NOERROR, authoritative. The reply is
+	// identical either way; only the metric result differs, so an AAAA trickle stays
+	// distinguishable from real A hits (see resultNoData). An A query whose stored
+	// record is not a parseable IPv4 also lands here — an empty answer is an empty
+	// answer, and a record-table defect surfacing as nodata on qtype=a is precisely
+	// the signal this split buys.
 	_ = w.WriteMsg(m)
+	if len(m.Answer) == 0 {
+		return resultNoData
+	}
 	return resultAnswered
 }
 


### PR DESCRIPTION
Follows #586, completes the deferred qtype/nodata split. #596 already delivered the other half of that item (the `proto` attribute + `aether.mesh_dns.responses_truncated_total`); this is the rest. Metrics-only.

## 1. `nodata` split out of `answered`

`serveMesh` recorded `answered` for BOTH a real A hit and the NODATA reply a *known* mesh name gets for a non-A type (AAAA → NOERROR + empty answer, deliberate so the name consistently EXISTS for c-ares). Those are operationally different: a healthy mesh shows a steady NODATA trickle from the AAAA half of every dual-stack lookup, so conflated, a *rise* in NODATA against real hits — clients failing over to IPv6, or a record table that stopped producing usable A records — is invisible.

The reply is byte-for-byte unchanged; only the metric result differs. An A query whose stored record is not a parseable IPv4 also lands in `nodata`, which is the point: a record-table defect showing up as unexpected `nodata` on `qtype="a"` is exactly the signal wanted.

NODATA still counts as an answer for `last_answered_timestamp_seconds` — it is an authoritative reply derived from the record table, produced by a handler that ran end to end (so watchdog/staleness semantics are unchanged).

## 2. Bucketed `qtype` attribute

**Cardinality was the whole risk, so the value set is closed.** DNS defines ~90 query types and the CNI DNATs every managed pod's `:53` straight at this resolver, so untrusted queries genuinely reach it and a raw `qtype` would let any pod on the node inflate the counter's series count at will. `queryQType` maps into a fixed set and everything unrecognised collapses to `other`:

| bucket | why it earns its own series |
|---|---|
| `a` | the only type the record table can answer — the hit path itself |
| `aaaa` | every dual-stack resolver (glibc getaddrinfo, c-ares, Go) fires it next to A; it is essentially the whole `nodata` trickle, and the IPv6-failover signal |
| `https` | curl 8.x / browsers / systemd-resolved query the HTTPS RR (65) alongside A+AAAA; high-volume and routine, so leaving it in `other` would bury the genuinely exotic queries `other` exists to expose |
| `srv` | headless Services and gRPC-style discovery; always forwarded, so it is the forward path's main non-address type |
| `ptr` | reverse lookups from tooling/logging; a burst is a classic accidental source of upstream latency |
| `txt` | forwarded, normally ~zero, and both a probe and an exfil channel — cheap to keep separable |
| `cname` | what debugging tools (`dig CNAME`) and some client libraries ask directly; separates an operator/tool pattern from workload traffic |
| `other` | everything else, including a message without exactly one question |

Worst case is bounded at 8 qtype x 6 result x 2 proto = **96 series per node**, no matter what is asked; in practice only a handful are ever non-zero.

**`qtype` is NOT added to the duration histogram.** Its 15 explicit buckets make every extra dimension expensive (proto would double it, qtype would multiply it by eight), and neither buys anything: latency here is decided by the PATH taken, which `result` already names. A mesh hit and an AAAA NODATA do the same map lookup under the same lock; a forwarded SRV costs the same kube-dns round trip as a forwarded A. `qtype`/`proto` answer "what is being asked, over what" — a counter question.

## Not changed

EDNS0 OPT echo, NODATA-for-non-A, authoritative never-forward-the-mesh-zone, SO_REUSEPORT, the #596 self-check watchdog and TCP-forward logic, the snapshot envelope/heartbeat. No chart change, so no Chart.yaml bump.

## Verification

Slim dep graph re-proven — both `somepath` queries from `//agent/cmd/mesh-dns:mesh-dns` are **empty**:

```
$ bazel query 'somepath(//agent/cmd/mesh-dns:mesh-dns, @io_k8s_sigs_controller_runtime//...)'
INFO: Empty results
$ bazel query 'somepath(//agent/cmd/mesh-dns:mesh-dns, @com_github_envoyproxy_go_control_plane//...)'
INFO: Empty results
```

- `bazel build //agent/... //charts/...` green; `bazel test //agent/...` 28/28 pass
- `bazel build --config=ci //agent/...` green (gocognit)
- `bazel run //:format` + `make format-check` clean; BUILD.bazel via `make gazelle` (no new external deps)

New `metrics_test.go` drives the real handler through a manual OTel reader and asserts on the attributes actually exported: A hit → `answered`/`qtype=a`; AAAA on a known name → `nodata`/`qtype=aaaa`; NAPTR/ANY/CAA/61234 all collapse to a single `other` series; `proto` still splits udp vs tcp; miss/cold results keep their qtype; plus a table pinning the closed bucket set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR