### PR TITLE
docs: fix stale claims across the living docs (staleness sweep)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,17 +20,20 @@ make format-check  # CI-friendly check (fails on drift)
 
 ## Toolchain
 
-- **Bazel:** 9.0.2 (via Bazelisk). Use `bazel` commands directly or via `Makefile`.
-- **Go:** 1.26.2
+- **Bazel:** 9.2.0 (via Bazelisk). Use `bazel` commands directly or via `Makefile`.
+- **Go:** 1.26.5
 - **Container images:** Built with `rules_img`, pushed to distroless (`gcr.io/distroless/static-debian12:nonroot`).
 - **Protobuf:** Uses `buf/validate` for validation, `protoc-gen-dynamo` for DynamoDB marshaling.
 
 ## Architecture
 
-**Three binaries:**
-- `agent/cmd/agent` — Node DaemonSet. Manages xDS server (Envoy), CNI gRPC server, SPIRE bridge via `controller-runtime` Manager.
-- `registrar/cmd/registrar` — In-cluster Deployment. Proxies external registry (DynamoDB/etcd), maintains endpoint snapshot, streams to agents via gRPC.
+**Binaries:**
+- `agent/cmd/agent` — Node DaemonSet. Manages xDS server (Envoy), CNI gRPC server, SPIRE bridge via `controller-runtime` Manager. Also hosts the `agent edge` and `agent proxy-supervisor` subcommands.
+- `agent/cmd/mesh-dns` — Slim standalone mesh-DNS daemon (own DaemonSet + image). Serves pods from the record snapshot the agent writes.
+- `registrar/cmd/registrar` — In-cluster Deployment. Proxies external registry (Kubernetes/DynamoDB/etcd), maintains endpoint snapshot, streams to agents via gRPC.
+- `controller/cmd/controller` — In-cluster Deployment (leader-elected). Serves the validating + pod-mutating admission webhooks and the `MeshConfig`→ConfigMap reconciler.
 - `cni/cmd/cni` — CNI plugin binary (Add/Del/Check/GC/Status).
+- `cni/cmd/cni-install` — Init container that installs the CNI plugin binary and config onto the host.
 
 **Key patterns:**
 - gRPC servers use Unix domain sockets for node-local communication.
@@ -54,7 +57,7 @@ make tidy        # Update go.mod dependencies
 
 ## Proto & Codegen
 
-- Proto files in `api/` under `aether/cni/v1/`, `aether/registry/v1/`, `aether/registrar/v1/`.
+- Proto files in `api/` under `aether/cni/v1/`, `aether/registry/v1/`, `aether/registrar/v1/`, `aether/config/v1/` (`MeshConfig`, `HTTPFilter`, `EdgeConfig`, `EndpointPolicy`).
 - DynamoDB marshaling via `protoc-gen-dynamo` (suffix: `pb.dynamo.go`).
 - Run `make gazelle` after proto or import changes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ bazel test //agent/internal/xds/config:config_test
 
 # Build
 make build-agent             # or: bazel build //agent/cmd/agent/...
+make build-mesh-dns          # or: bazel build //agent/cmd/mesh-dns/...
 make build-cni-install       # or: bazel build //cni/cmd/cni-install/...
 make build-registrar         # or: bazel build //registrar/cmd/registrar/...
 
@@ -42,6 +43,7 @@ bazel run @rules_go//go get <package>
 
 # Container images
 make load-agent-image        # Load agent image into local Docker
+make load-mesh-dns-image     # Load mesh-dns image into local Docker
 make load-cni-install-image  # Load cni-install image into local Docker
 make load-registrar-image    # Load registrar image into local Docker
 make load-all                # Load all images
@@ -53,6 +55,7 @@ make push-all                # Push all images
 ### Binaries (under `cmd/`)
 
 - **`agent/cmd/agent`** - Node agent DaemonSet. Uses `controller-runtime` manager to run the xDS server and CNI gRPC server as runnables. CLI built with Cobra. Also hosts two subcommands: `agent edge` (the north-south edge gateway control plane, proposal 003/018) and `agent proxy-supervisor` (the Envoy hot-restart supervisor, proposal 001).
+- **`agent/cmd/mesh-dns`** - Slim standalone mesh-DNS daemon (its own DaemonSet and its own image since #583). Serves `<svc>.<ns>.<mesh-domain>` from the record snapshot the node agent writes and forwards everything else upstream, so the resolver survives agent rolls (#578).
 - **`registrar/cmd/registrar`** - In-cluster Registrar Deployment. Proxies registry operations, caches an endpoint snapshot, and streams changes to agents via gRPC. Uses `controller-runtime` manager with leader election. Also hosts the cross-cluster config-export controller (proposal 026).
 - **`controller/cmd/controller`** - In-cluster Controller Deployment (leader-elected). Serves the admission webhooks (`MeshConfig`, `HTTPFilter`, `EdgeConfig`, `EndpointPolicy`, `HTTPRoute` validation on `/validate`; a pod-mutating webhook on `/mutate` for mesh-domain `ndots` + namespace-based mesh injection) and reconciles each namespace's `MeshConfig` CR into a projected ConfigMap.
 - **`cni/cmd/cni`** - CNI plugin binary invoked by the container runtime. Implements the CNI spec (Add/Del/Check/GC/Status) via `containernetworking/cni`.
@@ -60,10 +63,10 @@ make push-all                # Push all images
 
 ### Core Packages
 
-- **`xds/`** - Base gRPC server infrastructure and Envoy xDS server wrapping `go-control-plane`. `Server` provides lifecycle management (start, graceful shutdown, liveness/readiness) over Unix domain sockets or TCP. `XdsServer` embeds `Server` and registers Envoy discovery services (LDS, CDS, EDS, RDS, ADS).
+- **`common/xds/`** - Base gRPC server infrastructure and Envoy xDS server wrapping `go-control-plane`. `Server` provides lifecycle management (start, graceful shutdown, liveness/readiness) over Unix domain sockets or TCP. `XdsServer` embeds `Server` and registers Envoy discovery services (LDS, CDS, EDS, RDS, ADS).
 - **`agent/internal/xds/`** - Agent-specific xDS logic. `cache/` builds and versions the Envoy snapshot (listeners, clusters, endpoints, routes, capture/`cap_http`, gamma, edge). `proxy/` generates Envoy resource types (listeners, clusters, endpoints, routes, filter chains) and converts `registryv1.GammaRoute` protos into Envoy config. `config/` has shared Envoy config helpers (SPIRE mTLS, HTTP connection manager).
 - **`agent/internal/gamma/`** - The node agent's GAMMA reconciler. Watches `HTTPRoute`/`GRPCRoute`/`ReferenceGrant`/`HTTPFilter` parented to a Service, calls `common/gammaproject` to project them, and feeds the resulting routes into the xDS cache (outbound + capture paths). Gated by `--gamma`.
-- **`agent/internal/l4route/`** - The node agent's L4 route reconciler: watches `TCPRoute`/`TLSRoute`/`UDPRoute` parented to a Service and projects them into the capture listener as weighted TCP-floor chains / SNI-routed TLS chains (proposal 018, Phase 3b). Gated by `--l4-routes` (UDPRoute is control-plane only until the CNI UDP redirect lands).
+- **`agent/internal/l4route/`** - The node agent's L4 route reconciler: watches `TCPRoute`/`TLSRoute`/`UDPRoute` parented to a Service and projects them into the capture listener as weighted TCP-floor chains / SNI-routed TLS chains (proposal 018, Phase 3b). Unconditional since proposal 031 (the old `--l4-routes` flag was retired); each route type is gated only on its Gateway API CRD being installed. UDPRoute is served too — the CNI installs the UDP redirect and the agent builds a `udp_proxy` listener when UDPRoute backends exist — but UDP rides the mesh in plaintext (mTLS is a TCP/TLS construct; no DTLS).
 - **`agent/internal/endpointpolicy/`** - The node agent's `EndpointPolicy` reconciler: watches the service-scoped UDS delivery CRD (proposal 034 Phase 1b) and projects `<ns>/<svc>` → socket into the xDS cache. CRD-presence-gated; the pod annotation `endpoint.aether.io/uds-socket` wins over a policy.
 - **`agent/internal/configimport/`** - Cross-cluster config import (proposal 026, `--import-config`). A controller-runtime runnable that polls the registrar's `ListConfig` for `registryv1.ServiceConfigProjection`s peer clusters exported and materializes them into the node proxy's routes (merged with local; local wins; `--control-cluster` restricts trust to one origin).
 - **`agent/internal/edge/`** - The `agent edge` control plane: watches Gateway API objects cluster-wide and serves xDS to a single-identity ingress Envoy (proposals 003/018/021/028).
@@ -74,7 +77,9 @@ make push-all                # Push all images
 - **`registry/`** - Service registry interface with DynamoDB (`internal/ddb/`), etcd (`internal/etcd/`), and registrar (`internal/registrar/`) implementations. The registrar selects the backend via `--registry-backend`. Manages endpoint registration/discovery and, for etcd, the cross-cluster config plane (`ConfigExporter`/`ConfigImporter`).
 - **`registrar/internal/server/`** - Registrar server: versioned endpoint snapshot, broadcaster for fan-out to agent watch streams, sync loop polling the external registry for changes.
 - **`registrar/internal/configexport/`** - The registrar's cross-cluster config-export controller (proposal 026, leader-elected). Projects exported (`ServiceExport`-listed) `HTTPRoute`/`GRPCRoute` targets via `common/gammaproject` and writes `registryv1.ServiceConfigProjection`s to the shared registry (etcd config keys) for peer clusters to import.
-- **`agent/pkg/storage/`** - Local file-based storage with in-memory caching and fsnotify file watching. Stores protobuf-serialized CNI pod data.
+- **`agent/internal/meshdns/`** - The in-process mesh-DNS resolver: answers `<svc>.<ns>.<mesh-domain>` from the generated mesh Services, persists its record table to a host-local snapshot file (`--mesh-dns-snapshot-path`) that the standalone `agent/cmd/mesh-dns` daemon watches, and self-checks for a wedged resolver.
+- **`common/udspath/`** - Resolves a pod's `<volume>/<socket>` annotation onto its host path under kubelet's pod-volumes dir (`--kubelet-pods-dir`), enforcing the `emptyDir`-only shape and the 107-byte `AF_UNIX` budget (proposal 034).
+- **`agent/storage/`** - Local file-based storage with in-memory caching and fsnotify file watching. Stores CNI pod data as protojson (`<key>.json`).
 - **`api/`** - Protobuf definitions under `aether/cni/v1/`, `aether/registry/v1/`, `aether/registrar/v1/`, and `aether/config/v1/` (`MeshConfig`, `HTTPFilter`, `EdgeConfig`, `EndpointPolicy`). Uses `buf/validate` for proto validation and `protoc-gen-dynamo` for DynamoDB marshaling.
 - **`common/apis/config/v1/`** - Kubernetes CRD Go types (`MeshConfig`, `HTTPFilter`, `EdgeConfig`, `EndpointPolicy`) wrapping the `aether/config/v1` protos with deepcopy/jsonshim glue.
 - **`common/constants/`** - Shared Kubernetes labels, annotations (prefixes `aether.io/`, `endpoint.aether.io/`, `config.aether.io/`, `capture.aether.io/`), and registry/proxy/endpoint constants.

--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ graph TD
         CNI["CNI Plugin<br/><i>netns setup · endpoint registration</i>"]
         Agent["Agent<br/><i>xDS · CNI server · proxy supervisor</i>"]
         Proxy["aether-proxy<br/><i>custom Envoy, hot-restart supervised</i>"]
+        MeshDNS["mesh-dns<br/><i>own DaemonSet · snapshot-fed resolver</i>"]
         SPIRE["SPIRE Agent<br/><i>workload identity</i>"]
 
         Pod == "pod traffic" ==> Proxy
+        Pod -. "DNS :53 (CNI DNAT)" .-> MeshDNS
+        Agent -. "record snapshot (file)" .-> MeshDNS
         CNI -. "register (gRPC/UDS)" .-> Agent
         Agent -. "xDS, demand-scoped<br/>LDS·CDS·EDS·RDS·SDS·ODCDS" .-> Proxy
         Agent -. "Delegated Identity API" .-> SPIRE
@@ -38,17 +41,21 @@ graph TD
 
 **Agent** — Runs on each node via `controller-runtime`. Manages the xDS server, CNI gRPC server, SPIRE bridge, registrar client, and the proxy hot-restart supervisor as runnables. Generates Envoy configuration (listeners, clusters, endpoints, routes) from local pod data and the endpoint cache populated by the Registrar's push stream. Config is **demand-scoped** to each node's dependency set (see below).
 
-**aether-proxy** — A custom Envoy build maintained in a separate sibling Bazel workspace under `proxy/` (pinned to its own Bazel 7.7.1, built from Envoy source) with a compiled-in C++ `aether_stats` extension that records source→destination request metrics. The agent supervises it with cross-pod hot restart for hitless rollouts and two-phase connection draining. See [`proxy/README.md`](proxy/README.md) and proposals [010](docs/proposals/010_custom-proxy-workspace.md) / [012](docs/proposals/012_aether_stats_cpp_extension.md).
+**aether-proxy** — A custom Envoy build maintained in a separate sibling Bazel workspace under `proxy/` (pinned to its own Bazel 8.7.0, built from Envoy source) with a compiled-in C++ `aether_stats` extension that records source→destination request metrics. The agent supervises it with cross-pod hot restart for hitless rollouts and two-phase connection draining. See [`proxy/README.md`](proxy/README.md) and proposals [010](docs/proposals/010_custom-proxy-workspace.md) / [012](docs/proposals/012_aether_stats_cpp_extension.md).
 
 **Demand-scoped distribution** — Each agent generates only the clusters, registry watches, and endpoints its local pods declare a dependency on via the `config.aether.io/upstreams` annotation, with on-demand CDS (ODCDS) serving the cold path. This bounds per-node config to the node's actual footprint and replaces fleet-wide CDS and client-side active health checking. Multi-port and FQDN upstreams are demuxed via SNI with per-port EDS. See proposals [004](docs/proposals/004_demand-scoped-distribution.md) / [005](docs/proposals/005_multi-port-routing.md).
 
+**mesh-dns** — A slim per-node DaemonSet (its own binary and image) that answers `<svc>.<ns>.<meshDomain>` from a record snapshot the agent writes to a host path, and forwards everything else upstream. The CNI DNATs each managed pod's `:53` to it. It is deliberately decoupled from the agent (#578, #583) so an agent roll never gaps pod DNS.
+
 **Gateway API & GAMMA routing** — Routing is expressed with the Kubernetes **Gateway API**. East-west (mesh) traffic uses **GAMMA**: `HTTPRoute`/`GRPCRoute` objects with a `parentRef` to a **Service** enrich that service's outbound/capture routes (canary splits, header/method matches, timeouts, redirects). North-south traffic uses the same API against the edge gateway's `GatewayClass`. Both directions share one projector, **`common/gammaproject`**, which turns a route rule into a `registryv1.GammaRoute` proto; the node agent materializes it locally into Envoy config while the registrar can export it cross-cluster. An **`HTTPFilter`** CRD (proposal 025) is the escape hatch for attaching supported Envoy HTTP filters (ext_authz, RBAC, header-to-metadata) at route, service-wide (`CHAIN`), or destination-side (`INBOUND`) scope.
 
-**Controller** — In-cluster Deployment (leader-elected) that serves the admission webhooks (`MeshConfig`, `HTTPFilter`, `HTTPRoute` validation + a pod-mutating webhook for mesh-domain `ndots` and namespace-based mesh injection) and projects each namespace's `MeshConfig` CR into a ConfigMap the agent and edge mount.
+**Controller** — In-cluster Deployment (leader-elected) that serves the admission webhooks (`MeshConfig`, `HTTPFilter`, `EdgeConfig`, `EndpointPolicy`, `HTTPRoute` validation + a pod-mutating webhook for mesh-domain `ndots` and namespace-based mesh injection) and projects each namespace's `MeshConfig` CR into a ConfigMap the agent and edge mount.
 
 **Registrar** — In-cluster Deployment that acts as the sole bridge between agents and the external registry. Receives endpoint registrations from agents, persists them externally, maintains a versioned in-memory snapshot via periodic sync, and streams changes to all agents via gRPC server-streaming. Runs as an active/active Deployment (every replica serves gRPC and syncs; peers converge through the external registry), collapsing per-node external connections down to the registrar tier.
 
 **CNI Plugin** — Implements the CNI spec (Add/Del/Check/GC/Status) to set up each pod's network namespace. Communicates with the agent over a Unix domain socket to register the pod's endpoints on Add and deregister them on Del.
+
+**UDS delivery** — Workloads that serve on a Unix domain socket instead of a TCP port join the mesh with `endpoint.aether.io/uds-socket: <volume>/<file>` (or a service-scoped `EndpointPolicy` CR). The proxy delivers inbound requests to the socket through kubelet's pod-volumes directory; callers are unaffected — the pod is still reached at its pod IP over mTLS. See proposal [034](docs/proposals/034_pod-uds-support.md).
 
 **SPIRE Bridge** — Connects to the SPIRE agent via the Delegated Identity API to obtain X.509 SVIDs and trust bundles. Converts them into Envoy SDS (Secret Discovery Service) resources for automatic mTLS between workloads.
 
@@ -63,8 +70,8 @@ graph TD
 
 ### Prerequisites
 
-- [Bazelisk](https://github.com/bazelbuild/bazelisk) (Bazel 9.0.1)
-- Go 1.26.2
+- [Bazelisk](https://github.com/bazelbuild/bazelisk) (Bazel 9.2.0)
+- Go 1.26.5
 - Docker (or Colima) for container images and integration tests
 
 ### Setup (macOS with Colima)

--- a/charts/README.md
+++ b/charts/README.md
@@ -5,12 +5,13 @@ Bazel-built Helm charts for Aether, using
 
 | Chart | Path | Deploys |
 | --- | --- | --- |
-| `crds` | [`charts/crds`](./crds) | Aether CustomResourceDefinitions (`MeshConfig`, `HTTPFilter`, `EdgeConfig`). Install **first**; standalone so CRDs can be upgraded independently. |
-| `aether` | [`charts/aether`](./aether) | The whole system: agent DaemonSet (xDS + CNI install) + per-node Envoy proxy, registrar Deployment, and the controller (validating webhooks for `MeshConfig`/`HTTPFilter`/`EdgeConfig`/`HTTPRoute`, a pod-mutating webhook, and the `MeshConfig`→ConfigMap reconciler). Owns the `aether-system` namespace and RBAC. |
+| `crds` | [`charts/crds`](./crds) | Aether CustomResourceDefinitions (`MeshConfig`, `HTTPFilter`, `EdgeConfig`, `EndpointPolicy`). Install **first**; standalone so CRDs can be upgraded independently. |
+| `aether` | [`charts/aether`](./aether) | The whole system: agent DaemonSet (xDS + CNI install) + per-node Envoy proxy + the `mesh-dns` DaemonSet, registrar Deployment, the controller (validating webhooks for `MeshConfig`/`HTTPFilter`/`EdgeConfig`/`EndpointPolicy`/`HTTPRoute`, a pod-mutating webhook, and the `MeshConfig`→ConfigMap reconciler), and the optional north-south edge. Owns the `aether-system` namespace and RBAC. |
 | `prober` | [`charts/prober`](./prober) | External mesh-availability prober (proposal 013). |
+| `udsecho` | [`charts/udsecho`](./udsecho) | UDS validation workloads (proposal 034): both socket-delivery paths (annotation + `EndpointPolicy`) under continuous mesh traffic. |
 
-Agent, registrar and controller deploy together as one system from the single
-`aether` chart — system config (OTEL, SPIRE, mesh domain) is set once at the top
+Agent, proxy, mesh-dns, registrar and controller deploy together as one system
+from the single `aether` chart — system config (OTEL, SPIRE, mesh domain) is set once at the top
 level of its `values.yaml` and inherited by every component. The proxy data plane
 can override its own observability at runtime via the `MeshConfig` CR. See
 [`docs/proposals/015_mesh-config.md`](../docs/proposals/015_mesh-config.md).
@@ -42,7 +43,7 @@ substitutes at package time, so packaged charts are pinned to a concrete digest.
 
 | Field | Value | Notes |
 | --- | --- | --- |
-| Chart `version` | e.g. `0.65.0-{GIT_COMMIT}` (aether), `0.6.0-{GIT_COMMIT}` (crds) | SemVer pre-release; commit becomes the OCI tag (dash-separated — `+build` metadata would be rewritten to `_` by helm). Bump the chart's `version:` on any change to its templates/values (enforced in CI). |
+| Chart `version` | e.g. `0.8.0-{GIT_COMMIT}` (crds), `0.2.0-{GIT_COMMIT}` (prober) | SemVer pre-release; commit becomes the OCI tag (dash-separated — `+build` metadata would be rewritten to `_` by helm). The `aether` chart is the exception: it carries a plain version (e.g. `0.90.1`) with no `{GIT_COMMIT}` suffix. Bump the chart's `version:` on any change to its templates/values (enforced in CI). |
 | Chart `appVersion` | `{STABLE_GIT_VERSION}` | `git describe` value — matches the binaries' embedded `Version`. |
 | Image refs | `repo@sha256:…` | Pinned to the exact built digest (strongest form). |
 
@@ -83,9 +84,9 @@ helm maps it to the dash-separated tag):
 
 ```bash
 helm install aether-crds oci://ghcr.io/bpalermo/aether/charts/crds \
-  --version 0.6.0-<git-commit>
+  --version 0.8.0-<git-commit>
 helm install aether oci://ghcr.io/bpalermo/aether/charts/aether \
-  --version 0.65.0-<git-commit> -n aether-system --create-namespace
+  --version 0.90.1 -n aether-system --create-namespace
 ```
 
 ## Multiple instances & labels
@@ -115,6 +116,7 @@ path namespace:
 | crds chart | `ghcr.io/bpalermo/aether/charts/crds` |
 | aether chart | `ghcr.io/bpalermo/aether/charts/aether` |
 | agent image | `ghcr.io/bpalermo/aether/agent` |
+| mesh-dns image | `ghcr.io/bpalermo/aether/mesh-dns` |
 | registrar image | `ghcr.io/bpalermo/aether/registrar` |
 | controller image | `ghcr.io/bpalermo/aether/controller` |
 | cni-install image | `ghcr.io/bpalermo/aether/cni-install` |

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -2,14 +2,15 @@ apiVersion: v2
 name: aether
 description: |
   Aether service mesh — the whole system in one chart: the node agent (DaemonSet)
-  + per-node Envoy proxy, the in-cluster registrar, and the mesh-config controller
-  (MeshConfig validating webhook + CR→ConfigMap reconciler). System config (OTEL,
-  SPIRE, mesh domain) is set once at the top level. The MeshConfig CRD ships in the
-  separate `crds` chart, which must be installed first. See
-  docs/proposals/015_mesh-config.md.
+  + per-node Envoy proxy + the mesh-dns DaemonSet, the in-cluster registrar, the
+  controller (validating webhooks for MeshConfig, HTTPFilter, EdgeConfig,
+  EndpointPolicy and HTTPRoute, a pod-mutating webhook, and the MeshConfig→ConfigMap
+  reconciler), and the optional north-south edge gateway. System config (OTEL,
+  SPIRE, mesh domain) is set once at the top level. The CRDs ship in the separate
+  `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.90.0"
+version: "0.90.1"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/cni/internal/plugin/capture.go
+++ b/cni/internal/plugin/capture.go
@@ -58,13 +58,14 @@ func installCaptureRedirect(netnsPath string, excludePorts []uint16, excludeRang
 // so there is no collision). Both rules share the loopback exclusion so the
 // pod-local explicit fast-lane (127.x:meshPort) is never intercepted.
 //
-// NOTE: the UDP redirect only takes effect when --l4-routes is enabled (the
-// agent only generates the UDP capture listener when UDPRoute backends exist).
-// The nft rule itself is always installed when capture is on — the absence of a
-// bound UDP socket on ProxyCapturePort means redirected packets are silently
-// dropped until the agent creates the listener, which is correct behaviour
-// (UDPRoute without --l4-routes = no listener = datagrams discarded rather than
-// sent to an unexpected destination).
+// NOTE: the UDP redirect only takes effect once a UDPRoute exists (the agent
+// only generates the UDP capture listener when UDPRoute backends exist; L4
+// routing itself is unconditional since proposal 031). The nft rule is always
+// installed when capture is on — the absence of a bound UDP socket on
+// ProxyCapturePort means redirected packets are silently dropped until the
+// agent creates the listener, which is correct behaviour (no UDPRoute = no
+// listener = datagrams discarded rather than sent to an unexpected
+// destination).
 func programCaptureRedirect(excludePorts []uint16, excludeRanges []netip.Prefix, logger *zap.Logger) error {
 	meshPort := uint16(meshconst.ProxyOutboundPort)
 	capturePort := uint16(meshconst.ProxyCapturePort)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,8 +71,9 @@ access-log/tracing policy via the MeshConfig CR.
 | `agent.importConfig` | `false` | Cross-cluster config import (026): poll the registrar for peer-exported GAMMA projections and materialize them (merged with local; local wins). Pairs with `registrar.registryBackend=etcd`. |
 | `agent.eastWestWaypoint` | `false` | East/west waypoint (019): dial **cross-cluster** endpoints at their node's routable IP + the fixed tunnel port `18009` instead of the (unroutable) pod IP; this node's host-network proxy SNI-forwards inbound tunnel traffic to local pods. Intra-cluster stays direct pod-to-pod. Needs cross-cluster endpoint visibility (shared or replicated etcd) + a shared SPIRE trust domain. |
 | `agent.captureRedirectAllDefault` | `true` | Redirect-all as the DEFAULT for managed pods (022 Step 4); opt out per-pod with `capture.aether.io/redirect-all="false"`. `false` = per-pod opt-in via the same annotation set to `"true"`. (Transparent capture itself and the passthrough chain are unconditional since proposal 031.) |
-| `agent.meshDns` | `true` | Per-pod mesh DNS (018): resolve `<svc>.<meshDomain>` from generated mesh Services, forward the rest to `meshDnsUpstream`. |
-| `agent.meshDnsUpstream` | `[]` | Upstream resolver(s) for non-mesh queries. Empty = the agent's own resolv.conf (kube-dns). |
+| `agent.meshDns` | `true` | Per-pod mesh DNS (018). Gates BOTH halves: the agent's in-process resolver (which writes the record snapshot) and the separate `aether-mesh-dns` DaemonSet that serves pods from it. |
+| `agent.meshDnsUpstream` | `[]` | Upstream resolver(s) for non-mesh queries, passed to the **mesh-dns daemon** (`--mesh-dns-upstream`), not the agent. Empty = the daemon's own resolv.conf (kube-dns). |
+| `agent.meshDnsDaemon.image.*` / `.resources` | repo+digest placeholders | The slim `mesh-dns` image, pinned separately from the agent's (#583) — the DaemonSet ships only the `/mesh-dns` binary. Rendered when `agent.meshDns` is true. |
 | `agent.image.*` | repo+digest placeholders, `pullPolicy: Always` | Digest-pinned image; mirror by overriding `repository` alone. |
 | `agent.resources.{requests,limits}` | cpu `200m`, mem `64Mi` | |
 
@@ -93,6 +94,7 @@ access-log/tracing policy via the MeshConfig CR.
 | `proxy.hotRestart.parentShutdownTime` | `15s` | When the previous epoch is terminated (must exceed drainTime). |
 | `proxy.hotRestart.handoffDeadline` / `adminUnresponsiveDeadline` | `0` | Supervisor watchdogs (0 = built-in defaults). |
 | `proxy.hotRestart.shmHostPath` | `/run/aether/shm` | Shared-memory hostPath for cross-pod hot restart. |
+| `proxy.udsWorkloads.enabled` | `true` | UDS delivery (034). Gates the proxy's `/var/lib/kubelet/pods` hostPath mount, the agent's `--kubelet-pods-dir`, and the agent's read access to the `EndpointPolicy` CRD. Inert until a workload asks for it; turning it off later silently degrades annotated pods to TCP (nothing listens, so their endpoints stay unpromoted). |
 | `proxy.overload.enabled` | `true` | Envoy overload-manager graceful-degradation ladder. |
 | `proxy.overload.maxHeapSizeBytes` | `402653184` (384Mi) | Keep at ~75% of `resources.limits.memory`. |
 | `proxy.resources.{requests,limits}` | cpu `500m`, mem `512Mi` | |
@@ -189,6 +191,7 @@ controller's protovalidate webhook, not OpenAPI. All carry
 | `meshconfigs.config.aether.io` | `MeshConfig` (`mc`) | Per-namespace proxy observability overrides (access logs, tracing, per-pod stats). A namespace inherits the control-plane namespace's `MeshConfig` field-by-field unless it sets its own (proposal 015). |
 | `httpfilters.config.aether.io` | `HTTPFilter` (`htf`) | The proxy-extension escape hatch (proposal 025): attach a supported Envoy HTTP filter (ext_authz, RBAC, header-to-metadata) at a chosen scope. |
 | `edgeconfigs.config.aether.io` | `EdgeConfig` | Edge Envoy tuning (proposal 029): best-practices hardening defaults, HTTP/3 (QUIC, ALPN `h3`), timeouts/limits. Attached natively via Gateway API `parametersRef` on the `GatewayClass` (fleet default) or per-`Gateway` (override-wins merge). |
+| `endpointpolicies.config.aether.io` | `EndpointPolicy` | Service-scoped UDS delivery (proposal 034 Phase 1b): `spec.targetRef` (kind=Service, same namespace) + `spec.udsSocket` (`<volume>/<file>`) declares socket delivery for every pod of a service. The per-pod `endpoint.aether.io/uds-socket` annotation wins; one policy per Service (lexicographically smallest name wins). Read by the agent only when `proxy.udsWorkloads.enabled`. |
 
 **`HTTPFilter` scopes** (`spec.scope`, plus the `target_refs` attachment):
 
@@ -223,12 +226,14 @@ Node-agent-specific:
 | Flag | Default | Purpose |
 |---|---|---|
 | `--mounted-registry-dir` | `/host/var/lib/aether/registry` | Local pod-data dir for the CNI plugin. |
+| `--kubelet-pods-dir` | `/var/lib/kubelet/pods` | Kubelet's pod-volumes dir, mounted into the proxy at the identical host path, through which the proxy reaches a workload's Unix socket (034). Empty disables UDS delivery: pods annotated `endpoint.aether.io/uds-socket` fall back to TCP loopback. Gated by the chart's `proxy.udsWorkloads.enabled`. |
 | `--spire-admin-socket` | `/tmp/spire-agent/private/admin.sock` | SPIRE admin socket for proxy SVID delegation. |
 | `--gamma` | `true` | GAMMA east-west routing (018); default-on kill switch (031). CRD-detected. |
 | `--import-config` | `false` | Enable cross-cluster config import (026). |
 | `--control-cluster` | `""` | Trust imported config ONLY from this origin (026 EM3). Empty = federated. |
 | `--east-west-waypoint` | `false` | Per-node east/west waypoint for cross-cluster traffic (019); tunnel port is the fixed constant 18009. |
-| `--mesh-dns` | `false` | Per-pod mesh DNS (018). |
+| `--mesh-dns` | `false` | Per-pod mesh DNS (018): answer `<svc>.<ns>.<mesh-domain>` from the generated mesh Services. Upstream forwarding belongs to the `mesh-dns` daemon, not the agent. |
+| `--mesh-dns-snapshot-path` | `/host/var/lib/aether/registry/mesh-dns/records.json` | Host-persistent record table the in-process resolver writes and warm-loads at boot (and the `mesh-dns` daemon watches). Under the CNI registry hostPath so it survives a rolling restart; empty disables persistence. |
 | `--authz-sidecar` | `false` | Node-local ext_authz sidecar entry (027). |
 | `--authz-sidecar-timeout` | `200ms` | Per-check gRPC timeout. |
 | `--authz-sidecar-failure-mode-allow` | `false` | Fail-open (default: fail-closed). |
@@ -259,6 +264,18 @@ The Envoy hot-restart supervisor (proposal 001): `--envoy-path`
 (repeatable), `--handoff-deadline`/`--admin-unresponsive-deadline` (`0` = defaults),
 `--admin-address` (`127.0.0.1:9901`), `--readiness-check`, `--install-path`,
 `--otlp-endpoint`.
+
+### `mesh-dns` (standalone daemon — its own binary and image)
+
+The `aether-mesh-dns` DaemonSet (#578, #583). It answers `<svc>.<ns>.<mesh-domain>`
+from the snapshot file the agent writes and forwards everything else upstream, so
+agent rolls never gap pod DNS. It does **not** share the agent's flag set:
+`--snapshot-path` (`/host/var/lib/aether/registry/mesh-dns/records.json`),
+`--mesh-domain` (`aether.internal`), `--mesh-dns-upstream` (repeatable,
+`host[:port]`; empty = `/etc/resolv.conf`), `--ready-marker`
+(`/run/aether/mesh-dns.ready`), `--readiness-check`, `--otlp-endpoint`, `--debug`.
+It binds UDP+TCP on the host at port 18054, which the CNI DNATs each managed
+pod's `:53` to.
 
 ### `registrar`
 
@@ -317,6 +334,7 @@ Defined in [`common/constants/`](../common/constants). Prefixes:
 | `endpoint.aether.io/health-path` | `/` | Path the agent active-health-checks. |
 | `endpoint.aether.io/health-check-mode` | `eds` | `eds` (agent vets + publishes over EDS) or `active` (each client proxy probes). |
 | `endpoint.aether.io/protocol` | `http` | Wire protocol served: `http` or `tcp`. |
+| `endpoint.aether.io/uds-socket` | — | Deliver inbound to a Unix socket (`<volume>/<file>`, `emptyDir` only, no `subPath`) instead of the TCP port (034). Wins over an `EndpointPolicy` on the service; needs `proxy.udsWorkloads.enabled`. |
 | `metadata.endpoint.aether.io/<key>` | — | Free-form metadata → selectable routing subset (e.g. `…/version=v2`). |
 
 ### Config annotations (`config.aether.io/*`)

--- a/docs/conformance/gateway-api-features.md
+++ b/docs/conformance/gateway-api-features.md
@@ -42,10 +42,10 @@ e2e-validated on talos (aether 0.41.0).
 | Feature | Status | Notes |
 |---|---|---|
 | GAMMA Mesh profile (parentRef=Service) | Supported | producer routes; consumer (per-namespace) overrides Planned |
-| GAMMA rules on the transparent-capture path | Supported | applies to clients dialing `<svc>.<meshDomain>` (the default path) |
-| East-west L4 on the transparent-capture path | Supported | TCPRoute/TLSRoute/UDPRoute (parentRef=Service) project onto the capture floor; gated behind `--l4-routes` |
-| `ReferenceGrant` (cross-namespace backendRefs) | Supported (admission + status; namespace-blind resolution pending 020 Part 1) | A cross-namespace backendRef (namespace set and != the route's) is admitted only when a `ReferenceGrant` in the backend's namespace has a `from` matching `{group: gateway.networking.k8s.io, kind: <route kind>, namespace: <route ns>}` and a `to` matching `{group: "", kind: Service}` (optionally `name`). Without a grant the route's `ResolvedRefs` is `False`/`RefNotPermitted` and the backend is DROPPED from the data plane (rest of the route still applies). Enforced on edge HTTPRoute/TCPRoute/TLSRoute and east-west GAMMA HTTPRoute/GRPCRoute + L4 TCPRoute/TLSRoute/UDPRoute. CAVEAT: aether's data-plane cluster name is still namespace-free (`<svc>.<meshDomain>`), so a *granted* cross-ns ref resolves by name exactly as today; proper per-namespace resolution lands with proposal 020 Part 1 |
-| MCS `ServiceExport`/`ServiceImport`, `clusterset.local` | Planned | registry-backed (proposal 006), DNS strictly local |
+| GAMMA rules on the transparent-capture path | Supported | applies to clients dialing `<svc>.<ns>.<meshDomain>` (the default path) |
+| East-west L4 on the transparent-capture path | Supported | TCPRoute/TLSRoute/UDPRoute (parentRef=Service) project onto the capture floor; unconditional since proposal 031 (the `--l4-routes` flag was retired), gated only on the route CRDs being installed |
+| `ReferenceGrant` (cross-namespace backendRefs) | Supported (admission + status + per-namespace resolution) | A cross-namespace backendRef (namespace set and != the route's) is admitted only when a `ReferenceGrant` in the backend's namespace has a `from` matching `{group: gateway.networking.k8s.io, kind: <route kind>, namespace: <route ns>}` and a `to` matching `{group: "", kind: Service}` (optionally `name`). Without a grant the route's `ResolvedRefs` is `False`/`RefNotPermitted` and the backend is DROPPED from the data plane (rest of the route still applies). Enforced on edge HTTPRoute/TCPRoute/TLSRoute and east-west GAMMA HTTPRoute/GRPCRoute + L4 TCPRoute/TLSRoute/UDPRoute. The data-plane cluster name is namespace-qualified (`<svc>.<ns>.<meshDomain>`) since the proposal 020 cutover, so a *granted* cross-ns ref resolves to the backend's own namespace |
+| MCS `ServiceExport`/`ServiceImport`, `clusterset.local` | Supported (phase 1) | registry-backed (proposals 018 + 006), DNS strictly local. `registrar.enableMCS=true` exports local `ServiceExport`s to the registry and materializes peer-exported services as `ServiceImport`s + clusterset VIPs. Requires the etcd backend + the MCS-API CRDs |
 
 ## Transport / security
 
@@ -63,13 +63,14 @@ Gateway of its GatewayClass in ANY namespace and publishes the Gateway/Route sta
 conditions and per-listener `attachedRoutes`, which is what the upstream conformance
 suite's `NamespacesMustBeReady` gate requires before any test runs.
 
-Every class-`aether` Gateway also gets `status.addresses` (one `IPAddress` entry =
-the shared edge LoadBalancer IP), so the suite's "wait for at least one IP address in
-status" setup step passes and the GATEWAY-HTTP *traffic* tests run (proposal 021 Phase
-1). The address is resolved at runtime from the edge's own LoadBalancer Service status
-(robust to MetalLB assignment): until the LB IP is assigned the address is omitted
-rather than written empty. All class-`aether` Gateways currently share the one edge
-address; distinct per-Gateway addresses are proposal 021 Phase 2.
+Every class-`aether` Gateway also gets `status.addresses` (one `IPAddress` entry), so
+the suite's "wait for at least one IP address in status" setup step passes and the
+GATEWAY-HTTP *traffic* tests run. Each Gateway gets its **own** LoadBalancer Service
+and therefore its own distinct address (proposal 021 Phase 2, unconditional since 031
+round 2); the shared-address fallback of Phase 1 remains only when the edge Service
+name is unset or port allocation fails. The address is resolved at runtime from the
+Service's status (robust to MetalLB assignment): until the LB IP is assigned the
+address is omitted rather than written empty.
 
 The GatewayClass also publishes a machine-readable `status.supportedFeatures` list so
 the suite skips (rather than fails) the features aether does not implement. The
@@ -85,8 +86,8 @@ that both are implemented on edge + GAMMA HTTPRoute; host redirect carries no se
 flag (host+status is core), and only the 301/302 redirect status codes are implemented
 (the `303`/`307`/`308` status-code features are not advertised). Request mirroring is
 deliberately omitted (not implemented). `ReferenceGrant` is advertised now that
-cross-namespace backendRef admission + status enforcement is implemented (resolution
-stays namespace-blind until proposal 020 Part 1).
+cross-namespace backendRef admission, status enforcement, and namespace-qualified
+resolution (proposal 020) are all implemented.
 
 `GRPCRoute` is **not** advertised on the GatewayClass: aether serves `GRPCRoute` only
 east-west via GAMMA (`parentRef: Service`), which is a mesh feature with no
@@ -96,12 +97,12 @@ gRPC traffic through a Gateway the edge cannot serve (the tests run and fail/tim
 so it is omitted here while GAMMA continues to implement `GRPCRoute` for the mesh
 profile (see "Route types" above).
 
-### Data-plane / addressing gap
+### Data-plane / addressing
 
-The edge data plane is still a single Deployment on a single LoadBalancer address.
-Every class-`aether` Gateway now publishes that shared address in `status.addresses`
-(proposal 021 Phase 1), which unblocks the address-dependent GATEWAY-HTTP traffic
-tests; routes are served through the one shared address (demuxed by listener
-hostname/port). Tests that assert each Gateway has its OWN *distinct* address are not
-yet satisfied — distinct per-Gateway addressing (per-Gateway LoadBalancer Service +
-internal-port demux) is proposal 021 Phase 2.
+Per-Gateway addressing (proposal 021 Phase 2) is implemented and unconditional: each
+class-`aether` Gateway gets its own LoadBalancer Service and its own distinct address,
+published in `status.addresses`, with internal-port demux behind the one edge
+Deployment. This satisfies both the address-dependent GATEWAY-HTTP traffic tests and
+the tests asserting each Gateway has its OWN address. The Phase 1 shared-address
+behavior survives only as the fallback for when the edge Service name is unset or a
+per-Gateway port cannot be allocated.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -100,12 +100,12 @@ can be upgraded independently), then the system chart.
 # Pick the published version (chart version == git commit of the release).
 VERSION=0.x.0-<commit>
 
-# 1) CRDs (MeshConfig, HTTPFilter, EdgeConfig) — install/upgrade first.
+# 1) CRDs (MeshConfig, HTTPFilter, EdgeConfig, EndpointPolicy) — install/upgrade first.
 helm upgrade --install aether-crds \
   oci://ghcr.io/bpalermo/aether/charts/crds \
   --version "$VERSION"
 
-# 2) The system: agent + proxy + registrar + controller.
+# 2) The system: agent + proxy + mesh-dns + registrar + controller.
 helm upgrade --install aether \
   oci://ghcr.io/bpalermo/aether/charts/aether \
   --version "$VERSION" \
@@ -115,7 +115,8 @@ helm upgrade --install aether \
 ```
 
 Resource names derive from the **release** name — installing as `aether` yields
-`aether-agent`, `aether-proxy`, `aether-registrar`, `aether-controller`.
+`aether-agent`, `aether-proxy`, `aether-mesh-dns`, `aether-registrar`,
+`aether-controller`.
 
 > **Upgrade tip:** always pass the **full** values on every `helm upgrade` of the
 > `aether` chart — do **not** use `--reuse-values` (it keeps the stale
@@ -124,7 +125,7 @@ Resource names derive from the **release** name — installing as `aether` yield
 Verify:
 
 ```bash
-kubectl -n aether-system get pods         # agent + proxy per node, registrar ×2, controller
+kubectl -n aether-system get pods         # agent + proxy + mesh-dns per node, registrar ×2, controller
 kubectl -n aether-system get meshconfig   # the seeded "default" MeshConfig CR
 ```
 
@@ -144,12 +145,11 @@ Set once at the top of the `aether` chart's values; every component inherits it.
 | `clusterName` | `talos-main` | Cluster name in registry keys (registrars are per-cluster; names need not be unique across clusters). |
 | `meshDomain` | `aether.internal` | The authority suffix services are addressed under (`<svc>.<ns>.<meshDomain>`). Also defaults the SPIRE trust domain. |
 | `spire.enabled` | `true` | Mesh-wide mTLS switch. |
-| `spire.trustDomain` | `""` (→ `ROOTCA` sentinel) | SPIFFE trust domain authorized for the registrar's mTLS peers. |
-| `spire.workloadSocketPath` | `/run/secrets/workload-spiffe-uds/socket` | Workload API socket. |
+| `spire.workloadSocketPath` | `/run/secrets/workload-spiffe-uds/socket` | Workload API socket. Every component resolves its own trust domain from its SVID over this socket — there is no `trustDomain` value to configure (retired: it could silently disagree with what SPIRE issues). |
 | `spire.adminSocket.*` | see values | SPIRE agent admin/Delegated-Identity socket the agent uses to mint proxy SVIDs. |
 | `registrar.registryBackend` | `kubernetes` | `kubernetes` \| `dynamodb` \| `etcd`. |
 | `registrar.etcd.endpoints` | `[]` | etcd endpoints when backend is `etcd`. |
-| `registrar.aws.region` / `agent.awsCredentials` | — | DynamoDB backend config. |
+| `registrar.aws.region` / `registrar.aws.roleArn` | `us-east-1` / `""` | DynamoDB backend config (IRSA on the registrar; the agent carries no AWS credentials). |
 | `otel.enabled` / `otel.endpoint` | `false` / `""` | Turn on OTel and point at an OTLP gRPC collector (`host:port`). |
 | `proxy.enabled` | `true` | Deploy the per-node Envoy. Set false to run only the agent. |
 | `edge.enabled` | `false` | Deploy the north-south ingress gateway (see §11). |
@@ -269,6 +269,7 @@ Your service is now addressable mesh-wide as `my-svc.<namespace>.aether.internal
 | `endpoint.aether.io/health-path` | `/` | Path the node-local agent health-checks (delegated liveness). |
 | `endpoint.aether.io/health-check-mode` | `eds` | `eds` = agent vets the endpoint and publishes health over EDS (clients get pre-warmed endpoints); `active` = every client proxy probes the endpoint itself. |
 | `metadata.endpoint.aether.io/<key>` | — | Free-form endpoint metadata, usable as routing subsets (§9). |
+| `endpoint.aether.io/uds-socket` | — | Serve on a Unix socket (`<volume>/<file>`) instead of a TCP port — see [workload-requirements.md](./workload-requirements.md#serving-on-a-unix-domain-socket). |
 | `config.aether.io/upstreams` | — | Comma-separated services this pod **calls** (§7). |
 
 ---
@@ -440,14 +441,16 @@ What's supported, all applied **transparently on the capture path** as well as
 the explicit listener (so callers need no changes):
 
 - **`HTTPRoute`** — weighted canary, header/path matching + mutation,
-  redirects, timeouts, mirroring; Mesh conformance profile (MESH-HTTP Core)
-  green.
+  redirects, URL rewrites, timeouts; Mesh conformance profile (MESH-HTTP Core)
+  green. (Request mirroring is *not* implemented.)
 - **`GRPCRoute`** — method-based routing (`<svc>/<method>` matched as a path).
 - **`TCPRoute`** — weighted L4 splits across backends; an explicit `weight: 0`
   drains a backend. (TCPRoute/UDPRoute need the Gateway API *experimental*
   channel CRDs.)
 - **`TLSRoute`** — SNI-based passthrough routing.
-- (`UDPRoute` is accepted but control-plane-only for now.)
+- **`UDPRoute`** — a `udp_proxy` floor to the backend's app UDP port. Note that
+  UDP rides the mesh **in plaintext**: mTLS is a TCP/TLS construct and DTLS is
+  not implemented.
 - **Cross-namespace backends** need a standard `ReferenceGrant`.
 - The parent must be a **registry-backed mesh Service** (one with live
   endpoints) — a selectorless "anchor" Service won't survive reconciliation.
@@ -505,16 +508,16 @@ spec:
 ```
 
 - The edge routes **only** by explicit external hostname on the attached routes.
-  The internal mesh FQDN (`<svc>.<meshDomain>`) is deliberately **not** routable
-  from the edge.
+  The internal mesh FQDN (`<svc>.<ns>.<meshDomain>`) is deliberately **not**
+  routable from the edge.
 - **TLS:** set `edge.tls.enabled=true` and reference a `kubernetes.io/tls` Secret
   per Gateway listener (`spec.listeners[].tls.certificateRefs`, or the chart's
   `edge.gateway.tlsSecretName`). The edge agent serves the cert to Envoy over SDS
   (SNI-selected, hot rotation, no pod roll) and 301-redirects HTTP→HTTPS. Aether
   does **not** issue certs — bring your own (cert-manager, `kubectl`, …).
-- **Addressing:** per-Gateway addressing is on by default
-  (`edge.perGatewayAddressing=true`, proposal 021) — each `Gateway` gets its own
-  LoadBalancer Service and external IP; pin one with `edge.gateway.address`.
+- **Addressing:** per-Gateway addressing is unconditional (proposal 021 Phase 2;
+  the flag and chart value were retired in 031 round 2) — each `Gateway` gets its
+  own LoadBalancer Service and external IP; pin one with `edge.gateway.address`.
 - **GeoIP:** set `edge.geoip.enabled=true` with a MaxMind mmdb Secret to emit
   `x-geo-*` request headers (proposal 028).
 - The edge gets its own SVID straight from SPIRE; with `spire.enabled` the chart

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -69,7 +69,7 @@ kubectl get cm prometheus-server -n prometheus \
 
 Rules appear under **Alerts** in the Prometheus UI once loaded.
 
-> **Note — no notification delivery.** There is currently no Alertmanager deployed, so
-> firing alerts are visible in the Prometheus UI but are **not routed anywhere**.
-> Deploying Alertmanager (or moving these to Grafana-managed alert rules with a contact
-> point) is required before they page anyone.
+> **Notification delivery.** Alertmanager is deployed on `talos-main` and routes firing
+> alerts to Slack (`#alerts`) plus auto-closing GitHub issues on `bpalermo/aether`; the
+> routing config lives with the Prometheus HelmRelease in the `bpalermo/k8s-talos-main`
+> GitOps repo and is documented there, not here.

--- a/docs/registry-backend-evolution.md
+++ b/docs/registry-backend-evolution.md
@@ -214,9 +214,12 @@ Region B: agents → registrar(B) → etcd(B) ──own-prefix mirror──▶ e
 starting point but lacks lease management and origin-filtering, so the
 replicator is a thin purpose-built component (or a registrar mode). This is
 specified in **[proposal 006 — multi-region etcd federation](proposals/006_multi-region-etcd-federation.md)**:
-the region-scoped key schema (Phase 1, buildable now with no behavior change),
-the replicator spec (lease/tombstone/resume/compaction-resync, HA), and a
-region-failover e2e — not yet built.
+the region-scoped key schema (Phase 1), the replicator spec
+(lease/tombstone/resume/compaction-resync, HA), and a region-failover e2e. All of
+it has since **shipped**: the replicator lives in
+`registrar/internal/replicator/` and is wired via the registrar's `--peer-etcd`
+(chart `registrar.peerEtcd`), with the failover path covered nightly by
+`e2e/multicluster_replicator.sh`.
 
 **Net:** etcd is the substrate single- *and* multi-region. DynamoDB global
 tables are an alternative, not a requirement.
@@ -253,8 +256,7 @@ cross-replica propagation eliminated even those.
   *not* required by the multi-region case — we do not adopt a managed store
   solely for global tables. Agents always go through the registrar, never the
   store directly.
-- **Open items:** proposal 006 (multi-region etcd federation — key-schema
-  change + replicator); and `peer-watch` (registrar↔registrar) as the
-  backend-agnostic intra-cluster skew close — lower priority for etcd (Watch
-  already gets it to zero), relevant only if DynamoDB is the production
-  substrate.
+- **Open items:** `peer-watch` (registrar↔registrar) as the backend-agnostic
+  intra-cluster skew close — lower priority for etcd (Watch already gets it to
+  zero), relevant only if DynamoDB is the production substrate. (Proposal 006 —
+  multi-region etcd federation, key schema + replicator — is complete.)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -14,8 +14,8 @@ chart values and CLI/annotation reference, see
 
 | Tool | Why | Notes |
 |---|---|---|
-| **Bazel** via [Bazelisk](https://github.com/bazelbuild/bazelisk) | build system | The pinned version (`9.0.1`) is read from `.bazelversion`; just run `bazel …` and Bazelisk fetches it. |
-| **Go** 1.26.2 | language toolchain | Managed by `rules_go`; you rarely invoke `go` directly (use `bazel run @rules_go//go …`). |
+| **Bazel** via [Bazelisk](https://github.com/bazelbuild/bazelisk) | build system | The pinned version (`9.2.0`) is read from `.bazelversion`; just run `bazel …` and Bazelisk fetches it. |
+| **Go** 1.26.5 | language toolchain | Managed by `rules_go`; you rarely invoke `go` directly (use `bazel run @rules_go//go …`). |
 | **Docker** (or **Colima** on macOS) | container images + integration tests | Integration tests spin up real etcd / DynamoDB Local via testcontainers-go. |
 | **kubectl**, **Helm 3** (OCI) | deploy / e2e | |
 | **kind** | local multi-cluster e2e | Only needed for `e2e/multicluster_config.sh`. |
@@ -51,7 +51,7 @@ There is no `make build-controller`; build it directly with
 `bazel build //controller/cmd/controller/...`.
 
 > **The `aether-proxy` (custom Envoy) is NOT built here.** It lives in a separate
-> sibling Bazel workspace under `proxy/` (its own `.bazelversion` = 7.7.1) and
+> sibling Bazel workspace under `proxy/` (its own `.bazelversion` = 8.7.0) and
 > compiles Envoy from source (multi-hour; use a warm cache / CI). Build/load it
 > with `make load-proxy-image` only when you need a fresh proxy image. See
 > [`proxy/README.md`](../proxy/README.md) and proposal 010.
@@ -193,8 +193,8 @@ under a **shared trust domain** (shared upstream CA in `e2e/certs/`):
 Aether ships **two** charts, and **install order matters**:
 
 ```
-charts/crds     — the CRDs: MeshConfig + HTTPFilter + EdgeConfig   ← install FIRST
-charts/aether    — the whole system (agent DaemonSet + proxy + registrar + controller)
+charts/crds     — the CRDs: MeshConfig + HTTPFilter + EdgeConfig + EndpointPolicy   ← install FIRST
+charts/aether    — the whole system (agent DaemonSet + proxy + mesh-dns + registrar + controller)
 ```
 
 Install the CRDs before the system chart. **The agent crashes if it starts before
@@ -223,8 +223,11 @@ bazel run //charts/aether:aether.install
 > do **not** use `--reuse-values` (it keeps the stale digest-pinned image). Bump
 > the chart's `version:` on any change to its templates/values (CI enforces this).
 
-There is also a standalone **`prober`** chart (`charts/prober`) — an external
-mesh-availability prober (proposal 013), installed independently.
+There are also two standalone charts, installed independently: **`prober`**
+(`charts/prober`) — the external mesh-availability prober (proposal 013) — and
+**`udsecho`** (`charts/udsecho`) — the UDS validation workloads (proposal 034)
+that exercise both socket-delivery paths (annotation and `EndpointPolicy`) under
+continuous mesh traffic.
 
 See [`charts/README.md`](../charts/README.md) for chart layout, image mirroring,
 and the `--stamp` versioning scheme, and [`getting-started.md`](./getting-started.md)

--- a/docs/workload-requirements.md
+++ b/docs/workload-requirements.md
@@ -42,7 +42,7 @@ spec:
 | Annotation | Default | Meaning |
 |---|---|---|
 | `endpoint.aether.io/port` | `8080` | Application port the mesh routes to |
-| `endpoint.aether.io/weight` | `1` | Load-balancing weight |
+| `endpoint.aether.io/weight` | `1024` | Load-balancing weight |
 | `endpoint.aether.io/health-path` | `/` | Path the node-local agent health-checks (delegated liveness) |
 | `endpoint.aether.io/health-check-mode` | `eds` | `eds`: node-local agent vets the endpoint once and publishes health over EDS (endpoints enter clients pre-warmed). `active`: every client proxy probes the endpoint itself |
 | `metadata.endpoint.aether.io/<key>` | — | Free-form endpoint metadata (subset keys) |

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -6,7 +6,7 @@ A **custom Envoy** build for the Aether data plane, structured after
 > This is a **separate Bazel workspace** from the root `aether` repo. The root
 > `//.bazelignore` lists `proxy`, so `bazel build //...` / Gazelle in the repo
 > root never descend here. It pins its **own** Bazel version
-> (`.bazelversion = 7.7.1`, required by Envoy 1.38's WORKSPACE build) and uses
+> (`.bazelversion = 8.7.0`, required by Envoy 1.39's WORKSPACE build) and uses
 > Envoy's pre-bzlmod dependency macro chain. The two workspaces share only the
 > git repo. See [`docs/proposals/010`](../docs/proposals/010_custom-proxy-workspace.md).
 
@@ -46,9 +46,9 @@ Makefile targets do) to bake the production binary.
 | Path | Purpose |
 |---|---|
 | `WORKSPACE` | `@envoy` + Envoy's macro chain, rules_oci |
-| `.bazelversion` | `7.7.1` (independent of the root repo) |
+| `.bazelversion` | `8.7.0` (independent of the root repo) |
 | `.bazelrc` → `envoy.bazelrc` | build config; selects Envoy's hermetic clang on Linux |
-| `bazel/envoy/repository.bzl` | pinned Envoy **source** (`ENVOY_SHA` = v1.38.0) |
+| `bazel/envoy/repository.bzl` | pinned Envoy **source** (`ENVOY_SHA` = v1.39.0) |
 | `bazel/extension_config/` | the compiled-in Envoy extension set |
 | `bazel/oci/images.bzl` | `distroless/cc` base pull |
 | `BUILD.bazel` | custom `envoy_cc_binary` + `oci_image`/`oci_push`/`oci_load` |
@@ -72,6 +72,6 @@ tree, so there is no separate SDK version to keep in sync.
 ## Status
 
 **Custom Envoy + `aether_stats` C++ extension building on CI** (proposals 010 /
-012). The Envoy source compile requires a Bazel 7.7.1 build host with adequate
+012). The Envoy source compile requires a Bazel 8.7.0 build host with adequate
 RAM and runs on BuildBuddy RBE (amd64) / native arm64 runners; the
 `aether_stats` filter and its `envoy_cc_test` build and pass there.

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -1,7 +1,7 @@
 # Gateway API conformance runner
 
 Committed, reproducible driver for the upstream Kubernetes **Gateway API conformance
-suite** (`sigs.k8s.io/gateway-api/conformance` @ **v1.5.1**) against a live aether
+suite** (`sigs.k8s.io/gateway-api/conformance` @ **v1.6.1**) against a live aether
 cluster. This replaces the previously uncommitted one-off that lived in a gateway-api
 checkout (see `docs/conformance/baseline-*.md`). Design + feasibility analysis:
 `docs/proposals/024_conformance-ci.md`.
@@ -10,8 +10,8 @@ checkout (see `docs/conformance/baseline-*.md`). Design + feasibility analysis:
 
 | Test | Profile | Status | Run in CI? |
 |---|---|---|---|
-| `TestAetherGatewayHTTP` | GATEWAY-HTTP (north-south edge) | Fully conformant (43/43, talos rev21) | **Yes — gates** |
-| `TestAetherMeshHTTP` | MESH-HTTP (east-west GAMMA) | **Not conformant** (blocked on proposal 022) | No (reproducible only) |
+| `TestAetherGatewayHTTP` | GATEWAY-HTTP (north-south edge) | Conformant — see the latest `docs/conformance/baseline-*.md` for the run of record | **Yes — gates** |
+| `TestAetherMeshHTTP` | MESH-HTTP (east-west GAMMA) | Conformant — see the latest `docs/conformance/baseline-*.md` | **Yes — gates** |
 
 Both tests **skip** unless `AETHER_CONFORMANCE=1`, because they need a live cluster
 reachable via the ambient kubeconfig.
@@ -23,18 +23,18 @@ aether module** (Gazelle skips it; `go test ./...` / `bazel test //...` ignore i
 gateway-api **conformance suite is a separate Go module** whose `go.mod` has
 `replace sigs.k8s.io/gateway-api => ../` — it is buildable **only from inside a
 gateway-api source checkout** and cannot be consumed as an ordinary dependency
-(`go get sigs.k8s.io/gateway-api/conformance@v1.5.1` fails to resolve the `apis/*`
+(`go get sigs.k8s.io/gateway-api/conformance@v1.6.1` fails to resolve the `apis/*`
 imports). That is why the prior runner lived in a `/tmp` gateway-api checkout, and why
 this committed copy is **copied into a checked-out gateway-api tree at run time**.
 
 ## Run it
 
 Against any aether cluster with the **edge** enabled, the **Gateway API CRDs**
-(standard channel, v1.5.1) installed, and GatewayClass `aether` present:
+(standard channel, v1.6.1) installed, and GatewayClass `aether` present:
 
 ```bash
 # 1. Check out the suite at the pinned version and drop the runner + overlay in.
-git clone --depth 1 --branch v1.5.1 \
+git clone --depth 1 --branch v1.6.1 \
   https://github.com/kubernetes-sigs/gateway-api /tmp/gateway-api
 cp test/conformance/conformance_test.go /tmp/gateway-api/conformance/aether_conformance_test.go
 cp test/conformance/mesh/manifests.yaml /tmp/gateway-api/conformance/mesh/manifests.yaml
@@ -54,8 +54,10 @@ AETHER_CONFORMANCE=1 AETHER_CONFORMANCE_MESH=1 KUBECONFIG=/path/to/kubeconfig \
 Useful env vars: `AETHER_NOCLEANUP=1` (leave base resources for debugging),
 `AETHER_CONFORMANCE_REPORT=/path/report.yaml` (override the report output path).
 
-In CI this is driven by `.github/workflows/conformance.yaml` (kind, no SPIRE,
-GATEWAY-HTTP only), which performs the checkout + copy automatically.
+In CI this is driven by `.github/workflows/e2e.yaml` (kind, no SPIRE), which performs
+the checkout + copy automatically. It has a job per profile — `gateway-http` and
+`mesh-http` — both run nightly and selectable via the workflow's `only` input. (The
+former standalone `conformance.yaml` was consolidated into `e2e.yaml`.)
 
 ## `mesh/manifests.yaml` — the aether mesh overlay
 

--- a/test/e2e/edge/README.md
+++ b/test/e2e/edge/README.md
@@ -1,7 +1,7 @@
 # Edge proxy e2e (talos-main)
 
 Validates the north-south edge gateway (proposal 003): external traffic →
-edge Service → edge Envoy → destination pod's mesh inbound (`pod_ip:15008`,
+edge Service → edge Envoy → destination pod's mesh inbound (`pod_ip:18008`,
 mTLS), with **no node proxy / DaemonSet in the path**.
 
 This is a manual runbook against a live cluster (talos-main); it is not a CI
@@ -23,7 +23,8 @@ edge:
   # Downstream TLS is optional; omit for a plain-HTTP first pass.
   # tls:
   #   enabled: true
-  #   secretName: edge-cert       # a kubernetes.io/tls Secret in the edge namespace
+  # gateway:
+  #   tlsSecretName: edge-cert    # a kubernetes.io/tls Secret in the edge namespace
 ```
 
 The edge Deployment, Service, bootstrap ConfigMap, RBAC and ClusterSPIFFEID
@@ -43,13 +44,13 @@ kubectl get gateways,httproutes -n aether-ingress
 
 ```bash
 # External entrypoint (LoadBalancer IP or NodePort).
-EDGE=$(kubectl get svc -n aether-edge aether-edge -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+EDGE=$(kubectl get svc -n aether-ingress aether-edge -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
 # Host-routed (matches HTTPRoute.spec.hostnames):
 curl -sS -H 'Host: api.example.com' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'   # 200
 
 # The internal mesh FQDN is NOT routable from the edge -> 404:
-curl -sS -H 'Host: svc-1.aether.internal' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'  # 404
+curl -sS -H 'Host: svc-1.aether-test.aether.internal' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'  # 404
 
 # Unmatched authority -> 404 (the edge serves only its exposed set):
 curl -sS -H 'Host: nope.example.com' "http://${EDGE}/" -o /dev/null -w '%{http_code}\n'   # 404
@@ -65,8 +66,8 @@ With `edge.tls.enabled`, use `https://` and the cert's SNI.
   `curl ... | jq '.headers["x-forwarded-client-cert"]'`.
 - **No node proxy in the path.** Schedule the edge on a node and confirm there is
   no agent/proxy DaemonSet pod required for the request to succeed (the edge dials
-  `pod_ip:15008` directly).
-- **Hitless rollout.** `kubectl rollout restart deploy/aether-edge -n aether-edge`
+  `pod_ip:18008` directly).
+- **Hitless rollout.** `kubectl rollout restart deploy/aether-edge -n aether-ingress`
   under a load generator → no failed requests (Service + `/aether/readyz` readiness
   gate).
 - **Live route changes.** `kubectl apply`/`delete` an HTTPRoute → the route


### PR DESCRIPTION
## Summary

A verify-before-report audit of every living doc (CLAUDE.md, READMEs, docs/ minus proposals/baselines, chart comments) against the current tree, then the fixes. ~50 verified discrepancies across 16 files; every correction cites the code that contradicts the old claim.

Highlights by class:
- **Three-migrations-stale versions**: Bazel 9.0.1/9.0.2 → 9.2.0, Go 1.26.2 → 1.26.5, proxy workspace 7.7.1 → 8.7.0 and Envoy 1.38 → 1.39 (proxy/README had all of them)
- **Retired knobs still documented**: `--l4-routes` (031), `spire.trustDomain`, `edge.perGatewayAddressing`, `agent.awsCredentials` — each pinned retired by config tests or values.yaml
- **Feature status wrong in both directions**: MCS was "Planned" but is shipped (`registrar/internal/mcs/`); the namespace-blind ReferenceGrant caveat outlived the 020 cutover; MESH-HTTP was "not conformant" but is CI-hard-gated; and getting-started claimed request **mirroring** support that `status_test.go:555` proves is not advertised (the feature matrix's "Planned" was the correct side)
- **030 stragglers**: `pod_ip:15008` and the pre-rename `aether-edge` namespace in the edge e2e doc
- **Wrong default**: `endpoint.aether.io/weight` documented as 1; the constant is 1024
- **Missing coverage**: everything that shipped recently — mesh-dns (binary, daemon flags, chart value, image), EndpointPolicy (CRD row, webhook lists), udsecho chart, `--kubelet-pods-dir`, the uds-socket annotation
- **charts/aether Chart.yaml** description rewritten (components + all five webhooks) → **0.90.1** per the bump rule; `bazel test //charts/...` 8/8
- One code comment (cni capture.go) that narrated the retired flag

Deliberately untouched: `docs/proposals/**` and `baseline-*.md` (historical records, same stale strings by design).

## Testing

`bazel run //:format` clean; `bazel test //charts/...` 8/8 (chart bump re-ran aether lint/template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR