### PR TITLE
feat(website): docs rendering + the proposals series (Phases 2+3)

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -11,9 +11,16 @@ on:
   push:
     branches:
       - main
+    # Every repository document the site renders, since the site holds no copy
+    # of any of them: a docs or proposal edit *is* a site change. Keep this in
+    # step with //:website_docs and website/hooks.py.
     paths:
       - "website/**"
       - "README.md"
+      - "AGENTS.md"
+      - "docs/**"
+      - "charts/README.md"
+      - "proxy/README.md"
       - ".github/workflows/pages.yaml"
   workflow_dispatch: {}
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,6 +7,29 @@ exports_files([
     "README.md",
 ])
 
+# Every repository document aethermesh.dev renders. website/hooks.py reads these
+# at build time and stages them as generated pages; the site holds no copy of any
+# of them, so this filegroup is what makes the staged pages an actual dependency
+# of //website:site and //website:site_test rather than an ambient read.
+#
+# proxy/README.md is absent on purpose: //.bazelignore hides `proxy` (a sibling
+# Bazel workspace pinned to its own Bazel version), and a file under an ignored
+# directory cannot be an action input at all — a label to it resolves, but the
+# sandbox never stages it. //website:staged/proxy-README.md is a symlink that
+# reaches it; see the comment there.
+filegroup(
+    name = "website_docs",
+    srcs = [
+        "AGENTS.md",
+        "README.md",
+        "charts/README.md",
+    ] + glob(
+        ["docs/**/*.md"],
+        allow_empty = False,
+    ),
+    visibility = ["//website:__pkg__"],
+)
+
 # gazelle:prefix github.com/bpalermo/aether
 # gazelle:resolve proto buf/validate/validate.proto @protovalidate//proto/protovalidate/buf/validate:validate_proto
 # gazelle:resolve proto go buf/validate/validate.proto @build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go//buf/validate

--- a/website/BUILD.bazel
+++ b/website/BUILD.bazel
@@ -19,12 +19,19 @@ load("@rules_python//python/entry_points:py_console_script_binary.bzl", "py_cons
 
 package(default_visibility = ["//visibility:private"])
 
-# Everything mkdocs reads, minus the repository files staged in by hooks.py.
+# Everything mkdocs reads, minus the repository documents staged in by hooks.py
+# (those are //:website_docs).
 filegroup(
     name = "sources",
     srcs = [
         "hooks.py",
         "mkdocs.yml",
+        # A symlink, not a copy: `proxy` is in //.bazelignore, and a file under
+        # an ignored directory cannot be an action input, so //:website_docs
+        # cannot carry proxy/README.md. Bazel reads *through* the symlink, so
+        # the page still renders the one and only copy of that document, and
+        # hooks.py still points `edit` at proxy/README.md on GitHub.
+        "staged/proxy-README.md",
     ] + glob([
         "pages/**",
         "overrides/**",
@@ -61,7 +68,7 @@ genrule(
     srcs = [
         "mkdocs.yml",
         "mermaid.min.js",
-        "//:README.md",
+        "//:website_docs",
         ":sources",
     ],
     outs = ["site.tar"],
@@ -93,7 +100,7 @@ py_test(
     data = [
         "mkdocs.yml",
         "mermaid.min.js",
-        "//:README.md",
+        "//:website_docs",
         ":sources",
     ],
     legacy_create_init = 0,

--- a/website/build_site.py
+++ b/website/build_site.py
@@ -71,14 +71,47 @@ POLYFILL_STUB = "assets/javascripts/resize-observer-polyfill.js"
 
 MERMAID_DEST = "assets/javascripts/mermaid.min.js"
 
+#: One page per section of the information architecture, plus the artefacts that
+#: are easy to lose silently. A section that stops being staged fails the build
+#: instead of quietly disappearing from the site.
 REQUIRED_FILES = (
     "index.html",
     "architecture/index.html",
+    # Docs.
+    "docs/getting-started/index.html",
+    "docs/workloads/index.html",
+    "docs/configuration/index.html",
+    "docs/charts/index.html",
+    "docs/observability/index.html",
+    "docs/registry/index.html",
+    # Development.
+    "dev/runbook/index.html",
+    "dev/proxy/index.html",
+    "dev/agents/index.html",
+    # Proposals: the generated index, one known proposal, and its short link.
+    "proposals/index.html",
+    "proposals/018-gateway-api-gamma/index.html",
+    "proposals/018/index.html",
     "CNAME",
     "robots.txt",
     "sitemap.xml",
+    "search/search_index.json",
     MERMAID_DEST,
 )
+
+#: Terms that must survive into the search index. They come from pages staged in
+#: phase 2/3, so their absence means the search plugin stopped indexing a whole
+#: section — which no link check would catch.
+REQUIRED_SEARCH_TERMS = ("uds-socket", "demand-scoped")
+
+#: Private-notebook syntax. hooks.py neutralises it into a muted parenthetical;
+#: if a literal one ever reaches the HTML, a reader sees raw notebook syntax and
+#: a link to a document that does not exist publicly.
+_WIKI_RE = re.compile(r"\[\[[^\[\]]+\]\]")
+
+#: `[[ ... ]]` is also shell. Code is quoted verbatim on purpose, so the wiki-ref
+#: check looks only at prose.
+_CODE_RE = re.compile(r"<pre\b.*?</pre>|<code\b.*?</code>", re.IGNORECASE | re.DOTALL)
 
 TEXT_SUFFIXES = {".html", ".css", ".js", ".json", ".xml", ".txt", ".svg", ""}
 
@@ -190,6 +223,53 @@ def self_host(site_dir: Path, mermaid: Path) -> None:
 # --------------------------------------------------------------------------- #
 
 
+def verify_proposals(site_dir: Path) -> list[str]:
+    """The proposals series is generated, so check the shape, not a fixed list.
+
+    Every proposal must have a row on the index and a working short link, and the
+    index must be the only place either is written down.
+    """
+    problems: list[str] = []
+    root = site_dir / "proposals"
+    if not root.is_dir():
+        return ["no proposals section was generated"]
+
+    published = sorted(
+        path.parent.name
+        for path in root.glob("*/index.html")
+        if re.fullmatch(r"\d{3}-.+", path.parent.name)
+    )
+    if not published:
+        return ["the proposals section contains no proposal pages"]
+
+    index = (root / "index.html").read_text(encoding="utf-8")
+    for name in published:
+        number = name[:3]
+        if f'href="{name}/"' not in index and f'href="../{name}/"' not in index:
+            problems.append(f"proposal {name} is published but has no row on /proposals/")
+        redirect = root / number / "index.html"
+        if not redirect.is_file():
+            problems.append(f"proposal {name} has no short link at /proposals/{number}/")
+        elif f"url=../{name}/" not in redirect.read_text(encoding="utf-8"):
+            problems.append(f"short link /proposals/{number}/ does not point at {name}")
+
+    if "aether-dot--" not in index:
+        problems.append("the proposals index carries no status badges")
+    return problems
+
+
+def verify_search(site_dir: Path) -> list[str]:
+    index = site_dir / "search" / "search_index.json"
+    if not index.is_file():
+        return ["no search index was generated"]
+    content = index.read_text(encoding="utf-8")
+    return [
+        f"search index does not contain {term!r} — a staged section is not being indexed"
+        for term in REQUIRED_SEARCH_TERMS
+        if term not in content
+    ]
+
+
 def verify(site_dir: Path) -> None:
     problems: list[str] = []
 
@@ -208,6 +288,11 @@ def verify(site_dir: Path) -> None:
             problems.append("landing page has no mermaid block — the architecture diagram is gone")
         if "graph TD" not in html:
             problems.append("landing page mermaid block is not the README architecture graph")
+        if "aether-recent__row" not in html:
+            problems.append("landing page lists no recent proposals — the generated block is gone")
+
+    problems += verify_proposals(site_dir)
+    problems += verify_search(site_dir)
 
     for path in iter_text_files(site_dir):
         try:
@@ -222,6 +307,9 @@ def verify(site_dir: Path) -> None:
             match = _SUBRESOURCE_RE.search(content)
             if match:
                 problems.append(f"external subresource in {relative}: {match.group(0)!r}")
+            wiki = _WIKI_RE.search(_CODE_RE.sub("", content))
+            if wiki:
+                problems.append(f"unneutralised wiki ref in {relative}: {wiki.group(0)!r}")
 
     if problems:
         raise BuildError("site verification failed:\n  - " + "\n  - ".join(problems))

--- a/website/hooks.py
+++ b/website/hooks.py
@@ -1,32 +1,43 @@
 """MkDocs hooks that stage repository markdown into the site at build time.
 
 Nothing under ``website/pages`` is a copy of a repository document. Files that
-live in the repository (starting with ``README.md``) are read, transformed and
-injected as *generated* MkDocs files here, so the site can never drift from the
-source of truth and a stale duplicate can never be committed.
+live in the repository (``README.md``, ``docs/**``, ``charts/README.md``,
+``proxy/README.md``, ``AGENTS.md``) are read, transformed and injected as
+*generated* MkDocs files here, so the site can never drift from the source of
+truth and a stale duplicate can never be committed.
 
-Adding a page in a later phase is one entry in :data:`STAGED_PAGES` plus a ``nav``
-entry in ``mkdocs.yml``.
+Adding a hand-picked page is one entry in :data:`STATIC_PAGES` plus a ``nav``
+entry in ``mkdocs.yml``. The proposals series needs neither: every
+``docs/proposals/NNN_slug.md`` is discovered, staged, indexed and navigated
+automatically, so dropping a new proposal file into the repository is the whole
+publishing step.
 
-The transform does four things:
+The transform does five things:
 
-1. drops whole ``##`` sections by title (the site has its own Getting Started and
-   the licence lives in the footer);
-2. rewrites repository-relative links to absolute GitHub URLs, unless the target
-   is a page the site itself publishes (see :data:`SITE_LINKS`);
+1. drops whole ``##`` sections by title (the site has its own Getting Started,
+   the licence lives in the footer, and the theme's right-rail supersedes the
+   hand-rolled table of contents in ``getting-started.md``);
+2. resolves every repository-relative link *from the directory of the document
+   it appears in* — links to a document the site publishes become links between
+   site pages, everything else becomes an absolute GitHub URL;
 3. neutralises ``[[wiki refs]]`` — private-notebook syntax that must never be
    published as a live link — into a muted parenthetical;
-4. substitutes ``<!-- aether:readme-mermaid -->`` in any page with the
-   architecture diagram lifted from the README, so the landing page and the
-   architecture page share one source.
+4. injects the "design record" banner at the top of every proposal;
+5. substitutes ``<!-- aether:readme-mermaid -->`` and
+   ``<!-- aether:recent-proposals -->`` in any page, so the landing page shares
+   one source with the README and with the proposals index.
 
 Everything is fenced-code aware: nothing inside a ``` block is rewritten.
 """
 
 from __future__ import annotations
 
+import glob
 import os
+import posixpath
 import re
+import textwrap
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mkdocs.structure.files import File
@@ -41,18 +52,59 @@ BLOB_URL = f"{REPO_URL}/blob/main/"
 EDIT_URL = f"{REPO_URL}/edit/main/"
 
 #: Repository file -> (site URI, titles of ``##`` sections to drop).
-STAGED_PAGES: dict[str, tuple[str, tuple[str, ...]]] = {
+#:
+#: The site URI decides the URL: ``docs/workloads.md`` is served at
+#: ``/docs/workloads/``.
+STATIC_PAGES: dict[str, tuple[str, tuple[str, ...]]] = {
     "README.md": ("architecture.md", ("Getting Started", "License")),
+    # Docs.
+    # getting-started.md keeps its hand-rolled table of contents for GitHub
+    # readers; here the theme renders one in the right rail, so the section is
+    # dropped rather than duplicated.
+    "docs/getting-started.md": ("docs/getting-started.md", ("Table of contents",)),
+    "docs/workload-requirements.md": ("docs/workloads.md", ()),
+    "docs/configuration.md": ("docs/configuration.md", ()),
+    "charts/README.md": ("docs/charts.md", ()),
+    "docs/observability/README.md": ("docs/observability.md", ()),
+    "docs/registry-backend-evolution.md": ("docs/registry.md", ()),
+    # Development.
+    "docs/runbook.md": ("dev/runbook.md", ()),
+    "proxy/README.md": ("dev/proxy.md", ()),
+    "AGENTS.md": ("dev/agents.md", ()),
 }
 
-#: Repository paths that the site publishes itself. Links to these are rewritten
-#: to the site page instead of to GitHub. Empty in phase 1 — the docs and
-#: proposal sections are not published yet, so every link still points at the
-#: repository.
-SITE_LINKS: dict[str, str] = {}
+#: Repository documents Bazel cannot reach, and the symlink that stands in.
+#:
+#: ``proxy/`` is listed in ``//.bazelignore`` — it is a sibling Bazel workspace
+#: pinned to its own Bazel version — and a file under an ignored directory can
+#: never be an action input, so no filegroup can carry ``proxy/README.md`` into
+#: the sandbox. ``website/staged/proxy-README.md`` is a symlink to it: Bazel
+#: reads through it, the site still renders the single copy of that document,
+#: and everything else (links, ``edit_url``) keeps using the real path.
+READ_THROUGH: dict[str, str] = {
+    "proxy/README.md": "website/staged/proxy-README.md",
+}
 
-#: Placeholder replaced with the README's architecture diagram.
+#: Where the proposals live, and the directory they are published under.
+PROPOSALS_DIR = "docs/proposals"
+PROPOSALS_URI = "proposals"
+
+#: Injected at the top of every proposal. A proposal is a design record, not
+#: documentation: it is published as written, and the reader has to be told that
+#: before they read it as a description of the running system.
+BANNER_BODY = (
+    "**Design record.** This proposal is published as written, at its stated "
+    "status. Later proposals may supersede parts of it, and implementation "
+    "details drift. It documents the reasoning at a point in time, not the "
+    "current behaviour of the system — for that, see the {docs_link}."
+)
+
+#: Placeholders replaced on any page that carries them.
 MERMAID_MARKER = "<!-- aether:readme-mermaid -->"
+RECENT_PROPOSALS_MARKER = "<!-- aether:recent-proposals -->"
+
+#: How many proposals the landing page lists.
+RECENT_PROPOSALS = 5
 
 _FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<fence>```+|~~~+)")
 _LINK_RE = re.compile(r"(?<=\])\((?P<target>[^)\s]+)(?P<title>\s+\"[^\"]*\")?\)")
@@ -60,6 +112,8 @@ _REF_DEF_RE = re.compile(r"^(?P<prefix>\s{0,3}\[[^\]]+\]:\s+)(?P<target>\S+)", r
 _WIKI_RE = re.compile(r"\[\[(?P<ref>[^\[\]]+)\]\]")
 _MERMAID_BLOCK_RE = re.compile(r"^```mermaid\n.*?^```", re.MULTILINE | re.DOTALL)
 _EXTERNAL_RE = re.compile(r"^(?:[a-z][a-z0-9+.-]*:|//|#)", re.IGNORECASE)
+
+_PROPOSAL_FILE_RE = re.compile(r"^(?P<number>\d{3})_(?P<slug>.+)\.md$")
 
 
 # --------------------------------------------------------------------------- #
@@ -82,8 +136,95 @@ def _repo_root(config: MkDocsConfig) -> str:
 
 
 def _read(config: MkDocsConfig, repo_path: str) -> str:
-    with open(os.path.join(_repo_root(config), repo_path), encoding="utf-8") as handle:
+    read_path = READ_THROUGH.get(repo_path, repo_path)
+    with open(os.path.join(_repo_root(config), read_path), encoding="utf-8") as handle:
         return handle.read()
+
+
+# --------------------------------------------------------------------------- #
+# The staging table
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """One ``docs/proposals/NNN_slug.md``, parsed for the generated index."""
+
+    number: str
+    slug: str
+    src_uri: str
+    title: str
+    #: The status line exactly as the proposal states it, links rewritten. Never
+    #: replaced by the badge — the wording carries nuance the badge cannot.
+    status_raw: str
+    #: One of implemented / accepted / design / superseded / proposed.
+    status_key: str
+    date: str
+    #: Relates:/Supersedes:/Follows: text, folded into the client-side search.
+    refs: str
+    #: Number of the proposal that supersedes this one, when it is parseable.
+    superseded_by: str | None = None
+
+
+@dataclass
+class Staging:
+    """Everything derived from the repository for one build."""
+
+    #: repository path -> site source URI.
+    pages: dict[str, str] = field(default_factory=dict)
+    #: site source URI -> repository path (for ``edit_url``).
+    sources: dict[str, str] = field(default_factory=dict)
+    #: repository path -> ``##`` section titles to drop.
+    drops: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    proposals: list[Proposal] = field(default_factory=list)
+
+
+#: Rebuilt by :func:`on_config` on every build (``mkdocs serve`` included).
+_staging = Staging()
+
+
+def _proposal_paths(config: MkDocsConfig) -> list[tuple[str, str, str]]:
+    """``(number, slug, repository path)`` for every proposal, lowest first."""
+    root = _repo_root(config)
+    found: list[tuple[str, str, str]] = []
+    for path in sorted(glob.glob(os.path.join(root, PROPOSALS_DIR, "*.md"))):
+        name = os.path.basename(path)
+        match = _PROPOSAL_FILE_RE.match(name)
+        if match is None:
+            raise RuntimeError(
+                f"{PROPOSALS_DIR}/{name} is not named NNN_slug.md, so it has no stable "
+                "proposal number or URL. Rename it, or move it out of the proposals "
+                "directory."
+            )
+        found.append((match.group("number"), match.group("slug"), f"{PROPOSALS_DIR}/{name}"))
+    if not found:
+        raise RuntimeError(f"no proposals found under {PROPOSALS_DIR}")
+    return found
+
+
+def _build_staging(config: MkDocsConfig) -> Staging:
+    staging = Staging()
+
+    for repo_path, (src_uri, drops) in STATIC_PAGES.items():
+        staging.pages[repo_path] = src_uri
+        staging.sources[src_uri] = repo_path
+        staging.drops[repo_path] = drops
+
+    # Every proposal's URL is registered before any of them is parsed, so that
+    # cross-references between proposals resolve in both directions.
+    discovered: list[tuple[str, str, str, str]] = []
+    for number, slug, repo_path in _proposal_paths(config):
+        src_uri = f"{PROPOSALS_URI}/{number}-{slug.replace('_', '-')}.md"
+        staging.pages[repo_path] = src_uri
+        staging.sources[src_uri] = repo_path
+        discovered.append((number, slug, repo_path, src_uri))
+
+    for number, slug, repo_path, src_uri in discovered:
+        staging.proposals.append(
+            _parse_proposal(number, slug, repo_path, src_uri, _read(config, repo_path), staging)
+        )
+
+    return staging
 
 
 # --------------------------------------------------------------------------- #
@@ -145,25 +286,46 @@ def _drop_sections(markdown: str, titles: tuple[str, ...]) -> str:
     return "".join(kept).rstrip() + "\n"
 
 
-def _rewrite_link(target: str) -> str:
+def _resolve(repo_path: str, target: str) -> str:
+    """Resolve a link written inside ``repo_path`` to a repository-root path."""
+    joined = posixpath.normpath(posixpath.join(posixpath.dirname(repo_path), target))
+    # A link that climbs out of the repository is left alone rather than turned
+    # into a nonsense GitHub URL.
+    return target if joined.startswith("..") else joined
+
+
+def _rewrite_link(target: str, repo_path: str, src_uri: str, staging: Staging) -> str:
+    """Point one link at the site page that publishes it, or else at GitHub."""
     if _EXTERNAL_RE.match(target) or target.startswith("/"):
         return target
-    path = target.lstrip("./")
-    path, _, fragment = path.partition("#")
-    if path in SITE_LINKS:
-        rewritten = SITE_LINKS[path]
+
+    path, _, fragment = target.partition("#")
+    if not path:  # a bare in-page anchor
+        return target
+
+    resolved = _resolve(repo_path, path)
+    published = staging.pages.get(resolved)
+    if published is not None:
+        # Relative between site pages, so mkdocs resolves and validates the
+        # target — and its anchor — under `strict`, instead of the site shipping
+        # an absolute URL nothing checks.
+        rewritten = posixpath.relpath(published, posixpath.dirname(src_uri))
     else:
-        rewritten = BLOB_URL + path
+        rewritten = BLOB_URL + resolved
+
     return f"{rewritten}#{fragment}" if fragment else rewritten
 
 
-def _absolutize_links(markdown: str) -> str:
-    markdown = _LINK_RE.sub(
-        lambda m: f"({_rewrite_link(m.group('target'))}{m.group('title') or ''})", markdown
-    )
-    return _REF_DEF_RE.sub(
-        lambda m: f"{m.group('prefix')}{_rewrite_link(m.group('target'))}", markdown
-    )
+def _rewrite_links(markdown: str, repo_path: str, src_uri: str, staging: Staging) -> str:
+    def link(match: re.Match) -> str:
+        target = _rewrite_link(match.group("target"), repo_path, src_uri, staging)
+        return f"({target}{match.group('title') or ''})"
+
+    def ref_def(match: re.Match) -> str:
+        target = _rewrite_link(match.group("target"), repo_path, src_uri, staging)
+        return f"{match.group('prefix')}{target}"
+
+    return _REF_DEF_RE.sub(ref_def, _LINK_RE.sub(link, markdown))
 
 
 def _neutralize_wiki_refs(markdown: str) -> str:
@@ -173,11 +335,342 @@ def _neutralize_wiki_refs(markdown: str) -> str:
     )
 
 
-def transform(markdown: str, drop_sections: tuple[str, ...] = ()) -> str:
+def transform(
+    markdown: str,
+    repo_path: str,
+    src_uri: str,
+    staging: Staging,
+    drop_sections: tuple[str, ...] = (),
+) -> str:
     """Apply the full staging transform to a repository document."""
     markdown = _drop_sections(markdown, drop_sections)
-    markdown = _map_prose(markdown, _absolutize_links)
+    markdown = _map_prose(markdown, lambda text: _rewrite_links(text, repo_path, src_uri, staging))
     return _map_prose(markdown, _neutralize_wiki_refs)
+
+
+def _banner(src_uri: str) -> str:
+    """The design-record admonition, as markdown, for a page at ``src_uri``."""
+    docs_link = posixpath.relpath("docs/getting-started.md", posixpath.dirname(src_uri))
+    body = BANNER_BODY.format(docs_link=f"[docs]({docs_link})")
+    return '!!! note ""\n\n' + "".join(
+        f"    {line}\n" for line in textwrap.wrap(body, width=84, break_long_words=False)
+    )
+
+
+def _inject_banner(markdown: str, src_uri: str) -> str:
+    """Put the banner immediately after the H1, above the status block."""
+    banner = _banner(src_uri)
+    lines = markdown.splitlines(keepends=True)
+    for index, line in enumerate(lines):
+        if line.startswith("# "):
+            head = "".join(lines[: index + 1])
+            tail = "".join(lines[index + 1 :]).lstrip("\n")
+            return f"{head}\n{banner}\n{tail}"
+    return f"{banner}\n{markdown}"
+
+
+# --------------------------------------------------------------------------- #
+# Proposal parsing
+#
+# The corpus was hand-written over months and the header is not a schema: the
+# status is `**Status:** ...` on some proposals and `Status: ...` on others, it
+# wraps onto continuation lines, and it says things like "All findings fixed" or
+# "Phases 1 + 1b merged". Everything below is deliberately tolerant, and the raw
+# string is always published next to the badge, so nothing this normalisation
+# flattens is lost.
+# --------------------------------------------------------------------------- #
+
+_H1_RE = re.compile(r"^#\s+(?P<title>.+?)\s*$", re.MULTILINE)
+_TITLE_PREFIX_RE = re.compile(r"^(?:proposal\s*\d{0,3}\s*[:—–-]|\d{3}\s*[:—–-])\s*", re.IGNORECASE)
+_FIELD_RE = re.compile(r"^\s*(?:\*\*)?(?P<name>[A-Z][A-Za-z /-]{0,24}):(?:\*\*)?\s*(?P<value>.*)$")
+_BLOCK_START_RE = re.compile(r"^(?:#|>|\||```|~~~|[-*+]\s|\d+\.\s)")
+_DATE_RE = re.compile(r"\b(\d{4}-\d{2}-\d{2})\b")
+#: The head of a status is the claim, before the qualification introduced by a
+#: dash or a semicolon: `Implemented — the CRD was later retired` is Implemented,
+#: and the retirement is nuance that stays in the raw string.
+_STATUS_HEAD_RE = re.compile(r"\s+[—–]\s+|\s+-\s+|;")
+_SUPERSEDER_RE = re.compile(
+    r"\((?P<link>\d{3})_[^)]*\.md\)|proposals?\s+(?P<bare>\d{3})", re.IGNORECASE
+)
+
+#: Checked in order against the head of the status; first hit wins. `superseded`
+#: is first because "Implemented, then superseded" is superseded — and it does
+#: not match "supersedes", which is the opposite claim.
+_STATUS_RULES: tuple[tuple[str, str], ...] = (
+    (r"supersed(ed|ing)", "superseded"),
+    (r"implement|shipped|merged|validated|fixed|complete", "implemented"),
+    (r"accepted|approved", "accepted"),
+    (r"design|draft|spike|investigation|assessment", "design"),
+    (r"proposed|idea|open", "proposed"),
+)
+
+#: Badge label per normalised status. The five buckets, in index order.
+STATUS_LABELS: dict[str, str] = {
+    "implemented": "Implemented",
+    "accepted": "Accepted",
+    "design": "Design",
+    "proposed": "Proposed",
+    "superseded": "Superseded",
+}
+
+
+def _header_block(markdown: str) -> list[str]:
+    """The lines before the first ``##`` — where the metadata lives."""
+    lines: list[str] = []
+    for line in markdown.splitlines():
+        if line.startswith("## "):
+            break
+        lines.append(line)
+    return lines
+
+
+def _field(lines: list[str], *names: str) -> str:
+    """Read a ``**Name:** value`` field, following its continuation lines.
+
+    A continuation is any non-empty line that is not itself a field and does not
+    open a block (heading, quote, list, table, fence). ``*emphasis*`` and
+    ``**bold**`` open plenty of continuation lines, so a leading asterisk only
+    ends the field when it actually opens a list item.
+    """
+    wanted = {name.lower() for name in names}
+    collected: list[str] = []
+    for index, line in enumerate(lines):
+        match = _FIELD_RE.match(line)
+        if match is None or match.group("name").strip().lower() not in wanted:
+            continue
+        collected.append(match.group("value").strip())
+        for follow in lines[index + 1 :]:
+            stripped = follow.strip()
+            if not stripped or _FIELD_RE.match(follow) or _BLOCK_START_RE.match(stripped):
+                break
+            collected.append(stripped)
+        break
+    return " ".join(collected).strip()
+
+
+def _classify_status(status: str) -> str:
+    head = _STATUS_HEAD_RE.split(status, maxsplit=1)[0] if status else ""
+    for candidate in (head, status):
+        for pattern, key in _STATUS_RULES:
+            if re.search(pattern, candidate, re.IGNORECASE):
+                return key
+    # Unrecognisable wording: a proposal that states a status we cannot place is
+    # still a design record, and the raw string is on the page either way.
+    return "design"
+
+
+def _superseder(status: str, number: str) -> str | None:
+    at = status.lower().find("supersed")
+    if at < 0:
+        return None
+    for match in _SUPERSEDER_RE.finditer(status[at:]):
+        found = match.group("link") or match.group("bare")
+        if found and found != number:
+            return found
+    return None
+
+
+def _clean_title(raw: str) -> str:
+    return _TITLE_PREFIX_RE.sub("", raw).strip()
+
+
+def _parse_proposal(
+    number: str, slug: str, repo_path: str, src_uri: str, markdown: str, staging: Staging
+) -> Proposal:
+    heading = _H1_RE.search(markdown)
+    if heading is None:
+        raise RuntimeError(f"{repo_path} has no H1; the proposals index has no title to show.")
+
+    header = _header_block(markdown)
+    status_raw = _field(header, "Status")
+    if not status_raw:
+        raise RuntimeError(
+            f"{repo_path} states no Status in its header block. Every proposal states its "
+            "status, and the index badge is derived from it."
+        )
+
+    date = _field(header, "Date")
+    date_match = _DATE_RE.search(date) or _DATE_RE.search("\n".join(header))
+    refs = " ".join(
+        value
+        for value in (_field(header, name) for name in ("Relates", "Supersedes", "Follows"))
+        if value
+    )
+
+    # The status is republished on the index page, so the links inside it are
+    # rewritten relative to the index, not to the proposal.
+    status_for_index = _rewrite_links(status_raw, repo_path, f"{PROPOSALS_URI}/index.md", staging)
+
+    return Proposal(
+        number=number,
+        slug=slug,
+        src_uri=src_uri,
+        title=_clean_title(heading.group("title")),
+        status_raw=_neutralize_wiki_refs(status_for_index),
+        status_key=_classify_status(status_raw),
+        date=date_match.group(1) if date_match else "",
+        refs=refs,
+        superseded_by=_superseder(status_raw, number),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Generated pages
+# --------------------------------------------------------------------------- #
+
+
+_MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+
+
+def _cell(text: str) -> str:
+    """A markdown table cell holds no bare pipe and no line break."""
+    return " ".join(text.split()).replace("|", "\\|")
+
+
+def _plain(text: str) -> str:
+    """Strip markdown to bare words, for text that is only ever searched.
+
+    The hidden haystack in each row is never rendered, so any surviving markup
+    would be dead weight at best — and a relative link mkdocs would rightly
+    flag as dangling at worst.
+    """
+    text = _WIKI_RE.sub(lambda m: m.group("ref"), text)
+    text = _MD_LINK_RE.sub(r"\1", text)
+    text = re.sub(r"[_/]", " ", text)
+    text = re.sub(r"[`*\[\]<>&]", "", text)
+    return _cell(text)
+
+
+def _index_markdown(staging: Staging) -> str:
+    """The proposals index: one dense table over the files, filtered in the page.
+
+    Nothing here is hand-maintained. The rows, the counts on the filter chips and
+    the five buckets all come from the proposal files themselves.
+    """
+    proposals = sorted(staging.proposals, key=lambda p: p.number, reverse=True)
+    counts = {key: 0 for key in STATUS_LABELS}
+    for proposal in proposals:
+        counts[proposal.status_key] += 1
+
+    chips = [
+        '<button type="button" class="aether-chip is-on" data-status="all">All '
+        f"<span>{len(proposals)}</span></button>"
+    ]
+    chips += [
+        f'<button type="button" class="aether-chip" data-status="{key}">'
+        f'<span class="aether-dot aether-dot--{key}"></span>{label} '
+        f"<span>{counts[key]}</span></button>"
+        for key, label in STATUS_LABELS.items()
+        if counts[key]
+    ]
+
+    by_number = {proposal.number: proposal for proposal in staging.proposals}
+    rows: list[str] = []
+    for proposal in proposals:
+        href = posixpath.relpath(proposal.src_uri, PROPOSALS_URI)
+        status = proposal.status_raw
+        target = by_number.get(proposal.superseded_by or "")
+        if target is not None:
+            link = posixpath.relpath(target.src_uri, PROPOSALS_URI)
+            if f"({link})" not in status:
+                status = f"{status} → [{target.number}]({link})"
+        # The hidden span is invisible but part of textContent, so the free-text
+        # filter also searches the slug and the Relates:/Supersedes:/Follows: refs.
+        haystack = _plain(f"{proposal.slug.replace('_', ' ')} {proposal.refs}")
+        rows.append(
+            f"| [{proposal.number}]({href}) "
+            f"| [{_cell(proposal.title)}]({href})"
+            f'<span class="aether-hay" hidden>{haystack}</span> '
+            f'| <span class="aether-dot aether-dot--{proposal.status_key}" '
+            f'data-status="{proposal.status_key}" '
+            f'title="{STATUS_LABELS[proposal.status_key]}"></span> {_cell(status)} '
+            f"| {proposal.date or '—'} |"
+        )
+
+    lowest = min(proposals, key=lambda p: p.number)
+    return (
+        # The page is one table under one heading: a right-rail table of
+        # contents would hold a single entry and take a third of the width the
+        # table wants.
+        "---\n"
+        "hide:\n"
+        "  - toc\n"
+        "---\n"
+        "\n"
+        "# Proposals\n"
+        "\n"
+        "Every design decision in aether is written down before it is built, and each\n"
+        "record is published as it was written. The status is the proposal's own wording;\n"
+        "the dot beside it is that wording sorted into five buckets, nothing more.\n"
+        "\n"
+        # No `markdown` attribute: the control panel is HTML through and
+        # through, and passing it through raw keeps markdown from wrapping the
+        # input in a paragraph.
+        '<div class="aether-filter">\n'
+        '<input type="search" class="aether-filter__q" placeholder="Filter proposals…"'
+        ' aria-label="Filter proposals" autocomplete="off" spellcheck="false">\n'
+        '<div class="aether-chips" role="group" aria-label="Filter by status">\n'
+        f"{chr(10).join(chips)}\n"
+        "</div>\n"
+        '<p class="aether-filter__count" role="status" aria-live="polite"></p>\n'
+        "</div>\n"
+        "\n"
+        '<div class="aether-proposals" markdown="1">\n'
+        "\n"
+        "| # | Proposal | Status | Date |\n"
+        "|---|---|---|---|\n"
+        f"{chr(10).join(rows)}\n"
+        "\n"
+        "</div>\n"
+        "\n"
+        f"A number is enough to cite one: `/{PROPOSALS_URI}/{lowest.number}/` redirects to\n"
+        "the full URL of that proposal, and keeps working when its title changes.\n"
+    )
+
+
+def _redirect_html(proposal: Proposal) -> str:
+    """A dependency-free short link: ``/proposals/018/`` -> the full URL."""
+    target = f"../{posixpath.basename(proposal.src_uri)[: -len('.md')]}/"
+    title = f"Proposal {proposal.number}"
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        f'<meta http-equiv="refresh" content="0; url={target}">\n'
+        f'<link rel="canonical" href="{target}">\n'
+        '<meta name="robots" content="noindex, follow">\n'
+        f"<title>{title}</title>\n"
+        "</head>\n"
+        "<body>\n"
+        f'<p>{title} is at <a href="{target}">{target}</a>.</p>\n'
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def _recent_proposals_markdown(staging: Staging, src_uri: str) -> str:
+    """The landing page's design-record block. Generated, never hand-listed.
+
+    Each row is a *markdown* link, not raw HTML: mkdocs only resolves and
+    validates links it parsed itself, so an ``<a href>`` written here would ship
+    a raw ``.md`` path that `strict` never looks at.
+    """
+    base = posixpath.dirname(src_uri)
+    recent = sorted(staging.proposals, key=lambda p: p.number, reverse=True)[:RECENT_PROPOSALS]
+    index = posixpath.relpath(f"{PROPOSALS_URI}/index.md", base)
+
+    rows = [
+        f'[<span class="aether-recent__n">{proposal.number}</span>'
+        f'<span class="aether-recent__t">{proposal.title}</span>'
+        f'<span class="aether-dot aether-dot--{proposal.status_key}" '
+        f'title="{STATUS_LABELS[proposal.status_key]}"></span>]'
+        f"({posixpath.relpath(proposal.src_uri, base)})"
+        "{ .aether-recent__row }"
+        for proposal in recent
+    ]
+    body = "\n\n".join([*rows, f"[All proposals →]({index}){{ .aether-recent__all }}"])
+    return f'<div class="aether-recent" markdown>\n\n{body}\n\n</div>'
 
 
 def _architecture_diagram(config: MkDocsConfig) -> str:
@@ -195,21 +688,71 @@ def _architecture_diagram(config: MkDocsConfig) -> str:
 # --------------------------------------------------------------------------- #
 
 
+def on_config(config: MkDocsConfig) -> MkDocsConfig:
+    """Stage the repository, and extend ``nav`` with the generated proposals.
+
+    The proposals section is appended here rather than written into
+    ``mkdocs.yml`` so that adding ``docs/proposals/099_thing.md`` is the entire
+    publishing step: it then appears in the nav, in the index and at its short
+    link with no edit to the site at all.
+    """
+    global _staging
+    _staging = _build_staging(config)
+
+    entries: list[dict[str, str]] = [{"All proposals": f"{PROPOSALS_URI}/index.md"}]
+    entries += [
+        {f"{proposal.number} — {proposal.title}": proposal.src_uri}
+        for proposal in sorted(_staging.proposals, key=lambda p: p.number)
+    ]
+    config.nav = list(config.nav or []) + [{"Proposals": entries}]
+    return config
+
+
 def on_files(files: Files, config: MkDocsConfig) -> Files:
-    for repo_path, (src_uri, drop_sections) in STAGED_PAGES.items():
-        content = transform(_read(config, repo_path), drop_sections)
+    for repo_path, src_uri in _staging.pages.items():
+        content = transform(
+            _read(config, repo_path),
+            repo_path,
+            src_uri,
+            _staging,
+            _staging.drops.get(repo_path, ()),
+        )
+        if src_uri.startswith(f"{PROPOSALS_URI}/"):
+            content = _inject_banner(content, src_uri)
         files.append(File.generated(config, src_uri, content=content))
+
+    files.append(
+        File.generated(config, f"{PROPOSALS_URI}/index.md", content=_index_markdown(_staging))
+    )
+    # Short stable links. Emitted as plain HTML rather than as markdown pages so
+    # they stay out of the nav, the search index and the sitemap — and so the
+    # site needs no redirect plugin, and therefore no new dependency.
+    for proposal in _staging.proposals:
+        files.append(
+            File.generated(
+                config,
+                f"{PROPOSALS_URI}/{proposal.number}/index.html",
+                content=_redirect_html(proposal),
+            )
+        )
     return files
 
 
 def on_pre_page(page: Page, config: MkDocsConfig, files: Files) -> Page:
-    for repo_path, (src_uri, _) in STAGED_PAGES.items():
-        if page.file.src_uri == src_uri:
-            page.edit_url = EDIT_URL + repo_path
+    repo_path = _staging.sources.get(page.file.src_uri)
+    if repo_path:
+        page.edit_url = EDIT_URL + repo_path
+    elif page.file.src_uri == f"{PROPOSALS_URI}/index.md":
+        # Generated from the directory, so "edit" means the directory listing.
+        page.edit_url = f"{REPO_URL}/tree/main/{PROPOSALS_DIR}"
     return page
 
 
 def on_page_markdown(markdown: str, page: Page, config: MkDocsConfig, files: Files) -> str:
     if MERMAID_MARKER in markdown:
         markdown = markdown.replace(MERMAID_MARKER, _architecture_diagram(config))
+    if RECENT_PROPOSALS_MARKER in markdown:
+        markdown = markdown.replace(
+            RECENT_PROPOSALS_MARKER, _recent_proposals_markdown(_staging, page.file.src_uri)
+        )
     return markdown

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -83,6 +83,12 @@ markdown_extensions:
   - toc:
       permalink: true
       permalink_title: Link to this section
+      # Every page on this site is repository markdown, written to be read on
+      # GitHub first, so its in-page links use GitHub's heading anchors. This
+      # slugifier is the GitHub one: python-markdown's default collapses runs of
+      # whitespace into a single hyphen, which silently breaks a link like
+      # `#tensions--non-goals` (proposal 025) that `strict` would then reject.
+      slugify: !!python/object/apply:pymdownx.slugs.slugify {kwds: {case: lower}}
   - pymdownx.highlight:
       anchor_linenums: false
       line_spans: __span
@@ -100,11 +106,29 @@ markdown_extensions:
 extra_css:
   - assets/stylesheets/extra.css
 
+extra_javascript:
+  # Filters the generated proposals index in the page. Vanilla, same-origin, and
+  # inert on every other page.
+  - assets/javascripts/proposals.js
+
 extra:
   generator: false
 
+# Every entry below is a page hooks.py generates from a repository file at build
+# time; there is no committed copy of any of them. The Proposals section is not
+# here at all — hooks.py appends it in on_config from docs/proposals/*.md, so a
+# new proposal file publishes itself.
 nav:
   - Home: index.md
-  # Generated at build time from the repository README by hooks.py — there is no
-  # committed copy.
   - Architecture: architecture.md
+  - Docs:
+      - Getting started: docs/getting-started.md
+      - Workload requirements: docs/workloads.md
+      - Configuration: docs/configuration.md
+      - Charts: docs/charts.md
+      - Observability: docs/observability.md
+      - Registry backends: docs/registry.md
+  - Development:
+      - Runbook: dev/runbook.md
+      - Custom proxy: dev/proxy.md
+      - Repository guide: dev/agents.md

--- a/website/pages/assets/javascripts/proposals.js
+++ b/website/pages/assets/javascripts/proposals.js
@@ -1,0 +1,106 @@
+/*
+ * Filters the proposals index in the page.
+ *
+ * Vanilla, no dependencies, no network: aethermesh.dev makes no third-party
+ * requests, and a table of 35 rows does not need a library to hide some of them.
+ * The rows are markdown the site generates from docs/proposals/*.md, so this
+ * file knows nothing about the corpus — it reads the status off each row's dot
+ * and searches the row's own text.
+ *
+ * With JavaScript off the page is still complete: every row is visible, and the
+ * controls hide themselves (see .aether-filter in extra.css).
+ */
+
+(function () {
+  "use strict";
+
+  function ready(fn) {
+    if (document.readyState !== "loading") {
+      fn();
+    } else {
+      document.addEventListener("DOMContentLoaded", fn);
+    }
+  }
+
+  ready(function () {
+    var panel = document.querySelector(".aether-filter");
+    var table = document.querySelector(".aether-proposals table");
+    if (!panel || !table) {
+      return;
+    }
+
+    var query = panel.querySelector(".aether-filter__q");
+    var count = panel.querySelector(".aether-filter__count");
+    var chips = Array.prototype.slice.call(panel.querySelectorAll(".aether-chip"));
+    var rows = Array.prototype.slice.call(table.querySelectorAll("tbody tr"));
+
+    // Read each row once: textContent includes the hidden haystack span, which
+    // is where the slug and the Relates:/Supersedes:/Follows: refs live.
+    var entries = rows.map(function (row) {
+      var dot = row.querySelector(".aether-dot");
+      var status = (dot && dot.getAttribute("data-status")) || "";
+      if (status === "superseded") {
+        row.classList.add("is-superseded");
+      }
+      return {
+        row: row,
+        status: status,
+        text: (row.textContent || "").toLowerCase().replace(/\s+/g, " "),
+      };
+    });
+
+    var status = "all";
+
+    function apply() {
+      var terms = (query.value || "")
+        .toLowerCase()
+        .split(/\s+/)
+        .filter(Boolean);
+      var shown = 0;
+
+      entries.forEach(function (entry) {
+        var visible =
+          (status === "all" || entry.status === status) &&
+          terms.every(function (term) {
+            return entry.text.indexOf(term) !== -1;
+          });
+        entry.row.hidden = !visible;
+        if (visible) {
+          shown += 1;
+        }
+      });
+
+      panel.classList.toggle("is-filtered", shown !== entries.length);
+      count.textContent =
+        shown === entries.length
+          ? entries.length + " proposals"
+          : shown + " of " + entries.length + " proposals";
+    }
+
+    chips.forEach(function (chip) {
+      chip.addEventListener("click", function () {
+        status = chip.getAttribute("data-status") || "all";
+        chips.forEach(function (other) {
+          other.classList.toggle("is-on", other === chip);
+          other.setAttribute("aria-pressed", other === chip ? "true" : "false");
+        });
+        apply();
+      });
+    });
+
+    query.addEventListener("input", apply);
+    query.addEventListener("search", apply);
+
+    // Escape clears, so the keyboard alone gets you back to the full list.
+    query.addEventListener("keydown", function (event) {
+      if (event.key === "Escape" && query.value) {
+        event.stopPropagation();
+        query.value = "";
+        apply();
+      }
+    });
+
+    panel.classList.add("is-live");
+    apply();
+  });
+})();

--- a/website/pages/assets/stylesheets/extra.css
+++ b/website/pages/assets/stylesheets/extra.css
@@ -363,3 +363,280 @@
   margin: 1.2rem 0;
   padding: 1rem 0.6rem;
 }
+
+/* --------------------------------------------------------------------------
+ * Tables
+ *
+ * docs/configuration.md is a reference page: several of its tables are far
+ * wider than a phone. A wide table scrolls inside its own container and the
+ * page never scrolls sideways — at 375px or at any other width.
+ *
+ * Two containers can be that scroller. Material styles the table itself as an
+ * inline-block with `overflow: auto`, and its JavaScript additionally wraps
+ * each one in .md-typeset__scrollwrap once the page is live. Both are pinned
+ * here, so the guarantee survives a theme upgrade and does not depend on
+ * JavaScript having run.
+ * -------------------------------------------------------------------------- */
+
+.md-typeset__scrollwrap,
+.md-typeset table:not([class]) {
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+/* Belt and braces for the page itself: no descendant may widen the column. */
+.md-content__inner,
+.md-typeset {
+  min-width: 0;
+}
+
+/* A long identifier in a cell wraps rather than setting the table's width. */
+.md-typeset table:not([class]) td,
+.md-typeset table:not([class]) th {
+  overflow-wrap: anywhere;
+}
+
+.md-typeset table:not([class]) code {
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+@media screen and (max-width: 44.9375em) {
+  .md-typeset table:not([class]) {
+    font-size: 0.6rem;
+  }
+
+  /* Material reserves 5rem per header cell; on a phone that is most of the
+     viewport spent on one column of a six-column table. */
+  .md-typeset table:not([class]) th {
+    min-width: 3.4rem;
+  }
+
+  .md-typeset table:not([class]) td,
+  .md-typeset table:not([class]) th {
+    padding: 0.55em 0.7em;
+  }
+}
+
+/* --------------------------------------------------------------------------
+ * Status dots
+ *
+ * Five buckets, shown beside — never instead of — the status a proposal states
+ * in its own words. Colour is the only thing the dot carries, so it also has a
+ * title attribute and the label is written out on the filter chips.
+ * -------------------------------------------------------------------------- */
+
+.md-typeset .aether-dot {
+  background: var(--aether-muted);
+  border-radius: 50%;
+  display: inline-block;
+  flex: none;
+  height: 0.42rem;
+  margin-right: 0.34em;
+  vertical-align: 0.04em;
+  width: 0.42rem;
+}
+
+.md-typeset .aether-dot--implemented {
+  background: #7fd18b;
+}
+
+.md-typeset .aether-dot--accepted,
+.md-typeset .aether-dot--proposed {
+  background: #e5b06b;
+}
+
+.md-typeset .aether-dot--design {
+  background: #8fa3bf;
+}
+
+.md-typeset .aether-dot--superseded {
+  background: #6b7686;
+}
+
+/* --------------------------------------------------------------------------
+ * Proposals index
+ * -------------------------------------------------------------------------- */
+
+.md-typeset .aether-filter {
+  border-bottom: 1px solid var(--aether-border);
+  border-top: 1px solid var(--aether-border);
+  margin: 1.6rem 0 1.2rem;
+  padding: 0.9rem 0;
+}
+
+/* Controls that do nothing without JavaScript are not shown; the table below
+   them is complete either way. */
+.md-typeset .aether-filter:not(.is-live) {
+  display: none;
+}
+
+.md-typeset .aether-filter__q {
+  background: var(--aether-surface);
+  border: 1px solid var(--aether-border);
+  border-radius: 2px;
+  color: var(--md-default-fg-color);
+  font-family: inherit;
+  font-size: 0.72rem;
+  padding: 0.44em 0.7em;
+  width: 100%;
+}
+
+.md-typeset .aether-filter__q:focus {
+  border-color: var(--md-accent-fg-color);
+  outline: none;
+}
+
+.md-typeset .aether-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.6rem;
+}
+
+.md-typeset .aether-chip {
+  align-items: center;
+  background: transparent;
+  border: 1px solid var(--aether-border);
+  border-radius: 2px;
+  color: var(--aether-muted);
+  cursor: pointer;
+  display: inline-flex;
+  font-family: inherit;
+  font-size: 0.65rem;
+  gap: 0.1rem;
+  padding: 0.3em 0.6em;
+}
+
+.md-typeset .aether-chip span:last-child {
+  color: var(--md-default-fg-color--lighter);
+  margin-left: 0.35em;
+}
+
+.md-typeset .aether-chip:hover {
+  border-color: var(--md-accent-fg-color);
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .aether-chip.is-on {
+  border-color: var(--md-accent-fg-color);
+  color: var(--md-default-fg-color);
+}
+
+.md-typeset .aether-filter__count {
+  color: var(--aether-muted);
+  font-size: 0.62rem;
+  margin: 0.6rem 0 0;
+}
+
+/* The index is a directory, not prose: it gets more width than the 46rem
+   reading column. Browsers without :has() simply keep the reading column. */
+.md-content__inner:has(.aether-proposals) {
+  max-width: 62rem;
+}
+
+/* Material shrink-wraps tables (they are inline-block); this one is the page. */
+.md-typeset .aether-proposals table:not([class]) {
+  font-size: 0.68rem;
+  width: 100%;
+}
+
+.md-typeset .aether-proposals td,
+.md-typeset .aether-proposals th {
+  padding: 0.7em 0.9em;
+  vertical-align: top;
+}
+
+/* Left to itself the browser spends the width on the longest status and wraps
+   every title to one word per line. */
+.md-typeset .aether-proposals th:nth-child(1) {
+  min-width: 0;
+  width: 3rem;
+}
+
+.md-typeset .aether-proposals th:nth-child(2) {
+  width: 32%;
+}
+
+.md-typeset .aether-proposals th:nth-child(4) {
+  min-width: 0;
+  width: 5.6rem;
+}
+
+.md-typeset .aether-proposals td:first-child {
+  font-family: var(--md-code-font);
+  white-space: nowrap;
+}
+
+.md-typeset .aether-proposals td:last-child {
+  color: var(--aether-muted);
+  font-family: var(--md-code-font);
+  white-space: nowrap;
+}
+
+.md-typeset .aether-proposals td:nth-child(3) {
+  color: var(--aether-muted);
+}
+
+/* A superseded proposal stays readable and stays in place; it just stops
+   competing with the record that replaced it. */
+.md-typeset .aether-proposals tbody tr.is-superseded,
+.md-typeset .aether-proposals tbody tr:has(.aether-dot--superseded) {
+  opacity: 0.58;
+}
+
+.md-typeset .aether-proposals tbody tr.is-superseded:hover,
+.md-typeset .aether-proposals tbody tr:has(.aether-dot--superseded):hover {
+  opacity: 1;
+}
+
+/* --------------------------------------------------------------------------
+ * Landing page — recent design records
+ * -------------------------------------------------------------------------- */
+
+.md-typeset .aether-recent {
+  border-top: 1px solid var(--aether-border);
+  margin: 1.2rem 0;
+}
+
+/* Each row is its own paragraph so mkdocs parses (and validates) the link. */
+.md-typeset .aether-recent p {
+  margin: 0;
+}
+
+.md-typeset .aether-recent__all {
+  display: inline-block;
+  font-size: 0.7rem;
+  margin-top: 0.8rem;
+}
+
+.md-typeset a.aether-recent__row {
+  align-items: baseline;
+  border-bottom: 1px solid var(--aether-border);
+  color: var(--md-default-fg-color);
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.55rem 0.1rem;
+  text-decoration: none;
+}
+
+.md-typeset a.aether-recent__row:hover {
+  color: var(--md-accent-fg-color);
+}
+
+.md-typeset .aether-recent__n {
+  color: var(--aether-muted);
+  flex: none;
+  font-family: var(--md-code-font);
+  font-size: 0.68rem;
+}
+
+.md-typeset .aether-recent__t {
+  flex: 1 1 auto;
+  font-size: 0.72rem;
+}
+
+.md-typeset .aether-recent .aether-dot {
+  margin: 0;
+}

--- a/website/pages/index.md
+++ b/website/pages/index.md
@@ -11,7 +11,7 @@ Written in Go. Routed with the Gateway API. Each node receives only the
 configuration its own pods actually use.
 { .aether-subline }
 
-[Get started →](https://github.com/bpalermo/aether/blob/main/docs/getting-started.md){ .md-button .aether-button }
+[Get started →](docs/getting-started.md){ .md-button .aether-button }
 [Architecture](architecture.md){ .md-button .aether-button }
 
 Apache-2.0 · pre-1.0 · images and charts on GHCR
@@ -50,7 +50,7 @@ Each node receives only the clusters, registry watches, and endpoints its local
 pods actually depend on, declared with the `config.aether.io/upstreams`
 annotation, with on-demand CDS for the cold path. Config size tracks the node's
 footprint, not the size of the mesh.
-[Proposal 004 →](https://github.com/bpalermo/aether/blob/main/docs/proposals/004_demand-scoped-distribution.md)
+[Proposal 004 →](proposals/004-demand-scoped-distribution.md)
 
 </div>
 
@@ -62,7 +62,7 @@ The agent supervises Envoy through a cross-pod hot restart with two-phase
 connection draining. Zero dropped requests across eight-hour soak tests driving
 30-plus rollouts of the data plane, measured by an external prober rather than
 the mesh's own telemetry.
-[Proposal 001 →](https://github.com/bpalermo/aether/blob/main/docs/proposals/001_proxy-hot-restart.md)
+[Proposal 001 →](proposals/001-proxy-hot-restart.md)
 
 </div>
 
@@ -74,12 +74,20 @@ No bespoke routing CRDs. East-west traffic uses GAMMA — `HTTPRoute` and
 `GRPCRoute` parented to a Service — and north-south uses the same API against
 the edge gateway. The GATEWAY-HTTP profile is fully conformant, Core 33/33 and
 Extended 10/10, and conformance is gated in CI.
-[Proposal 018 →](https://github.com/bpalermo/aether/blob/main/docs/proposals/018_gateway-api-gamma.md) ·
-[Proposal 024 →](https://github.com/bpalermo/aether/blob/main/docs/proposals/024_conformance-ci.md)
+[Proposal 018 →](proposals/018-gateway-api-gamma.md) ·
+[Proposal 024 →](proposals/024-conformance-ci.md)
 
 </div>
 
 </div>
+
+## The design record
+
+Every decision above was argued in writing before it was built, and the argument
+is published as it was written — status, dead ends and all. These are the five
+most recent.
+
+<!-- aether:recent-proposals -->
 
 ## Install
 
@@ -109,7 +117,7 @@ helm upgrade --install aether \
 Aether is pre-1.0 and built by one person. It is soak-tested on a real cluster
 and gated on Gateway API conformance in CI, but it has no support commitment.
 Read the
-[proposals](https://github.com/bpalermo/aether/tree/main/docs/proposals) and the
+[proposals](proposals/index.md) and the
 [conformance baselines](https://github.com/bpalermo/aether/tree/main/docs/conformance)
 before you run it.
 

--- a/website/staged/proxy-README.md
+++ b/website/staged/proxy-README.md
@@ -1,0 +1,1 @@
+../../proxy/README.md


### PR DESCRIPTION
## Summary

Phases 2+3 of aethermesh.dev: the docs portal and the design-record centerpiece.

**Docs (Phase 2)**: nine repo docs at their planned URLs, staged from the same commit at build time. Cross-doc links resolve as site-relative (so `--strict` validates targets *and anchors*); links to unstaged files become GitHub URLs; `[[private-ref]]`s neutralize with a build assertion (code-fence aware — `[[ ]]` is also shell). The 19 wide tables in the configuration reference scroll internally, browser-verified at 375px with zero body scroll. TOC anchors use GitHub's slug algorithm — the default slugger produced a dangling `#tensions--non-goals` that strict mode caught.

**Proposals (Phase 3)**: all 34 render verbatim with the design-record banner; the index is generated from the files themselves — raw status string always shown, normalized to a colored dot beside it, never replaced. The parser handles the wording zoo honestly (see the PR-linked report highlights): 017 "Implemented, then superseded" → Superseded with a `→ 018` link; 010 "supersedes 009" stays Implemented; 032's "(implemented …)" beats its "Accepted" head; 025/026 stay Accepted because that is what the files declare. `/proposals/NNN/` short links are meta-refresh stubs excluded from nav/search/sitemap. **Acceptance test passed live: dropping in a fake `099_*.md` and rebuilding produced the row, page, redirect, and nav entry with no other edit.**

Machinery notes: `pages.yaml` path filter now covers `docs/**` + staged sources; `proxy/README.md` is reached via a checked-in symlink because `proxy/` is `.bazelignore`d and ignored-dir files can never be action inputs (probe-verified); proposals index page drops its TOC rail and widens — it's a directory, not prose. No new pip deps; the lock is untouched.

## Testing

`bazel test //website:all` + full tree 86/86 on this branch; browser-verified filter behavior (34 rows → 2 superseded dimmed → 9 "gamma" → reset), mermaid on staged pages, zero external hosts, search reaches `uds-socket` and hidden refs ("waypoint" → 4 rows).

Deploys on merge (path filter matches). Phase 4 + /api follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR