### PR TITLE
fix(website): mermaid self-host URL must survive any mount point

### DIFF
--- a/website/build_site.py
+++ b/website/build_site.py
@@ -57,9 +57,22 @@ FORBIDDEN_HOSTS = (
 #: overrides/partials/source.html drops the `data-md-component="source"` marker
 #: that mounts it; repointing the endpoint as well means no future theme change
 #: can quietly revive the call.
+#: The self-hosted replacements must resolve correctly at ANY mount point (the
+#: bpalermo.github.io/aether/ project-pages subpath today, the aethermesh.dev
+#: root later) from ANY page depth. Neither a root-absolute "/assets/..." (404s
+#: on the subpath — how the first deploy shipped a non-rendering diagram) nor a
+#: bare relative "./..." (import() in a classic script resolves against the
+#: DOCUMENT URL, not the script URL — browser-verified) can do that as a string
+#: literal. So the quoted literal is replaced with a runtime EXPRESSION anchored
+#: to the theme bundle's own <script src>, which exists on every page and lives
+#: in the same directory as the self-hosted files. Keys that include quotes are
+#: replaced verbatim (expression injection); bare keys keep their quotes.
+_SELF_HOST_EXPR = (
+    'new URL("./{name}",document.querySelector(\'script[src*="assets/javascripts/bundle"]\').src).href'
+)
 CDN_REWRITES = {
-    "https://unpkg.com/mermaid@11/dist/mermaid.min.js": "/assets/javascripts/mermaid.min.js",
-    "https://unpkg.com/resize-observer-polyfill": "/assets/javascripts/resize-observer-polyfill.js",
+    '"https://unpkg.com/mermaid@11/dist/mermaid.min.js"': _SELF_HOST_EXPR.format(name="mermaid.min.js"),
+    '"https://unpkg.com/resize-observer-polyfill"': _SELF_HOST_EXPR.format(name="resize-observer-polyfill.js"),
     "https://api.github.com/repos/": "/_third-party-disabled/repos/",
     "https://api.github.com/users/": "/_third-party-disabled/users/",
 }


### PR DESCRIPTION
## Summary

Fixes the non-rendering architecture diagram on the live site.

**Root cause chain**: the CDN rewrite installed a root-absolute `/assets/javascripts/mermaid.min.js`, which 404s under the project-pages subpath (`bpalermo.github.io/aether/`); Material's loader observable errors and its subscriber — the render step — never fires, leaving the raw `graph TD` text. Phase 1's browser verification served the tar at root, which masked it.

**Why the obvious fix is also wrong**: a `./mermaid.min.js` string literal resolves against the *document* URL, not the script URL (browser-verified: it fetched `/aether/mermaid.min.js` from the landing page and 404'd inside the site).

**The fix**: replace the *quoted* literal with a runtime expression anchored to the theme bundle's own `<script src>` — that tag exists on every page and lives in the same directory as the self-hosted files, so resolution is correct at any page depth and any mount point (subpath today, aethermesh.dev root later, local previews):

```js
new URL("./mermaid.min.js", document.querySelector('script[src*="assets/javascripts/bundle"]').src).href
```

The rewrite map now distinguishes quoted keys (expression injection) from bare keys (string swap); the fail-if-string-vanishes guard is unchanged.

**Verified in a real browser against a server mounted at `/aether/`**: mermaid fetches 200, zero failed requests, and the architecture diagram renders at 825×542 — measured by layout height, because Material renders into a **closed** shadow root that element queries cannot see (which also explains why the earlier "renders locally" claim was checked at root only).

## Testing

`bazel test //website:all` strict build green; bundle inspected (expression present, zero `unpkg` refs); Chrome verification on the subpath mount as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EioJVuoepwStjHoRLB52WR