### PR TITLE
perf: eliminate hot-path recompute in the registrar snapshot and xDS cache

### DIFF
--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -265,6 +265,11 @@ type SnapshotCache struct {
 	depSetTTL    time.Duration
 	depSetExpiry time.Time
 	depSetValid  bool
+	// depDeclaredCount/depObservedCount are the snapshot-shape metric's two
+	// dependency counts, recorded with the depSet memo above (they are functions
+	// of the same inputs and share its validity window). Guarded by depMu.
+	depDeclaredCount int
+	depObservedCount int
 	// effRoutes/effRoutesGen/effRoutesValid memoize serviceRoutesSnapshot
 	// (issue #540): the effective (local ∪ imported) GAMMA rules with
 	// unavailable extension filters stripped. Served while depGen is unchanged

--- a/agent/internal/xds/cache/capture.go
+++ b/agent/internal/xds/cache/capture.go
@@ -50,7 +50,13 @@ func (c *SnapshotCache) generateUDPCaptureListener(cniPod *cniv1.CNIPod) (types.
 
 // generateCaptureListener builds a pod's transparent-capture listener, or returns
 // nil when capture is disabled (so the listenerEntry carries no capture resource).
-func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Resource, error) {
+//
+// extensionFilters is the pod's escape-hatch HCM chain (proposal 025): the node-
+// global union from extensionHTTPFilters, per-pod-adjusted by
+// podExtensionHTTPFilters. It is passed in rather than recomputed here because
+// the union is node-global and every caller in a per-pod loop would otherwise
+// rebuild it once (twice, on the outbound+capture path) per pod.
+func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod, extensionFilters []*http_connection_managerv3.HttpFilter) (types.Resource, error) {
 	if !c.captureEnabled {
 		return nil, nil
 	}
@@ -72,13 +78,6 @@ func (c *SnapshotCache) generateCaptureListener(cniPod *cniv1.CNIPod) (types.Res
 		}
 	}
 	c.captureMu.RUnlock()
-
-	// Escape-hatch extension filters (proposal 025): the HCM must carry every
-	// allow-listed filter any in-scope route references, default-disabled, so the
-	// route's typed_per_filter_config can re-enable it (per-route config only
-	// overrides a chain filter, never adds one). Union over all GammaRoutes; disabled
-	// entries are inert, so the (broader-than-per-pod) union is harmless.
-	extensionFilters := c.podExtensionHTTPFilters(cniPod)
 
 	l, err := proxy.GenerateCaptureListener(cniPod, meshconst.ProxyCapturePort, c.meshDomain, c.emitStatsPod, tcpServices, c.captureRedirectAll, extensionFilters)
 	if err != nil {
@@ -233,12 +232,14 @@ func (c *SnapshotCache) SetCaptureTCPServices(services []capture.CaptureTCPServi
 
 	// Per-pod capture listeners embed TCP floor chains; regenerate all of them.
 	if c.captureEnabled {
+		// Node-global union, built once for the whole loop (see extensionHTTPFilters).
+		shared := c.extensionHTTPFilters()
 		c.listenerMu.Lock()
 		for netns, entry := range c.listeners {
 			if entry.cniPod == nil {
 				continue
 			}
-			newCapture, err := c.generateCaptureListener(entry.cniPod)
+			newCapture, err := c.generateCaptureListener(entry.cniPod, c.podExtensionHTTPFilters(entry.cniPod, shared))
 			if err != nil {
 				c.log.Error("failed to regenerate capture listener on TCP-services change",
 					"netns", netns, "pod", entry.cniPod.GetName(), "error", err)
@@ -457,7 +458,8 @@ func (c *SnapshotCache) captureUDPClusters() []types.Resource {
 // <svc>.<meshDomain> cluster. Scoped to the dependency set so cap_http only references
 // clusters the scoped snapshot carries; unknown authorities hit the 404 default.
 func (c *SnapshotCache) captureVhosts() []*routev3.VirtualHost {
-	deps := c.DependencySet()
+	// Read-only membership tests only, so take the shared memo rather than a copy.
+	deps := c.dependencySetShared()
 	// GAMMA (HTTPRoute/GRPCRoute) rules enrich the captured path too — capture is the
 	// default client path (mesh-DNS), so the same L7 vocabulary the outbound listener
 	// applies must apply here; no rules = passthrough to the service cluster. The
@@ -831,6 +833,11 @@ func applyChainFilter(vh *routev3.VirtualHost, filters map[string]proxy.Extensio
 // Shared by the capture AND outbound HTTP listener builds: typed_per_filter_config —
 // per-route or vhost-level — can only re-enable a filter already in the chain, and
 // both route tables carry GAMMA/chain config, so both HCMs need the union.
+//
+// The result is node-global, so a caller looping over pods computes it ONCE and
+// threads it through podExtensionHTTPFilters. The returned slice is shared by
+// every such pod and must be treated as immutable — appending to it would land
+// one pod's entry in another's chain.
 func (c *SnapshotCache) extensionHTTPFilters() []*http_connection_managerv3.HttpFilter {
 	var allRules []proxy.GammaRoute
 	for _, rules := range c.serviceRoutesSnapshot() {
@@ -875,15 +882,17 @@ func (c *SnapshotCache) SetAuthzSidecar(timeout time.Duration, failureModeAllow 
 }
 
 // podExtensionHTTPFilters returns the extension union for one pod's EGRESS chains:
-// the shared union plus, when the authz sidecar is enabled, a per-pod set_metadata
-// entry (PREPENDED — it must run before ext_authz) carrying the calling workload's
-// identity in aether.source. Egress-only: the inbound chains take the shared union
-// (caller identity there is the verified XFCC, and stamping the destination pod as
-// "source" would mislead policies).
-func (c *SnapshotCache) podExtensionHTTPFilters(cniPod *cniv1.CNIPod) []*http_connection_managerv3.HttpFilter {
-	union := c.extensionHTTPFilters()
-	if c.authzSidecar && proxy.HasExtAuthz(union) {
-		union = append([]*http_connection_managerv3.HttpFilter{proxy.SourceMetadataHTTPFilter(cniPod, c.trustDomain)}, union...)
+// the shared union (from extensionHTTPFilters) plus, when the authz sidecar is
+// enabled, a per-pod set_metadata entry (PREPENDED — it must run before ext_authz)
+// carrying the calling workload's identity in aether.source. Egress-only: the
+// inbound chains take the shared union (caller identity there is the verified XFCC,
+// and stamping the destination pod as "source" would mislead policies).
+//
+// shared is never mutated: the prepend allocates a fresh slice, so the caller's
+// node-global union stays valid for the next pod.
+func (c *SnapshotCache) podExtensionHTTPFilters(cniPod *cniv1.CNIPod, shared []*http_connection_managerv3.HttpFilter) []*http_connection_managerv3.HttpFilter {
+	if c.authzSidecar && proxy.HasExtAuthz(shared) {
+		return append([]*http_connection_managerv3.HttpFilter{proxy.SourceMetadataHTTPFilter(cniPod, c.trustDomain)}, shared...)
 	}
-	return union
+	return shared
 }

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -152,6 +152,32 @@ func (c *SnapshotCache) DependencySet() map[string]struct{} {
 	return out
 }
 
+// dependencySetShared returns the memoized dependency set without DependencySet's
+// defensive copy. The returned map is shared across callers until the next
+// rebuild and must be treated as read-only (the depSet convention, same as
+// effRoutes/routeDomains). For internal read-only consumers on the snapshot
+// path, where the copy is pure overhead.
+func (c *SnapshotCache) dependencySetShared() map[string]struct{} {
+	// Write lock (not RLock): dependencySetLocked may rebuild and store the memo.
+	c.depMu.Lock()
+	defer c.depMu.Unlock()
+	return c.dependencySetLocked()
+}
+
+// dependencyCounts returns the number of distinct declared upstream services and
+// of live observed dependencies, for the snapshot-shape metric. Both are derived
+// from the dependency-set inputs and recorded when the memo is built, so a
+// snapshot rebuild costs a memo validity check instead of two full walks.
+func (c *SnapshotCache) dependencyCounts() (declared, observed int) {
+	c.depMu.Lock()
+	defer c.depMu.Unlock()
+	// Refresh through the memo so the counts obey the same validity rules as the
+	// set itself — including the wall-clock expiry horizon, which is exactly when
+	// the observed count could otherwise go stale.
+	c.dependencySetLocked()
+	return c.depDeclaredCount, c.depObservedCount
+}
+
 // bumpDepGenLocked invalidates the memoized dependency set. EVERY writer of
 // ANY depMu-guarded field must call it after the write (rule of thumb: any
 // write under depMu bumps, even for fields dependencySetLocked does not read
@@ -183,13 +209,19 @@ func (c *SnapshotCache) dependencySetLocked() map[string]struct{} {
 	set := make(map[string]struct{}, len(c.podDeps)*4+len(c.observedDeps)+len(c.staticDeps))
 	c.populateStaticDepsLocked(set)
 	c.populatePodDepsLocked(set)
-	nextExpiry := c.populateObservedDepsLocked(set, now, ttl)
+	nextExpiry, observed := c.populateObservedDepsLocked(set, now, ttl)
 	eff := c.effectiveServiceRoutesLocked()
 	c.populateRouteDepsLocked(set, eff)
 	c.depSet = set
 	c.depSetGen = c.depGen
 	c.depSetTTL = ttl
 	c.depSetExpiry = nextExpiry
+	// The snapshot-shape counts are functions of the same inputs, so they ride
+	// the same memo: while it is valid no declared upstream changed (depGen) and
+	// no observed entry crossed its TTL (depSetExpiry), which is precisely the
+	// condition under which recomputing them would return the same numbers.
+	c.depDeclaredCount = c.declaredCountLocked()
+	c.depObservedCount = observed
 	c.depSetValid = true
 	return set
 }
@@ -236,21 +268,24 @@ func (c *SnapshotCache) populatePodDepsLocked(set map[string]struct{}) {
 }
 
 // populateObservedDepsLocked adds live observed dependencies to set and returns
-// the earliest expiry instant for the memo. Caller must hold depMu for writing.
-func (c *SnapshotCache) populateObservedDepsLocked(set map[string]struct{}, now time.Time, ttl time.Duration) time.Time {
+// the earliest expiry instant for the memo plus how many entries were live.
+// Caller must hold depMu for writing.
+func (c *SnapshotCache) populateObservedDepsLocked(set map[string]struct{}, now time.Time, ttl time.Duration) (time.Time, int) {
 	// Live observed dependencies, tracking the earliest wall-clock instant a
 	// memoized entry expires (an entry is live while now <= last+ttl, so the
 	// memo stays valid through that exact instant and rebuilds after).
 	var nextExpiry time.Time
+	live := 0
 	for svc, last := range c.observedDeps {
 		if now.Sub(last) <= ttl {
 			set[svc] = struct{}{}
+			live++
 			if exp := last.Add(ttl); nextExpiry.IsZero() || exp.Before(nextExpiry) {
 				nextExpiry = exp
 			}
 		}
 	}
-	return nextExpiry
+	return nextExpiry, live
 }
 
 // populateRouteDepsLocked adds GAMMA route targets and their backends (L7 and L4)
@@ -289,22 +324,9 @@ func (c *SnapshotCache) populateRouteDepsLocked(set map[string]struct{}, eff map
 	}
 }
 
-// observedCountLocked returns the number of live observed dependencies.
-// Caller must hold depMu.
-func (c *SnapshotCache) observedCountLocked() int {
-	now := time.Now()
-	ttl := c.observedTTLValue()
-	n := 0
-	for _, last := range c.observedDeps {
-		if now.Sub(last) <= ttl {
-			n++
-		}
-	}
-	return n
-}
-
 // declaredCountLocked returns the number of distinct declared upstream
-// services (excluding own services). Caller must hold depMu.
+// services (excluding own services). Called from the memo rebuild, not per
+// snapshot. Caller must hold depMu.
 func (c *SnapshotCache) declaredCountLocked() int {
 	declared := make(map[string]struct{})
 	for _, deps := range c.podDeps {

--- a/agent/internal/xds/cache/gamma.go
+++ b/agent/internal/xds/cache/gamma.go
@@ -409,13 +409,16 @@ func equalAny(a, b *anypb.Any) bool {
 // re-enable a filter already present in the chain — a stale chain silently disables
 // the feature (2026-07-05 talos finding: the outbound HCM never carried the union).
 func (c *SnapshotCache) regenerateAllHTTPListeners() {
+	// Node-global union, built once for the whole loop (see extensionHTTPFilters):
+	// the rebuilt union is exactly what this regeneration exists to propagate.
+	shared := c.extensionHTTPFilters()
 	c.listenerMu.Lock()
 	for netns, entry := range c.listeners {
 		if entry.cniPod == nil {
 			continue
 		}
-		extensionFilters := c.podExtensionHTTPFilters(entry.cniPod)
-		newCapture, err := c.generateCaptureListener(entry.cniPod)
+		extensionFilters := c.podExtensionHTTPFilters(entry.cniPod, shared)
+		newCapture, err := c.generateCaptureListener(entry.cniPod, extensionFilters)
 		if err != nil {
 			c.log.Error("failed to regenerate capture listener on extension-union change",
 				"netns", netns, "pod", entry.cniPod.GetName(), "error", err)

--- a/agent/internal/xds/cache/l4route.go
+++ b/agent/internal/xds/cache/l4route.go
@@ -149,12 +149,14 @@ func (c *SnapshotCache) regenerateAllUDPCaptureListeners() {
 // Called when TCPRoute or TLSRoute rules change: the per-ClusterIP floor chains
 // are embedded in the per-pod capture listener, so they must be regenerated.
 func (c *SnapshotCache) regenerateAllCaptureListeners() {
+	// Node-global union, built once for the whole loop (see extensionHTTPFilters).
+	shared := c.extensionHTTPFilters()
 	c.listenerMu.Lock()
 	for netns, entry := range c.listeners {
 		if entry.cniPod == nil {
 			continue
 		}
-		newCapture, err := c.generateCaptureListener(entry.cniPod)
+		newCapture, err := c.generateCaptureListener(entry.cniPod, c.podExtensionHTTPFilters(entry.cniPod, shared))
 		if err != nil {
 			c.log.Error("failed to regenerate capture listener on L4-route change",
 				"netns", netns, "pod", entry.cniPod.GetName(), "error", err)

--- a/agent/internal/xds/cache/listener.go
+++ b/agent/internal/xds/cache/listener.go
@@ -57,12 +57,16 @@ func (c *SnapshotCache) AddPod(ctx context.Context, cniPod *cniv1.CNIPod, trustD
 	netns := cniPod.GetNetworkNamespace()
 	c.log.DebugContext(ctx, "adding listeners for pod", "pod", cniPod.GetName(), "namespace", cniPod.GetNamespace(), "netns", netns)
 
-	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, c.podExtensionHTTPFilters(cniPod), c.inboundFilterForPod(cniPod))
+	// One node-global extension union for both the pod's HTTP listeners and its
+	// capture listener (see extensionHTTPFilters).
+	extensionFilters := c.podExtensionHTTPFilters(cniPod, c.extensionHTTPFilters())
+
+	inbound, outbound, appClusters, healthCluster, err := proxy.GenerateListenersFromRegistryPod(cniPod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, extensionFilters, c.inboundFilterForPod(cniPod))
 	if err != nil {
 		return err
 	}
 	c.applyWaypointInboundServerNames(inbound, cniPod)
-	capture, err := c.generateCaptureListener(cniPod)
+	capture, err := c.generateCaptureListener(cniPod, extensionFilters)
 	if err != nil {
 		return err
 	}
@@ -311,6 +315,9 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 	var errs []error
 	local := make(map[string]string, len(pods))
 
+	// Node-global union, built once for the whole loop (see extensionHTTPFilters).
+	shared := c.extensionHTTPFilters()
+
 	c.listenerMu.Lock()
 	for _, pod := range pods {
 		netns := pod.GetNetworkNamespace()
@@ -326,14 +333,15 @@ func (c *SnapshotCache) LoadListenersFromStorage(ctx context.Context, store stor
 		}
 		c.log.DebugContext(ctx, "generating listeners for pod", "pod", pod.GetName(), "namespace", pod.GetNamespace(), "netns", netns)
 
-		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, c.podExtensionHTTPFilters(pod), c.inboundFilterForPod(pod))
+		extensionFilters := c.podExtensionHTTPFilters(pod, shared)
+		inbound, outbound, appClusters, healthCluster, listenerErr := proxy.GenerateListenersFromRegistryPod(pod, trustDomain, c.meshDomain, c.emitStatsPod, !c.spireEnabled, extensionFilters, c.inboundFilterForPod(pod))
 		if listenerErr != nil {
 			c.log.ErrorContext(ctx, "failed to generate listeners for pod", "error", listenerErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())
 			errs = append(errs, listenerErr)
 			continue
 		}
 		c.applyWaypointInboundServerNames(inbound, pod)
-		capture, captureErr := c.generateCaptureListener(pod)
+		capture, captureErr := c.generateCaptureListener(pod, extensionFilters)
 		if captureErr != nil {
 			c.log.ErrorContext(ctx, "failed to generate capture listener for pod", "error", captureErr, "pod", pod.GetName(), "namespace", pod.GetNamespace())
 			errs = append(errs, captureErr)

--- a/agent/internal/xds/cache/snapshot.go
+++ b/agent/internal/xds/cache/snapshot.go
@@ -159,10 +159,7 @@ func (c *SnapshotCache) generateSnapshot(ctx context.Context) (retErr error) {
 		attribute.Int("aether.snapshot.secrets", len(secrets)),
 	)
 
-	c.depMu.RLock()
-	declared := c.declaredCountLocked()
-	observed := c.observedCountLocked()
-	c.depMu.RUnlock()
+	declared, observed := c.dependencyCounts()
 	c.metrics.SnapshotShape(ctx, len(clusters), declared, observed)
 
 	snapshot, err := cachev3.NewSnapshot(v, resources)

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -162,14 +162,11 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 	// Tally the enqueued events per type and record them once the read lock is
 	// released: the fan-out is O(events × watchers) and the counter is only
 	// meaningful in aggregate, so the instrument call does not belong inside it.
-	var broadcast map[registrarv1.WatchEndpointsResponse_EventType]int64
+	broadcast := make(map[registrarv1.WatchEndpointsResponse_EventType]int64, 4)
 
 	send := func(id string, w *watcher, event *registrarv1.WatchEndpointsResponse) {
 		select {
 		case w.ch <- event:
-			if broadcast == nil {
-				broadcast = make(map[registrarv1.WatchEndpointsResponse_EventType]int64, 4)
-			}
 			broadcast[event.GetType()]++
 		default:
 			// This watcher's view has diverged — schedule a force-resync.

--- a/registrar/internal/server/broadcaster.go
+++ b/registrar/internal/server/broadcaster.go
@@ -159,11 +159,18 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 	// Collect overflowed watchers under the read lock; closing them requires
 	// the write lock, taken afterwards to avoid lock-upgrade deadlocks.
 	var dropped []droppedWatcher
+	// Tally the enqueued events per type and record them once the read lock is
+	// released: the fan-out is O(events × watchers) and the counter is only
+	// meaningful in aggregate, so the instrument call does not belong inside it.
+	var broadcast map[registrarv1.WatchEndpointsResponse_EventType]int64
 
 	send := func(id string, w *watcher, event *registrarv1.WatchEndpointsResponse) {
 		select {
 		case w.ch <- event:
-			b.metrics.eventBroadcast(context.Background(), event.GetType().String())
+			if broadcast == nil {
+				broadcast = make(map[registrarv1.WatchEndpointsResponse_EventType]int64, 4)
+			}
+			broadcast[event.GetType()]++
 		default:
 			// This watcher's view has diverged — schedule a force-resync.
 			// The counter is the staleness alarm.
@@ -193,6 +200,10 @@ func (b *Broadcaster) Broadcast(events []*registrarv1.WatchEndpointsResponse) {
 		}
 	}
 	b.mu.RUnlock()
+
+	if len(broadcast) > 0 {
+		b.metrics.eventsBroadcast(context.Background(), broadcast)
+	}
 
 	if len(dropped) > 0 {
 		b.closeDroppedWatchers(dropped)

--- a/registrar/internal/server/metrics.go
+++ b/registrar/internal/server/metrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	registrarv1 "github.com/bpalermo/aether/api/aether/registrar/v1"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -12,6 +13,37 @@ import (
 // attrEventType labels endpoint-change events by their type (ADDED, UPDATED,
 // REMOVED, FULL_SNAPSHOT). Bounded cardinality: one series per event type.
 const attrEventType = attribute.Key("aether.event.type")
+
+// eventTypeOptions holds the pre-built attribute set for every declared event
+// type, indexed by the enum value. The broadcast fan-out is O(events ×
+// watchers), so building metric.WithAttributes there would allocate on the
+// hottest path in the registrar. Derived from the generated enum table so a new
+// proto value is covered without touching this file.
+var eventTypeOptions = buildEventTypeOptions()
+
+func buildEventTypeOptions() []metric.MeasurementOption {
+	maxValue := int32(0)
+	for v := range registrarv1.WatchEndpointsResponse_EventType_name {
+		if v > maxValue {
+			maxValue = v
+		}
+	}
+	opts := make([]metric.MeasurementOption, maxValue+1)
+	for v, name := range registrarv1.WatchEndpointsResponse_EventType_name {
+		opts[v] = metric.WithAttributes(attrEventType.String(name))
+	}
+	return opts
+}
+
+// eventTypeOption returns the cached attribute set for an event type, falling
+// back to building one for a value outside the generated table (a proto enum
+// carries unknown values through unchanged).
+func eventTypeOption(t registrarv1.WatchEndpointsResponse_EventType) metric.MeasurementOption {
+	if t >= 0 && int(t) < len(eventTypeOptions) && eventTypeOptions[t] != nil {
+		return eventTypeOptions[t]
+	}
+	return metric.WithAttributes(attrEventType.String(t.String()))
+}
 
 // Metrics holds the registrar server's OTel instruments. All methods are
 // nil-receiver-safe so the server runs unchanged when telemetry is disabled
@@ -115,11 +147,16 @@ func (m *Metrics) filteredWatchers(ctx context.Context, n int) {
 	m.filteredSubs.Record(ctx, int64(n))
 }
 
-func (m *Metrics) eventBroadcast(ctx context.Context, eventType string) {
+// eventsBroadcast records a whole fan-out batch: one Add per event type rather
+// than one per enqueued event, so the totals are unchanged while the counter
+// work leaves the per-watcher loop.
+func (m *Metrics) eventsBroadcast(ctx context.Context, counts map[registrarv1.WatchEndpointsResponse_EventType]int64) {
 	if m == nil {
 		return
 	}
-	m.broadcastEvents.Add(ctx, 1, metric.WithAttributes(attrEventType.String(eventType)))
+	for eventType, n := range counts {
+		m.broadcastEvents.Add(ctx, n, eventTypeOption(eventType))
+	}
 }
 
 func (m *Metrics) eventDropped(ctx context.Context, eventType string) {

--- a/registrar/internal/server/metrics_test.go
+++ b/registrar/internal/server/metrics_test.go
@@ -80,7 +80,9 @@ func TestMetrics_NilReceiverSafe(t *testing.T) {
 	ctx := context.Background()
 	m.watcherSubscribed(ctx)
 	m.watcherUnsubscribed(ctx)
-	m.eventBroadcast(ctx, "EVENT_TYPE_ENDPOINT_ADDED")
+	m.eventsBroadcast(ctx, map[registrarv1.WatchEndpointsResponse_EventType]int64{
+		registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED: 1,
+	})
 	m.eventDropped(ctx, "EVENT_TYPE_ENDPOINT_ADDED")
 	m.syncCompleted(ctx, 0.1, 1, map[string]int{"EVENT_TYPE_ENDPOINT_ADDED": 1})
 	m.syncFailed(ctx, 0.1)

--- a/registrar/internal/server/server.go
+++ b/registrar/internal/server/server.go
@@ -197,7 +197,7 @@ func (s *RegistrarServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest,
 		return err
 	}
 
-	events, currentVersion := s.snapshot.FullSnapshotEvents()
+	events, currentVersion := s.snapshot.FullSnapshotEvents(filterSet)
 	if req.GetLastVersion() != currentVersion {
 		if err := sendFilteredSnapshot(stream, events, filterSet); err != nil {
 			return err
@@ -245,6 +245,8 @@ func buildWatchFilter(req *registrarv1.WatchEndpointsRequest) ([]string, map[str
 }
 
 // sendFilteredSnapshot sends snapshot events scoped to filterSet (nil = send all).
+// FullSnapshotEvents already applied the same filter; the check is kept as
+// defense in depth so no out-of-scope endpoint can reach a scoped watcher.
 func sendFilteredSnapshot(stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse], events []*registrarv1.WatchEndpointsResponse, filterSet map[string]struct{}) error {
 	for _, event := range events {
 		if filterSet != nil {

--- a/registrar/internal/server/snapshot.go
+++ b/registrar/internal/server/snapshot.go
@@ -262,39 +262,58 @@ func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) (string, 
 			IP:          event.GetEndpoint().GetIp(),
 		}
 
+		var tr *registrarv1.WatchEndpointsResponse
 		switch event.GetType() {
 		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED:
-			before := s.serviceCountLocked(key.ServiceName)
-			// An UPDATED event replacing an existing entry must not raise the
-			// count: only a key that was absent adds an endpoint.
-			_, existed := s.entries[key]
-			s.entries[key] = &snapshotEntry{
-				ServiceName: event.GetServiceName(),
-				Protocol:    event.GetProtocol(),
-				Endpoint:    event.GetEndpoint(),
-			}
-			if !existed {
-				s.serviceCounts[key.ServiceName]++
-			}
-			if before == 0 {
-				transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, key.ServiceName))
-			}
+			tr = s.applyUpsertLocked(key, event)
 		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED:
-			if _, existed := s.entries[key]; existed {
-				delete(s.entries, key)
-				if n := s.serviceCounts[key.ServiceName] - 1; n > 0 {
-					s.serviceCounts[key.ServiceName] = n
-				} else {
-					// Never leave a zero resting in the map: its key set is the
-					// service catalog.
-					delete(s.serviceCounts, key.ServiceName)
-					transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, key.ServiceName))
-				}
-			}
+			tr = s.applyRemoveLocked(key)
+		}
+		if tr != nil {
+			transitions = append(transitions, tr)
 		}
 	}
 
 	return s.nextVersion(), transitions
+}
+
+// applyUpsertLocked stores an added/updated endpoint, maintaining serviceCounts,
+// and returns the SERVICE_ADDED transition when this is the service's first
+// endpoint (nil otherwise). Caller must hold mu for writing.
+func (s *Snapshot) applyUpsertLocked(key serviceKey, event *registrarv1.WatchEndpointsResponse) *registrarv1.WatchEndpointsResponse {
+	before := s.serviceCountLocked(key.ServiceName)
+	// An UPDATED event replacing an existing entry must not raise the count:
+	// only a key that was absent adds an endpoint.
+	_, existed := s.entries[key]
+	s.entries[key] = &snapshotEntry{
+		ServiceName: event.GetServiceName(),
+		Protocol:    event.GetProtocol(),
+		Endpoint:    event.GetEndpoint(),
+	}
+	if !existed {
+		s.serviceCounts[key.ServiceName]++
+	}
+	if before == 0 {
+		return serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, key.ServiceName)
+	}
+	return nil
+}
+
+// applyRemoveLocked deletes an endpoint if present, maintaining serviceCounts,
+// and returns the SERVICE_REMOVED transition when the service's last endpoint
+// went away (nil otherwise). Caller must hold mu for writing.
+func (s *Snapshot) applyRemoveLocked(key serviceKey) *registrarv1.WatchEndpointsResponse {
+	if _, existed := s.entries[key]; !existed {
+		return nil
+	}
+	delete(s.entries, key)
+	if n := s.serviceCounts[key.ServiceName] - 1; n > 0 {
+		s.serviceCounts[key.ServiceName] = n
+		return nil
+	}
+	// Never leave a zero resting in the map: its key set is the service catalog.
+	delete(s.serviceCounts, key.ServiceName)
+	return serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, key.ServiceName)
 }
 
 // FullSnapshotEvents returns the current contents of the snapshot as a slice of

--- a/registrar/internal/server/snapshot.go
+++ b/registrar/internal/server/snapshot.go
@@ -32,26 +32,27 @@ type snapshotEntry struct {
 type Snapshot struct {
 	mu      sync.RWMutex
 	entries map[serviceKey]*snapshotEntry
-	version atomic.Uint64
+	// serviceCounts is the per-service endpoint count derived from entries,
+	// maintained incrementally so the 0<->1 catalog transitions cost a map
+	// lookup instead of a full scan per event. INVARIANT: a service is present
+	// here iff it holds at least one entry (a count never rests at 0), so the
+	// key set is exactly the service catalog. Guarded by mu.
+	serviceCounts map[string]int
+	version       atomic.Uint64
 }
 
 // NewSnapshot creates an empty Snapshot starting at version 0.
 func NewSnapshot() *Snapshot {
 	return &Snapshot{
-		entries: make(map[serviceKey]*snapshotEntry),
+		entries:       make(map[serviceKey]*snapshotEntry),
+		serviceCounts: make(map[string]int),
 	}
 }
 
 // serviceCountLocked returns the number of endpoints stored for a service
 // across protocols. Caller must hold mu (read or write).
 func (s *Snapshot) serviceCountLocked(serviceName string) int {
-	n := 0
-	for key := range s.entries {
-		if key.ServiceName == serviceName {
-			n++
-		}
-	}
-	return n
+	return s.serviceCounts[serviceName]
 }
 
 // serviceTransition builds a catalog event (SERVICE_ADDED/SERVICE_REMOVED).
@@ -65,12 +66,8 @@ func (s *Snapshot) ServiceNames() []string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	set := make(map[string]struct{})
-	for key := range s.entries {
-		set[key.ServiceName] = struct{}{}
-	}
-	names := make([]string, 0, len(set))
-	for name := range set {
+	names := make([]string, 0, len(s.serviceCounts))
+	for name := range s.serviceCounts {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -185,16 +182,22 @@ func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol]
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	oldServices := make(map[string]struct{})
-	for key := range s.entries {
-		oldServices[key.ServiceName] = struct{}{}
+	// The count map's key set is the service catalog (see the invariant on
+	// serviceCounts), so the old catalog is read straight off it.
+	oldServices := make(map[string]struct{}, len(s.serviceCounts))
+	for name := range s.serviceCounts {
+		oldServices[name] = struct{}{}
 	}
 
 	s.entries = make(map[serviceKey]*snapshotEntry)
+	s.serviceCounts = make(map[string]int)
 	for svcName, protocols := range endpoints {
 		for protocol, eps := range protocols {
 			for _, ep := range eps {
 				key := serviceKey{ServiceName: svcName, Protocol: protocol, IP: ep.GetIp()}
+				if _, dup := s.entries[key]; !dup {
+					s.serviceCounts[svcName]++
+				}
 				s.entries[key] = &snapshotEntry{
 					ServiceName: svcName,
 					Protocol:    protocol,
@@ -204,9 +207,9 @@ func (s *Snapshot) Replace(endpoints map[string]map[registryv1.Service_Protocol]
 		}
 	}
 
-	newServices := make(map[string]struct{})
-	for key := range s.entries {
-		newServices[key.ServiceName] = struct{}{}
+	newServices := make(map[string]struct{}, len(s.serviceCounts))
+	for name := range s.serviceCounts {
+		newServices[name] = struct{}{}
 	}
 
 	return s.nextVersion(), computeTransitions(oldServices, newServices)
@@ -262,10 +265,16 @@ func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) (string, 
 		switch event.GetType() {
 		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED, registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED:
 			before := s.serviceCountLocked(key.ServiceName)
+			// An UPDATED event replacing an existing entry must not raise the
+			// count: only a key that was absent adds an endpoint.
+			_, existed := s.entries[key]
 			s.entries[key] = &snapshotEntry{
 				ServiceName: event.GetServiceName(),
 				Protocol:    event.GetProtocol(),
 				Endpoint:    event.GetEndpoint(),
+			}
+			if !existed {
+				s.serviceCounts[key.ServiceName]++
 			}
 			if before == 0 {
 				transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, key.ServiceName))
@@ -273,7 +282,12 @@ func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) (string, 
 		case registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED:
 			if _, existed := s.entries[key]; existed {
 				delete(s.entries, key)
-				if s.serviceCountLocked(key.ServiceName) == 0 {
+				if n := s.serviceCounts[key.ServiceName] - 1; n > 0 {
+					s.serviceCounts[key.ServiceName] = n
+				} else {
+					// Never leave a zero resting in the map: its key set is the
+					// service catalog.
+					delete(s.serviceCounts, key.ServiceName)
 					transitions = append(transitions, serviceTransition(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, key.ServiceName))
 				}
 			}
@@ -285,14 +299,29 @@ func (s *Snapshot) Apply(events []*registrarv1.WatchEndpointsResponse) (string, 
 
 // FullSnapshotEvents returns the current contents of the snapshot as a slice of
 // FULL_SNAPSHOT events. This is used to send the initial state to a new watcher.
-func (s *Snapshot) FullSnapshotEvents() ([]*registrarv1.WatchEndpointsResponse, string) {
+// A non-nil filter scopes the result to those service names (a nil filter is
+// the unfiltered, cluster-wide snapshot): a demand-scoped watcher discards
+// everything outside its filter anyway, so the out-of-scope events are skipped
+// before their protos are ever built.
+func (s *Snapshot) FullSnapshotEvents(filter map[string]struct{}) ([]*registrarv1.WatchEndpointsResponse, string) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	events := make([]*registrarv1.WatchEndpointsResponse, 0, len(s.entries))
+	// A filtered watcher keeps at most its filter's services; sizing on the
+	// whole snapshot would reserve the very memory the filter exists to avoid.
+	capacity := len(s.entries)
+	if filter != nil {
+		capacity = min(capacity, len(filter))
+	}
+	events := make([]*registrarv1.WatchEndpointsResponse, 0, capacity)
 	version := s.Version()
 
 	for _, entry := range s.entries {
+		if filter != nil {
+			if _, inScope := filter[entry.ServiceName]; !inScope {
+				continue
+			}
+		}
 		events = append(events, &registrarv1.WatchEndpointsResponse{
 			Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_FULL_SNAPSHOT,
 			ServiceName: entry.ServiceName,

--- a/registrar/internal/server/snapshot_test.go
+++ b/registrar/internal/server/snapshot_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"sort"
 	"sync"
 	"testing"
 
@@ -636,7 +637,7 @@ func TestFullSnapshotEvents(t *testing.T) {
 			s := NewSnapshot()
 			_, _ = s.Replace(tt.seed)
 
-			events, version := s.FullSnapshotEvents()
+			events, version := s.FullSnapshotEvents(nil)
 
 			assert.Equal(t, tt.wantVersion, version)
 			assert.Len(t, events, tt.wantCount)
@@ -649,6 +650,128 @@ func TestFullSnapshotEvents(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestFullSnapshotEvents_Filter pins the watch-filter scoping: a demand-scoped
+// watcher's snapshot carries only its own services, a nil filter is the
+// cluster-wide snapshot, and a non-nil empty filter carries nothing.
+func TestFullSnapshotEvents_Filter(t *testing.T) {
+	s := NewSnapshot()
+	_, _ = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
+		"svc-a": {registryv1.Service_PROTOCOL_HTTP: {makeEndpoint("10.0.0.1")}},
+		"svc-b": {registryv1.Service_PROTOCOL_HTTP: {makeEndpoint("10.0.0.2")}},
+		"svc-c": {registryv1.Service_PROTOCOL_HTTP: {makeEndpoint("10.0.0.3")}},
+	})
+
+	t.Run("nil filter is unfiltered", func(t *testing.T) {
+		events, _ := s.FullSnapshotEvents(nil)
+		assert.Len(t, events, 3)
+	})
+
+	t.Run("scoped filter keeps only its services", func(t *testing.T) {
+		events, _ := s.FullSnapshotEvents(map[string]struct{}{"svc-a": {}, "svc-c": {}})
+		names := make([]string, 0, len(events))
+		for _, ev := range events {
+			names = append(names, ev.GetServiceName())
+		}
+		sort.Strings(names)
+		assert.Equal(t, []string{"svc-a", "svc-c"}, names)
+	})
+
+	t.Run("unknown service in the filter matches nothing", func(t *testing.T) {
+		events, _ := s.FullSnapshotEvents(map[string]struct{}{"svc-missing": {}})
+		assert.Empty(t, events)
+	})
+
+	t.Run("empty non-nil filter watches nothing", func(t *testing.T) {
+		events, version := s.FullSnapshotEvents(map[string]struct{}{})
+		assert.Empty(t, events)
+		assert.Equal(t, s.Version(), version)
+	})
+}
+
+// TestSnapshot_ServiceCountsStaySynced pins the serviceCounts invariant the
+// catalog transitions depend on: the map mirrors the per-service entry count
+// exactly through Apply and Replace, and never keeps a zero-count key (its key
+// set IS the service catalog).
+func TestSnapshot_ServiceCountsStaySynced(t *testing.T) {
+	assertSynced := func(t *testing.T, s *Snapshot) {
+		t.Helper()
+		want := make(map[string]int)
+		for key := range s.entries {
+			want[key.ServiceName]++
+		}
+		assert.Equal(t, want, s.serviceCounts, "serviceCounts must mirror entries")
+		for svc, n := range s.serviceCounts {
+			assert.Positive(t, n, "service %q must not rest at a zero count", svc)
+		}
+	}
+
+	event := func(t registrarv1.WatchEndpointsResponse_EventType, svc, ip string) *registrarv1.WatchEndpointsResponse {
+		return &registrarv1.WatchEndpointsResponse{
+			Type: t, ServiceName: svc, Protocol: registryv1.Service_PROTOCOL_HTTP,
+			Endpoint: &registryv1.ServiceEndpoint{Ip: ip},
+		}
+	}
+	added := registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_ADDED
+	updated := registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_UPDATED
+	removed := registrarv1.WatchEndpointsResponse_EVENT_TYPE_ENDPOINT_REMOVED
+
+	s := NewSnapshot()
+
+	// Adds across services and protocols.
+	_, _ = s.Apply([]*registrarv1.WatchEndpointsResponse{
+		event(added, "svc-a", "10.0.0.1"),
+		event(added, "svc-a", "10.0.0.2"),
+		event(added, "svc-b", "10.0.1.1"),
+	})
+	assertSynced(t, s)
+	assert.Equal(t, 2, s.serviceCountLocked("svc-a"))
+
+	// An UPDATED event replacing an existing entry must not double-count; an
+	// UPDATED event for an unseen key behaves as an add.
+	_, tr := s.Apply([]*registrarv1.WatchEndpointsResponse{
+		event(updated, "svc-a", "10.0.0.1"),
+		event(updated, "svc-c", "10.0.2.1"),
+	})
+	assertSynced(t, s)
+	assert.Equal(t, 2, s.serviceCountLocked("svc-a"))
+	require.Len(t, tr, 1, "only the previously-absent service transitions")
+	assert.Equal(t, "svc-c", tr[0].GetServiceName())
+
+	// A removal for an absent key must not decrement.
+	_, _ = s.Apply([]*registrarv1.WatchEndpointsResponse{
+		event(removed, "svc-a", "10.9.9.9"),
+		event(removed, "svc-ghost", "10.9.9.9"),
+	})
+	assertSynced(t, s)
+	assert.Equal(t, 2, s.serviceCountLocked("svc-a"))
+
+	// Draining a service drops its key entirely.
+	_, _ = s.Apply([]*registrarv1.WatchEndpointsResponse{
+		event(removed, "svc-a", "10.0.0.1"),
+		event(removed, "svc-a", "10.0.0.2"),
+	})
+	assertSynced(t, s)
+	assert.NotContains(t, s.serviceCounts, "svc-a")
+	assert.Equal(t, 0, s.serviceCountLocked("svc-a"))
+
+	// Replace rebuilds the counts from scratch.
+	_, _ = s.Replace(map[string]map[registryv1.Service_Protocol][]*registryv1.ServiceEndpoint{
+		"svc-d": {
+			registryv1.Service_PROTOCOL_HTTP: {makeEndpoint("10.0.3.1"), makeEndpoint("10.0.3.2")},
+			registryv1.Service_PROTOCOL_TCP:  {makeEndpoint("10.0.3.1")},
+		},
+	})
+	assertSynced(t, s)
+	assert.Equal(t, 3, s.serviceCountLocked("svc-d"))
+	assert.Equal(t, []string{"svc-d"}, s.ServiceNames())
+
+	// A service re-added after a full drain transitions again.
+	_, tr = s.Apply([]*registrarv1.WatchEndpointsResponse{event(added, "svc-a", "10.0.0.1")})
+	assertSynced(t, s)
+	require.Len(t, tr, 1)
+	assert.Equal(t, registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, tr[0].GetType())
 }
 
 func TestSnapshotThreadSafety(t *testing.T) {
@@ -687,7 +810,7 @@ func TestSnapshotThreadSafety(t *testing.T) {
 			case 3:
 				s.GetAllWithVersion(registryv1.Service_PROTOCOL_HTTP)
 			case 4:
-				s.FullSnapshotEvents()
+				s.FullSnapshotEvents(nil)
 			}
 		}(i)
 	}


### PR DESCRIPTION
## Summary

Final cohort of the improvement sweep: the six **SAFE** findings from the hot-path analysis, implemented exactly as specified; the four NEEDS-CARE findings are deferred (listed below). No behavior change; no iteration or sort order that feeds xDS output was touched.

### registrar (`internal/server`)
1. **`Snapshot.serviceCounts`** — the per-event full scan in `serviceCountLocked` (O(events × total endpoints) under the write lock, per Register/Unregister RPC cluster-wide) becomes an incrementally-maintained map lookup. Invariant: the key set IS the service catalog (no zero rests in the map); `ServiceNames()` iterates it (sort kept). SERVICE_ADDED/REMOVED transitions are byte-identical.
2. **`FullSnapshotEvents(filter)`** — a new watcher's initial snapshot skips out-of-scope entries *before* allocating their protos. Agents reconnect with a fresh filter on every dependency-set change, so this was `N_reconnects × N_cluster_endpoints` proto allocations during a roll — the dominant registrar allocation source under churn. `sendFilteredSnapshot` keeps its guard as defense in depth.
3. **Broadcast metrics batching** — per-type tallies during the fan-out, one counter `Add` per type after the read lock drops, with measurement options pre-built from the generated enum table (was one `WithAttributes` allocation per event per watcher inside the lock). Totals identical.

### agent xDS cache
4. **Extension-union hoist** — the node-global escape-hatch filter union is computed once per regeneration loop (`AddPod`, `LoadListenersFromStorage`, `regenerateAllHTTPListeners`, `SetCaptureTCPServices`, `regenerateAllCaptureListeners`) instead of once-or-twice per pod. The shared slice is documented immutable; the per-pod authz prepend still allocates fresh. Side benefit: `depMu` is no longer acquired under `listenerMu` on these paths.
5. **Snapshot-shape counts ride the dep-set memo** — declared/observed counts are recorded when the memo rebuilds and share its exact validity window (depGen + the observed-TTL expiry horizon), replacing two full walks per snapshot. The wall-clock expiry path cannot serve a stale count — expiry invalidates the memo.
6. **`dependencySetShared()`** — `captureVhosts` (read-only membership tests on the hottest path) reads the memo directly instead of deep-copying it per snapshot; the exported `DependencySet` still copies.

### Deferred (NEEDS-CARE, from the same analysis — candidates for follow-ups)
- Cache the built `cap_http` route table keyed on `(depGen, captureAuthGen, depSet identity)` — the single biggest remaining win, needs per-trigger invalidation tests
- TCP-floor clusters: cache the injected cluster on `clusterEntry` beside `mtlsCluster` (per-snapshot Any-marshals ∝ pods × identities today)
- Storage `AddResource`: move marshal+fsync out of the mutex (CNI ADD latency path)
- Shared static `RetryPolicy` via `sync.OnceValue` (concurrent-marshal `sizeCache` caveat)

### Tests
New: `TestSnapshot_ServiceCountsStaySynced` (pins the invariant through Apply — add / UPDATED-replace / UPDATED-as-add / remove-absent / full-drain / re-add — and Replace) and `TestFullSnapshotEvents_Filter` (nil = unfiltered, scoped, unknown-service, empty-non-nil). Existing callers updated for the two signature changes.

`bazel test --test_output=errors //...` — 79/79 pass. Note: the repo has no benchmarks; if you want before/after numbers I'd add micro-benchmarks for `Snapshot.Apply` and `generateSnapshot` in a follow-up rather than pad this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR