### PR TITLE
docs(proposals): refresh stale status lines against what actually shipped

### DIFF
--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -1,6 +1,6 @@
 # Proposal: Hot Restart for the aether-proxy Envoy (Spike)
 
-**Status:** Strategies A and B **validated GREEN on talos-main** (B incl. zero-drop app e2e)
+**Status:** Implemented — the `agent proxy-supervisor` hot-restart supervisor shipped (Strategy B), zero-drop validated on talos-main; follow-on audits merged (#109–#111). (2026-06-09 spike.)
 **Author:** Bruno Palermo
 **Date:** 2026-06-09
 

--- a/docs/proposals/004_demand-scoped-distribution.md
+++ b/docs/proposals/004_demand-scoped-distribution.md
@@ -1,6 +1,6 @@
 # Proposal: Demand-Scoped Service Distribution
 
-**Status:** Accepted — cold path = ODCDS; ships as a breaking change (no fallback flag)
+**Status:** Implemented — demand-scoped CDS/watch/health-checking shipped as a breaking change (no fallback flag); cold path = ODCDS, including the capture on-demand catch-all (#288). (2026-06-12 design.)
 **Author:** Bruno Palermo
 **Date:** 2026-06-12
 

--- a/docs/proposals/006_multi-region-etcd-federation.md
+++ b/docs/proposals/006_multi-region-etcd-federation.md
@@ -1,6 +1,6 @@
 # Proposal: multi-region etcd federation (region-scoped registry ownership)
 
-**Status:** Design — 2026-06-20
+**Status:** Implemented — the registrar's `--peer-etcd` replicator (origin-partitioned keys, origin-heartbeat lease) shipped and is exercised by the nightly two-cluster replication e2e gate. (2026-06-20 design.)
 **Relates:** [`docs/registry-backend-evolution.md`](../registry-backend-evolution.md)
 (the multi-region directive this implements), proposal 004 (demand-scoped
 distribution), proposal 000 (in-cluster registrar); [[project_registrar_etcd_vs_ddb]],

--- a/docs/proposals/008_rust-in-bazel.md
+++ b/docs/proposals/008_rust-in-bazel.md
@@ -1,6 +1,6 @@
 # Proposal: Rust in the Bazel build (rules_rust + hermetic_cc_toolchain)
 
-**Status:** Draft — toolchain validated by a smoke target (host + Zig cross, 2026-06-13)
+**Status:** Implemented, then superseded by [proposal 010](010_custom-proxy-workspace.md) — the rules_rust + hermetic_cc toolchain shipped (#177) and carried the proposal-007 Rust dynamic module (#178), but was removed when `aether_stats` moved to a native C++ extension in the custom proxy workspace (proposals 010–012). No Rust remains in the tree. (2026-06-13 design.)
 **Author:** Bruno Palermo
 **Date:** 2026-06-13
 

--- a/docs/proposals/011_stats-filter-in-proxy-build.md
+++ b/docs/proposals/011_stats-filter-in-proxy-build.md
@@ -1,6 +1,6 @@
 # Proposal: Port the aether_stats filter into the proxy build
 
-**Status:** Design — 2026-06-15
+**Status:** Implemented — superseded in direction by proposal 012: the filter rides the custom proxy build as a native C++ extension rather than a bundled dynamic module (this proposal's `envoy --mode validate` harness lives on as `//test/envoy_validate`). (2026-06-15 design.)
 **Author:** Bruno Palermo
 **Follows:** proposal 010 (custom proxy workspace), proposal 007 (telemetry filter)
 

--- a/docs/proposals/012_aether_stats_cpp_extension.md
+++ b/docs/proposals/012_aether_stats_cpp_extension.md
@@ -1,6 +1,6 @@
 # Proposal: aether_stats as a native C++ Envoy extension
 
-**Status:** Design — 2026-06-15
+**Status:** Implemented — `aether_stats` ships as a native C++ extension in the custom proxy workspace (`proxy/source/extensions/filters/http/aether_stats/`), default-on in the mesh. (2026-06-15 design.)
 **Supersedes:** proposal 011 (the Rust dynamic-module port) for the chosen direction
 **Follows:** proposal 007 (telemetry filter), proposal 010 (custom proxy workspace)
 

--- a/docs/proposals/018_gateway-api-gamma.md
+++ b/docs/proposals/018_gateway-api-gamma.md
@@ -1,6 +1,6 @@
 # Proposal: Gateway API for aether — north-south + GAMMA east-west
 
-**Status:** Implemented — Phases 1–2 (edge `HTTPRoute` + GAMMA east-west) and Phase 3a (HTTP transparent capture) shipped and default-on. Phase 3b (L4 `TCPRoute`/`TLSRoute`/`UDPRoute`) is behind `agent.l4Routes`; the remaining TCP-floor/`VirtualHost`-retirement items are tracked as follow-ups. (2026-06-22 design.)
+**Status:** Implemented — all phases shipped and default-on: Phases 1–2 (edge `HTTPRoute` + GAMMA east-west), Phase 3a (HTTP transparent capture), and Phase 3b (L4 `TCPRoute`/`TLSRoute`/`UDPRoute`, default-on since #493; the `agent.l4Routes` flag was retired by proposal 031 — each route type now gates only on its Gateway API CRD being installed). (2026-06-22 design.)
 **Relates:** proposal 017 (VirtualHost — the north-south CRD this subsumes),
 proposal 003 (edge proxy), proposal 004 (demand-scoped distribution),
 proposal 005 (multi-port), proposal 006 (origin-partitioned registry — the

--- a/docs/proposals/019_multicluster-node-waypoint.md
+++ b/docs/proposals/019_multicluster-node-waypoint.md
@@ -1,6 +1,6 @@
 # Proposal: Multi-cluster pod-to-pod via a per-node waypoint (non-routable pod IPs)
 
-**Status:** Design — 2026-06-24
+**Status:** Implemented — the node proxy acts as the per-node E/W gateway behind `--east-west-waypoint` (default off; needs shared etcd + shared SPIRE trust domain), e2e-validated. (2026-06-24 design.)
 **Relates:** proposal 018 (Gateway API/GAMMA — the *connectivity modes* this refines),
 proposal 006 (origin-partitioned per-region registry — the cross-cluster plane),
 proposal 003 (edge proxy — the SNI-passthrough primitive this reuses),

--- a/docs/proposals/020_namespace-aware-services-and-endpoint-projection.md
+++ b/docs/proposals/020_namespace-aware-services-and-endpoint-projection.md
@@ -1,6 +1,6 @@
 # Proposal: Namespace-aware services + opt-in non-mesh endpoint projection
 
-**Status:** Design — 2026-06-25
+**Status:** Implemented — the namespace-aware `<ns>/<serviceAccount>` registry-key cutover completed and is the mesh's identity model (registry keys, SVIDs, generated mesh Services). (2026-06-25 design.)
 **Relates:** proposal 006 (origin-partitioned registry key schema — the migration
 pattern this follows), proposal 018 (Gateway API/GAMMA + MCS — the alignment driver),
 proposal 019 (multi-cluster waypoint — bounds cross-cluster non-mesh reachability),

--- a/docs/proposals/023_service-based-routing.md
+++ b/docs/proposals/023_service-based-routing.md
@@ -1,6 +1,6 @@
 # Proposal: Service-based routing — decoupling the GAMMA route target from ServiceAccount identity
 
-**Status:** Design — 2026-06-28
+**Status:** Implemented — the route-target catalog + real-`ClusterIP:port` capture shipped (GAMMA-on-capture); the versioned-backend shape it exists for is exercised by the MESH-HTTP conformance profile, which is green and a hard CI gate (proposal 024). (2026-06-28 design.)
 **Relates:** proposal 018 (Gateway API/GAMMA), proposal 020 (namespace-aware services
 — the `<ns>/<svc>` registry key + SA-identity model this refines), proposal 022
 (arbitrary-Service interception — captures the *real* Service ClusterIP:port this

--- a/docs/proposals/025_proxy-extension-escape-hatch.md
+++ b/docs/proposals/025_proxy-extension-escape-hatch.md
@@ -1,12 +1,10 @@
 # Proposal: Proxy-extension escape hatch for Gateway API / GAMMA
 
-**Status:** Accepted — 2026-06-29 (**Option C**: ExtensionRef → typed CRD, opaque body, fail-closed
-**in-process proto-validate** — no Envoy binary in the webhook). Implementation tracked as
-milestones M1–M4 (below). The route-rule `ExtensionRef` form (caller-side, cluster-local) is
-unblocked and is v1 (M1–M2); the Service-`targetRef` (policy-attachment) form is **blocked on
-proposal 026** (multi-cluster config propagation, Accepted — Option E) — a service-global
-escape-hatch policy cannot be consistent across clusters until 026's C/E channel or D-enforcement
-lands, so it is deferred to M3+.
+**Status:** Implemented — **Option C** (ExtensionRef → typed `HTTPFilter` CRD, opaque body, fail-closed
+**in-process proto-validate** — no Envoy binary in the webhook) shipped in full and is talos-validated:
+the route-rule `ExtensionRef` form, the Service-`targetRef` (policy-attachment) form (unblocked once
+proposal 026 landed), and CHAIN-scoped filters. `common/extensionfilter` is the single source of truth
+for the allow-list + validation/rendering. (Accepted 2026-06-29.)
 **Relates:** proposal 026 (multi-cluster config propagation — gates the Service-targetRef form),
 proposal 018 (Gateway API/GAMMA), proposal 017 (VirtualHost CRD — the edge escape-hatch
 precedent), proposal 015 (MeshConfig CRD — the policy-attachment precedent), proposal 011 / #396

--- a/docs/proposals/026_multi-cluster-config-propagation.md
+++ b/docs/proposals/026_multi-cluster-config-propagation.md
@@ -1,11 +1,13 @@
 # Proposal: Multi-cluster config propagation
 
-**Status:** Accepted — 2026-06-29. **Decision: Option E (control cluster — centralized config
-authority)**, implemented on Option C's export/import channel (the hub is the sole exporter; spokes
-import read-only, no cross-cluster K8s credentials); Option D (producer-waypoint) for class-1
-*enforcement*; Option A (GitOps) for class-2 consumer-local config; Option B rejected. Run the
-control cluster as a pure-management cluster (no mesh workloads). This decides the authority
-topology; the export schema + materializer are the implementation follow-up.
+**Status:** Implemented — **Option E (control cluster — centralized config authority)** shipped on
+Option C's export/import channel: the registrar's leader-elected config-export controller writes
+`ServiceConfigProjection`s to the shared registry, and the agent's `--import-config` materializer
+(with `--control-cluster` restricting trust to one origin; local config wins) imports them —
+validated by a two-kind-cluster e2e. Option D (producer-waypoint) for class-1 *enforcement*;
+Option A (GitOps) for class-2 consumer-local config; Option B rejected. Run the control cluster as
+a pure-management cluster (no mesh workloads). etcd key-ACL hardening is parked as a follow-up.
+(Accepted 2026-06-29.)
 **Relates:** proposal 006 (multi-region etcd federation — the registry bus), proposal 019
 (multicluster node-waypoint — the producer-side enforcement option), proposal 018 (Gateway
 API/GAMMA — the config that needs to propagate), proposal 023 (route-by-Service), proposal 015

--- a/docs/proposals/027_ext-authz.md
+++ b/docs/proposals/027_ext-authz.md
@@ -1,6 +1,6 @@
 # Proposal: external authorization (ext_authz) via a node-proxy sidecar
 
-**Status:** Accepted — 2026-07-05
+**Status:** Implemented — the node-local ext_authz sidecar (UDS transport, OPA preset) shipped; deployed enabled-but-inert on talos-main. (Accepted 2026-07-05.)
 **Relates:** proposal 025 (proxy-extension escape hatch — the enablement machinery),
 proposal 015 (MeshConfig — the system-config half), proposal 026 (config propagation —
 policy parameters ride the channel), proposal 019 (waypoint — the alternative

--- a/docs/proposals/028_geoip.md
+++ b/docs/proposals/028_geoip.md
@@ -1,6 +1,6 @@
 # Proposal: GeoIP at the edge
 
-**Status:** Accepted — 2026-07-06
+**Status:** Implemented — edge GeoIP shipped: `x-geo-*` request enrichment with inbound spoof-strip and route-cache clearing. (Accepted 2026-07-06.)
 **Relates:** proposal 003/017/018 (the edge + Gateway API HTTPRoute — geo-routing
 consumers), #476 RBAC / proposal 027 ext_authz (geo-blocking consumers), proposal
 027 (the preset-sidecar pattern the DB updater follows).

--- a/docs/proposals/029_edge-config.md
+++ b/docs/proposals/029_edge-config.md
@@ -1,6 +1,6 @@
 # Proposal: EdgeConfig — edge best-practices, per-instance, native Gateway API
 
-**Status:** Accepted — 2026-07-06
+**Status:** Implemented — `EdgeConfig` shipped: edge best-practices defaults, per-Gateway `parametersRef` overrides, and HTTP/3 (QUIC) support, with its admission webhook in the controller. (Accepted 2026-07-06.)
 **Relates:** proposal 018 (Gateway API edge), 015 (MeshConfig — the CRD + proto.Merge
 default/override precedent), 028 (geoip — folds onto this config), the Envoy edge
 best-practices doc (envoyproxy.io/docs/.../best_practices/edge).

--- a/docs/proposals/030_port-range-migration.md
+++ b/docs/proposals/030_port-range-migration.md
@@ -1,6 +1,6 @@
 # 030 — Move the remaining data-plane ports out of Istio's reserved range
 
-Status: Proposed
+Status: Implemented — the data-plane ports moved to 18008/18009/18021; nothing remains in Istio's reserved 15xxx range.
 
 ## Motivation
 

--- a/docs/proposals/031_agent-flag-surface-reduction.md
+++ b/docs/proposals/031_agent-flag-surface-reduction.md
@@ -1,6 +1,6 @@
 # 031 — Reduce the agent's feature-flag surface
 
-Status: Accepted (assessment 2026-07-12)
+Status: Implemented — the assessed flag retirements landed (e.g. `--l4-routes` removed; L4 route types now gate only on their Gateway API CRDs being installed). (Assessment 2026-07-12.)
 
 ## Motivation
 

--- a/docs/proposals/033_node-taint-lifecycle.md
+++ b/docs/proposals/033_node-taint-lifecycle.md
@@ -1,6 +1,6 @@
 # Proposal: Node-taint lifecycle — re-arm the agent-not-ready taint across reboots and agent outages
 
-**Status:** Accepted — 2026-07-19
+**Status:** Implemented — the taint lifecycle shipped (`agent/internal/node`): the agent-not-ready taint re-arms across reboots and agent outages. (Accepted 2026-07-19.)
 **Relates:** issue #263 / #261 (the startup taint + one-shot removal), proposal 031
 (agent flag-surface reduction — the "no new flags" philosophy this follows).
 **Fixes:** #569. **Non-goal:** container-restart waves on a re-armed node (#567).

--- a/docs/proposals/034_pod-uds-support.md
+++ b/docs/proposals/034_pod-uds-support.md
@@ -1,7 +1,9 @@
 # Proposal 034: UDS Support for Pods
 
-**Status:** Phases 1 + 1b merged (#616/#617/#618); kind e2e in CI, talos
-validation and Phase 2 (outbound) pending
+**Status:** Implemented (Phases 1 + 1b) and production-validated — annotation path (#616/#617)
+and `EndpointPolicy` CRD path (#618) shipped, kind e2e in CI (#619), and both paths validated
+under an 8-hour churn soak on talos-main (2026-08-03; follow-ups tracked in #628/#629).
+Phase 2 (outbound egress socket) remains deferred post-redirect-all.
 **Author:** Bruno Palermo
 **Date:** 2026-06-11, revised 2026-08-01 against current main
 **History:** originally numbered 002; renumbered (002 is taken by the merged


### PR DESCRIPTION
## What

Assessed all 35 proposal (ADR) status lines against the current tree and updated the 19 that were stale — most were frozen at their design/acceptance date while the work has long since shipped.

## Verification per claim

Every status change was checked against code or CI, not memory:

| Proposal | Was | Now | Evidence |
|---|---|---|---|
| 001 hot-restart | spike wording | Implemented | `agent proxy-supervisor` subcommand; audits #109–#111 |
| 004 demand-scoped | Accepted | Implemented | shipped breaking, ODCDS catch-all #288 |
| 006 etcd federation | Design | Implemented | `--peer-etcd` in registrar + `internal/replicator`; nightly e2e gate |
| 008 rust-in-bazel | Draft | Implemented, then superseded by 010 | #177/#178 shipped; no `rules_rust` left in MODULE.bazel |
| 011 stats-in-proxy | Design | Implemented (direction superseded by 012) | `//test/envoy_validate` exists |
| 012 aether_stats C++ | Design | Implemented | `proxy/source/extensions/filters/http/aether_stats/` |
| 018 Gateway API | Phase 3b "behind agent.l4Routes" | all phases default-on | flag gone from charts (retired by 031) |
| 019 E/W waypoint | Design | Implemented (default off) | `--east-west-waypoint` flag in root.go |
| 020 ns-aware services | Design | Implemented | `<ns>/<sa>` is the live identity model |
| 023 service-based routing | Design | Implemented | MESH-HTTP conformance green + hard-gated |
| 025 escape hatch | Accepted (targetRef "blocked on 026") | Implemented | 026 landed; targetRef + CHAIN shipped |
| 026 config propagation | Accepted | Implemented | registrar configexport + agent `--import-config` |
| 027 ext_authz | Accepted | Implemented | `authzSidecar` in chart values |
| 028 geoip | Accepted | Implemented | x-geo-* + spoof-strip at edge |
| 029 EdgeConfig | Accepted | Implemented | webhook + parametersRef + HTTP/3 |
| 030 port migration | Proposed | Implemented | 18008/18009/18021 live, 15008 gone |
| 031 flag reduction | Accepted | Implemented | `--l4-routes` retired |
| 033 taint lifecycle | Accepted | Implemented | `agent/internal/node/taint.go` |
| 034 pod UDS | Phases 1+1b merged, talos pending | production-validated | 2026-08-03 soak PASS; follow-ups #628/#629 |

Unchanged (already accurate): 000, 002, 003, 005, 007, 009, 010, 013–015, 017, 021, 022, 024, 032.

## Website

The proposals index is generated from these exact lines. `bazel test //website:site_test` passes, and wording was checked against the `hooks.py` badge classifier (head-segment-first matching; "supersedes" ≠ "superseded" — 008 now intentionally badges Superseded with a 010 link, matching 017's convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr