### PR TITLE
chore: stop Dependabot PRs against the generated website pip lock

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# The website pip lock (website/requirements_lock.txt) is GENERATED wholesale
+# from website/requirements.in via `uv pip compile --universal --generate-hashes`
+# (command recorded in that file). Piecemeal pin edits break hash/constraint
+# consistency — Dependabot's first attempt (#623) bumped a transitive pin past
+# mkdocs-material's own `~=10.2` constraint, producing an uninstallable lock.
+# Dependency bumps happen by editing requirements.in and regenerating.
+#
+# Dependabot PRs also run without repo secrets, so the BuildBuddy-backed CI can
+# never pass on them: every such PR fails the required gate on UNAUTHENTICATED.
+#
+# Security visibility is unaffected: alerts still appear under Security ->
+# Dependabot alerts; they just don't open doomed PRs.
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /website
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
## Summary

Dependabot opened #623 against `website/requirements_lock.txt` — bumping a transitive pin (`pymdown-extensions` → 11.0) past mkdocs-material 9.5.50's own `~=10.2` constraint, i.e. an uninstallable lock — and its CI failed structurally anyway: Dependabot PRs run without repo secrets, so the BuildBuddy remote-cache auth fails (`UNAUTHENTICATED: missing API Key`) on every bazel-touching Dependabot PR, forever.

This config (the repo had none) zeroes pip version-update PRs for `/website` and ignores all pip dependencies. The lock is generated wholesale from `requirements.in` (`uv pip compile --universal --generate-hashes`, command recorded in the file); bumps happen by regenerating. Security **alerts** remain visible under Security → Dependabot alerts — they just stop opening doomed PRs.

No other ecosystems are affected (none were configured before; version updates only run for configured ecosystems).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR