### PR TITLE
feat(charts): spread the control plane and UDS fleet off the hot-spot node (#629)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.90.1"
+version: "0.91.0"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/controller-deployment.yaml
+++ b/charts/aether/templates/controller-deployment.yaml
@@ -27,6 +27,29 @@ spec:
         - key: aether.io/agent-not-ready
           operator: Exists
           effect: NoSchedule
+      # Keep the singleton controller off the registrars' node when possible.
+      # Preferred, not required: a small or single-node cluster still schedules.
+      # The controller + both-registrars pile-up on one node is the #629 density
+      # suspect. Override via controller.affinity.
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                    - key: app.kubernetes.io/part-of
+                      operator: In
+                      values: [aether]
+                    - key: app.kubernetes.io/component
+                      operator: In
+                      values: [registrar]
+      {{- end }}
       containers:
         - name: controller
           image: {{ include "aether.image" .Values.controller.image | quote }}

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -57,6 +57,22 @@ spec:
         - key: aether.io/agent-not-ready
           operator: Exists
           effect: NoSchedule
+      # Spread the gateway replicas across nodes — two ingress replicas on one
+      # node is a single point of failure behind the LB. Soft (ScheduleAnyway)
+      # so single-node kind e2e still schedules. Override via
+      # edge.topologySpreadConstraints.
+      {{- with .Values.edge.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "aether.edge.selectorLabels" . | nindent 14 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532

--- a/charts/aether/templates/registrar-deployment.yaml
+++ b/charts/aether/templates/registrar-deployment.yaml
@@ -24,6 +24,22 @@ spec:
         - key: aether.io/agent-not-ready
           operator: Exists
           effect: NoSchedule
+      # Spread the two replicas across nodes. Soft (ScheduleAnyway) on purpose:
+      # single-node kind e2e must still schedule. Both replicas stacking onto
+      # one node made main-worker-01 the density hot spot implicated in
+      # #628/#629. Override via registrar.topologySpreadConstraints.
+      {{- with .Values.registrar.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- else }}
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              {{- include "aether.registrar.selectorLabels" . | nindent 14 }}
+      {{- end }}
       containers:
         - name: registrar
           image: {{ include "aether.image" .Values.registrar.image | quote }}

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -348,6 +348,9 @@ edge:
   # Gateway replicas behind the Service; rolled with the standard RollingUpdate
   # + readiness gate (no hot-restart supervisor — nothing node-local to preserve).
   replicaCount: 2
+  # Empty = chart default: a soft hostname spread across the gateway replicas
+  # (maxSkew 1, ScheduleAnyway). Set to replace the default entirely.
+  topologySpreadConstraints: []
   # The edge reuses the agent image (run as `agent edge`) and the proxy image
   # (plain Envoy entrypoint). Override agent.image / proxy.image to mirror.
   # Ports the edge's public-facing listeners bind (north-south). Privileged ports
@@ -478,6 +481,9 @@ registrar:
   # 2 replicas ALWAYS (directive 2026-06-11): exercises the multi-replica
   # write-behind topology permanently.
   replicaCount: 2
+  # Empty = chart default: a soft hostname spread across the replicas
+  # (maxSkew 1, ScheduleAnyway). Set to replace the default entirely.
+  topologySpreadConstraints: []
   resources:
     requests:
       cpu: 100m
@@ -532,6 +538,9 @@ controller:
     pullPolicy: Always
   # Leader election is on; extra replicas are warm standbys.
   replicaCount: 1
+  # Empty = chart default: preferred podAntiAffinity away from the registrars'
+  # node (soft). Set to replace the default entirely.
+  affinity: {}
   # Pod-ndots mutating webhook (proposal 018, mesh-global FQDN): inject dnsConfig
   # ndots (= the mesh-domain label count) into managed pods so a mesh FQDN
   # (<svc>.<meshDomain>) resolves absolute-first, before the cluster.local search

--- a/charts/udsecho/Chart.yaml
+++ b/charts/udsecho/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   socket delivery, because the TCP-fallback path finds nothing listening.
 type: application
 # Stamped at package time when built with `--stamp` (see registrar Chart.yaml).
-version: "0.1.0-{GIT_COMMIT}"
+version: "0.2.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/udsecho/templates/uds-cr-echo.yaml
+++ b/charts/udsecho/templates/uds-cr-echo.yaml
@@ -26,6 +26,13 @@ spec:
         endpoint.aether.io/port: "8080"
     spec:
       serviceAccountName: uds-cr-echo
+      # Soft hostname spread — same rationale as uds-echo (#629 hot spot).
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: {app: uds-cr-echo}
       securityContext: {fsGroup: 65532}
       containers:
         - name: app

--- a/charts/udsecho/templates/uds-echo.yaml
+++ b/charts/udsecho/templates/uds-echo.yaml
@@ -28,6 +28,14 @@ spec:
         endpoint.aether.io/uds-socket: {{ .Values.socket | quote }}
     spec:
       serviceAccountName: uds-echo
+      # Soft hostname spread: the whole UDS fleet landed on one node, feeding
+      # the #629 density hot spot. Soft so single-node kind e2e still schedules.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: {app: uds-echo}
       # fsGroup makes the emptyDir group-writable for the distroless nonroot
       # user, so the app can create the socket in it.
       securityContext: {fsGroup: 65532}


### PR DESCRIPTION
## What

Phase 1 of the #629 follow-up (also the #628 mitigation): stop the scheduler from stacking the whole control plane + UDS fleet on one node.

**Live placement today** — everything on `main-worker-01`: controller, **both** registrar replicas, **both** edge replicas, all five udsecho pods. That node is implicated in three consecutive soaks' only blemishes and carries the highest standing Envoy heap plateau (306Mi vs 130–172Mi elsewhere).

## How

| component | mechanism | default | knob |
|---|---|---|---|
| registrar (2r) | topologySpreadConstraints, hostname, maxSkew 1 | soft (ScheduleAnyway) | `registrar.topologySpreadConstraints` |
| edge (2r) | same — two ingress replicas on one node is an SPOF behind the LB | soft | `edge.topologySpreadConstraints` |
| controller (1r) | preferred podAntiAffinity vs `component=registrar` | soft | `controller.affinity` |
| uds-echo / uds-cr-echo (2r each) | topologySpreadConstraints per workload | soft, hardcoded (fixed-shape harness chart) | — |

All soft on purpose: single-node kind e2e (conformance, uds jobs) must keep scheduling.

## Verification

- `bazel test //charts/...` — all 8 lint/template tests pass.
- Chart bumps: aether **0.91.0**, udsecho **0.2.0** (CI-enforced).
- Phase 2 of #629 (one more TRIPLE observation post-spread) rides the next soak; #628's under-load plateau sampling does too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr