### PR TITLE
feat(website): serve the vanity Go import path aethermesh.dev (proposal 035)

### DIFF
--- a/docs/proposals/035_vanity-import-path.md
+++ b/docs/proposals/035_vanity-import-path.md
@@ -1,0 +1,104 @@
+# Proposal: Vanity Go module path `aethermesh.dev`
+
+**Status:** Accepted — 2026-08-08 (apex `aethermesh.dev`, served by the docs site).
+The serving half (go-import meta + build guard) ships first; the module rename
+is the follow-up PR and is gated on the meta being live.
+**Author:** Bruno Palermo
+**Relates:** the aethermesh.dev website (the serving surface), proposal 010
+(the sibling proxy workspace — C++, unaffected).
+
+## Problem Statement
+
+The Go module is named after its hosting, `github.com/bpalermo/aether`. The
+project now has its own domain and website; the import path is the one public
+name that still points at repository plumbing rather than the project. A module
+path is forever once anything depends on it, so if it is ever going to change,
+it changes now — before the vanity domain appears in docs and the module
+gathers external importers.
+
+## Decision
+
+`module aethermesh.dev` — the apex, no `go.` prefix, no `/aether` suffix.
+
+- **Apex over `go.` subdomain** (tailscale.com / gvisor.dev precedent, vs
+  go.uber.org): the `go.` host would exist only to serve two static files and
+  needs its own Pages repo, CNAME, and certificate. The docs site already
+  serves the apex and already has a fail-closed verification culture to keep
+  the meta tag honest. Imports read better: `aethermesh.dev/common/udspath`.
+- **Bare apex over `aethermesh.dev/aether`**: the `/aether` segment would
+  restate the project name that is already the domain. All Go code lives in
+  this one module (the proxy workspace is C++), so the whole host can map to
+  the one repository.
+
+## Mechanism
+
+`go get` resolves a custom import path by fetching
+`https://aethermesh.dev/<pkg>?go-get=1` and reading a `go-import` meta tag; it
+parses the tag regardless of HTTP status. Two tags in the site's shared
+`extrahead` block therefore cover every URL on the host:
+
+```html
+<meta name="go-import" content="aethermesh.dev git https://github.com/bpalermo/aether">
+<meta name="go-source" content="aethermesh.dev https://github.com/bpalermo/aether https://github.com/bpalermo/aether/tree/main{/dir} https://github.com/bpalermo/aether/blob/main{/dir}/{file}#L{line}">
+```
+
+- Real pages serve the meta at 200; every other path — which is what package
+  subpaths like `/agent/internal/...` are — is served by the site's `404.html`,
+  which extends the same template and carries the same tags.
+- `go-source` gives pkg.go.dev working "view source" links into GitHub.
+- The meta sits **outside** the `{% if page %}` guard in
+  `website/overrides/main.html`: static templates (404.html) render with
+  `page = None`, and they are the load-bearing case.
+
+**The coupling risk, and its guard.** Module resolution now depends on a docs
+site that gets redesigned. The mitigation is the same pattern as every other
+invariant this site holds: `build_site.py` fails the build — and with it the
+required `//website:site_test` gate — if either `index.html` or `404.html`
+stops carrying the exact `go-import` tag. proxy.golang.org caching insulates
+existing users from transient outages either way; only first-fetches of new
+versions and `GOPROXY=direct` reach the site.
+
+## The rename (follow-up PR)
+
+Atomic, mechanical, wide:
+
+1. `go.mod`: `module aethermesh.dev`; `# gazelle:prefix aethermesh.dev` in the
+   root BUILD.bazel.
+2. Rewrite every `github.com/bpalermo/aether` import across `**/*.go`.
+3. `option go_package` in every proto under `api/`, then regenerate.
+4. `make gazelle` (rewrites every `importpath`) + `make tidy`.
+5. Sweep docs, CLAUDE.md, website content, e2e scripts.
+
+CI never network-fetches its own module, so the build does not depend on DNS —
+but the moment the rename merges, the vanity path is the **only** installable
+path, which is why the meta must be verified live first:
+
+```sh
+curl -s 'https://aethermesh.dev/common/udspath?go-get=1' | grep go-import
+```
+
+## Consequences
+
+- `go get github.com/bpalermo/aether` is frozen at pre-rename tags; new
+  versions exist only under `aethermesh.dev`. There is no dual-path option for
+  a Go module. README gets a note.
+- A future second module (say, a carved-out `api`) would live at
+  `aethermesh.dev/api` and need its own meta tag with the longer prefix; the
+  single-tag setup maps the whole host to this one repository until then.
+
+## Verification
+
+- Build-time: the `verify_go_import` check in `build_site.py` (index + 404).
+- Post-deploy: the `curl … ?go-get=1` gate above, on a real package path.
+- Post-rename: `GOPROXY=direct go mod download aethermesh.dev@latest`, then the
+  default proxy path, then pkg.go.dev indexing with working source links.
+
+## Alternatives considered (and rejected)
+
+- **`go.aethermesh.dev`**: a second Pages repo + DNS record + certificate to
+  serve two files that never change. Isolation from site redesigns is its one
+  real advantage; the build guard buys the same property without the
+  infrastructure.
+- **Keep `github.com/bpalermo/aether`**: free, but permanent — the import path
+  is the one name that cannot be migrated gradually, and its cost only grows
+  with adoption.

--- a/website/build_site.py
+++ b/website/build_site.py
@@ -376,6 +376,30 @@ def verify_api(site_dir: Path) -> list[str]:
     return problems
 
 
+#: The exact go-import tag `go get aethermesh.dev` resolves against (proposal
+#: 035). index.html proves the shared extrahead block still emits it; 404.html
+#: is the page that actually answers for package subpaths, so losing the tag
+#: there breaks `go get` for every new fetch that misses the module proxy cache.
+GO_IMPORT_META = '<meta name="go-import" content="aethermesh.dev git https://github.com/bpalermo/aether">'
+
+
+def verify_go_import(site_dir: Path) -> list[str]:
+    problems: list[str] = []
+    for name in ("index.html", "404.html"):
+        page = site_dir / name
+        if not page.is_file():
+            continue  # already reported as a missing required file
+        html = page.read_text(encoding="utf-8")
+        if GO_IMPORT_META not in html:
+            problems.append(
+                f"{name} lost the go-import meta tag — the vanity module path "
+                "aethermesh.dev stops resolving (proposal 035)"
+            )
+        if 'name="go-source"' not in html:
+            problems.append(f"{name} lost the go-source meta tag — pkg.go.dev source links break")
+    return problems
+
+
 def verify_search(site_dir: Path) -> list[str]:
     index = site_dir / "search" / "search_index.json"
     if not index.is_file():
@@ -412,6 +436,7 @@ def verify(site_dir: Path) -> None:
     problems += verify_proposals(site_dir)
     problems += verify_conformance(site_dir)
     problems += verify_api(site_dir)
+    problems += verify_go_import(site_dir)
     problems += verify_search(site_dir)
 
     for path in iter_text_files(site_dir):

--- a/website/overrides/main.html
+++ b/website/overrides/main.html
@@ -20,6 +20,14 @@
 {% extends "base.html" %}
 
 {% block extrahead %}
+  {#- Vanity Go import path (proposal 035): `go get aethermesh.dev` resolves by
+      fetching any path on this host with `?go-get=1` and reading these tags.
+      They sit OUTSIDE the `if page` guard because 404.html — rendered with
+      `page = None` — is the page that answers for package subpaths, and the
+      go tool parses the tags regardless of HTTP status. Exact content is
+      asserted by verify_go_import in build_site.py; change both together. -#}
+  <meta name="go-import" content="aethermesh.dev git https://github.com/bpalermo/aether">
+  <meta name="go-source" content="aethermesh.dev https://github.com/bpalermo/aether https://github.com/bpalermo/aether/tree/main{/dir} https://github.com/bpalermo/aether/blob/main{/dir}/{file}#L{line}">
   {%- if page %}
     {%- set title = page.meta.title if page.meta and page.meta.title else page.title %}
     {#- Same shape as the document title Material renders: a shared card that


### PR DESCRIPTION
## What

Proposal 035 + its serving half: `aethermesh.dev` becomes a Go vanity import host, served by the docs site.

- **`docs/proposals/035_vanity-import-path.md`** — the decision record: apex over `go.` subdomain, bare apex over `/aether` suffix, the coupling risk and its guard, and the follow-up rename PR this gates.
- **`website/overrides/main.html`** — `go-import` + `go-source` meta in the shared extrahead block, deliberately outside the `{% if page %}` guard: `404.html` renders with `page = None` and is the page that answers for arbitrary package subpaths (`/agent/internal/...?go-get=1`); the go tool parses the tags regardless of HTTP status.
- **`website/build_site.py`** — `verify_go_import`: the required `//website:site_test` gate now fails if `index.html` or `404.html` loses the exact tag, so a future site redesign breaks CI instead of `go get`.

## Verified

- `//website:site_test` passes.
- Built tar inspected: the exact `go-import` meta present on `index.html`, `404.html`, and a deep docs page.
- aethermesh.dev custom domain confirmed live (HTTPS 200 apex, correct A records, site 404 page serving).

## Not in this PR

The module rename (`module aethermesh.dev`, gazelle prefix, all imports, proto go_package) is the follow-up, gated on this deploying:

```
curl -s 'https://aethermesh.dev/common/udspath?go-get=1' | grep go-import
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr