### PR TITLE
fix(udsecho): declare the client's upstreams in the format the parser accepts (#636)

### DIFF
--- a/charts/udsecho/Chart.yaml
+++ b/charts/udsecho/Chart.yaml
@@ -9,7 +9,7 @@ description: |
   socket delivery, because the TCP-fallback path finds nothing listening.
 type: application
 # Stamped at package time when built with `--stamp` (see registrar Chart.yaml).
-version: "0.2.0-{GIT_COMMIT}"
+version: "0.2.1-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/udsecho/templates/client.yaml
+++ b/charts/udsecho/templates/client.yaml
@@ -24,9 +24,15 @@ spec:
         app: uds-client
         aether.io/managed: "true"
       annotations:
-        # Warm the clusters on this node (demand-scoped distribution) instead
-        # of paying an ODCDS round trip on first dial.
-        config.aether.io/upstreams: "uds-echo.{{ .Values.namespace }}{{ if .Values.policyPath.enabled }},uds-cr-echo.{{ .Values.namespace }}{{ end }}"
+        # Pin the upstream clusters into the node dependency set (demand-scoped
+        # distribution) instead of riding TTL'd ODCDS-observed membership.
+        # FORMAT MATTERS (#636): a value with no "/" is namespace-qualified with
+        # the POD's namespace — bare "uds-echo" is correct here (same-namespace);
+        # cross-namespace needs "<ns>/<svc>". The original dot-form
+        # "uds-echo.<ns>" parsed to the junk key "<ns>/uds-echo.<ns>", so the
+        # declaration silently never applied and every observed-TTL expiry cut
+        # the client's clusters mid-traffic.
+        config.aether.io/upstreams: "uds-echo{{ if .Values.policyPath.enabled }},uds-cr-echo{{ end }}"
     spec:
       serviceAccountName: uds-client
       containers:


### PR DESCRIPTION
Immediate mitigation for #636 (root-caused live mid-soak): the uds-client's `config.aether.io/upstreams` used dot-form `uds-echo.<ns>`, which `UpstreamsFromPod` namespace-qualifies into the junk key `<ns>/uds-echo.<ns>` — the declaration silently never applied. Both UDS services therefore rode 1h-TTL ODCDS-observed membership, and every TTL expiry (pruned on refresher activity, i.e. seconds after whatever unrelated roll came next) dropped the client's egress clusters mid-traffic: `503 NC cluster_not_found` bursts, worst 5.5 min under roll-driven snapshot churn.

Bare names (same-namespace) are the correct form; the template comment now documents the trap. The core defects (warm traffic not renewing observed membership; unbounded ODCDS recovery under churn) stay open in #636.

Chart 0.2.1. `bazel test //charts/udsecho/...` green. **Deploy after the running soak grades** — merging only publishes the chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr