### PR TITLE
chore(bazel): rename the Bazel module to aethermesh

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,9 @@
-module(name = "aether")
+# "aethermesh", not "aether": reserves the identity we'd publish under if this
+# ever lands on the Bazel Central Registry (BCR names are short project
+# identifiers, not domains — the Go module path aethermesh.dev is a separate
+# namespace, see proposal 035). Nothing references the name today (no @aether
+# labels, no external bazel_dep consumers), so this is free to hold.
+module(name = "aethermesh")
 
 bazel_dep(name = "bazel_skylib", version = "1.9.2")
 bazel_dep(name = "platforms", version = "1.1.0")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1051,7 +1051,7 @@
     "@@rules_buf+//buf:extensions.bzl%buf": {
       "general": {
         "bzlTransitiveDigest": "IjW2he5lp+L/zEfsBKIilXijyHH6PC4Lf3y19MA6G4c=",
-        "usagesDigest": "rCFeXFGO+GgbLQ/6FGalLI+p2jWmH6lfEW9D+L3YJAg=",
+        "usagesDigest": "Rteok9tRDOXzNCRZpjQ+8JSR0/6X8muwWsRagtg3wHs=",
         "recordedInputs": [
           "REPO_MAPPING:rules_buf+,bazel_tools bazel_tools"
         ],
@@ -1743,7 +1743,7 @@
     "@@toolchains_buildbuddy+//:extensions.bzl%buildbuddy": {
       "general": {
         "bzlTransitiveDigest": "YThiSErJv+jiCHJzZIEyk0yegQRS/x+T/ce309eGTvA=",
-        "usagesDigest": "Eg5kNhK3yxgMh/3Yj5f6J3z4DApjfuvCv6LfZBv1V5o=",
+        "usagesDigest": "gDZVkwlfP0akn4XWoFM11KnUtXLpTn/+54wA+zOVUzs=",
         "recordedInputs": [],
         "generatedRepoSpecs": {
           "buildbuddy_toolchain": {


### PR DESCRIPTION
Follow-through on the proposal-035 discussion: `module(name = "aethermesh")`, reserving the registry-idiomatic identity now while the rename is provably free — zero `@aether` label references in the tree, no external `bazel_dep` consumers, and the sibling `proxy/` workspace is decoupled. A MODULE.bazel comment records why the Bazel name intentionally does NOT match the Go module path.

Verified: `bazel mod tidy` (lockfile self-name hash only), full `bazel build //...`, spot tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr