### PR TITLE
chore: remove dead code surfaced by the improvement sweep

### DIFF
--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -132,13 +132,10 @@ type AgentConfig struct {
 	EastWestWaypoint bool
 
 	// MeshDNS enables the per-pod mesh-DNS listener (proposal 018, mesh-global FQDN):
-	// the agent answers <svc>.<meshDomain> from the generated mesh Services' ClusterIPs
-	// and forwards the rest to MeshDNSUpstream. Pairs with the CNI :53 redirect.
-	// Default off.
+	// the agent answers <svc>.<meshDomain> from the generated mesh Services' ClusterIPs.
+	// Upstream forwarding lives in the mesh-dns daemon (agent/cmd/mesh-dns) since the
+	// #578 decouple. Pairs with the CNI :53 redirect. Default off.
 	MeshDNS bool
-	// MeshDNSUpstream is the upstream resolver(s) (host[:port]) the mesh-DNS filter
-	// forwards non-mesh queries to — the cluster kube-dns.
-	MeshDNSUpstream []string
 	// MeshDNSSnapshotPath is the host-persistent file the mesh-DNS resolver writes
 	// its last-known record table to on every reconcile and warm-loads at boot, so a
 	// rolling agent restart answers mesh names from last-known ClusterIPs within ms

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -124,8 +124,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.AuthzSidecarFailureModeAllow, "authz-sidecar-failure-mode-allow", false, "Fail-open: allow requests when the authz sidecar is unreachable (default fail-closed: deny)")
 	rootCmd.Flags().StringVar(&cfg.ControlCluster, "control-cluster", "", "Name of the single authorized config-exporting cluster (proposal 026 EM3, Option E). When set, imported config is trusted ONLY from this origin; empty = federated (trust any peer)")
 	rootCmd.Flags().BoolVar(&cfg.EastWestWaypoint, "east-west-waypoint", false, "Enable the split-horizon east/west waypoint (proposal 019): dial cross-cluster endpoints at their node's routable IP + the fixed tunnel port (18009) instead of their pod IP, and SNI-forward to the local pod. Intra-cluster stays direct pod-to-pod. Needs cross-cluster endpoint visibility (shared etcd) and a shared SPIRE trust domain.")
-	rootCmd.Flags().BoolVar(&cfg.MeshDNS, "mesh-dns", false, "Enable per-pod mesh DNS: answer <svc>.<mesh-domain> from the generated mesh Services and forward the rest to --mesh-dns-upstream (proposal 018, mesh-global FQDN)")
-	rootCmd.Flags().StringSliceVar(&cfg.MeshDNSUpstream, "mesh-dns-upstream", cfg.MeshDNSUpstream, "Upstream resolver(s) (host[:port]) the mesh-DNS filter forwards non-mesh queries to (the cluster kube-dns)")
+	rootCmd.Flags().BoolVar(&cfg.MeshDNS, "mesh-dns", false, "Enable per-pod mesh DNS: answer <svc>.<mesh-domain> from the generated mesh Services (proposal 018, mesh-global FQDN); the mesh-dns daemon (agent/cmd/mesh-dns) owns upstream forwarding")
 	rootCmd.Flags().StringVar(&cfg.MeshDNSSnapshotPath, "mesh-dns-snapshot-path", cfg.MeshDNSSnapshotPath, "Host-persistent file the in-process mesh-DNS resolver persists its last-known record table to and warm-loads at boot, closing the agent-roll cold window (proposal 018, mesh-global FQDN). Defaults under the CNI registry hostPath so it survives a rolling restart; empty disables persistence")
 }
 

--- a/agent/internal/edge/gatewayapi/attachment/refs.go
+++ b/agent/internal/edge/gatewayapi/attachment/refs.go
@@ -191,51 +191,6 @@ func firstBackendService(refs []gatewayv1.HTTPBackendRef, routeNamespace string,
 	return ""
 }
 
-// firstBackendPort returns the port of the first admissible (same-namespace or
-// granted cross-namespace) backendRef, so the port matches the backend
-// firstBackendService selects.
-func firstBackendPort(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) uint32 {
-	for _, b := range refs {
-		if b.Group != nil && string(*b.Group) != "" {
-			continue
-		}
-		if b.Kind != nil && string(*b.Kind) != "Service" {
-			continue
-		}
-		if !BackendPermitted(b.Namespace, routeNamespace, "HTTPRoute", string(b.Name), grants) {
-			continue
-		}
-		if b.Port != nil {
-			return uint32(*b.Port)
-		}
-	}
-	return 0
-}
-
-// firstBackendNamespace returns the resolved namespace of the first admissible
-// (same-namespace or granted cross-namespace) backendRef. Same-namespace refs
-// default to the route's own namespace when backendRef.Namespace is unset.
-// Matches the selection logic of firstBackendService so they return data for
-// the same ref.
-func firstBackendNamespace(refs []gatewayv1.HTTPBackendRef, routeNamespace string, grants []gatewayv1beta1.ReferenceGrant) string {
-	for _, b := range refs {
-		if b.Group != nil && string(*b.Group) != "" {
-			continue
-		}
-		if b.Kind != nil && string(*b.Kind) != "Service" {
-			continue
-		}
-		if !BackendPermitted(b.Namespace, routeNamespace, "HTTPRoute", string(b.Name), grants) {
-			continue
-		}
-		if b.Namespace != nil && string(*b.Namespace) != "" {
-			return string(*b.Namespace)
-		}
-		return routeNamespace
-	}
-	return routeNamespace
-}
-
 // DerefBackendNamespace returns the backendRef namespace ("" when unset).
 func DerefBackendNamespace(ns *gatewayv1.Namespace) string {
 	if ns == nil {

--- a/agent/internal/gamma/BUILD.bazel
+++ b/agent/internal/gamma/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//common/gammaproject",
         "//common/log",
         "//common/referencegrant",
-        "//common/serviceref",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/client",

--- a/agent/internal/gamma/reconciler.go
+++ b/agent/internal/gamma/reconciler.go
@@ -12,8 +12,6 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/bpalermo/aether/common/serviceref"
-
 	"github.com/bpalermo/aether/agent/internal/gatewaystatus"
 	"github.com/bpalermo/aether/agent/internal/xds/proxy"
 	configprotov1 "github.com/bpalermo/aether/api/aether/config/v1"
@@ -439,36 +437,12 @@ func (r *Reconciler) backendsResolve(_ context.Context, routeNamespace, routeKin
 	return true, string(gatewayv1.RouteReasonResolvedRefs), "All backend references resolved"
 }
 
-// backendServiceKey resolves a backendRef to its namespace-qualified "<ns>/<svc>"
-// registry key (020 Part 1): the backendRef's own namespace when set, else the
-// route's namespace. The resulting key feeds both the data-plane cluster name
-// (ServiceClusterName) and the node dependency set (routeBackendsLocked).
-func backendServiceKey(backendNamespace *gatewayv1.Namespace, routeNamespace, name string) string {
-	ns := routeNamespace
-	if bn := derefBackendNamespace(backendNamespace); bn != "" {
-		ns = bn
-	}
-	return serviceref.New(ns, name).Key()
-}
-
 // derefBackendNamespace returns the backendRef namespace ("" when unset).
 func derefBackendNamespace(ns *gatewayv1.Namespace) string {
 	if ns == nil {
 		return ""
 	}
 	return string(*ns)
-}
-
-// backendPermitted reports whether a backendRef is allowed onto the data plane: a
-// same-namespace ref always is; a cross-namespace ref needs a matching ReferenceGrant.
-// Non-permitted cross-namespace backends are dropped from the built route (the rest of
-// the route still applies), mirroring the RefNotPermitted status.
-func backendPermitted(backendNamespace *gatewayv1.Namespace, routeNamespace, routeKind, name string, grants []gatewayv1beta1.ReferenceGrant) bool {
-	ns := derefBackendNamespace(backendNamespace)
-	if !referencegrant.CrossNamespace(ns, routeNamespace) {
-		return true
-	}
-	return referencegrant.PermitsBackend(grants, gatewayv1.GroupName, routeKind, routeNamespace, ns, name)
 }
 
 func httpBackendRefs(rules []gatewayv1.HTTPRouteRule) []gatewayv1.BackendObjectReference {

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -145,16 +145,6 @@ func (b *Bridge) Started() <-chan struct{} {
 	return b.started
 }
 
-// NodeSpiffeID returns the SPIFFE ID of the agent's node identity once the node
-// SVID has been served, or "" if node-SVID serving is disabled or not yet ready.
-// It is the SDS secret name proxies reference for node-originated upstream mTLS
-// (the outbound clusters' no-match client cert) and the node-health listener.
-func (b *Bridge) NodeSpiffeID() string {
-	b.mu.RLock()
-	defer b.mu.RUnlock()
-	return b.nodeSpiffeID
-}
-
 // Start connects to the SPIRE agent and begins subscribing to trust bundles.
 // It blocks until the context is canceled. Implements controller-runtime Runnable.
 func (b *Bridge) Start(ctx context.Context) error {

--- a/agent/internal/xds/proxy/edge.go
+++ b/agent/internal/xds/proxy/edge.go
@@ -93,26 +93,6 @@ func EdgeGatewayRouteName(namespace, gatewayName string) string {
 	return fmt.Sprintf("edge_rt_%s_%s", namespace, gatewayName)
 }
 
-// EdgeGatewayListener is the inputs for building one per-Gateway edge listener
-// (proposal 021 Phase 2). The listener binds on InternalPort (the container/pod
-// port the per-Gateway LoadBalancer Service's targetPort points at) and serves
-// only the routes for this Gateway.
-type EdgeGatewayListener struct {
-	// Namespace is the Gateway's namespace.
-	Namespace string
-	// GatewayName is the Gateway's name.
-	GatewayName string
-	// InternalPort is the container port this listener binds. It is uniquely
-	// allocated per (Gateway, listener section) by the port allocator.
-	InternalPort uint32
-	// TLSSecretNames are the SDS cert names to present for downstream TLS on this
-	// listener (empty = plain HTTP). Cert bytes are already in the snapshot Secrets.
-	TLSSecretNames []string
-	// HTTPRedirect when true emits an HTTP→HTTPS 301 redirect (replaces the route
-	// listener for this Gateway's HTTP port).
-	HTTPRedirect bool
-}
-
 // BuildEdgeGatewayHTTPListener builds a per-Gateway plain-HTTP or HTTP→HTTPS
 // redirect listener. Listener name and RDS route config name are unique per
 // Gateway (proposal 021 Phase 2). When httpRedirect is true, the listener emits

--- a/agent/internal/xds/proxy/l4route.go
+++ b/agent/internal/xds/proxy/l4route.go
@@ -64,13 +64,6 @@ type L4Backend struct {
 	Weight uint32
 }
 
-// UDPServiceRoute holds the UDP routing rules for one mesh service derived from a
-// UDPRoute parentRef=Service.
-type UDPServiceRoute struct {
-	// Backends are the weighted backend clusters.
-	Backends []L4Backend
-}
-
 // BuildCaptureTCPRouteFilterChain builds a per-ClusterIP TCP floor filter chain
 // for a service that has a TCPRoute. It matches the service's ClusterIP as the
 // original destination (/32 prefix_ranges) and routes via tcp_proxy

--- a/agent/internal/xds/proxy/waypoint.go
+++ b/agent/internal/xds/proxy/waypoint.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"fmt"
 	"time"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -112,7 +111,3 @@ func BuildWaypointIngressCluster(fqdn string, podIPs []string) *clusterv3.Cluste
 		},
 	}
 }
-
-// waypointTunnelChainName is exported indirectly via BuildWaypointTunnelChain; a
-// tiny helper kept for symmetry / tests.
-func waypointTunnelChainName(fqdn string) string { return fmt.Sprintf("ew_%s", fqdn) }

--- a/agent/internal/xds/proxy/waypoint_test.go
+++ b/agent/internal/xds/proxy/waypoint_test.go
@@ -41,5 +41,4 @@ func TestBuildWaypointIngressCluster(t *testing.T) {
 		assert.Equal(t, uint32(defaultInboundPort), ep.GetEndpoint().GetAddress().GetSocketAddress().GetPortValue(),
 			"pods are dialed at the mesh inbound port")
 	}
-	_ = waypointTunnelChainName // symmetry helper
 }

--- a/cni/internal/install/install.go
+++ b/cni/internal/install/install.go
@@ -152,13 +152,3 @@ func (in *Installer) copyFileAtomic(src, dst string) error {
 
 	return nil
 }
-
-// checkValidCNIConfig returns an error if an invalid CNI configuration is detected
-// - CNIConfName is the name of the primary CNI config file which may or may not contain the Istio CNI config
-// depending on whether Istio owned CNI config is enabled
-// - cniConfigFilepath is the path to the CNI config file that is currently being used. This may be different
-// from the primary CNI config file if using an Istio owned CNI config is enabled. The value is unset on the
-// first call of checkValidCNIConfig
-func checkValidCNIConfig(ctx context.Context, cfg *InstallerConfig, cniConfigFilepath string) error {
-	return nil
-}

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -291,12 +291,10 @@ func programCaptureRedirectAll(excludePorts []uint16, excludeRanges []netip.Pref
 //	established = 0x2 (NFT_CT_STATE_ESTABLISHED)
 //	related     = 0x4 (NFT_CT_STATE_RELATED)
 func conntrackEstablishedAcceptExprs() []expr.Any {
-	// Conntrack state bitmask: established(2) | related(4) = 6.
-	const ctStateEstablishedRelated = 0x00000006
 	return []expr.Any{
 		// load ct state into reg1
 		&expr.Ct{Register: 1, SourceRegister: false, Key: expr.CtKeySTATE},
-		// reg1 & ctStateEstablishedRelated != 0  (bitwise AND then NEQ 0)
+		// reg1 & (established|related = 0x06) != 0  (bitwise AND then NEQ 0)
 		&expr.Bitwise{
 			SourceRegister: 1,
 			DestRegister:   1,

--- a/common/constants/registry.go
+++ b/common/constants/registry.go
@@ -13,7 +13,4 @@ package constants
 const (
 	// DefaultDynamoDBServiceTableName is the default DynamoDB table name for storing service information
 	DefaultDynamoDBServiceTableName = "AetherService"
-
-	// DefaultEtcdKeyPrefix is the default prefix for all registry keys in etcd
-	DefaultEtcdKeyPrefix = "/aether/services"
 )

--- a/common/telemetry/attributes.go
+++ b/common/telemetry/attributes.go
@@ -19,12 +19,6 @@ const (
 	AttrPodNamespace = attribute.Key("aether.pod.namespace")
 	// AttrContainerID is the pod sandbox container ID from the CNI invocation.
 	AttrContainerID = attribute.Key("aether.container.id")
-	// AttrNodeName is the Kubernetes node name.
-	AttrNodeName = attribute.Key("aether.node.name")
-	// AttrClusterName is the Kubernetes cluster name.
-	AttrClusterName = attribute.Key("aether.cluster.name")
-	// AttrServiceName is the mesh service name an endpoint belongs to.
-	AttrServiceName = attribute.Key("aether.service.name")
 	// AttrSnapshotVersion is the xDS or registrar snapshot version.
 	AttrSnapshotVersion = attribute.Key("aether.snapshot.version")
 )

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,7 +229,6 @@ Node-agent-specific:
 | `--control-cluster` | `""` | Trust imported config ONLY from this origin (026 EM3). Empty = federated. |
 | `--east-west-waypoint` | `false` | Per-node east/west waypoint for cross-cluster traffic (019); tunnel port is the fixed constant 18009. |
 | `--mesh-dns` | `false` | Per-pod mesh DNS (018). |
-| `--mesh-dns-upstream` | `[]` | Upstream resolver(s) for non-mesh queries. |
 | `--authz-sidecar` | `false` | Node-local ext_authz sidecar entry (027). |
 | `--authz-sidecar-timeout` | `200ms` | Per-check gRPC timeout. |
 | `--authz-sidecar-failure-mode-allow` | `false` | Fail-open (default: fail-closed). |


### PR DESCRIPTION
## Summary

Dead-code cohort. Every deletion was verified two ways: `golang.org/x/tools/cmd/deadcode` across all **7** main packages (including `agent/cmd/mesh-dns` and `prober` — omitting them produces ~70 false hits), then grep for zero non-test references. **Deletion-only; −146 lines, no behavior change.**

| what | why it died |
|---|---|
| `attachment.firstBackendPort` / `firstBackendNamespace` | edge Phase 1 leftovers; live selection logic is in the projector |
| gamma `backendServiceKey` / `backendPermitted` (+ `serviceref` import) | duplicates of the live copies in `common/gammaproject` and `l4route` |
| `proxy.EdgeGatewayListener` struct | superseded by discrete params (proposal 021) |
| `proxy.UDPServiceRoute` | parked UDP data plane uses `map[string][]L4Backend` |
| `waypointTunnelChainName` (+ test symmetry line) | name is built inline as `"ew_" + fqdn` |
| cni `checkValidCNIConfig` | istio-derived stub whose whole body is `return nil` |
| cni `ctStateEstablishedRelated` local const | mask is hardcoded two lines below |
| `constants.DefaultEtcdKeyPrefix` | unreferenced **and misleading** — real default is `/aether/v1/regions` in `registry/internal/etcd` |
| `telemetry.AttrNodeName/AttrClusterName/AttrServiceName` | never emitted anywhere (the other 4 keys in the block are live) |
| `spire.Bridge.NodeSpiffeID` getter | zero callers; the underlying field stays (read internally for first-serve detection) |
| agent `--mesh-dns-upstream` flag + `Config.MeshDNSUpstream` + doc row | orphaned by the #578 mesh-DNS decouple; the daemon registers its own flag |

**Flag-removal note:** the chart only passes `--mesh-dns-upstream` to the mesh-dns container (`agent-daemonset.yaml` mentions it in a comment only), so in-repo deployment is unaffected. Cobra hard-errors on unknown flags, so any *out-of-tree* agent manifest still passing it would crash-loop at startup — flagging since it's technically user-visible.

**Deliberately NOT deleted** (test-only, judgment calls — say the word and they go too):
- `proxy.ToConfigProjection` + 2 helpers — the export half is production-dead (registrar's configexport builds protos directly); only a round-trip test uses it. Deleting means deleting `projection_test.go`'s round-trip too.
- `attachment.firstBackendService` — same family as the two deleted here, but it has dedicated tests.
- `config.Http1ProtocolOptions`, `meshdns.NewServer`, `ddb.WithTableName`, `storage.MockStorage`, `registry/registrytest` — legit test seams / symmetric API; keep.

Zero whole files or packages were deletable — the tree is clean after all the refactor waves.

## Testing

- `bazel run //:gazelle` (dropped the stale gamma→serviceref BUILD dep) + `bazel run //:format`
- `bazel test --test_output=errors //...` — 79/79 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR