### PR TITLE
fix(website): emit the go-import meta before Material's inline scripts

### DIFF
--- a/website/build_site.py
+++ b/website/build_site.py
@@ -390,11 +390,25 @@ def verify_go_import(site_dir: Path) -> list[str]:
         if not page.is_file():
             continue  # already reported as a missing required file
         html = page.read_text(encoding="utf-8")
-        if GO_IMPORT_META not in html:
+        at = html.find(GO_IMPORT_META)
+        if at < 0:
             problems.append(
                 f"{name} lost the go-import meta tag — the vanity module path "
                 "aethermesh.dev stops resolving (proposal 035)"
             )
+        else:
+            # Position matters as much as presence: cmd/go parses with a
+            # lenient XML decoder that aborts at the first raw `<` inside an
+            # inline script (Material's palette bootstrap has one), forgiving
+            # the error only if a go-import tag was already collected. The tag
+            # after the script is exactly how the first deploy shipped broken.
+            script = html.find("<script")
+            if 0 <= script < at:
+                problems.append(
+                    f"{name} emits an inline <script> before the go-import meta — "
+                    "cmd/go's parser dies at the script and never sees the tag "
+                    "(proposal 035)"
+                )
         if 'name="go-source"' not in html:
             problems.append(f"{name} lost the go-source meta tag — pkg.go.dev source links break")
     return problems

--- a/website/overrides/main.html
+++ b/website/overrides/main.html
@@ -19,15 +19,26 @@
 -#}
 {% extends "base.html" %}
 
-{% block extrahead %}
+{% block site_meta %}
   {#- Vanity Go import path (proposal 035): `go get aethermesh.dev` resolves by
       fetching any path on this host with `?go-get=1` and reading these tags.
-      They sit OUTSIDE the `if page` guard because 404.html — rendered with
-      `page = None` — is the page that answers for package subpaths, and the
-      go tool parses the tags regardless of HTTP status. Exact content is
-      asserted by verify_go_import in build_site.py; change both together. -#}
+      Placement is load-bearing twice over:
+      - OUTSIDE any `if page` guard, because 404.html — rendered with
+        `page = None` — is the page that answers for package subpaths.
+      - In site_meta, the FIRST block of <head>, ahead of `super()`: cmd/go
+        parses the page with a lenient XML decoder that dies at Material's
+        inline palette script (`e<<5` — a raw `<`). The error is forgiven only
+        if a go-import tag was already collected, so the tags must precede
+        every inline script. extrahead (where these first lived) is too late —
+        that shipped as `unrecognized import path ... XML syntax error`.
+      Exact content AND head-position are asserted by verify_go_import in
+      build_site.py; change both together. -#}
   <meta name="go-import" content="aethermesh.dev git https://github.com/bpalermo/aether">
   <meta name="go-source" content="aethermesh.dev https://github.com/bpalermo/aether https://github.com/bpalermo/aether/tree/main{/dir} https://github.com/bpalermo/aether/blob/main{/dir}/{file}#L{line}">
+  {{ super() }}
+{% endblock %}
+
+{% block extrahead %}
   {%- if page %}
     {%- set title = page.meta.title if page.meta and page.meta.title else page.title %}
     {#- Same shape as the document title Material renders: a shared card that


### PR DESCRIPTION
## What

The live-fire test of proposal 035 failed:

```
$ GOPROXY=direct go mod download -json aethermesh.dev@main
"Error": "aethermesh.dev@main: unrecognized import path \"aethermesh.dev\": parsing aethermesh.dev: XML syntax error on line 49: expected element name after <"
```

Line 49 is Material's inline palette-bootstrap script — `(e<<5)` contains a raw `<`, and cmd/go's discovery parser is a lenient XML decoder, not an HTML parser. It aborts there, and forgives the abort **only if a go-import tag was already collected**. Ours rendered in `extrahead`, which Material emits *after* that script.

## Fix

- Move both meta tags to `site_meta` — the first block of `<head>` — ahead of `{{ super() }}`. Built pages now carry the meta at byte 67, before anything else.
- `verify_go_import` now asserts **position** (meta before the first `<script>`) as well as presence and exact content, so this failure mode is build-fatal instead of discovered by `go get`.

## Verified

- `//website:site_test` passes; built tar inspected: meta precedes the first script on `index.html`, `404.html`, and a deep docs page.
- The end-to-end `go mod download` re-verification runs against the deployed site after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr