### PR TITLE
feat(uds): shared plumbing for pod UDS delivery (034, PR 1)

### DIFF
--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -281,6 +281,9 @@ func (s *CNIServer) enhanceCNIPod(ctx context.Context, cniPod *cniv1.CNIPod) (_ 
 	cniPod.Annotations = k8sPod.Annotations
 	cniPod.Labels = k8sPod.Labels
 	cniPod.ServiceAccount = k8sPod.Spec.ServiceAccountName
+	// Persisted (not just returned) so listener regeneration from storage can
+	// resolve kubelet pod-volume paths (proposal 034) without the API server.
+	cniPod.Uid = string(k8sPod.UID)
 	// A pod whose deletion has already been requested must never (re-)enter the
 	// registry: CNI CHECK re-sends AddPod for existing pods, which would
 	// otherwise clear the terminating flag and resurrect the endpoint mid-drain.

--- a/agent/internal/cni/server/resubscribe.go
+++ b/agent/internal/cni/server/resubscribe.go
@@ -18,8 +18,10 @@ import (
 //
 // It waits for the SPIRE bridge to connect (SubscribePod no-ops before then),
 // then re-subscribes every managed stored pod, re-fetching the pod UID from the
-// API server (the UID is needed for the SPIRE k8s:pod-uid selector and is not
-// persisted in storage). Idempotent: SubscribePod no-ops for an
+// API server. The UID is persisted in storage since proposal 034, but the
+// re-fetch stays: records written before the field existed lack it, and the
+// lookup doubles as liveness proof for the pod (deleted-while-down pods fail
+// it and are skipped). Idempotent: SubscribePod no-ops for an
 // already-subscribed network namespace, so racing a concurrent CNI ADD is safe.
 // Pods deleted while the agent was down fail the UID lookup and are skipped;
 // their CNI DEL cleans them up.

--- a/api/aether/cni/v1/cni.proto
+++ b/api/aether/cni/v1/cni.proto
@@ -45,4 +45,10 @@ message CNIPod {
   // liveness loop must never re-register it. Local xDS resources stay until the
   // CNI DEL performs final teardown.
   bool terminating = 10;
+
+  // uid is the Kubernetes pod UID, fetched from the API server on CNI ADD and
+  // persisted so listener regeneration from storage can resolve kubelet
+  // pod-volume paths (proposal 034, UDS delivery) without the API server.
+  // Empty on records written before the field existed.
+  string uid = 11;
 }

--- a/common/constants/annotations/annotations.go
+++ b/common/constants/annotations/annotations.go
@@ -51,6 +51,14 @@ const (
 
 	// AnnotationEndpointPort is the pod annotation key for specifying the service port
 	AnnotationEndpointPort = annotationAetherEndpointPrefix + "port"
+	// AnnotationEndpointUDSSocket is the pod annotation switching app DELIVERY to
+	// a Unix domain socket (proposal 034 Phase 1). Value: "<volume>/<file>", an
+	// emptyDir volume name declared by the pod and the socket file inside it,
+	// resolved to a kubelet pod-volumes host path by common/udspath. Ports stay
+	// required — they keep naming the service ports for inbound demux and EDS;
+	// this annotation only changes what the app_<pod>_<port> clusters dial (all
+	// declared ports dial the same socket).
+	AnnotationEndpointUDSSocket = annotationAetherEndpointPrefix + "uds-socket"
 	// AnnotationEndpointPorts is the pod annotation listing ALL application ports
 	// the pod serves, comma-separated (e.g. "8080,9090"), for multi-port routing
 	// (proposal 005). AnnotationEndpointPort remains the default/primary port;

--- a/common/udspath/BUILD.bazel
+++ b/common/udspath/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "udspath",
+    srcs = ["udspath.go"],
+    importpath = "github.com/bpalermo/aether/common/udspath",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "udspath_test",
+    srcs = ["udspath_test.go"],
+    embed = [":udspath"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/common/udspath/udspath.go
+++ b/common/udspath/udspath.go
@@ -1,0 +1,66 @@
+// Package udspath resolves the endpoint.aether.io/uds-socket annotation to the
+// host path of a workload's Unix socket (proposal 034).
+//
+// Pathname Unix sockets are mount-namespace-scoped, so the node proxy (host
+// mount namespace) reaches a workload socket through kubelet's pod-volumes
+// directory: a socket in a pod emptyDir is host-visible at
+//
+//	<kubelet-pods-dir>/<pod-UID>/volumes/kubernetes.io~empty-dir/<volume>/<file>
+//
+// The annotation value ("<volume>/<file>") is attacker-influenced input (any
+// pod author can set it), so resolution is fail-closed: both components must
+// be single, clean path segments — a malicious annotation must never address
+// another pod's volume or an arbitrary host path.
+package udspath
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// emptyDirSegment is the kubelet volume-plugin directory for emptyDir volumes.
+// It is part of the validated contract: only emptyDir volumes carry sockets
+// (CSI/projected volumes are out of scope, see proposal 034).
+const emptyDirSegment = "kubernetes.io~empty-dir"
+
+// Resolve maps an endpoint.aether.io/uds-socket annotation value plus the
+// pod's Kubernetes UID onto the socket's host path under kubeletPodsDir.
+// kubeletPodsDir must be an absolute path (the --kubelet-pods-dir flag).
+func Resolve(kubeletPodsDir, podUID, annotation string) (string, error) {
+	if !filepath.IsAbs(kubeletPodsDir) {
+		return "", fmt.Errorf("kubelet pods dir %q is not absolute", kubeletPodsDir)
+	}
+	if err := validateSegment("pod UID", podUID); err != nil {
+		return "", err
+	}
+	volume, file, ok := strings.Cut(annotation, "/")
+	if !ok {
+		return "", fmt.Errorf("uds-socket annotation %q is not <volume>/<file>", annotation)
+	}
+	if err := validateSegment("volume name", volume); err != nil {
+		return "", err
+	}
+	if err := validateSegment("socket file", file); err != nil {
+		return "", err
+	}
+	return filepath.Join(kubeletPodsDir, podUID, "volumes", emptyDirSegment, volume, file), nil
+}
+
+// validateSegment rejects anything that is not a single, clean, relative path
+// segment: empty strings, path separators (which would smuggle extra
+// components past the <volume>/<file> split), "." and ".." (traversal), and
+// NUL (C-string truncation at the syscall boundary).
+func validateSegment(what, s string) error {
+	switch {
+	case s == "":
+		return fmt.Errorf("%s is empty", what)
+	case s == "." || s == "..":
+		return fmt.Errorf("%s %q is a relative path element", what, s)
+	case strings.ContainsAny(s, "/\x00"):
+		return fmt.Errorf("%s %q contains a path separator or NUL", what, s)
+	case filepath.Clean(s) != s:
+		return fmt.Errorf("%s %q is not a clean path segment", what, s)
+	}
+	return nil
+}

--- a/common/udspath/udspath_test.go
+++ b/common/udspath/udspath_test.go
@@ -1,0 +1,48 @@
+package udspath
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolve(t *testing.T) {
+	got, err := Resolve("/var/lib/kubelet/pods", "0f52c50e-99cf-4a3c-a5e3-6a1e60e2b5f1", "sockets/app.sock")
+	require.NoError(t, err)
+	assert.Equal(t, "/var/lib/kubelet/pods/0f52c50e-99cf-4a3c-a5e3-6a1e60e2b5f1/volumes/kubernetes.io~empty-dir/sockets/app.sock", got)
+}
+
+// TestResolve_Rejections pins the fail-closed contract: the annotation is
+// attacker-influenced, so anything that is not exactly <segment>/<segment>
+// must fail, never escape the pod's own emptyDir directory.
+func TestResolve_Rejections(t *testing.T) {
+	const (
+		podsDir = "/var/lib/kubelet/pods"
+		uid     = "0f52c50e-99cf-4a3c-a5e3-6a1e60e2b5f1"
+	)
+	cases := map[string]struct {
+		podsDir, uid, annotation string
+	}{
+		"no separator":              {podsDir, uid, "appsock"},
+		"empty annotation":          {podsDir, uid, ""},
+		"empty volume":              {podsDir, uid, "/app.sock"},
+		"empty file":                {podsDir, uid, "sockets/"},
+		"extra segment":             {podsDir, uid, "sockets/deep/app.sock"},
+		"volume traversal":          {podsDir, uid, "../app.sock"},
+		"file traversal":            {podsDir, uid, "sockets/.."},
+		"dot volume":                {podsDir, uid, "./app.sock"},
+		"absolute smuggle":          {podsDir, uid, "//etc/passwd"},
+		"NUL in file":               {podsDir, uid, "sockets/app\x00.sock"},
+		"empty uid":                 {podsDir, "", "sockets/app.sock"},
+		"uid traversal":             {podsDir, "..", "sockets/app.sock"},
+		"uid with separator":        {podsDir, "a/b", "sockets/app.sock"},
+		"relative kubelet pods dir": {"var/lib/kubelet/pods", uid, "sockets/app.sock"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Resolve(tc.podsDir, tc.uid, tc.annotation)
+			assert.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

First implementation PR of proposal 034 (pod UDS support), exactly the "shared plumbing" slice:

- **`CNIPod.uid = 11`** — `enhanceCNIPod` already fetches the Pod UID on ADD (SPIRE `k8s:pod-uid` selectors) but only returned it transiently; it is now also persisted in storage, so `LoadListenersFromStorage` can resolve pipe paths on agent restart without the API server. protojson storage makes this backward-compatible (pre-034 records simply lack the field); `runResubscribeStoredPods` keeps its API re-fetch — old records need it and the lookup doubles as pod-liveness proof.
- **`endpoint.aether.io/uds-socket`** annotation constant (`<volume>/<file>`). Per the revised proposal: `port(s)` stay required for inbound demux/EDS; this annotation only changes what the `app_<pod>_<port>` clusters dial.
- **`common/udspath`** — the fail-closed annotation→host-path resolver: `Resolve(kubeletPodsDir, podUID, "<volume>/<file>")` → `<dir>/<uid>/volumes/kubernetes.io~empty-dir/<volume>/<file>`. The annotation is attacker-influenced input, so every component must be a single clean path segment: empty, `.`, `..`, separators, NUL, and non-clean segments are all rejected (14-case rejection table pins the contract, including UID-side traversal and a relative pods-dir).

No behavior change for existing pods; nothing reads the new field or annotation yet — that's PR 2 (Phase 1 pipe clusters + chart gate), which stacks on this.

## Testing

`bazel run //:gazelle` + `//:format`; `bazel test --test_output=errors //...` — 80/80 pass (36 re-executed, including the regenerated cniv1 protos and CNI server suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR