### PR TITLE
fix(build): stamp the GNU build-ID with the release commit SHA (#651)

### DIFF
--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -64,6 +64,34 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # aether #651 acceptance gate, run BEFORE the push so a proxy with the
+      # wrong GNU build-ID can never reach the registry. Two cheap assertions
+      # compose into "the binary's build-ID is this release's commit":
+      #   1. //integration:build_id_test — the linked binary's
+      #      .note.gnu.build-id equals the id the stamped link was handed;
+      #   2. the ldscript the linker was handed says --build-id=0x<github.sha>.
+      # Only the ldscript (one line) is fetched locally; the ~150 MB binary stays
+      # on the executor. The Envoy compile is shared with the push step below.
+      - name: Verify the Envoy GNU build-ID is the release commit
+        working-directory: proxy
+        run: |
+          bazel test \
+            --config=ci \
+            --config=${{ matrix.bazel_config }} \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //integration:build_id_test
+          bazel build \
+            --config=ci \
+            --config=${{ matrix.bazel_config }} \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            @envoy//bazel:gnu_build_id.ldscript
+          ldscript="$(bazel cquery \
+            --config=ci \
+            --config=${{ matrix.bazel_config }} \
+            --output=files @envoy//bazel:gnu_build_id.ldscript)"
+          echo "linker build-ID argument: $(cat "$ldscript")"
+          grep -qi -- "--build-id=0x${{ github.sha }}" "$ldscript"
+
       - name: Build + push ${{ matrix.arch }} by digest (${{ matrix.bazel_config }})
         # remote_tags=[] and no --tag → oci_push pushes the image by digest only
         # (no tag lingers in the registry). Capture the pushed manifest digest.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,6 +37,17 @@ jobs:
         # hosted executor pool and reuses the cache warmed by PR `ci` builds.
         run: |
           bazel build --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //...
+      # Acceptance guard for #651. Under --stamp, //tools/buildid:release_build_ids
+      # fails the build unless every binary that ships in a released image carries
+      # a GNU build-ID equal to this commit's SHA. It is already covered by the
+      # `//...` build above; this step re-states it so a failure names the cause
+      # and prints the per-binary report the Pyroscope symbol upload is keyed on.
+      - name: Verify released GNU build-IDs
+        run: |
+          bazel build --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            //tools/buildid:release_build_ids
+          echo "expected build-ID (release commit): ${{ github.sha }}"
+          cat bazel-bin/tools/buildid/release_build_ids.txt
       # `*.push` publishes each chart together with the images it references
       # (aether.push -> agent + mesh-dns + cni-install + registrar + controller
       # images + the aether chart; crds.push -> the MeshConfig CRD chart;

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ load-agent-image:
 
 .PHONY: push-agent-image
 push-agent-image:
-	@bazel run //agent/cmd/agent:image_push
+	@bazel run --stamp //agent/cmd/agent:image_push
 
 # The slim mesh-DNS daemon (#583) — its own binary AND its own image, so the
 # aether-mesh-dns DaemonSet no longer ships the full agent.
@@ -62,7 +62,7 @@ load-mesh-dns-image:
 
 .PHONY: push-mesh-dns-image
 push-mesh-dns-image:
-	@bazel run //agent/cmd/mesh-dns:image_push
+	@bazel run --stamp //agent/cmd/mesh-dns:image_push
 
 .PHONY: build-cni-install
 build-cni-install:
@@ -74,7 +74,7 @@ load-cni-install-image:
 
 .PHONY: push-cni-install-image
 push-cni-install-image:
-	@bazel run //cni/cmd/cni-install:image_push
+	@bazel run --stamp //cni/cmd/cni-install:image_push
 
 .PHONY: build-registrar
 build-registrar:
@@ -86,13 +86,25 @@ load-registrar-image:
 
 .PHONY: push-registrar-image
 push-registrar-image:
-	@bazel run //registrar/cmd/registrar:image_push
+	@bazel run --stamp //registrar/cmd/registrar:image_push
 
 .PHONY: load-all
 load-all: load-agent-image load-mesh-dns-image load-cni-install-image load-registrar-image
 
+# Every push target passes --stamp: that is what pins each released binary's GNU
+# build-ID to the release commit SHA (#651, //tools/buildid). Without it the
+# images ship the rules_go constant build-ID and profile symbolization silently
+# attributes the new release's samples to the previous release's symbols.
 .PHONY: push-all
 push-all: push-agent-image push-mesh-dns-image push-cni-install-image push-registrar-image
+
+# Print (and assert) the GNU build-ID of every binary that ships in a released
+# image. With --stamp it must equal `git rev-parse HEAD`; the build fails if not.
+.PHONY: check-build-id
+check-build-id:
+	@bazel build --stamp //tools/buildid:release_build_ids
+	@echo "expected build-ID (HEAD): $$(git rev-parse HEAD)"
+	@cat bazel-bin/tools/buildid/release_build_ids.txt
 
 # Publish everything in the order that works: image manifests FIRST, then the
 # charts (chart-only push targets). The combined `:*.push` targets race the

--- a/bazel/img/go_multi_arch_image.bzl
+++ b/bazel/img/go_multi_arch_image.bzl
@@ -4,10 +4,17 @@ load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "file_metadata", "image_layer")
 load("@rules_img//img:load.bzl", "image_load")
 load("@rules_img//img:push.bzl", "image_push")
+load("//tools/buildid:defs.bzl", "stamp_select", "stamped_build_id")
 
 def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "@distroless_static", container_test_configs = ["testdata/container_test.yaml"], tars_layer = None):
     """
     Creates a containerized binary from Go sources.
+
+    Every ELF that goes into the image passes through `stamped_build_id` first,
+    which rewrites its GNU build-ID to the release commit SHA under `--stamp`
+    (#651). Dev and PR-CI builds are `--nostamp` and get a byte-identical copy of
+    the plain binary, so `bazel run`/`bazel test` behaviour is unchanged.
+
     Parameters:
         name:  name of the image
         binary:  go binary
@@ -19,6 +26,29 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
     binary_name = binary[1:]
     entrypoint = "/{}".format(binary_name)
 
+    stamped_binary = "{}_stamped_binary".format(name)
+    stamped_build_id(
+        name = stamped_binary,
+        binary = binary,
+        stamp = stamp_select(),
+        # Public so //tools/buildid:release_build_ids can assert on the exact
+        # ELF that ships, not on a rebuild of it.
+        visibility = ["//visibility:public"],
+    )
+
+    stamped_tars_layer = None
+    if tars_layer:
+        stamped_tars_layer = {}
+        for i, path in enumerate(tars_layer.keys()):
+            stamped_extra = "{}_stamped_extra_{}".format(name, i)
+            stamped_build_id(
+                name = stamped_extra,
+                binary = tars_layer[path],
+                stamp = stamp_select(),
+                visibility = ["//visibility:public"],
+            )
+            stamped_tars_layer[path] = ":" + stamped_extra
+
     string_flag(
         name = "release_tag",
         build_setting_default = "dev",
@@ -27,7 +57,7 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
     image_layer(
         name = "binary_layer",
         srcs = {
-            entrypoint: binary,
+            entrypoint: ":" + stamped_binary,
         },
         default_metadata = file_metadata(
             mode = "0755",
@@ -38,7 +68,7 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
 
     image_layer(
         name = "additional_layer",
-        srcs = tars_layer,
+        srcs = stamped_tars_layer,
         default_metadata = file_metadata(
             mode = "0755",
         ),
@@ -49,7 +79,7 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
     image_manifest(
         name = "image_manifest",
         base = base,
-        layers = [":binary_layer", ":additional_layer"] if tars_layer and len(tars_layer) > 0 else [":binary_layer"],
+        layers = [":binary_layer", ":additional_layer"] if stamped_tars_layer else [":binary_layer"],
         visibility = ["//visibility:private"],
         entrypoint = [entrypoint],
     )

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -3,6 +3,12 @@
 # If their values changes, a target may still include
 # a stale value from a previous build.
 echo "STABLE_GIT_VERSION $(git describe --tags --always --long --dirty --abbrev=40 2>/dev/null || echo 'unknown')"
+# The release commit, STABLE_ so it is cache-key material: //tools/buildid stamps
+# it into every released binary's GNU build-ID (#651), which is the only key the
+# Pyroscope symbolizer joins samples to symbols by. It must therefore be exact
+# (not derived from `git describe`) and must invalidate the stamping action when
+# it changes. The volatile GIT_COMMIT below stays: rules_img uses it for tags.
+echo "STABLE_GIT_COMMIT $(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
 echo "BUILD_TIMESTAMP $(date +%s)"
 echo "GIT_COMMIT $(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
 echo "GIT_BRANCH $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -13,6 +13,22 @@ AETHER_EXTENSIONS = [
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
+    # stamped = True is Envoy's own build-ID mechanism: it links with
+    # `-Wl,@$(location @envoy//bazel:gnu_build_id.ldscript)`, a generated response
+    # file holding `--build-id=0x<BUILD_SCM_REVISION>` — i.e. the GNU build-ID
+    # becomes the source commit SHA. Without it the hermetic LLVM toolchain
+    # supplies its default (an md5 uuid), which is unique per link but says
+    # nothing about which commit produced the binary, so nothing can key a symbol
+    # upload to a release. aether #651: the eBPF profiler joins samples to symbols
+    # by build-ID alone, so it must be the release commit and nothing else.
+    # BUILD_SCM_REVISION comes from //bazel/get_workspace_status (git rev-parse
+    # HEAD of this repo). It is a *volatile* status variable — Envoy's convention
+    # — which means a long-lived incremental workspace can keep a stale ldscript;
+    # release builds run on fresh CI checkouts, and //integration:build_id_test
+    # asserts the binary carries exactly the id the linker was handed.
+    stamped = True,
+    # //integration:build_id_test reads the linked ELF directly.
+    visibility = ["//integration:__pkg__"],
     deps = AETHER_EXTENSIONS + [
         "@envoy//source/exe:envoy_main_entry_lib",
     ],

--- a/proxy/integration/BUILD.bazel
+++ b/proxy/integration/BUILD.bazel
@@ -1,1 +1,26 @@
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+
 exports_files(["image.yaml"])
+
+# aether #651: assert the custom Envoy's `.note.gnu.build-id` is present and is
+# exactly the id the stamped link was handed — Envoy's generated
+# gnu_build_id.ldscript, i.e. `--build-id=0x<BUILD_SCM_REVISION>`. Comparing
+# against the ldscript rather than against a second read of the workspace status
+# keeps the test free of stamping races while still proving end-to-end that
+# `envoy_cc_binary(stamped = True)` took effect; the release workflow does the
+# `== github.sha` comparison on top.
+#
+# No extra build cost: //:envoy is already compiled for //:image_test.
+sh_test(
+    name = "build_id_test",
+    size = "small",
+    srcs = ["check_build_id.sh"],
+    args = [
+        "$(rootpath //:envoy)",
+        "$(rootpath @envoy//bazel:gnu_build_id.ldscript)",
+    ],
+    data = [
+        "//:envoy",
+        "@envoy//bazel:gnu_build_id.ldscript",
+    ],
+)

--- a/proxy/integration/check_build_id.sh
+++ b/proxy/integration/check_build_id.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Assert the GNU build-ID baked into a linked ELF binary (aether #651).
+#
+# Usage:
+#   check_build_id.sh <binary> [<expected>]
+#
+# <expected> may be
+#   * a 40-hex SHA — the build-ID must equal it exactly;
+#   * a path to Envoy's `gnu_build_id.ldscript` (`--build-id=0x<sha>`) — the
+#     build-ID must equal the id the linker was handed, which proves the stamped
+#     link actually took effect;
+#   * omitted or "-" — presence check only.
+#
+# Deliberately dependency-free: `od` + `awk` are POSIX, so this runs unchanged on
+# a GitHub runner and inside a BuildBuddy RBE executor image, neither of which is
+# guaranteed to ship binutils `readelf`.
+set -euo pipefail
+
+binary=${1:?usage: check_build_id.sh <binary> [<expected>]}
+expected_arg=${2:--}
+
+# The ELF note header for a 20-byte NT_GNU_BUILD_ID, little-endian:
+#   namesz=4 | descsz=0x14 | type=3 | "GNU\0"
+# Both architectures aether ships (x86-64, aarch64) are little-endian.
+note_prefix="040000001400000003000000474e5500"
+
+# extract_build_id <file> [byte-limit]
+# Streams the file through od/awk with a sliding window, so a match that straddles
+# an od line — or a 150 MB Envoy binary — is handled without buffering the lot.
+extract_build_id() {
+	local file=$1 limit=${2:-}
+	local od_args=(-An -v -tx1)
+	[ -n "$limit" ] && od_args+=(-N "$limit")
+	# awk exits as soon as it has the id, which SIGPIPEs od; that is the point of
+	# the early exit, so pipefail is off for this pipeline only.
+	set +o pipefail
+	od "${od_args[@]}" "$file" 2>/dev/null | awk -v pfx="$note_prefix" '
+    BEGIN { plen = length(pfx) }
+    {
+      gsub(/ /, "", $0)
+      buf = buf $0
+      i = index(buf, pfx)
+      if (i > 0 && length(buf) >= i + plen + 39) {
+        print substr(buf, i + plen, 40)
+        exit
+      }
+      if (length(buf) > 8192) buf = substr(buf, length(buf) - 200)
+    }
+  '
+	set -o pipefail
+}
+
+if [ ! -f "$binary" ]; then
+	echo "FAIL: $binary does not exist" >&2
+	exit 1
+fi
+
+# The note lives in the first PT_LOAD, a few hundred bytes in; 4 MiB is a wildly
+# generous fast path. Fall back to the whole file rather than reporting a false
+# "no build-ID" if a future linker moves it.
+got=$(extract_build_id "$binary" 4194304)
+if [ -z "$got" ]; then
+	got=$(extract_build_id "$binary")
+fi
+
+if [ -z "$got" ]; then
+	echo "FAIL: $binary carries no .note.gnu.build-id" >&2
+	echo "      (aether #651: released binaries must be linked with a stamped build-ID)" >&2
+	exit 1
+fi
+
+if [ "$expected_arg" = "-" ]; then
+	echo "OK: $binary build-ID $got (presence only)"
+	exit 0
+fi
+
+if [ -f "$expected_arg" ]; then
+	# Envoy's ldscript: the exact linker argument the stamped link consumed.
+	expected=$(tr -d ' \r\n' <"$expected_arg" |
+		sed -n 's/.*--build-id=0x\([0-9a-fA-F]\{40\}\).*/\1/p')
+	if [ -z "$expected" ]; then
+		echo "FAIL: $expected_arg holds no 40-hex --build-id=0x<sha>" >&2
+		echo "      contents: $(cat "$expected_arg")" >&2
+		exit 1
+	fi
+else
+	expected=$expected_arg
+fi
+expected=$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')
+
+if [ "$got" != "$expected" ]; then
+	echo "FAIL: $binary build-ID is $got, want $expected" >&2
+	echo "      (aether #651: the build-ID must be the release commit SHA)" >&2
+	exit 1
+fi
+
+echo "OK: $binary build-ID $got"

--- a/tools/buildid/BUILD.bazel
+++ b/tools/buildid/BUILD.bazel
@@ -1,0 +1,54 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("//tools/buildid:defs.bzl", "build_id_check", "stamp_select")
+
+# `--stamp` is a native Bazel option, so `values` reads it directly — the same
+# config_setting rules_go uses for its own stamping. Everything downstream (the
+# image macro, the release guard) selects on this, so a plain dev build keeps the
+# unmodified go_binary and only release builds pay for the extra copy.
+config_setting(
+    name = "stamp_enabled",
+    values = {"stamp": "true"},
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "buildid_lib",
+    srcs = [
+        "buildid.go",
+        "main.go",
+    ],
+    importpath = "aethermesh.dev/tools/buildid",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "buildid",
+    embed = [":buildid_lib"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "buildid_test",
+    srcs = ["buildid_test.go"],
+    embed = [":buildid_lib"],
+)
+
+# Acceptance guard for #651: fails the build if any binary that ships in a
+# released image lacks a GNU build-ID note, or — under `--stamp`, i.e. the
+# publish workflow — carries anything other than the release commit SHA.
+# Built by `bazel build //...` and explicitly (with --stamp) by the publish
+# workflow, so a regression cannot reach a published image.
+build_id_check(
+    name = "release_build_ids",
+    binaries = [
+        "//agent/cmd/agent:agent_image_stamped_binary",
+        "//agent/cmd/mesh-dns:mesh-dns_image_stamped_binary",
+        "//cni/cmd/cni-install:cni-install_image_stamped_binary",
+        # The CNI plugin the installer drops on the host — a second released ELF
+        # inside the cni-install image.
+        "//cni/cmd/cni-install:cni-install_image_stamped_extra_0",
+        "//controller/cmd/controller:controller_image_stamped_binary",
+        "//registrar/cmd/registrar:registrar_image_stamped_binary",
+    ],
+    stamp = stamp_select(),
+)

--- a/tools/buildid/buildid.go
+++ b/tools/buildid/buildid.go
@@ -1,0 +1,193 @@
+// Package main implements the GNU build-ID stamping tool used by the Bazel
+// `stamped_build_id` rule (see defs.bzl).
+//
+// Why this exists: rules_go links every Go binary with `-buildid=redacted` for
+// reproducibility, and since Go 1.24 the Go linker derives the ELF
+// `.note.gnu.build-id` note from that Go build ID by default (`-B gobuildid`).
+// A constant input yields a constant note, so every aether Go binary ever built
+// carries the same GNU build-ID (498919aff001d8366249403a2544fba2d833084f) no
+// matter what code is in it (issue #651). Profilers that join samples to symbols
+// purely by build-ID — the Pyroscope eBPF symbolizer does — then silently
+// symbolize a new release against the previous release's offsets.
+//
+// rules_go does not stamp-expand `gc_linkopts`, so `-B 0x<sha>` cannot be fed to
+// the linker from the workspace status. Instead this tool rewrites the note
+// in place after the link: the note's descriptor is exactly 20 bytes, which is
+// also the width of a git commit SHA-1, so the release commit drops straight in
+// without moving a single byte of the ELF.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"debug/elf"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+const (
+	// buildIDSection is the ELF section holding the GNU build-ID note.
+	buildIDSection = ".note.gnu.build-id"
+	// buildIDLen is the descriptor width the Go linker emits (SHA-1 shaped),
+	// and the width of a git commit SHA-1. They match on purpose: the note is
+	// patched in place, never resized.
+	buildIDLen = 20
+	// noteTypeGNUBuildID is NT_GNU_BUILD_ID.
+	noteTypeGNUBuildID = 3
+)
+
+// gnuNoteName is the note owner, NUL-terminated as the ELF note format requires.
+var gnuNoteName = []byte("GNU\x00")
+
+// errNoBuildIDNote reports an ELF file that carries no GNU build-ID note at all.
+var errNoBuildIDNote = errors.New("no " + buildIDSection + " note")
+
+// buildIDOffset returns the file offset of the 20-byte build-ID descriptor in
+// the ELF image held by r, or errNoBuildIDNote when the image has no such note.
+//
+// ELF note layout (Elf_Nhdr, all fields in the file's byte order):
+//
+//	namesz uint32 | descsz uint32 | type uint32 | name [namesz]byte (4-aligned) | desc [descsz]byte
+func buildIDOffset(r io.ReaderAt) (int64, error) {
+	f, err := elf.NewFile(r)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	sec := f.Section(buildIDSection)
+	if sec == nil || sec.Type != elf.SHT_NOTE {
+		return 0, errNoBuildIDNote
+	}
+	// SHT_NOBITS sections occupy no file bytes, so there would be nothing to
+	// patch; treat it as absent rather than corrupting the image.
+	if sec.Type == elf.SHT_NOBITS || sec.Size < 12 {
+		return 0, errNoBuildIDNote
+	}
+
+	hdr := make([]byte, 12)
+	if _, err := r.ReadAt(hdr, int64(sec.Offset)); err != nil {
+		return 0, fmt.Errorf("reading note header: %w", err)
+	}
+	bo := f.ByteOrder
+	namesz := bo.Uint32(hdr[0:4])
+	descsz := bo.Uint32(hdr[4:8])
+	typ := bo.Uint32(hdr[8:12])
+
+	if typ != noteTypeGNUBuildID {
+		return 0, fmt.Errorf("%s: unexpected note type %d (want %d)", buildIDSection, typ, noteTypeGNUBuildID)
+	}
+	if namesz != uint32(len(gnuNoteName)) {
+		return 0, fmt.Errorf("%s: unexpected note namesz %d (want %d)", buildIDSection, namesz, len(gnuNoteName))
+	}
+	if descsz != buildIDLen {
+		return 0, fmt.Errorf("%s: descriptor is %d bytes, want %d — cannot patch in place", buildIDSection, descsz, buildIDLen)
+	}
+
+	name := make([]byte, namesz)
+	if _, err := r.ReadAt(name, int64(sec.Offset)+12); err != nil {
+		return 0, fmt.Errorf("reading note name: %w", err)
+	}
+	if !bytes.Equal(name, gnuNoteName) {
+		return 0, fmt.Errorf("%s: unexpected note owner %q (want %q)", buildIDSection, name, gnuNoteName)
+	}
+
+	// The name is padded to a 4-byte boundary; "GNU\0" is already 4 bytes.
+	descOff := int64(sec.Offset) + 12 + int64(align4(namesz))
+	if descOff+buildIDLen > int64(sec.Offset)+int64(sec.Size) {
+		return 0, fmt.Errorf("%s: descriptor runs past the section", buildIDSection)
+	}
+	return descOff, nil
+}
+
+func align4(n uint32) uint32 {
+	return (n + 3) &^ 3
+}
+
+// readBuildID returns the current 20-byte build-ID descriptor of an ELF image.
+func readBuildID(r io.ReaderAt) ([]byte, error) {
+	off, err := buildIDOffset(r)
+	if err != nil {
+		return nil, err
+	}
+	id := make([]byte, buildIDLen)
+	if _, err := r.ReadAt(id, off); err != nil {
+		return nil, err
+	}
+	return id, nil
+}
+
+// patch rewrites the GNU build-ID descriptor of the ELF image in buf to id.
+func patch(buf []byte, id []byte) error {
+	if len(id) != buildIDLen {
+		return fmt.Errorf("build ID is %d bytes, want %d", len(id), buildIDLen)
+	}
+	off, err := buildIDOffset(bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	copy(buf[off:off+buildIDLen], id)
+	return nil
+}
+
+// parseStatus reads a Bazel workspace status file ("KEY value" per line).
+func parseStatus(r io.Reader) map[string]string {
+	out := map[string]string{}
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		key, value, found := strings.Cut(strings.TrimSpace(sc.Text()), " ")
+		if !found || key == "" {
+			continue
+		}
+		out[key] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+// commitFromStatus extracts the release commit SHA from a parsed workspace
+// status map. STABLE_GIT_COMMIT is the dedicated variable; STABLE_GIT_VERSION
+// (`git describe --long --abbrev=40`) is accepted as a fallback so the stamp
+// still resolves if the status script is rolled back. Returns "" when no commit
+// can be resolved — the caller then leaves the binary untouched.
+func commitFromStatus(status map[string]string) string {
+	if sha := status["STABLE_GIT_COMMIT"]; isSHA1(sha) {
+		return sha
+	}
+	// `v0.91.0-12-g<40 hex>[-dirty]` or a bare 40-hex from `--always`.
+	for _, field := range strings.Split(status["STABLE_GIT_VERSION"], "-") {
+		if isSHA1(field) {
+			return field
+		}
+		if len(field) == 41 && field[0] == 'g' && isSHA1(field[1:]) {
+			return field[1:]
+		}
+	}
+	return ""
+}
+
+func isSHA1(s string) bool {
+	if len(s) != 2*buildIDLen {
+		return false
+	}
+	_, err := hex.DecodeString(s)
+	return err == nil
+}
+
+// readCommit resolves the release commit from a workspace status file. An empty
+// path (no stamping requested) yields "".
+func readCommit(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	return commitFromStatus(parseStatus(f)), nil
+}

--- a/tools/buildid/buildid_test.go
+++ b/tools/buildid/buildid_test.go
@@ -1,0 +1,307 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const releaseSHA = "c46dd35abc0123456789abcdef0123456789abcd"
+
+// synthELF builds a minimal little-endian ELF64 image carrying a single
+// SHT_NOTE section named .note.gnu.build-id whose descriptor is id. It is a
+// stand-in for a linked Go binary: the stamping tool only ever reads the section
+// header table and rewrites 20 bytes, so nothing else needs to be real.
+func synthELF(t *testing.T, id []byte) []byte {
+	t.Helper()
+
+	const (
+		ehdrSize = 64
+		shdrSize = 64
+	)
+	le := binary.LittleEndian
+
+	// Note payload: namesz | descsz | type | "GNU\0" | desc.
+	note := make([]byte, 0, 12+4+len(id))
+	note = le.AppendUint32(note, 4)
+	note = le.AppendUint32(note, uint32(len(id)))
+	note = le.AppendUint32(note, noteTypeGNUBuildID)
+	note = append(note, gnuNoteName...)
+	note = append(note, id...)
+
+	// Section name table: "\0" + ".shstrtab\0" + ".note.gnu.build-id\0".
+	shstrtab := append([]byte{0}, ".shstrtab\x00"...)
+	shstrtab = append(shstrtab, buildIDSection...)
+	shstrtab = append(shstrtab, 0)
+	noteNameOff := uint32(len(shstrtab) - len(buildIDSection) - 1)
+
+	noteOff := uint32(ehdrSize)
+	shstrtabOff := noteOff + uint32(len(note))
+	shoff := shstrtabOff + uint32(len(shstrtab))
+
+	shdr := func(name, typ uint32, off, size uint32) []byte {
+		b := make([]byte, 0, shdrSize)
+		b = le.AppendUint32(b, name)
+		b = le.AppendUint32(b, typ)
+		b = le.AppendUint64(b, 0) // sh_flags
+		b = le.AppendUint64(b, 0) // sh_addr
+		b = le.AppendUint64(b, uint64(off))
+		b = le.AppendUint64(b, uint64(size))
+		b = le.AppendUint32(b, 0) // sh_link
+		b = le.AppendUint32(b, 0) // sh_info
+		b = le.AppendUint64(b, 4) // sh_addralign
+		b = le.AppendUint64(b, 0) // sh_entsize
+		return b
+	}
+
+	img := make([]byte, 0, shoff+3*shdrSize)
+	ehdr := make([]byte, ehdrSize)
+	copy(ehdr, []byte{0x7f, 'E', 'L', 'F', 2 /*ELFCLASS64*/, 1 /*ELFDATA2LSB*/, 1 /*EV_CURRENT*/})
+	le.PutUint16(ehdr[16:], 2)  // e_type = ET_EXEC
+	le.PutUint16(ehdr[18:], 62) // e_machine = EM_X86_64
+	le.PutUint32(ehdr[20:], 1)  // e_version
+	le.PutUint64(ehdr[40:], uint64(shoff))
+	le.PutUint16(ehdr[52:], ehdrSize) // e_ehsize
+	le.PutUint16(ehdr[58:], shdrSize) // e_shentsize
+	le.PutUint16(ehdr[60:], 3)        // e_shnum
+	le.PutUint16(ehdr[62:], 2)        // e_shstrndx
+	img = append(img, ehdr...)
+	img = append(img, note...)
+	img = append(img, shstrtab...)
+	img = append(img, shdr(0, 0 /*SHT_NULL*/, 0, 0)...)
+	img = append(img, shdr(noteNameOff, 7 /*SHT_NOTE*/, noteOff, uint32(len(note)))...)
+	img = append(img, shdr(1, 3 /*SHT_STRTAB*/, shstrtabOff, uint32(len(shstrtab)))...)
+	return img
+}
+
+func TestReadBuildID(t *testing.T) {
+	want := bytes.Repeat([]byte{0xab}, buildIDLen)
+	got, err := readBuildID(bytes.NewReader(synthELF(t, want)))
+	if err != nil {
+		t.Fatalf("readBuildID: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("readBuildID = %x, want %x", got, want)
+	}
+}
+
+func TestPatchReplacesOnlyTheDescriptor(t *testing.T) {
+	original := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen))
+	patched := append([]byte(nil), original...)
+
+	want, err := hex.DecodeString(releaseSHA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := patch(patched, want); err != nil {
+		t.Fatalf("patch: %v", err)
+	}
+
+	got, err := readBuildID(bytes.NewReader(patched))
+	if err != nil {
+		t.Fatalf("readBuildID after patch: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("build ID = %x, want %x", got, want)
+	}
+	if len(patched) != len(original) {
+		t.Fatalf("patch resized the image: %d -> %d", len(original), len(patched))
+	}
+
+	// Exactly the 20 descriptor bytes may differ.
+	var differing int
+	for i := range original {
+		if original[i] != patched[i] {
+			differing++
+		}
+	}
+	if differing != buildIDLen {
+		t.Fatalf("%d bytes differ, want exactly %d", differing, buildIDLen)
+	}
+
+	// Patching is idempotent: the same commit yields the same image.
+	again := append([]byte(nil), original...)
+	if err := patch(again, want); err != nil {
+		t.Fatalf("patch (second): %v", err)
+	}
+	if !bytes.Equal(again, patched) {
+		t.Fatal("patching the same commit twice produced different images")
+	}
+}
+
+func TestPatchWrongIDLength(t *testing.T) {
+	img := synthELF(t, bytes.Repeat([]byte{0}, buildIDLen))
+	if err := patch(img, []byte{1, 2, 3}); err == nil {
+		t.Fatal("expected an error for a short build ID")
+	}
+}
+
+func TestBuildIDOffsetMissingNote(t *testing.T) {
+	img := synthELF(t, bytes.Repeat([]byte{0}, buildIDLen))
+	// Rename the note section so the lookup misses it (shstrtab offset 1 is
+	// ".shstrtab").
+	le := binary.LittleEndian
+	shoff := le.Uint64(img[40:])
+	le.PutUint32(img[int(shoff)+64:], 1)
+
+	if _, err := readBuildID(bytes.NewReader(img)); !errors.Is(err, errNoBuildIDNote) {
+		t.Fatalf("err = %v, want errNoBuildIDNote", err)
+	}
+}
+
+func TestCommitFromStatus(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+		want   string
+	}{
+		{
+			name:   "dedicated variable",
+			status: "STABLE_GIT_VERSION v0.91.0-3-g" + releaseSHA + "\nSTABLE_GIT_COMMIT " + releaseSHA + "\n",
+			want:   releaseSHA,
+		},
+		{
+			name:   "falls back to the describe output",
+			status: "STABLE_GIT_VERSION v0.91.0-3-g" + releaseSHA + "\n",
+			want:   releaseSHA,
+		},
+		{
+			name:   "falls back to a describe --always bare sha",
+			status: "STABLE_GIT_VERSION " + releaseSHA + "\n",
+			want:   releaseSHA,
+		},
+		{
+			name:   "dirty tree still resolves the parent commit",
+			status: "STABLE_GIT_VERSION v0.91.0-3-g" + releaseSHA + "-dirty\n",
+			want:   releaseSHA,
+		},
+		{
+			name:   "no git",
+			status: "STABLE_GIT_VERSION unknown\nSTABLE_GIT_COMMIT unknown\n",
+			want:   "",
+		},
+		{
+			name:   "empty",
+			status: "",
+			want:   "",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := commitFromStatus(parseStatus(strings.NewReader(tc.status))); got != tc.want {
+				t.Fatalf("commitFromStatus = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// writeStatus writes a stable-status.txt naming the release commit.
+func writeStatus(t *testing.T, dir string) string {
+	t.Helper()
+	path := filepath.Join(dir, "stable-status.txt")
+	body := "BUILD_EMBED_LABEL \nSTABLE_GIT_COMMIT " + releaseSHA + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestRunStampAndVerify(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "binary")
+	out := filepath.Join(dir, "binary_stamped")
+	if err := os.WriteFile(in, synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	status := writeStatus(t, dir)
+
+	if err := runStamp([]string{"-in", in, "-out", out, "-status-file", status}); err != nil {
+		t.Fatalf("runStamp: %v", err)
+	}
+	if err := runVerify([]string{"-status-file", status, out}); err != nil {
+		t.Fatalf("runVerify: %v", err)
+	}
+	// The unstamped input must fail the stamped verification.
+	if err := runVerify([]string{"-status-file", status, in}); err == nil {
+		t.Fatal("expected the unstamped binary to fail verification")
+	}
+	// Without a status file, verification only asserts the note is present.
+	if err := runVerify([]string{in}); err != nil {
+		t.Fatalf("runVerify (presence only): %v", err)
+	}
+
+	info, err := os.Stat(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Fatalf("stamped output is not executable: %v", info.Mode())
+	}
+}
+
+func TestRunStampWithoutStatusFileCopies(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "binary")
+	out := filepath.Join(dir, "binary_stamped")
+	img := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen))
+	if err := os.WriteFile(in, img, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runStamp([]string{"-in", in, "-out", out}); err != nil {
+		t.Fatalf("runStamp: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, img) {
+		t.Fatal("an unstamped build must copy the binary byte-for-byte")
+	}
+}
+
+func TestRunStampNonELFCopies(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "not-an-elf")
+	out := filepath.Join(dir, "not-an-elf_stamped")
+	payload := []byte("#!/bin/sh\necho hello\n")
+	if err := os.WriteFile(in, payload, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	status := writeStatus(t, dir)
+
+	if err := runStamp([]string{"-in", in, "-out", out, "-status-file", status}); err != nil {
+		t.Fatalf("runStamp: %v", err)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("a non-ELF input must be copied unchanged")
+	}
+}
+
+func TestRunVerifyWritesMarker(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "binary")
+	if err := os.WriteFile(bin, synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(dir, "marker.txt")
+	if err := runVerify([]string{"-marker", marker, bin}); err != nil {
+		t.Fatalf("runVerify: %v", err)
+	}
+	body, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), strings.Repeat("49", buildIDLen)) {
+		t.Fatalf("marker does not report the build ID: %q", body)
+	}
+}

--- a/tools/buildid/defs.bzl
+++ b/tools/buildid/defs.bzl
@@ -1,0 +1,146 @@
+"""Stamp the GNU build-ID of a linked binary with the release commit SHA (#651).
+
+rules_go links every Go binary with `-buildid=redacted`, and since Go 1.24 the Go
+linker derives `.note.gnu.build-id` from that constant by default — so every
+aether Go binary ever produced carries the same GNU build-ID. Profilers that key
+symbols purely by build-ID (the Pyroscope eBPF symbolizer does) then attribute a
+new release's samples to the previous release's symbol offsets, silently.
+
+rules_go does not stamp-expand `gc_linkopts`, so the linker's `-B 0x<sha>` cannot
+be fed from the workspace status. `stamped_build_id` instead rewrites the note
+after the link: the descriptor is exactly 20 bytes, the width of a git commit
+SHA-1, so the release commit drops in without moving any other byte.
+
+Guarantees:
+  * two different commits produce two different build-IDs;
+  * rebuilding the same commit reproduces the same build-ID (the id comes from
+    the *stable* workspace status, so the cache stays warm — only the copy action
+    re-runs when the commit changes, never the link or the compiles);
+  * `--nostamp` builds (every dev build, every PR CI build) get a byte-identical
+    copy of the plain binary, so nothing about local iteration changes.
+
+`build_id_check` is the guard: it fails the build if a released binary has no
+build-ID note, or (under `--stamp`) if the note is not the release commit.
+"""
+
+# `--stamp` is a native Bazel option, so a plain `values` config_setting reads it
+# — the same trick rules_go uses for its own stamping (@rules_go//go/private:stamp).
+STAMP_ENABLED = "//tools/buildid:stamp_enabled"
+
+def _status_file(ctx):
+    """The STABLE workspace status file, or None on a --nostamp build.
+
+    `ctx.info_file` is stable-status.txt; `ctx.version_file` is the *volatile*
+    one. Only the stable file is cache-key material, which is precisely what is
+    wanted here: the same commit rebuilds to the same build-ID and the same
+    remote-cache entry, and a new commit re-runs the copy action alone.
+    """
+    return ctx.info_file if ctx.attr.stamp else None
+
+def _stamped_build_id_impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name)
+    binary = ctx.file.binary
+
+    args = ctx.actions.args()
+    args.add("stamp")
+    args.add("-in", binary)
+    args.add("-out", out)
+
+    inputs = [binary]
+    status = _status_file(ctx)
+    if status:
+        args.add("-status-file", status)
+        inputs.append(status)
+
+    ctx.actions.run(
+        executable = ctx.executable._tool,
+        arguments = [args],
+        inputs = inputs,
+        outputs = [out],
+        mnemonic = "StampBuildID",
+        progress_message = "Stamping GNU build-ID into %{output}",
+    )
+
+    return [DefaultInfo(
+        files = depset([out]),
+        executable = out,
+        runfiles = ctx.runfiles().merge(ctx.attr.binary[DefaultInfo].default_runfiles),
+    )]
+
+stamped_build_id = rule(
+    implementation = _stamped_build_id_impl,
+    executable = True,
+    doc = "Copies `binary`, rewriting its GNU build-ID note to the release commit SHA.",
+    attrs = {
+        "binary": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "The binary to stamp. Non-ELF inputs are copied unchanged.",
+        ),
+        "stamp": attr.bool(
+            default = False,
+            doc = "Whether to read the commit from the stable workspace status. " +
+                  "Set from a select() on //tools/buildid:stamp_enabled.",
+        ),
+        "_tool": attr.label(
+            default = Label("//tools/buildid"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def _build_id_check_impl(ctx):
+    marker = ctx.actions.declare_file(ctx.label.name + ".txt")
+    binaries = ctx.files.binaries
+    if not binaries:
+        fail("build_id_check needs at least one binary")
+
+    args = ctx.actions.args()
+    args.add("verify")
+    args.add("-marker", marker)
+
+    inputs = list(binaries)
+    status = _status_file(ctx)
+    if status:
+        args.add("-status-file", status)
+        inputs.append(status)
+    args.add_all(binaries)
+
+    ctx.actions.run(
+        executable = ctx.executable._tool,
+        arguments = [args],
+        inputs = inputs,
+        outputs = [marker],
+        mnemonic = "CheckBuildID",
+        progress_message = "Checking GNU build-IDs of the released binaries",
+    )
+    return [DefaultInfo(files = depset([marker]))]
+
+build_id_check = rule(
+    implementation = _build_id_check_impl,
+    doc = "Fails the build unless every binary carries the expected GNU build-ID.",
+    attrs = {
+        "binaries": attr.label_list(
+            mandatory = True,
+            allow_files = True,
+            doc = "Stamped binaries to check.",
+        ),
+        "stamp": attr.bool(
+            default = False,
+            doc = "Whether to require the note to equal the release commit.",
+        ),
+        "_tool": attr.label(
+            default = Label("//tools/buildid"),
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
+def stamp_select():
+    """select() that turns stamping on exactly when `--stamp` is passed."""
+    return select({
+        STAMP_ENABLED: True,
+        "//conditions:default": False,
+    })

--- a/tools/buildid/main.go
+++ b/tools/buildid/main.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+	}
+	var err error
+	switch os.Args[1] {
+	case "stamp":
+		err = runStamp(os.Args[2:])
+	case "verify":
+		err = runVerify(os.Args[2:])
+	default:
+		usage()
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "buildid: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `usage:
+  buildid stamp  -in FILE -out FILE [-status-file FILE]
+  buildid verify [-status-file FILE] -marker FILE FILE...
+`)
+	os.Exit(2)
+}
+
+// runStamp copies -in to -out, rewriting the GNU build-ID note to the release
+// commit SHA read from -status-file.
+//
+// Fallbacks, all of which produce a byte-identical copy of the input rather than
+// an error, so that unstamped and non-Go/non-ELF inputs keep building:
+//   - no -status-file (i.e. --nostamp): copy unchanged;
+//   - status file with no resolvable commit SHA: copy unchanged;
+//   - input is not an ELF image (e.g. a Mach-O host build, or a data file
+//     riding in an image layer): copy unchanged.
+//
+// An ELF input that *is* being stamped but carries no build-ID note is a hard
+// error: that would silently ship an unsymbolizable binary.
+func runStamp(args []string) error {
+	fs := flag.NewFlagSet("stamp", flag.ExitOnError)
+	in := fs.String("in", "", "input binary")
+	out := fs.String("out", "", "output binary")
+	statusFile := fs.String("status-file", "", "Bazel stable workspace status file (empty: do not stamp)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *in == "" || *out == "" {
+		return errors.New("stamp: -in and -out are required")
+	}
+
+	commit, err := readCommit(*statusFile)
+	if err != nil {
+		return err
+	}
+
+	buf, err := os.ReadFile(*in)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(*in)
+	if err != nil {
+		return err
+	}
+
+	switch {
+	case commit == "":
+		fmt.Fprintf(os.Stderr, "buildid: no release commit in the workspace status; leaving %s untouched\n", *in)
+	case !isELF(buf):
+		fmt.Fprintf(os.Stderr, "buildid: %s is not an ELF image; leaving it untouched\n", *in)
+	default:
+		id, err := hex.DecodeString(commit)
+		if err != nil {
+			return fmt.Errorf("decoding commit %q: %w", commit, err)
+		}
+		if err := patch(buf, id); err != nil {
+			return fmt.Errorf("%s: %w", *in, err)
+		}
+	}
+
+	return os.WriteFile(*out, buf, info.Mode().Perm())
+}
+
+// runVerify asserts that every named ELF binary carries a GNU build-ID note and,
+// when the build is stamped, that the note equals the release commit SHA. It is
+// the build-time guard for issue #651: wire it into a target that CI builds and
+// a regression can never reach a published image.
+func runVerify(args []string) error {
+	fs := flag.NewFlagSet("verify", flag.ExitOnError)
+	statusFile := fs.String("status-file", "", "Bazel stable workspace status file (empty: presence check only)")
+	marker := fs.String("marker", "", "file to write on success")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files := fs.Args()
+	if len(files) == 0 {
+		return errors.New("verify: no files given")
+	}
+
+	want, err := wantBuildID(*statusFile)
+	if err != nil {
+		return err
+	}
+
+	var report bytes.Buffer
+	var failures int
+	for _, path := range files {
+		got, err := checkOne(path, want)
+		if err != nil {
+			fmt.Fprintf(&report, "%s: %v\n", path, err)
+			failures++
+			continue
+		}
+		fmt.Fprintf(&report, "%s: %s\n", path, got)
+	}
+	if failures > 0 {
+		return fmt.Errorf("%d binary(ies) failed the GNU build-ID check (see #651):\n%s", failures, report.String())
+	}
+	if *marker != "" {
+		return os.WriteFile(*marker, report.Bytes(), 0o644)
+	}
+	_, err = os.Stdout.Write(report.Bytes())
+	return err
+}
+
+// wantBuildID returns the build-ID every checked binary must carry, or nil when
+// the build is not stamped (presence check only).
+func wantBuildID(statusFile string) ([]byte, error) {
+	commit, err := readCommit(statusFile)
+	if err != nil || commit == "" {
+		return nil, err
+	}
+	want, err := hex.DecodeString(commit)
+	if err != nil {
+		return nil, fmt.Errorf("decoding commit %q: %w", commit, err)
+	}
+	return want, nil
+}
+
+// checkOne returns the hex build-ID of path, or an error describing why it is
+// missing or wrong.
+func checkOne(path string, want []byte) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+
+	got, err := readBuildID(f)
+	if err != nil {
+		return "", err
+	}
+	if want != nil && !bytes.Equal(got, want) {
+		return "", fmt.Errorf("build-ID is %x, want the release commit %x", got, want)
+	}
+	return fmt.Sprintf("%x", got), nil
+}
+
+func isELF(buf []byte) bool {
+	return len(buf) >= 4 && bytes.Equal(buf[:4], []byte("\x7fELF"))
+}


### PR DESCRIPTION
Fixes #651.

## Why stamp (rather than "make it a content hash")

The issue's desired end state was `--build-id=sha1` (content hash). Per explicit direction this lands the stronger form instead: **the build-ID *is* the release commit SHA**.

- A 20-byte git commit SHA-1 is exactly the width of a GNU build-ID descriptor, so it drops in without changing the ELF layout.
- It matches **upstream Envoy's own convention** — every stock Envoy in the fleet carries a 20-byte sha1 equal to its source SHA — and it's the mechanism Envoy already ships (`envoy_cc_binary(stamped = True)`).
- Symbol uploads become keyed by a value you can *look up*: given a build-ID from a flamegraph you know the exact commit, and given a release you know what to upload, without needing the artifact in hand.

## Mechanism

**Go binaries (`//tools/buildid`).** rules_go links with `-buildid=redacted`, and since Go 1.24 the Go linker derives `.note.gnu.build-id` from that constant by default (`-B gobuildid`) — a constant input, hence the constant `498919af…` note on every binary the repo has ever produced. rules_go does **not** stamp-expand `gc_linkopts`, so `-B 0x<sha>` cannot be fed to the linker from the workspace status. So a small Starlark rule rewrites the note *after* the link:

- `bazel/workspace_status.sh` gains `STABLE_GIT_COMMIT` (**stable**, so it is cache-key material — the volatile `GIT_COMMIT` stays for rules_img tags).
- `stamped_build_id` (`tools/buildid/defs.bzl`) runs a stdlib-only Go tool that parses the ELF section header table, locates the `.note.gnu.build-id` descriptor and overwrites its 20 bytes with the commit. Nothing else in the image moves — verified byte-for-byte in a unit test.
- It reads `ctx.info_file` (stable-status.txt), **not** `ctx.version_file` (that one is volatile and would let a stale build-ID survive a cache hit).
- `bazel/img/go_multi_arch_image.bzl` pipes **every ELF that enters an image** through it: the entrypoint binary and every extra layer file, so the CNI plugin at `/opt/cni/bin/aether-cni` is covered too.

**Proxy (`proxy/`).** Adopts Envoy's own mechanism: `envoy_cc_binary(stamped = True)` links with `-Wl,@$(location @envoy//bazel:gnu_build_id.ldscript)`, a generated response file holding `--build-id=0x<BUILD_SCM_REVISION>`. `proxy/bazel/get_workspace_status` already emits `BUILD_SCM_REVISION` as `git rev-parse HEAD`, so no new plumbing. This replaces the toolchain's implicit 16-byte md5 uuid. It also **supersedes** the "pin `--build-id=sha1` in `proxy/.bazelrc`" follow-up from the symbolization plan — an explicitly stamped id is strictly more useful than a content hash.

## Guarantees

1. **Two different commits ⇒ two different build-IDs.** Demonstrated below across three successive local commits.
2. **Rebuilding the same commit ⇒ the same build-ID.** The id comes from the *stable* status, so the remote cache stays warm; a new commit re-runs only the ~1 s copy action, never a compile or a link.
3. **Non-stamped builds keep working.** Everything is gated on a `--stamp` `config_setting` (the same one rules_go uses). `--nostamp` — every dev build and every PR-CI build — gets a **byte-identical copy** of the plain binary; `bazel run` and `bazel test` are unchanged. The tool also copies unchanged when the status has no resolvable commit or the input isn't an ELF at all.
4. **Remote-cache friendly.** `ctx.info_file` is precisely the input designed for this: only the stamping action is invalidated by a commit change.

## CI guards

- `//tools/buildid:release_build_ids` — a build-time check over the six binaries that ship in released images (agent, mesh-dns, cni-install, the CNI plugin, controller, registrar). It fails the build if any lacks a build-ID note or, under `--stamp`, if the note isn't the release commit. It's part of `bazel build //...`, so bazel-diff picks it up on any PR that touches those binaries, and `publish.yaml` re-states it under `--stamp` and prints the per-binary report.
- `//integration:build_id_test` (proxy) — asserts the linked Envoy's `.note.gnu.build-id` equals the id the linker was handed. Reads the note with `od` + `awk` so it needs no binutils on the runner or the RBE executor, and costs **no extra compile** (`//:envoy` is already built for `//:image_test`).
- `proxy-release.yml` — **before** the push, asserts the ldscript the linker consumed says `--build-id=0x<github.sha>`. Composed with the test above, that pins the published binary to the release commit. Only the one-line ldscript is fetched locally; the ~150 MB binary stays on the executor.
- `make check-build-id` for the same check locally.

## Validation

**Go side — fully validated locally.** `readelf -n` on a `--stamp` build:

```
$ git rev-parse HEAD
e84ad3b74dd023bbaeb6c3a28382e59deed07a73

$ readelf -n bazel-bin/agent/cmd/agent/agent_image_stamped_binary
Displaying notes found in: .note.gnu.build-id
  GNU  0x00000014  NT_GNU_BUILD_ID (unique build ID bitstring)
    Build ID: e84ad3b74dd023bbaeb6c3a28382e59deed07a73

$ readelf -n bazel-bin/agent/cmd/agent/agent_/agent    # the unstamped go_binary
    Build ID: 498919aff001d8366249403a2544fba2d833084f
```

Guarantee 1 across three successive commits on this branch — `aaae36d3…` → `06643598…` → `e84ad3b7…`, each time equal to `HEAD`, while the unstamped binary stayed `498919af…`.

Extracted from the actual image layers (`cni-install`, both ELFs):

```
ex/cni-install:             Build ID: <release commit>
ex/opt/cni/bin/aether-cni:  Build ID: <release commit>
```

`bazel test //...` (unit + container-structure) green; `--config=lint` green; gazelle and `make format` clean.

**Proxy side — mechanism validated structurally, no full Envoy compile** (that is a multi-hour build; deliberately not run):

- `bazel aquery 'mnemonic("CppLink", //:envoy)'` in `proxy/` confirms the link action now carries `-Wl,@bazel-out/k8-fastbuild/bin/external/envoy/bazel/gnu_build_id.ldscript`, with the ldscript declared as an action input.
- `bazel build @envoy//bazel:gnu_build_id.ldscript` produces `--build-id=0x<this repo's HEAD>` — the genrule resolves against our workspace status, and it built **on RBE**, so the status files stage correctly on the executor.
- The linker semantics were confirmed independently: linking a trivial program with `-Wl,@<that ldscript>` yields `Build ID: <the commit>` verbatim.
- `//integration:build_id_test` analyzes cleanly (`bazel cquery --output=build`), and the `$(rootpath …)` → runfiles-cwd contract it relies on was proven with a throwaway `sh_test` in the same workspace (since removed).
- `check_build_id.sh` itself was exercised against real ELFs: match, mismatch, presence-only, ldscript-expected form, missing file, non-ELF, and the whole-file fallback path — all correct.

**Awaits the next real proxy build:** the end-to-end assertion that the compiled Envoy's note equals the ldscript value. That is exactly what `//integration:build_id_test` runs on the first proxy PR/release, so it is gated, not assumed.

## Operational note (Pyroscope)

After this lands, **each release's binaries get fresh, distinct build-IDs** — which is the point, and it changes the symbol-upload workflow:

- The old debuginfo for `498919af…` was already deleted from Pyroscope (it would have served wrong offsets); nothing to clean up.
- The agent binary can be uploaded again. Per the standing procedure, re-upload only when an image **digest** actually moves (images publish only when their Bazel deps change), keying off the chart's pinned digest, not the tag:

```
cid=$(docker create --platform linux/arm64 <image@digest>); docker cp $cid:<path> ./bin; docker rm $cid
kubectl -n o11y port-forward svc/pyroscope 14040:4040 &
docker run --rm --network host -v $PWD:/w --entrypoint profilecli grafana/pyroscope:2.2.1 \
  debuginfo upload --url=http://127.0.0.1:14040 /w/bin      # idempotent; `debuginfo list` to verify
```

- One agent-binary upload still covers agent / supervisor / mesh-dns comms (one multi-call ELF), but the **standalone `mesh-dns` image and the `cni` plugin are separate ELFs with their own build-IDs** — upload them separately if their native frames matter.
- The proxy's build-ID changes shape (16-byte md5 → 20-byte commit sha1) on its next publish, so its existing upload will no longer match and must be re-done then.
- Uploads are now *safe*: a stale upload can no longer shadow a newer build, because the IDs differ.

## Not touched

No `charts/` changes, so no chart version bump. The cluster was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
