### PR TITLE
fix(build): derive the GNU build-ID from binary content so every released binary is unique (#653)

### DIFF
--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -64,15 +64,19 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # aether #651 acceptance gate, run BEFORE the push so a proxy with the
+      # aether #651/#653 acceptance gate, run BEFORE the push so a proxy with the
       # wrong GNU build-ID can never reach the registry. Two cheap assertions
-      # compose into "the binary's build-ID is this release's commit":
-      #   1. //integration:build_id_test — the linked binary's
-      #      .note.gnu.build-id equals the id the stamped link was handed;
-      #   2. the ldscript the linker was handed says --build-id=0x<github.sha>.
-      # Only the ldscript (one line) is fetched locally; the ~150 MB binary stays
-      # on the executor. The Envoy compile is shared with the push step below.
-      - name: Verify the Envoy GNU build-ID is the release commit
+      # compose into "the binary's build-ID is a content hash of this binary":
+      #   1. //integration:build_id_test — the linked binary carries a
+      #      .note.gnu.build-id and it is 20 bytes wide (the SHA-1 shape only
+      #      --build-id=sha1 produces);
+      #   2. the link action's own command line ends in --build-id=sha1, i.e.
+      #      that width came from the content-hash setting and not from some
+      #      other 20-byte id (a commit stamp, say — which is what #653 was).
+      # Assertion 2 is analysis-only (`aquery`), so it costs no compile, and the
+      # ~150 MB binary never leaves the executor. The Envoy compile is shared
+      # with the push step below.
+      - name: Verify the Envoy GNU build-ID is a content hash
         working-directory: proxy
         run: |
           bazel test \
@@ -80,17 +84,14 @@ jobs:
             --config=${{ matrix.bazel_config }} \
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
             //integration:build_id_test
-          bazel build \
+          # lld honours the LAST --build-id on the command line; the toolchain
+          # supplies --build-id=md5 earlier, so assert ours is the final one.
+          bazel aquery \
             --config=ci \
             --config=${{ matrix.bazel_config }} \
             --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
-            @envoy//bazel:gnu_build_id.ldscript
-          ldscript="$(bazel cquery \
-            --config=ci \
-            --config=${{ matrix.bazel_config }} \
-            --output=files @envoy//bazel:gnu_build_id.ldscript)"
-          echo "linker build-ID argument: $(cat "$ldscript")"
-          grep -qi -- "--build-id=0x${{ github.sha }}" "$ldscript"
+            'mnemonic("CppLink", //:envoy)' | tee /tmp/envoy-link.txt | grep -- '--build-id'
+          test "$(grep -o -- '--build-id=[a-z0-9]*' /tmp/envoy-link.txt | tail -1)" = "--build-id=sha1"
 
       - name: Build + push ${{ matrix.arch }} by digest (${{ matrix.bazel_config }})
         # remote_tags=[] and no --tag → oci_push pushes the image by digest only

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,16 +37,18 @@ jobs:
         # hosted executor pool and reuses the cache warmed by PR `ci` builds.
         run: |
           bazel build --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //...
-      # Acceptance guard for #651. Under --stamp, //tools/buildid:release_build_ids
-      # fails the build unless every binary that ships in a released image carries
-      # a GNU build-ID equal to this commit's SHA. It is already covered by the
-      # `//...` build above; this step re-states it so a failure names the cause
-      # and prints the per-binary report the Pyroscope symbol upload is keyed on.
+      # Acceptance guard for #651 and #653. //tools/buildid:release_build_ids
+      # fails the build unless every binary that ships in a released image
+      # carries a GNU build-ID that (a) is present, (b) equals the SHA-1
+      # recomputed from that binary's own bytes, and (c) is shared with no other
+      # released binary. It is already covered by the `//...` build above; this
+      # step re-states it so a failure names the cause and prints the per-binary
+      # report the Pyroscope symbol upload is keyed on.
       - name: Verify released GNU build-IDs
         run: |
           bazel build --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
             //tools/buildid:release_build_ids
-          echo "expected build-ID (release commit): ${{ github.sha }}"
+          echo "per-binary GNU build-IDs (content-derived, pairwise distinct):"
           cat bazel-bin/tools/buildid/release_build_ids.txt
       # `*.push` publishes each chart together with the images it references
       # (aether.push -> agent + mesh-dns + cni-install + registrar + controller

--- a/Makefile
+++ b/Makefile
@@ -91,19 +91,19 @@ push-registrar-image:
 .PHONY: load-all
 load-all: load-agent-image load-mesh-dns-image load-cni-install-image load-registrar-image
 
-# Every push target passes --stamp: that is what pins each released binary's GNU
-# build-ID to the release commit SHA (#651, //tools/buildid). Without it the
-# images ship the rules_go constant build-ID and profile symbolization silently
-# attributes the new release's samples to the previous release's symbols.
+# Every push target passes --stamp so the released artifacts carry the git
+# version information (charts, x_defs). The GNU build-IDs do NOT depend on it:
+# //tools/buildid derives each one from the binary's own content (#651, #653),
+# in every build configuration.
 .PHONY: push-all
 push-all: push-agent-image push-mesh-dns-image push-cni-install-image push-registrar-image
 
 # Print (and assert) the GNU build-ID of every binary that ships in a released
-# image. With --stamp it must equal `git rev-parse HEAD`; the build fails if not.
+# image. Each must hash that binary's own content and no two may be equal — the
+# collision that made Pyroscope symbol upload unsafe (#653).
 .PHONY: check-build-id
 check-build-id:
-	@bazel build --stamp //tools/buildid:release_build_ids
-	@echo "expected build-ID (HEAD): $$(git rev-parse HEAD)"
+	@bazel build //tools/buildid:release_build_ids
 	@cat bazel-bin/tools/buildid/release_build_ids.txt
 
 # Publish everything in the order that works: image manifests FIRST, then the

--- a/bazel/img/go_multi_arch_image.bzl
+++ b/bazel/img/go_multi_arch_image.bzl
@@ -4,16 +4,18 @@ load("@rules_img//img:image.bzl", "image_index", "image_manifest")
 load("@rules_img//img:layer.bzl", "file_metadata", "image_layer")
 load("@rules_img//img:load.bzl", "image_load")
 load("@rules_img//img:push.bzl", "image_push")
-load("//tools/buildid:defs.bzl", "stamp_select", "stamped_build_id")
+load("//tools/buildid:defs.bzl", "content_build_id")
 
 def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "@distroless_static", container_test_configs = ["testdata/container_test.yaml"], tars_layer = None):
     """
     Creates a containerized binary from Go sources.
 
-    Every ELF that goes into the image passes through `stamped_build_id` first,
-    which rewrites its GNU build-ID to the release commit SHA under `--stamp`
-    (#651). Dev and PR-CI builds are `--nostamp` and get a byte-identical copy of
-    the plain binary, so `bazel run`/`bazel test` behaviour is unchanged.
+    Every ELF that goes into the image passes through `content_build_id` first,
+    which rewrites its GNU build-ID to a hash of its own bytes (#651, #653) so
+    that no two released binaries share an ID. It is unconditional — a content
+    hash needs no workspace status — so dev, PR-CI and release images all carry
+    correct, self-verifying IDs and `bazel run`/`bazel test` behaviour is
+    unchanged.
 
     Parameters:
         name:  name of the image
@@ -26,28 +28,26 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
     binary_name = binary[1:]
     entrypoint = "/{}".format(binary_name)
 
-    stamped_binary = "{}_stamped_binary".format(name)
-    stamped_build_id(
-        name = stamped_binary,
+    image_binary = "{}_buildid_binary".format(name)
+    content_build_id(
+        name = image_binary,
         binary = binary,
-        stamp = stamp_select(),
         # Public so //tools/buildid:release_build_ids can assert on the exact
         # ELF that ships, not on a rebuild of it.
         visibility = ["//visibility:public"],
     )
 
-    stamped_tars_layer = None
+    image_tars_layer = None
     if tars_layer:
-        stamped_tars_layer = {}
+        image_tars_layer = {}
         for i, path in enumerate(tars_layer.keys()):
-            stamped_extra = "{}_stamped_extra_{}".format(name, i)
-            stamped_build_id(
-                name = stamped_extra,
+            extra = "{}_buildid_extra_{}".format(name, i)
+            content_build_id(
+                name = extra,
                 binary = tars_layer[path],
-                stamp = stamp_select(),
                 visibility = ["//visibility:public"],
             )
-            stamped_tars_layer[path] = ":" + stamped_extra
+            image_tars_layer[path] = ":" + extra
 
     string_flag(
         name = "release_tag",
@@ -57,7 +57,7 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
     image_layer(
         name = "binary_layer",
         srcs = {
-            entrypoint: ":" + stamped_binary,
+            entrypoint: ":" + image_binary,
         },
         default_metadata = file_metadata(
             mode = "0755",
@@ -68,7 +68,7 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
 
     image_layer(
         name = "additional_layer",
-        srcs = stamped_tars_layer,
+        srcs = image_tars_layer,
         default_metadata = file_metadata(
             mode = "0755",
         ),
@@ -79,7 +79,7 @@ def go_multi_arch_image(name, binary, repository, registry = "ghcr.io", base = "
     image_manifest(
         name = "image_manifest",
         base = base,
-        layers = [":binary_layer", ":additional_layer"] if stamped_tars_layer else [":binary_layer"],
+        layers = [":binary_layer", ":additional_layer"] if image_tars_layer else [":binary_layer"],
         visibility = ["//visibility:private"],
         entrypoint = [entrypoint],
     )

--- a/bazel/workspace_status.sh
+++ b/bazel/workspace_status.sh
@@ -3,12 +3,6 @@
 # If their values changes, a target may still include
 # a stale value from a previous build.
 echo "STABLE_GIT_VERSION $(git describe --tags --always --long --dirty --abbrev=40 2>/dev/null || echo 'unknown')"
-# The release commit, STABLE_ so it is cache-key material: //tools/buildid stamps
-# it into every released binary's GNU build-ID (#651), which is the only key the
-# Pyroscope symbolizer joins samples to symbols by. It must therefore be exact
-# (not derived from `git describe`) and must invalidate the stamping action when
-# it changes. The volatile GIT_COMMIT below stays: rules_img uses it for tags.
-echo "STABLE_GIT_COMMIT $(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
 echo "BUILD_TIMESTAMP $(date +%s)"
 echo "GIT_COMMIT $(git rev-parse HEAD 2>/dev/null || echo 'unknown')"
 echo "GIT_BRANCH $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo 'unknown')"

--- a/proxy/.bazelrc
+++ b/proxy/.bazelrc
@@ -8,6 +8,25 @@ import %workspace%/envoy.bazelrc
 # applies the :linux config automatically on Linux hosts.
 build:linux --config=clang
 
+# Give the linked Envoy a GNU build-ID derived from its own content (aether
+# #651/#653). This is the only key the Pyroscope symbolizer joins samples to
+# uploaded debuginfo by, so it has to identify *this* ELF and nothing else:
+# `sha1` makes lld hash the linked output, so the id is unique by construction,
+# reproducible for identical inputs, and can never collide with the six Go
+# binaries (which get the same treatment from //tools/buildid).
+#
+# The hermetic toolchain already passes `-Wl,--build-id=md5` earlier on the link
+# command line; lld honours the LAST --build-id, so this line wins and widens the
+# note from a 16-byte md5 to the 20-byte sha1 that debuginfod/Pyroscope tooling
+# and the Go binaries use. (Verified with `bazel aquery 'mnemonic("CppLink",
+# //:envoy)'` — proxy-release.yml asserts the ordering before publishing.)
+#
+# It is a --linkopt rather than `linkopts` on //:envoy because envoy_cc_binary
+# does `if not linkopts: linkopts = _envoy_linkopts()` — passing linkopts to the
+# target would silently drop Envoy's own default link flags. envoy.bazelrc
+# passes -fuse-ld=lld the same way.
+build --linkopt=-Wl,--build-id=sha1
+
 # Optimized, stripped release build — the binary baked into the proxy image.
 # Plain `bazel build //:image` is fastbuild (dev); image build paths (CI, the
 # Makefile load/push targets, the README) pass --config=release to bake the

--- a/proxy/BUILD.bazel
+++ b/proxy/BUILD.bazel
@@ -13,20 +13,21 @@ AETHER_EXTENSIONS = [
 envoy_cc_binary(
     name = "envoy",
     repository = "@envoy",
-    # stamped = True is Envoy's own build-ID mechanism: it links with
-    # `-Wl,@$(location @envoy//bazel:gnu_build_id.ldscript)`, a generated response
-    # file holding `--build-id=0x<BUILD_SCM_REVISION>` — i.e. the GNU build-ID
-    # becomes the source commit SHA. Without it the hermetic LLVM toolchain
-    # supplies its default (an md5 uuid), which is unique per link but says
-    # nothing about which commit produced the binary, so nothing can key a symbol
-    # upload to a release. aether #651: the eBPF profiler joins samples to symbols
-    # by build-ID alone, so it must be the release commit and nothing else.
-    # BUILD_SCM_REVISION comes from //bazel/get_workspace_status (git rev-parse
-    # HEAD of this repo). It is a *volatile* status variable — Envoy's convention
-    # — which means a long-lived incremental workspace can keep a stale ldscript;
-    # release builds run on fresh CI checkouts, and //integration:build_id_test
-    # asserts the binary carries exactly the id the linker was handed.
-    stamped = True,
+    # NOTE: deliberately NOT `stamped = True`, and deliberately no `linkopts`
+    # here. See the `--build-id=sha1` --linkopt in .bazelrc.
+    #
+    # `stamped = True` is Envoy's own mechanism (`--build-id=0x<BUILD_SCM_REVISION>`
+    # via a generated ldscript). It works for upstream because they ship one
+    # binary per commit; aether ships seven, and a commit-derived id makes all
+    # seven share one GNU build-ID — which is the only key the Pyroscope
+    # symbolizer joins samples to symbols by, so one debuginfo upload would
+    # silently resolve all of them (aether #653).
+    #
+    # `linkopts = [...]` is not the way to add the flag either: envoy_cc_binary
+    # does `if not linkopts: linkopts = _envoy_linkopts()`, so passing any
+    # linkopts *replaces* Envoy's defaults (-pthread, -lrt, -ldl, -z relro/now,
+    # --hash-style=gnu, -pie, -Wl,-E). The flag therefore goes on the command
+    # line via --linkopt, exactly as envoy.bazelrc itself passes -fuse-ld=lld.
     # //integration:build_id_test reads the linked ELF directly.
     visibility = ["//integration:__pkg__"],
     deps = AETHER_EXTENSIONS + [

--- a/proxy/integration/BUILD.bazel
+++ b/proxy/integration/BUILD.bazel
@@ -2,25 +2,23 @@ load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 exports_files(["image.yaml"])
 
-# aether #651: assert the custom Envoy's `.note.gnu.build-id` is present and is
-# exactly the id the stamped link was handed — Envoy's generated
-# gnu_build_id.ldscript, i.e. `--build-id=0x<BUILD_SCM_REVISION>`. Comparing
-# against the ldscript rather than against a second read of the workspace status
-# keeps the test free of stamping races while still proving end-to-end that
-# `envoy_cc_binary(stamped = True)` took effect; the release workflow does the
-# `== github.sha` comparison on top.
+# aether #651/#653: assert the custom Envoy carries a `.note.gnu.build-id` and
+# that it is 20 bytes wide — the SHA-1 shape only `--build-id=sha1` produces
+# (the toolchain default is a 16-byte uuid, `fast` is 8 bytes, and the clang
+# driver emits no note at all unless `--build-id` is passed). That is the
+# content hash lld computes over the linked output, so the proxy can never again
+# share an id with the Go binaries the way the commit stamp made it.
+#
+# The hash is not recomputed here: lld's sha1 build-ID is a tree hash over its
+# output buffer, an internal detail of the linker. That the flag produced the
+# note is asserted at the source instead — proxy-release.yml greps the CppLink
+# action's command line for `--build-id=sha1` before publishing.
 #
 # No extra build cost: //:envoy is already compiled for //:image_test.
 sh_test(
     name = "build_id_test",
     size = "small",
     srcs = ["check_build_id.sh"],
-    args = [
-        "$(rootpath //:envoy)",
-        "$(rootpath @envoy//bazel:gnu_build_id.ldscript)",
-    ],
-    data = [
-        "//:envoy",
-        "@envoy//bazel:gnu_build_id.ldscript",
-    ],
+    args = ["$(rootpath //:envoy)"],
+    data = ["//:envoy"],
 )

--- a/proxy/integration/check_build_id.sh
+++ b/proxy/integration/check_build_id.sh
@@ -1,48 +1,64 @@
 #!/usr/bin/env bash
-# Assert the GNU build-ID baked into a linked ELF binary (aether #651).
+# Assert the GNU build-ID of the linked custom Envoy (aether #651, #653).
 #
 # Usage:
-#   check_build_id.sh <binary> [<expected>]
+#   check_build_id.sh <binary>
 #
-# <expected> may be
-#   * a 40-hex SHA — the build-ID must equal it exactly;
-#   * a path to Envoy's `gnu_build_id.ldscript` (`--build-id=0x<sha>`) — the
-#     build-ID must equal the id the linker was handed, which proves the stamped
-#     link actually took effect;
-#   * omitted or "-" — presence check only.
+# What it proves, and why that is the right assertion here:
 #
-# Deliberately dependency-free: `od` + `awk` are POSIX, so this runs unchanged on
-# a GitHub runner and inside a BuildBuddy RBE executor image, neither of which is
+#   * the binary carries a `.note.gnu.build-id` at all — without one the eBPF
+#     profiler has no key to join samples to uploaded symbols (#651);
+#   * the descriptor is exactly 20 bytes, i.e. SHA-1 shaped. That width is what
+#     pins the *kind* of ID: the hermetic toolchain's own `--build-id=md5` gives
+#     16 bytes and `--build-id=fast` gives 8, so 20 bytes means the
+#     `--build-id=sha1` --linkopt in proxy/.bazelrc was the last one on the link
+#     command line and lld's content hash of the linked output is what landed
+#     (#653);
+#   * the descriptor is not all zeroes (a hex-string build-ID placeholder).
+#
+# It deliberately does NOT recompute the hash: lld's `--build-id=sha1` is a tree
+# hash over the output buffer, an internal detail of the linker rather than a
+# published function of the file, so recomputing it in a shell test would assert
+# an lld implementation detail. That the flag is what produced the note is
+# asserted at the source instead — proxy-release.yml greps the CppLink action's
+# command line for `--build-id=sha1` before publishing.
+#
+# Dependency-free on purpose: `od` + `awk` are POSIX, so this runs unchanged on a
+# GitHub runner and inside a BuildBuddy RBE executor image, neither of which is
 # guaranteed to ship binutils `readelf`.
 set -euo pipefail
 
-binary=${1:?usage: check_build_id.sh <binary> [<expected>]}
-expected_arg=${2:--}
+binary=${1:?usage: check_build_id.sh <binary>}
 
-# The ELF note header for a 20-byte NT_GNU_BUILD_ID, little-endian:
-#   namesz=4 | descsz=0x14 | type=3 | "GNU\0"
-# Both architectures aether ships (x86-64, aarch64) are little-endian.
-note_prefix="040000001400000003000000474e5500"
+# An ELF note is: namesz | descsz | type | name | desc, each header field a
+# 32-bit little-endian word (both architectures aether ships are little-endian).
+# Anchor on the fixed tail of the header — type=NT_GNU_BUILD_ID(3) followed by
+# the NUL-terminated owner "GNU" — then read namesz/descsz back off the front,
+# so a note of any descriptor width is *found* and can be reported as wrong
+# rather than looking like no note at all.
+anchor="03000000474e5500"
 
-# extract_build_id <file> [byte-limit]
+# extract_note <file> [byte-limit] -> "<descsz-hex> <first-20-desc-bytes-hex>"
 # Streams the file through od/awk with a sliding window, so a match that straddles
 # an od line — or a 150 MB Envoy binary — is handled without buffering the lot.
-extract_build_id() {
+extract_note() {
 	local file=$1 limit=${2:-}
 	local od_args=(-An -v -tx1)
 	[ -n "$limit" ] && od_args+=(-N "$limit")
-	# awk exits as soon as it has the id, which SIGPIPEs od; that is the point of
-	# the early exit, so pipefail is off for this pipeline only.
+	# awk exits as soon as it has the note, which SIGPIPEs od; that is the point
+	# of the early exit, so pipefail is off for this pipeline only.
 	set +o pipefail
-	od "${od_args[@]}" "$file" 2>/dev/null | awk -v pfx="$note_prefix" '
-    BEGIN { plen = length(pfx) }
+	od "${od_args[@]}" "$file" 2>/dev/null | awk -v anchor="$anchor" '
+    BEGIN { alen = length(anchor) }
     {
       gsub(/ /, "", $0)
       buf = buf $0
-      i = index(buf, pfx)
-      if (i > 0 && length(buf) >= i + plen + 39) {
-        print substr(buf, i + plen, 40)
-        exit
+      i = index(buf, anchor)
+      if (i > 16 && length(buf) >= i + alen + 39) {
+        if (substr(buf, i - 16, 8) == "04000000") {   # namesz == 4 ("GNU\0")
+          print substr(buf, i - 8, 8) " " substr(buf, i + alen, 40)
+          exit
+        }
       }
       if (length(buf) > 8192) buf = substr(buf, length(buf) - 200)
     }
@@ -58,40 +74,33 @@ fi
 # The note lives in the first PT_LOAD, a few hundred bytes in; 4 MiB is a wildly
 # generous fast path. Fall back to the whole file rather than reporting a false
 # "no build-ID" if a future linker moves it.
-got=$(extract_build_id "$binary" 4194304)
-if [ -z "$got" ]; then
-	got=$(extract_build_id "$binary")
+note=$(extract_note "$binary" 4194304)
+if [ -z "$note" ]; then
+	note=$(extract_note "$binary")
 fi
 
-if [ -z "$got" ]; then
+if [ -z "$note" ]; then
 	echo "FAIL: $binary carries no .note.gnu.build-id" >&2
-	echo "      (aether #651: released binaries must be linked with a stamped build-ID)" >&2
+	echo "      (aether #651: released binaries must be linked with --build-id=sha1;" >&2
+	echo "       see the --linkopt in proxy/.bazelrc)" >&2
 	exit 1
 fi
 
-if [ "$expected_arg" = "-" ]; then
-	echo "OK: $binary build-ID $got (presence only)"
-	exit 0
-fi
+descsz=${note%% *}
+got=${note#* }
 
-if [ -f "$expected_arg" ]; then
-	# Envoy's ldscript: the exact linker argument the stamped link consumed.
-	expected=$(tr -d ' \r\n' <"$expected_arg" |
-		sed -n 's/.*--build-id=0x\([0-9a-fA-F]\{40\}\).*/\1/p')
-	if [ -z "$expected" ]; then
-		echo "FAIL: $expected_arg holds no 40-hex --build-id=0x<sha>" >&2
-		echo "      contents: $(cat "$expected_arg")" >&2
-		exit 1
-	fi
-else
-	expected=$expected_arg
-fi
-expected=$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')
-
-if [ "$got" != "$expected" ]; then
-	echo "FAIL: $binary build-ID is $got, want $expected" >&2
-	echo "      (aether #651: the build-ID must be the release commit SHA)" >&2
+# 0x00000014 little-endian == 20 bytes == SHA-1.
+if [ "$descsz" != "14000000" ]; then
+	width=$((16#${descsz:6:2}${descsz:4:2}${descsz:2:2}${descsz:0:2}))
+	echo "FAIL: $binary has a $width-byte build-ID descriptor, want 20" >&2
+	echo "      (aether #653: the id must be lld's --build-id=sha1 content hash, not the" >&2
+	echo "       toolchain's 16-byte uuid and not an 8-byte --build-id=fast hash)" >&2
 	exit 1
 fi
 
-echo "OK: $binary build-ID $got"
+if [ "$got" = "0000000000000000000000000000000000000000" ]; then
+	echo "FAIL: $binary has an all-zero build-ID" >&2
+	exit 1
+fi
+
+echo "OK: $binary build-ID $got (20-byte content hash)"

--- a/tools/buildid/BUILD.bazel
+++ b/tools/buildid/BUILD.bazel
@@ -1,15 +1,5 @@
 load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
-load("//tools/buildid:defs.bzl", "build_id_check", "stamp_select")
-
-# `--stamp` is a native Bazel option, so `values` reads it directly — the same
-# config_setting rules_go uses for its own stamping. Everything downstream (the
-# image macro, the release guard) selects on this, so a plain dev build keeps the
-# unmodified go_binary and only release builds pay for the extra copy.
-config_setting(
-    name = "stamp_enabled",
-    values = {"stamp": "true"},
-    visibility = ["//visibility:public"],
-)
+load("//tools/buildid:defs.bzl", "build_id_check")
 
 go_library(
     name = "buildid_lib",
@@ -33,22 +23,24 @@ go_test(
     embed = [":buildid_lib"],
 )
 
-# Acceptance guard for #651: fails the build if any binary that ships in a
-# released image lacks a GNU build-ID note, or — under `--stamp`, i.e. the
-# publish workflow — carries anything other than the release commit SHA.
-# Built by `bazel build //...` and explicitly (with --stamp) by the publish
-# workflow, so a regression cannot reach a published image.
+# Acceptance guard for #651 and #653 over every binary that ships in a released
+# image. It fails the build if any of them lacks a GNU build-ID note, carries a
+# note that is not the hash of its own content, or shares an ID with another —
+# the collision that made Pyroscope symbol upload unsafe.
+#
+# It needs no `--stamp`: the IDs are content-derived, so the property holds (and
+# is checked) in every build configuration, including PR CI. `bazel build //...`
+# covers it, and publish.yaml re-states it to print the per-binary report.
 build_id_check(
     name = "release_build_ids",
     binaries = [
-        "//agent/cmd/agent:agent_image_stamped_binary",
-        "//agent/cmd/mesh-dns:mesh-dns_image_stamped_binary",
-        "//cni/cmd/cni-install:cni-install_image_stamped_binary",
+        "//agent/cmd/agent:agent_image_buildid_binary",
+        "//agent/cmd/mesh-dns:mesh-dns_image_buildid_binary",
+        "//cni/cmd/cni-install:cni-install_image_buildid_binary",
         # The CNI plugin the installer drops on the host — a second released ELF
         # inside the cni-install image.
-        "//cni/cmd/cni-install:cni-install_image_stamped_extra_0",
-        "//controller/cmd/controller:controller_image_stamped_binary",
-        "//registrar/cmd/registrar:registrar_image_stamped_binary",
+        "//cni/cmd/cni-install:cni-install_image_buildid_extra_0",
+        "//controller/cmd/controller:controller_image_buildid_binary",
+        "//registrar/cmd/registrar:registrar_image_buildid_binary",
     ],
-    stamp = stamp_select(),
 )

--- a/tools/buildid/buildid.go
+++ b/tools/buildid/buildid.go
@@ -1,43 +1,71 @@
-// Package main implements the GNU build-ID stamping tool used by the Bazel
-// `stamped_build_id` rule (see defs.bzl).
+// Package main implements the GNU build-ID tool used by the Bazel
+// `content_build_id` rule (see defs.bzl).
 //
-// Why this exists: rules_go links every Go binary with `-buildid=redacted` for
-// reproducibility, and since Go 1.24 the Go linker derives the ELF
-// `.note.gnu.build-id` note from that Go build ID by default (`-B gobuildid`).
-// A constant input yields a constant note, so every aether Go binary ever built
-// carries the same GNU build-ID (498919aff001d8366249403a2544fba2d833084f) no
-// matter what code is in it (issue #651). Profilers that join samples to symbols
-// purely by build-ID — the Pyroscope eBPF symbolizer does — then silently
-// symbolize a new release against the previous release's offsets.
+// # Why this exists
 //
-// rules_go does not stamp-expand `gc_linkopts`, so `-B 0x<sha>` cannot be fed to
-// the linker from the workspace status. Instead this tool rewrites the note
-// in place after the link: the note's descriptor is exactly 20 bytes, which is
-// also the width of a git commit SHA-1, so the release commit drops straight in
-// without moving a single byte of the ELF.
+// rules_go links every Go binary with `-buildid=redacted` for reproducibility,
+// and since Go 1.24 the Go linker derives the ELF `.note.gnu.build-id` note from
+// that Go build ID by default (`-B gobuildid`). A constant input yields a
+// constant note, so every aether Go binary ever built carried the same GNU
+// build-ID (498919aff001d8366249403a2544fba2d833084f) no matter what code was in
+// it (issue #651). Profilers that join samples to symbols purely by build-ID —
+// the Pyroscope eBPF symbolizer does — then silently symbolize one binary
+// against another binary's offsets.
+//
+// The first fix (#652) rewrote the note to the release commit SHA. That traded
+// one collision for another: a commit produces *seven* released ELFs, so all
+// seven ended up sharing a single ID (issue #653). A GNU build-ID identifies a
+// *linked object*, not a source revision.
+//
+// # What this tool writes
+//
+// The ID is derived from the binary's own bytes, which is what `ld --build-id=sha1`
+// does natively and what the custom Envoy now gets from the linker:
+//
+//	build_id = SHA-1( image bytes, with the 20-byte build-ID descriptor
+//	                  field replaced by 20 zero bytes )
+//
+// Zeroing the descriptor before hashing is what makes the value well defined:
+// the descriptor is the one field the hash is about to overwrite, so excluding it
+// removes the circular dependency. Three properties follow, and all three are
+// covered by unit tests:
+//
+//   - deterministic — the same image bytes always yield the same ID, so the ID is
+//     remote-cache-friendly and reproducible;
+//   - idempotent — writing the ID changes only the descriptor, which the hash
+//     ignores, so re-running the tool on an already-written binary computes and
+//     writes exactly the same 20 bytes;
+//   - collision-free in practice — two ELFs that differ anywhere outside the
+//     descriptor get different IDs, which is precisely the #653 requirement.
+//
+// Nothing else in the image moves: the descriptor is exactly 20 bytes wide, the
+// same width as a SHA-1 digest, so the note is patched in place.
+//
+// Release traceability does not live in this note. It lives in the `--stamp`
+// x_defs version information and in the image tags; the ELF note is the
+// symbolizer's key and nothing else.
 package main
 
 import (
-	"bufio"
 	"bytes"
+	"crypto/sha1" //nolint:gosec // Not security: SHA-1 is the GNU build-ID convention (`ld --build-id=sha1`) and the note is exactly 20 bytes wide.
 	"debug/elf"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"strings"
 )
 
 const (
 	// buildIDSection is the ELF section holding the GNU build-ID note.
 	buildIDSection = ".note.gnu.build-id"
-	// buildIDLen is the descriptor width the Go linker emits (SHA-1 shaped),
-	// and the width of a git commit SHA-1. They match on purpose: the note is
-	// patched in place, never resized.
-	buildIDLen = 20
+	// buildIDLen is the descriptor width the Go linker emits and the width of a
+	// SHA-1 digest. They match on purpose: the note is patched in place, never
+	// resized.
+	buildIDLen = sha1.Size
 	// noteTypeGNUBuildID is NT_GNU_BUILD_ID.
 	noteTypeGNUBuildID = 3
+	// noteHeaderLen is the fixed part of an ELF note: namesz, descsz, type.
+	noteHeaderLen = 12
 )
 
 // gnuNoteName is the note owner, NUL-terminated as the ELF note format requires.
@@ -60,36 +88,25 @@ func buildIDOffset(r io.ReaderAt) (int64, error) {
 	defer func() { _ = f.Close() }()
 
 	sec := f.Section(buildIDSection)
-	if sec == nil || sec.Type != elf.SHT_NOTE {
-		return 0, errNoBuildIDNote
-	}
-	// SHT_NOBITS sections occupy no file bytes, so there would be nothing to
-	// patch; treat it as absent rather than corrupting the image.
-	if sec.Type == elf.SHT_NOBITS || sec.Size < 12 {
+	if sec == nil || sec.Type != elf.SHT_NOTE || sec.Size < noteHeaderLen {
+		// SHT_NOBITS sections occupy no file bytes, so there would be nothing to
+		// patch; treat anything that is not a real note as absent rather than
+		// corrupting the image.
 		return 0, errNoBuildIDNote
 	}
 
-	hdr := make([]byte, 12)
+	hdr := make([]byte, noteHeaderLen)
 	if _, err := r.ReadAt(hdr, int64(sec.Offset)); err != nil {
 		return 0, fmt.Errorf("reading note header: %w", err)
 	}
 	bo := f.ByteOrder
-	namesz := bo.Uint32(hdr[0:4])
-	descsz := bo.Uint32(hdr[4:8])
-	typ := bo.Uint32(hdr[8:12])
-
-	if typ != noteTypeGNUBuildID {
-		return 0, fmt.Errorf("%s: unexpected note type %d (want %d)", buildIDSection, typ, noteTypeGNUBuildID)
-	}
-	if namesz != uint32(len(gnuNoteName)) {
-		return 0, fmt.Errorf("%s: unexpected note namesz %d (want %d)", buildIDSection, namesz, len(gnuNoteName))
-	}
-	if descsz != buildIDLen {
-		return 0, fmt.Errorf("%s: descriptor is %d bytes, want %d — cannot patch in place", buildIDSection, descsz, buildIDLen)
+	namesz, descsz, typ := bo.Uint32(hdr[0:4]), bo.Uint32(hdr[4:8]), bo.Uint32(hdr[8:12])
+	if err := checkNoteHeader(namesz, descsz, typ); err != nil {
+		return 0, err
 	}
 
 	name := make([]byte, namesz)
-	if _, err := r.ReadAt(name, int64(sec.Offset)+12); err != nil {
+	if _, err := r.ReadAt(name, int64(sec.Offset)+noteHeaderLen); err != nil {
 		return 0, fmt.Errorf("reading note name: %w", err)
 	}
 	if !bytes.Equal(name, gnuNoteName) {
@@ -97,11 +114,25 @@ func buildIDOffset(r io.ReaderAt) (int64, error) {
 	}
 
 	// The name is padded to a 4-byte boundary; "GNU\0" is already 4 bytes.
-	descOff := int64(sec.Offset) + 12 + int64(align4(namesz))
+	descOff := int64(sec.Offset) + noteHeaderLen + int64(align4(namesz))
 	if descOff+buildIDLen > int64(sec.Offset)+int64(sec.Size) {
 		return 0, fmt.Errorf("%s: descriptor runs past the section", buildIDSection)
 	}
 	return descOff, nil
+}
+
+// checkNoteHeader rejects a note that is not a 20-byte NT_GNU_BUILD_ID owned by
+// "GNU" — the only shape this tool can rewrite without moving other bytes.
+func checkNoteHeader(namesz, descsz, typ uint32) error {
+	switch {
+	case typ != noteTypeGNUBuildID:
+		return fmt.Errorf("%s: unexpected note type %d (want %d)", buildIDSection, typ, noteTypeGNUBuildID)
+	case namesz != uint32(len(gnuNoteName)):
+		return fmt.Errorf("%s: unexpected note namesz %d (want %d)", buildIDSection, namesz, len(gnuNoteName))
+	case descsz != buildIDLen:
+		return fmt.Errorf("%s: descriptor is %d bytes, want %d — cannot patch in place", buildIDSection, descsz, buildIDLen)
+	}
+	return nil
 }
 
 func align4(n uint32) uint32 {
@@ -121,73 +152,38 @@ func readBuildID(r io.ReaderAt) ([]byte, error) {
 	return id, nil
 }
 
-// patch rewrites the GNU build-ID descriptor of the ELF image in buf to id.
-func patch(buf []byte, id []byte) error {
-	if len(id) != buildIDLen {
-		return fmt.Errorf("build ID is %d bytes, want %d", len(id), buildIDLen)
+// contentBuildID returns the content-derived build-ID of the ELF image in buf:
+// SHA-1 over the whole image with the build-ID descriptor field zeroed. The
+// image is not modified — the zeroes are fed to the hash in place of the
+// descriptor's current bytes, which is why the result does not depend on
+// whatever ID the image already carries (and hence why writing it is idempotent).
+func contentBuildID(buf []byte) ([]byte, error) {
+	off, err := buildIDOffset(bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	h := sha1.New() //nolint:gosec // See the package comment: build-ID convention, not security.
+	h.Write(buf[:off])
+	h.Write(make([]byte, buildIDLen))
+	h.Write(buf[off+buildIDLen:])
+	return h.Sum(nil), nil
+}
+
+// setContentBuildID rewrites the GNU build-ID descriptor of the ELF image in buf
+// to the image's content hash and returns the value written.
+func setContentBuildID(buf []byte) ([]byte, error) {
+	id, err := contentBuildID(buf)
+	if err != nil {
+		return nil, err
 	}
 	off, err := buildIDOffset(bytes.NewReader(buf))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	copy(buf[off:off+buildIDLen], id)
-	return nil
+	return id, nil
 }
 
-// parseStatus reads a Bazel workspace status file ("KEY value" per line).
-func parseStatus(r io.Reader) map[string]string {
-	out := map[string]string{}
-	sc := bufio.NewScanner(r)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-	for sc.Scan() {
-		key, value, found := strings.Cut(strings.TrimSpace(sc.Text()), " ")
-		if !found || key == "" {
-			continue
-		}
-		out[key] = strings.TrimSpace(value)
-	}
-	return out
-}
-
-// commitFromStatus extracts the release commit SHA from a parsed workspace
-// status map. STABLE_GIT_COMMIT is the dedicated variable; STABLE_GIT_VERSION
-// (`git describe --long --abbrev=40`) is accepted as a fallback so the stamp
-// still resolves if the status script is rolled back. Returns "" when no commit
-// can be resolved — the caller then leaves the binary untouched.
-func commitFromStatus(status map[string]string) string {
-	if sha := status["STABLE_GIT_COMMIT"]; isSHA1(sha) {
-		return sha
-	}
-	// `v0.91.0-12-g<40 hex>[-dirty]` or a bare 40-hex from `--always`.
-	for _, field := range strings.Split(status["STABLE_GIT_VERSION"], "-") {
-		if isSHA1(field) {
-			return field
-		}
-		if len(field) == 41 && field[0] == 'g' && isSHA1(field[1:]) {
-			return field[1:]
-		}
-	}
-	return ""
-}
-
-func isSHA1(s string) bool {
-	if len(s) != 2*buildIDLen {
-		return false
-	}
-	_, err := hex.DecodeString(s)
-	return err == nil
-}
-
-// readCommit resolves the release commit from a workspace status file. An empty
-// path (no stamping requested) yields "".
-func readCommit(path string) (string, error) {
-	if path == "" {
-		return "", nil
-	}
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer func() { _ = f.Close() }()
-	return commitFromStatus(parseStatus(f)), nil
+func isELF(buf []byte) bool {
+	return len(buf) >= 4 && bytes.Equal(buf[:4], []byte("\x7fELF"))
 }

--- a/tools/buildid/buildid_test.go
+++ b/tools/buildid/buildid_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha1" //nolint:gosec // Mirrors the tool: GNU build-ID convention, not security.
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
@@ -11,13 +12,12 @@ import (
 	"testing"
 )
 
-const releaseSHA = "c46dd35abc0123456789abcdef0123456789abcd"
-
 // synthELF builds a minimal little-endian ELF64 image carrying a single
-// SHT_NOTE section named .note.gnu.build-id whose descriptor is id. It is a
-// stand-in for a linked Go binary: the stamping tool only ever reads the section
+// SHT_NOTE section named .note.gnu.build-id whose descriptor is id, plus a
+// `filler` payload so that two images can be made to differ outside the note.
+// It is a stand-in for a linked Go binary: the tool only ever reads the section
 // header table and rewrites 20 bytes, so nothing else needs to be real.
-func synthELF(t *testing.T, id []byte) []byte {
+func synthELF(t *testing.T, id []byte, filler ...byte) []byte {
 	t.Helper()
 
 	const (
@@ -42,7 +42,8 @@ func synthELF(t *testing.T, id []byte) []byte {
 
 	noteOff := uint32(ehdrSize)
 	shstrtabOff := noteOff + uint32(len(note))
-	shoff := shstrtabOff + uint32(len(shstrtab))
+	fillerOff := shstrtabOff + uint32(len(shstrtab))
+	shoff := fillerOff + uint32(len(filler))
 
 	shdr := func(name, typ uint32, off, size uint32) []byte {
 		b := make([]byte, 0, shdrSize)
@@ -73,10 +74,20 @@ func synthELF(t *testing.T, id []byte) []byte {
 	img = append(img, ehdr...)
 	img = append(img, note...)
 	img = append(img, shstrtab...)
+	img = append(img, filler...)
 	img = append(img, shdr(0, 0 /*SHT_NULL*/, 0, 0)...)
 	img = append(img, shdr(noteNameOff, 7 /*SHT_NOTE*/, noteOff, uint32(len(note)))...)
 	img = append(img, shdr(1, 3 /*SHT_STRTAB*/, shstrtabOff, uint32(len(shstrtab)))...)
 	return img
+}
+
+func mustSet(t *testing.T, img []byte) []byte {
+	t.Helper()
+	id, err := setContentBuildID(img)
+	if err != nil {
+		t.Fatalf("setContentBuildID: %v", err)
+	}
+	return id
 }
 
 func TestReadBuildID(t *testing.T) {
@@ -90,27 +101,50 @@ func TestReadBuildID(t *testing.T) {
 	}
 }
 
-func TestPatchReplacesOnlyTheDescriptor(t *testing.T) {
-	original := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen))
-	patched := append([]byte(nil), original...)
+// The definition of the ID is load-bearing and documented in the package
+// comment: SHA-1 over the image with the descriptor field replaced by zeroes.
+// Pin it so a refactor cannot quietly change what gets uploaded to Pyroscope.
+func TestContentBuildIDIsSHA1OfTheZeroedImage(t *testing.T) {
+	img := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), 1, 2, 3, 4)
 
-	want, err := hex.DecodeString(releaseSHA)
+	off, err := buildIDOffset(bytes.NewReader(img))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := patch(patched, want); err != nil {
-		t.Fatalf("patch: %v", err)
-	}
+	zeroed := append([]byte(nil), img...)
+	copy(zeroed[off:off+buildIDLen], make([]byte, buildIDLen))
+	want := sha1.Sum(zeroed) //nolint:gosec // See above.
 
+	got, err := contentBuildID(img)
+	if err != nil {
+		t.Fatalf("contentBuildID: %v", err)
+	}
+	if !bytes.Equal(got, want[:]) {
+		t.Fatalf("contentBuildID = %x, want sha1(zeroed image) = %x", got, want)
+	}
+	// contentBuildID must not disturb the image it hashes.
+	if !bytes.Equal(img, synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), 1, 2, 3, 4)) {
+		t.Fatal("contentBuildID mutated its input")
+	}
+}
+
+func TestSetContentBuildIDReplacesOnlyTheDescriptor(t *testing.T) {
+	original := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen))
+	patched := append([]byte(nil), original...)
+
+	id := mustSet(t, patched)
+	if len(id) != buildIDLen {
+		t.Fatalf("build ID is %d bytes, want %d", len(id), buildIDLen)
+	}
 	got, err := readBuildID(bytes.NewReader(patched))
 	if err != nil {
-		t.Fatalf("readBuildID after patch: %v", err)
+		t.Fatalf("readBuildID after set: %v", err)
 	}
-	if !bytes.Equal(got, want) {
-		t.Fatalf("build ID = %x, want %x", got, want)
+	if !bytes.Equal(got, id) {
+		t.Fatalf("note is %x, want the returned id %x", got, id)
 	}
 	if len(patched) != len(original) {
-		t.Fatalf("patch resized the image: %d -> %d", len(original), len(patched))
+		t.Fatalf("set resized the image: %d -> %d", len(original), len(patched))
 	}
 
 	// Exactly the 20 descriptor bytes may differ.
@@ -123,21 +157,54 @@ func TestPatchReplacesOnlyTheDescriptor(t *testing.T) {
 	if differing != buildIDLen {
 		t.Fatalf("%d bytes differ, want exactly %d", differing, buildIDLen)
 	}
+}
 
-	// Patching is idempotent: the same commit yields the same image.
-	again := append([]byte(nil), original...)
-	if err := patch(again, want); err != nil {
-		t.Fatalf("patch (second): %v", err)
+// Deterministic: the same input bytes always produce the same ID (so the ID is
+// reproducible and the remote cache stays warm).
+func TestSetContentBuildIDIsDeterministic(t *testing.T) {
+	a := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), 7, 7, 7)
+	b := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), 7, 7, 7)
+	if !bytes.Equal(mustSet(t, a), mustSet(t, b)) {
+		t.Fatal("identical inputs produced different build IDs")
 	}
-	if !bytes.Equal(again, patched) {
-		t.Fatal("patching the same commit twice produced different images")
+	if !bytes.Equal(a, b) {
+		t.Fatal("identical inputs produced different images")
 	}
 }
 
-func TestPatchWrongIDLength(t *testing.T) {
-	img := synthELF(t, bytes.Repeat([]byte{0}, buildIDLen))
-	if err := patch(img, []byte{1, 2, 3}); err == nil {
-		t.Fatal("expected an error for a short build ID")
+// Idempotent: zeroing → hashing → writing, re-run on an already-written binary,
+// yields the identical ID and the identical image. This is what makes the ID
+// self-verifying (`buildid verify` recomputes it from the shipped bytes).
+func TestSetContentBuildIDIsIdempotent(t *testing.T) {
+	img := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), 9, 9)
+	first := mustSet(t, img)
+	once := append([]byte(nil), img...)
+
+	second := mustSet(t, img)
+	if !bytes.Equal(first, second) {
+		t.Fatalf("re-running changed the id: %x -> %x", first, second)
+	}
+	if !bytes.Equal(once, img) {
+		t.Fatal("re-running changed the image")
+	}
+
+	// The ID is independent of whatever ID the image arrived with.
+	fresh := synthELF(t, bytes.Repeat([]byte{0xff}, buildIDLen), 9, 9)
+	if !bytes.Equal(mustSet(t, fresh), first) {
+		t.Fatal("the id depends on the previous descriptor value")
+	}
+}
+
+// The headline #653 property: binaries that differ anywhere outside the
+// descriptor get different IDs.
+func TestSetContentBuildIDIsPairwiseDistinct(t *testing.T) {
+	seen := map[string]int{}
+	for i := range 8 {
+		img := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), byte(i))
+		seen[string(mustSet(t, img))]++
+	}
+	if len(seen) != 8 {
+		t.Fatalf("8 distinct images produced %d distinct build IDs: %v", len(seen), seen)
 	}
 }
 
@@ -152,131 +219,83 @@ func TestBuildIDOffsetMissingNote(t *testing.T) {
 	if _, err := readBuildID(bytes.NewReader(img)); !errors.Is(err, errNoBuildIDNote) {
 		t.Fatalf("err = %v, want errNoBuildIDNote", err)
 	}
-}
-
-func TestCommitFromStatus(t *testing.T) {
-	tests := []struct {
-		name   string
-		status string
-		want   string
-	}{
-		{
-			name:   "dedicated variable",
-			status: "STABLE_GIT_VERSION v0.91.0-3-g" + releaseSHA + "\nSTABLE_GIT_COMMIT " + releaseSHA + "\n",
-			want:   releaseSHA,
-		},
-		{
-			name:   "falls back to the describe output",
-			status: "STABLE_GIT_VERSION v0.91.0-3-g" + releaseSHA + "\n",
-			want:   releaseSHA,
-		},
-		{
-			name:   "falls back to a describe --always bare sha",
-			status: "STABLE_GIT_VERSION " + releaseSHA + "\n",
-			want:   releaseSHA,
-		},
-		{
-			name:   "dirty tree still resolves the parent commit",
-			status: "STABLE_GIT_VERSION v0.91.0-3-g" + releaseSHA + "-dirty\n",
-			want:   releaseSHA,
-		},
-		{
-			name:   "no git",
-			status: "STABLE_GIT_VERSION unknown\nSTABLE_GIT_COMMIT unknown\n",
-			want:   "",
-		},
-		{
-			name:   "empty",
-			status: "",
-			want:   "",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := commitFromStatus(parseStatus(strings.NewReader(tc.status))); got != tc.want {
-				t.Fatalf("commitFromStatus = %q, want %q", got, tc.want)
-			}
-		})
+	if _, err := setContentBuildID(img); !errors.Is(err, errNoBuildIDNote) {
+		t.Fatalf("setContentBuildID err = %v, want errNoBuildIDNote", err)
 	}
 }
 
-// writeStatus writes a stable-status.txt naming the release commit.
-func writeStatus(t *testing.T, dir string) string {
+func writeELF(t *testing.T, path string, filler ...byte) {
 	t.Helper()
-	path := filepath.Join(dir, "stable-status.txt")
-	body := "BUILD_EMBED_LABEL \nSTABLE_GIT_COMMIT " + releaseSHA + "\n"
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+	img := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen), filler...)
+	if err := os.WriteFile(path, img, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	return path
 }
 
-func TestRunStampAndVerify(t *testing.T) {
+func TestRunSetAndVerify(t *testing.T) {
 	dir := t.TempDir()
-	in := filepath.Join(dir, "binary")
-	out := filepath.Join(dir, "binary_stamped")
-	if err := os.WriteFile(in, synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen)), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	status := writeStatus(t, dir)
+	inA, outA := filepath.Join(dir, "a"), filepath.Join(dir, "a_out")
+	inB, outB := filepath.Join(dir, "b"), filepath.Join(dir, "b_out")
+	writeELF(t, inA, 1)
+	writeELF(t, inB, 2)
 
-	if err := runStamp([]string{"-in", in, "-out", out, "-status-file", status}); err != nil {
-		t.Fatalf("runStamp: %v", err)
+	for _, pair := range [][2]string{{inA, outA}, {inB, outB}} {
+		if err := runSet([]string{"-in", pair[0], "-out", pair[1]}); err != nil {
+			t.Fatalf("runSet(%s): %v", pair[0], err)
+		}
 	}
-	if err := runVerify([]string{"-status-file", status, out}); err != nil {
+
+	if err := runVerify([]string{outA, outB}); err != nil {
 		t.Fatalf("runVerify: %v", err)
 	}
-	// The unstamped input must fail the stamped verification.
-	if err := runVerify([]string{"-status-file", status, in}); err == nil {
-		t.Fatal("expected the unstamped binary to fail verification")
-	}
-	// Without a status file, verification only asserts the note is present.
-	if err := runVerify([]string{in}); err != nil {
-		t.Fatalf("runVerify (presence only): %v", err)
+	// The un-rewritten inputs still carry the linker's constant note, so they
+	// fail self-verification.
+	if err := runVerify([]string{inA, inB}); err == nil {
+		t.Fatal("expected binaries whose note is not their content hash to fail")
 	}
 
-	info, err := os.Stat(out)
+	info, err := os.Stat(outA)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if info.Mode().Perm()&0o111 == 0 {
-		t.Fatalf("stamped output is not executable: %v", info.Mode())
+		t.Fatalf("output is not executable: %v", info.Mode())
 	}
 }
 
-func TestRunStampWithoutStatusFileCopies(t *testing.T) {
+// Two copies of the same binary share an ID by construction; the guard must
+// still reject the set, because that is exactly the #653 failure mode.
+func TestRunVerifyRejectsSharedBuildIDs(t *testing.T) {
 	dir := t.TempDir()
-	in := filepath.Join(dir, "binary")
-	out := filepath.Join(dir, "binary_stamped")
-	img := synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen))
-	if err := os.WriteFile(in, img, 0o755); err != nil {
-		t.Fatal(err)
+	one, two := filepath.Join(dir, "one"), filepath.Join(dir, "two")
+	writeELF(t, one, 3)
+	writeELF(t, two, 3)
+	for _, p := range []string{one, two} {
+		if err := runSet([]string{"-in", p, "-out", p}); err != nil {
+			t.Fatalf("runSet: %v", err)
+		}
 	}
 
-	if err := runStamp([]string{"-in", in, "-out", out}); err != nil {
-		t.Fatalf("runStamp: %v", err)
+	err := runVerify([]string{one, two})
+	if err == nil {
+		t.Fatal("expected two identical binaries to fail the distinctness check")
 	}
-	got, err := os.ReadFile(out)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !bytes.Equal(got, img) {
-		t.Fatal("an unstamped build must copy the binary byte-for-byte")
+	if !strings.Contains(err.Error(), "is shared by 2 binaries") {
+		t.Fatalf("error does not name the collision: %v", err)
 	}
 }
 
-func TestRunStampNonELFCopies(t *testing.T) {
+func TestRunSetNonELFCopies(t *testing.T) {
 	dir := t.TempDir()
 	in := filepath.Join(dir, "not-an-elf")
-	out := filepath.Join(dir, "not-an-elf_stamped")
+	out := filepath.Join(dir, "not-an-elf_out")
 	payload := []byte("#!/bin/sh\necho hello\n")
 	if err := os.WriteFile(in, payload, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	status := writeStatus(t, dir)
 
-	if err := runStamp([]string{"-in", in, "-out", out, "-status-file", status}); err != nil {
-		t.Fatalf("runStamp: %v", err)
+	if err := runSet([]string{"-in", in, "-out", out}); err != nil {
+		t.Fatalf("runSet: %v", err)
 	}
 	got, err := os.ReadFile(out)
 	if err != nil {
@@ -289,19 +308,36 @@ func TestRunStampNonELFCopies(t *testing.T) {
 
 func TestRunVerifyWritesMarker(t *testing.T) {
 	dir := t.TempDir()
-	bin := filepath.Join(dir, "binary")
-	if err := os.WriteFile(bin, synthELF(t, bytes.Repeat([]byte{0x49}, buildIDLen)), 0o755); err != nil {
-		t.Fatal(err)
+	one, two := filepath.Join(dir, "one"), filepath.Join(dir, "two")
+	writeELF(t, one, 4)
+	writeELF(t, two, 5)
+	var ids []string
+	for _, p := range []string{one, two} {
+		if err := runSet([]string{"-in", p, "-out", p}); err != nil {
+			t.Fatalf("runSet: %v", err)
+		}
+		buf, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+		id, err := readBuildID(bytes.NewReader(buf))
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, string(id))
 	}
+
 	marker := filepath.Join(dir, "marker.txt")
-	if err := runVerify([]string{"-marker", marker, bin}); err != nil {
+	if err := runVerify([]string{"-marker", marker, one, two}); err != nil {
 		t.Fatalf("runVerify: %v", err)
 	}
 	body, err := os.ReadFile(marker)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(body), strings.Repeat("49", buildIDLen)) {
-		t.Fatalf("marker does not report the build ID: %q", body)
+	for _, id := range ids {
+		if !strings.Contains(string(body), hex.EncodeToString([]byte(id))) {
+			t.Fatalf("marker %q does not report build ID %x", body, id)
+		}
 	}
 }

--- a/tools/buildid/defs.bzl
+++ b/tools/buildid/defs.bzl
@@ -1,64 +1,55 @@
-"""Stamp the GNU build-ID of a linked binary with the release commit SHA (#651).
+"""Derive each released binary's GNU build-ID from its own content (#651, #653).
 
 rules_go links every Go binary with `-buildid=redacted`, and since Go 1.24 the Go
 linker derives `.note.gnu.build-id` from that constant by default — so every
-aether Go binary ever produced carries the same GNU build-ID. Profilers that key
-symbols purely by build-ID (the Pyroscope eBPF symbolizer does) then attribute a
-new release's samples to the previous release's symbol offsets, silently.
+aether Go binary carried one and the same GNU build-ID (#651). Stamping the note
+with the release commit (#652) removed that collision but created another: one
+commit produces seven released ELFs, so all seven shared a single ID (#653).
+Profilers that key symbols purely by build-ID (the Pyroscope eBPF symbolizer
+does) then resolve every one of them against whichever binary's debuginfo was
+uploaded — silently, with plausible-looking frames.
 
-rules_go does not stamp-expand `gc_linkopts`, so the linker's `-B 0x<sha>` cannot
-be fed from the workspace status. `stamped_build_id` instead rewrites the note
-after the link: the descriptor is exactly 20 bytes, the width of a git commit
-SHA-1, so the release commit drops in without moving any other byte.
+`content_build_id` rewrites the note after the link to
+`sha1(image bytes with the 20-byte descriptor zeroed)` — the same thing
+`ld --build-id=sha1` computes natively, which is what the custom Envoy now gets
+from the linker. The descriptor is exactly a SHA-1 wide, so it is patched in
+place and no other byte of the image moves.
 
-Guarantees:
-  * two different commits produce two different build-IDs;
-  * rebuilding the same commit reproduces the same build-ID (the id comes from
-    the *stable* workspace status, so the cache stays warm — only the copy action
-    re-runs when the commit changes, never the link or the compiles);
-  * `--nostamp` builds (every dev build, every PR CI build) get a byte-identical
-    copy of the plain binary, so nothing about local iteration changes.
+Properties:
+  * **pairwise distinct** — two ELFs that differ anywhere outside the descriptor
+    get different IDs, so no two released binaries can collide;
+  * **changes when the code changes** — a commit that alters a binary alters its
+    ID; a commit that leaves a binary byte-identical keeps it, which is correct
+    (its uploaded symbols are still the right ones, and the upload dedupes);
+  * **reproducible** — the ID is a pure function of the input bytes, so the same
+    inputs rebuild to the same ID and the remote cache stays warm;
+  * **unconditional** — a content hash needs no workspace status, so there is no
+    `--stamp` gating and no `ctx.info_file` input. Dev, PR-CI and release builds
+    all produce correct, self-verifying IDs, and the action's cache key is just
+    (input binary, tool). Release traceability lives in the `--stamp` x_defs
+    version information and the image tags, not in the ELF note.
 
 `build_id_check` is the guard: it fails the build if a released binary has no
-build-ID note, or (under `--stamp`) if the note is not the release commit.
+build-ID note, if a note does not match the hash recomputed from that binary's
+own bytes, or if any two of them share an ID.
 """
 
-# `--stamp` is a native Bazel option, so a plain `values` config_setting reads it
-# — the same trick rules_go uses for its own stamping (@rules_go//go/private:stamp).
-STAMP_ENABLED = "//tools/buildid:stamp_enabled"
-
-def _status_file(ctx):
-    """The STABLE workspace status file, or None on a --nostamp build.
-
-    `ctx.info_file` is stable-status.txt; `ctx.version_file` is the *volatile*
-    one. Only the stable file is cache-key material, which is precisely what is
-    wanted here: the same commit rebuilds to the same build-ID and the same
-    remote-cache entry, and a new commit re-runs the copy action alone.
-    """
-    return ctx.info_file if ctx.attr.stamp else None
-
-def _stamped_build_id_impl(ctx):
+def _content_build_id_impl(ctx):
     out = ctx.actions.declare_file(ctx.label.name)
     binary = ctx.file.binary
 
     args = ctx.actions.args()
-    args.add("stamp")
+    args.add("set")
     args.add("-in", binary)
     args.add("-out", out)
-
-    inputs = [binary]
-    status = _status_file(ctx)
-    if status:
-        args.add("-status-file", status)
-        inputs.append(status)
 
     ctx.actions.run(
         executable = ctx.executable._tool,
         arguments = [args],
-        inputs = inputs,
+        inputs = [binary],
         outputs = [out],
-        mnemonic = "StampBuildID",
-        progress_message = "Stamping GNU build-ID into %{output}",
+        mnemonic = "ContentBuildID",
+        progress_message = "Deriving the GNU build-ID of %{output} from its content",
     )
 
     return [DefaultInfo(
@@ -67,20 +58,15 @@ def _stamped_build_id_impl(ctx):
         runfiles = ctx.runfiles().merge(ctx.attr.binary[DefaultInfo].default_runfiles),
     )]
 
-stamped_build_id = rule(
-    implementation = _stamped_build_id_impl,
+content_build_id = rule(
+    implementation = _content_build_id_impl,
     executable = True,
-    doc = "Copies `binary`, rewriting its GNU build-ID note to the release commit SHA.",
+    doc = "Copies `binary`, rewriting its GNU build-ID note to a hash of its own content.",
     attrs = {
         "binary": attr.label(
             mandatory = True,
             allow_single_file = True,
-            doc = "The binary to stamp. Non-ELF inputs are copied unchanged.",
-        ),
-        "stamp": attr.bool(
-            default = False,
-            doc = "Whether to read the commit from the stable workspace status. " +
-                  "Set from a select() on //tools/buildid:stamp_enabled.",
+            doc = "The binary to rewrite. Non-ELF inputs are copied unchanged.",
         ),
         "_tool": attr.label(
             default = Label("//tools/buildid"),
@@ -93,42 +79,33 @@ stamped_build_id = rule(
 def _build_id_check_impl(ctx):
     marker = ctx.actions.declare_file(ctx.label.name + ".txt")
     binaries = ctx.files.binaries
-    if not binaries:
-        fail("build_id_check needs at least one binary")
+    if len(binaries) < 2:
+        fail("build_id_check needs at least two binaries — pairwise distinctness is the point")
 
     args = ctx.actions.args()
     args.add("verify")
     args.add("-marker", marker)
-
-    inputs = list(binaries)
-    status = _status_file(ctx)
-    if status:
-        args.add("-status-file", status)
-        inputs.append(status)
     args.add_all(binaries)
 
     ctx.actions.run(
         executable = ctx.executable._tool,
         arguments = [args],
-        inputs = inputs,
+        inputs = binaries,
         outputs = [marker],
         mnemonic = "CheckBuildID",
-        progress_message = "Checking GNU build-IDs of the released binaries",
+        progress_message = "Checking the GNU build-IDs of the released binaries are self-verifying and distinct",
     )
     return [DefaultInfo(files = depset([marker]))]
 
 build_id_check = rule(
     implementation = _build_id_check_impl,
-    doc = "Fails the build unless every binary carries the expected GNU build-ID.",
+    doc = "Fails the build unless every binary's GNU build-ID hashes its own " +
+          "content and no two of them are equal.",
     attrs = {
         "binaries": attr.label_list(
             mandatory = True,
             allow_files = True,
-            doc = "Stamped binaries to check.",
-        ),
-        "stamp": attr.bool(
-            default = False,
-            doc = "Whether to require the note to equal the release commit.",
+            doc = "The released binaries to check.",
         ),
         "_tool": attr.label(
             default = Label("//tools/buildid"),
@@ -137,10 +114,3 @@ build_id_check = rule(
         ),
     },
 )
-
-def stamp_select():
-    """select() that turns stamping on exactly when `--stamp` is passed."""
-    return select({
-        STAMP_ENABLED: True,
-        "//conditions:default": False,
-    })

--- a/tools/buildid/main.go
+++ b/tools/buildid/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 )
 
 func main() {
@@ -15,8 +16,8 @@ func main() {
 	}
 	var err error
 	switch os.Args[1] {
-	case "stamp":
-		err = runStamp(os.Args[2:])
+	case "set":
+		err = runSet(os.Args[2:])
 	case "verify":
 		err = runVerify(os.Args[2:])
 	default:
@@ -30,39 +31,30 @@ func main() {
 
 func usage() {
 	fmt.Fprint(os.Stderr, `usage:
-  buildid stamp  -in FILE -out FILE [-status-file FILE]
-  buildid verify [-status-file FILE] -marker FILE FILE...
+  buildid set    -in FILE -out FILE
+  buildid verify [-marker FILE] FILE...
 `)
 	os.Exit(2)
 }
 
-// runStamp copies -in to -out, rewriting the GNU build-ID note to the release
-// commit SHA read from -status-file.
+// runSet copies -in to -out, rewriting the GNU build-ID note to the content hash
+// of the image (see the package comment for the exact definition).
 //
-// Fallbacks, all of which produce a byte-identical copy of the input rather than
-// an error, so that unstamped and non-Go/non-ELF inputs keep building:
-//   - no -status-file (i.e. --nostamp): copy unchanged;
-//   - status file with no resolvable commit SHA: copy unchanged;
-//   - input is not an ELF image (e.g. a Mach-O host build, or a data file
-//     riding in an image layer): copy unchanged.
+// A non-ELF input — a Mach-O host build, or a data file riding in an image
+// layer — is copied unchanged rather than treated as an error, so the rule can
+// be applied uniformly to everything that enters an image.
 //
-// An ELF input that *is* being stamped but carries no build-ID note is a hard
-// error: that would silently ship an unsymbolizable binary.
-func runStamp(args []string) error {
-	fs := flag.NewFlagSet("stamp", flag.ExitOnError)
+// An ELF input that carries no build-ID note at all is a hard error: that would
+// silently ship an unsymbolizable binary.
+func runSet(args []string) error {
+	fs := flag.NewFlagSet("set", flag.ExitOnError)
 	in := fs.String("in", "", "input binary")
 	out := fs.String("out", "", "output binary")
-	statusFile := fs.String("status-file", "", "Bazel stable workspace status file (empty: do not stamp)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
 	if *in == "" || *out == "" {
-		return errors.New("stamp: -in and -out are required")
-	}
-
-	commit, err := readCommit(*statusFile)
-	if err != nil {
-		return err
+		return errors.New("set: -in and -out are required")
 	}
 
 	buf, err := os.ReadFile(*in)
@@ -74,31 +66,32 @@ func runStamp(args []string) error {
 		return err
 	}
 
-	switch {
-	case commit == "":
-		fmt.Fprintf(os.Stderr, "buildid: no release commit in the workspace status; leaving %s untouched\n", *in)
-	case !isELF(buf):
-		fmt.Fprintf(os.Stderr, "buildid: %s is not an ELF image; leaving it untouched\n", *in)
-	default:
-		id, err := hex.DecodeString(commit)
-		if err != nil {
-			return fmt.Errorf("decoding commit %q: %w", commit, err)
-		}
-		if err := patch(buf, id); err != nil {
+	if isELF(buf) {
+		if _, err := setContentBuildID(buf); err != nil {
 			return fmt.Errorf("%s: %w", *in, err)
 		}
+	} else {
+		fmt.Fprintf(os.Stderr, "buildid: %s is not an ELF image; leaving it untouched\n", *in)
 	}
 
 	return os.WriteFile(*out, buf, info.Mode().Perm())
 }
 
-// runVerify asserts that every named ELF binary carries a GNU build-ID note and,
-// when the build is stamped, that the note equals the release commit SHA. It is
-// the build-time guard for issue #651: wire it into a target that CI builds and
-// a regression can never reach a published image.
+// runVerify is the build-time acceptance guard for #651 and #653. Over the set
+// of binaries that ship in released images it asserts:
+//
+//  1. every one carries a 20-byte GNU build-ID note (#651: no note, no symbols);
+//  2. every note equals the SHA-1 recomputed from that binary's own content —
+//     self-verification, i.e. the ID really does identify *this* ELF and the
+//     `content_build_id` rule actually ran on it;
+//  3. the notes are pairwise distinct (#653: seven released ELFs must not share
+//     one ID, or a symbol upload for one silently resolves all of them).
+//
+// Property 3 follows from 2 for distinct binaries, but is asserted directly
+// because it is the property the Pyroscope workflow depends on and the one the
+// previous, commit-stamped guard actively violated.
 func runVerify(args []string) error {
 	fs := flag.NewFlagSet("verify", flag.ExitOnError)
-	statusFile := fs.String("status-file", "", "Bazel stable workspace status file (empty: presence check only)")
 	marker := fs.String("marker", "", "file to write on success")
 	if err := fs.Parse(args); err != nil {
 		return err
@@ -108,65 +101,63 @@ func runVerify(args []string) error {
 		return errors.New("verify: no files given")
 	}
 
-	want, err := wantBuildID(*statusFile)
-	if err != nil {
-		return err
-	}
-
 	var report bytes.Buffer
-	var failures int
+	var problems []string
+	ids := map[string][]string{}
 	for _, path := range files {
-		got, err := checkOne(path, want)
+		id, err := checkOne(path)
 		if err != nil {
-			fmt.Fprintf(&report, "%s: %v\n", path, err)
-			failures++
+			problems = append(problems, fmt.Sprintf("%s: %v", path, err))
 			continue
 		}
-		fmt.Fprintf(&report, "%s: %s\n", path, got)
+		fmt.Fprintf(&report, "%s: %s\n", path, id)
+		ids[id] = append(ids[id], path)
 	}
-	if failures > 0 {
-		return fmt.Errorf("%d binary(ies) failed the GNU build-ID check (see #651):\n%s", failures, report.String())
+	problems = append(problems, collisions(ids)...)
+
+	if len(problems) > 0 {
+		return fmt.Errorf("GNU build-ID check failed (see #651, #653):\n  %s", strings.Join(problems, "\n  "))
 	}
 	if *marker != "" {
 		return os.WriteFile(*marker, report.Bytes(), 0o644)
 	}
-	_, err = os.Stdout.Write(report.Bytes())
+	_, err := os.Stdout.Write(report.Bytes())
 	return err
 }
 
-// wantBuildID returns the build-ID every checked binary must carry, or nil when
-// the build is not stamped (presence check only).
-func wantBuildID(statusFile string) ([]byte, error) {
-	commit, err := readCommit(statusFile)
-	if err != nil || commit == "" {
-		return nil, err
-	}
-	want, err := hex.DecodeString(commit)
-	if err != nil {
-		return nil, fmt.Errorf("decoding commit %q: %w", commit, err)
-	}
-	return want, nil
-}
-
-// checkOne returns the hex build-ID of path, or an error describing why it is
-// missing or wrong.
-func checkOne(path string, want []byte) (string, error) {
-	f, err := os.Open(path)
+// checkOne returns the hex build-ID of path after asserting that it equals the
+// hash recomputed from path's own bytes.
+func checkOne(path string) (string, error) {
+	buf, err := os.ReadFile(path)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = f.Close() }()
-
-	got, err := readBuildID(f)
+	if !isELF(buf) {
+		return "", errors.New("not an ELF image")
+	}
+	got, err := readBuildID(bytes.NewReader(buf))
 	if err != nil {
 		return "", err
 	}
-	if want != nil && !bytes.Equal(got, want) {
-		return "", fmt.Errorf("build-ID is %x, want the release commit %x", got, want)
+	want, err := contentBuildID(buf)
+	if err != nil {
+		return "", err
+	}
+	if !bytes.Equal(got, want) {
+		return "", fmt.Errorf("build-ID is %x but its content hashes to %x — the note does not identify this binary", got, want)
 	}
 	return fmt.Sprintf("%x", got), nil
 }
 
-func isELF(buf []byte) bool {
-	return len(buf) >= 4 && bytes.Equal(buf[:4], []byte("\x7fELF"))
+// collisions reports every build-ID claimed by more than one binary.
+func collisions(ids map[string][]string) []string {
+	var out []string
+	for id, paths := range ids {
+		if len(paths) > 1 {
+			sort.Strings(paths)
+			out = append(out, fmt.Sprintf("build-ID %s is shared by %d binaries: %s", id, len(paths), strings.Join(paths, ", ")))
+		}
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
Fixes #653. Amends the mechanism #652 shipped.

## The collision

#651/#652 fixed *build-to-build* build-ID constancy by stamping the note with the
release commit SHA. But a GNU build-ID identifies a *linked object*, not a source
revision, and one aether commit produces seven released ELFs — so all seven ended
up with one ID. Verified on the artifacts published from `4aabff2`:

| binary | image | GNU build-ID |
|---|---|---|
| agent (multi-call) | `agent@sha256:47fa37d8…` | `4aabff27ace47e82c0df2e637e99e253442dc5a8` |
| mesh-dns | `mesh-dns@sha256:2e186f02…` | same |
| registrar | `registrar@sha256:b3fc0d97…` | same |
| controller | `controller@sha256:47a3383b…` | same |
| cni-install | `cni-install@sha256:bee97fb5…` | same |
| aether-cni (plugin) | same image, `/opt/cni/bin/` | same |
| **envoy** (custom proxy) | `aether-proxy:4aabff27…` | same |

Pyroscope keys symbol lookup **solely** by build-ID, so uploading debuginfo for
any one of these would make the symbolizer resolve all seven against it — six of
them wrong, silently, with plausible-looking frames. Symbol upload has been
blocked on this.

## Why a content hash, not a per-target-namespaced stamp

The issue's option 2 (`sha1(commit || target_label)`) would also give
distinctness, but the content hash (option 1) wins on three counts:

- **Canonical.** It is what `ld --build-id=sha1` computes natively and what
  debuginfod conventions assume. Both toolchains in this repo can produce it: the
  proxy gets it straight from lld, the Go binaries from a 20-byte note rewrite
  that hashes the same thing.
- **Self-verifying.** Given only a shipped ELF you can recompute its build-ID and
  confirm the note belongs to that binary. A namespaced stamp is an assertion you
  have to trust; a content hash is a proof. The CI guard exploits this directly.
- **Correct by construction.** Distinctness is not a rule someone has to remember
  to apply to a new target — it falls out of hashing different bytes.

Release traceability does not need the ELF note and does not live there: it lives
in the `--stamp` x_defs version information baked into the binaries and in the
image tags. The note is the symbolizer's key and nothing else.

## Mechanism

**Go binaries — `//tools/buildid`.** rules_go links with `-buildid=redacted` and
Go ≥1.24 derives `.note.gnu.build-id` from that constant, so the plain
`go_binary` still carries `498919aff001d8366249403a2544fba2d833084f`. The
post-link note rewrite from #652 stays; only the value changes:

```
build_id = SHA-1( image bytes, with the 20-byte build-ID descriptor
                  field replaced by 20 zero bytes )
```

Zeroing the descriptor is what makes the value well defined — it is the one field
the hash is about to overwrite, so excluding it removes the circular dependency
and makes writing the ID **idempotent**. The descriptor is exactly a SHA-1 wide,
so it is patched in place and no other byte of the image moves. All of that is
documented in the tool's package comment and covered by unit tests
(`TestContentBuildIDIsSHA1OfTheZeroedImage`, `…IsDeterministic`,
`…IsIdempotent`, `…IsPairwiseDistinct`, `…ReplacesOnlyTheDescriptor`).

**The stable-status dependency is dropped.** A content hash needs no workspace
status, so `ctx.info_file`, the `--stamp` `config_setting`, `stamp_select()` and
the `STABLE_GIT_COMMIT` variable #652 added are all gone, and the rewrite is
unconditional. That is the cleaner end state, and strictly better than gating it:

- dev and PR-CI builds now get *correct, unique* IDs instead of the rules_go
  constant, so what CI validates is what releases ship;
- the action's cache key is just (input binary, tool). Under #652 every new
  commit invalidated all seven stamping actions; now nothing invalidates unless
  the binary itself changes.

`--stamp` still does what it always did for charts and x_defs; it simply no
longer has anything to do with build-IDs.

**Proxy — `proxy/`.** `envoy_cc_binary(stamped = True)` is dropped (that is
Envoy's commit-SHA ldscript, i.e. exactly the #653 shape) in favour of
`--build-id=sha1`, lld's own content hash of the linked output.

It is passed as `build --linkopt=-Wl,--build-id=sha1` in `proxy/.bazelrc`, **not**
as `linkopts` on `//:envoy`: `envoy_cc_binary` does
`if not linkopts: linkopts = _envoy_linkopts()`, so passing any target linkopts
would silently *replace* Envoy's defaults (`-pthread -lrt -ldl -Wl,-z,relro,-z,now
--hash-style=gnu -pie -Wl,-E`). A `--linkopt` composes instead of replacing —
which is how `envoy.bazelrc` itself passes `-fuse-ld=lld`. The hermetic toolchain
already supplies `-Wl,--build-id=md5` earlier on the link line; lld honours the
last `--build-id`, so ours wins and widens the note from 16 to the conventional
20 bytes.

## The four properties

1. **Pairwise distinct — the headline fix.** Two ELFs that differ anywhere
   outside the descriptor hash differently. Asserted directly by
   `//tools/buildid:release_build_ids` over the six released Go ELFs, and by a
   unit test.
2. **Different commits → different IDs** (does not regress #651): whenever a
   commit changes a binary's bytes, its ID moves. Honestly: a commit that leaves a
   given binary *byte-identical* keeps that binary's ID — and that is correct and
   desirable, not a regression. The previously uploaded symbols are still exactly
   the right ones for those bytes, and re-uploading dedupes.
3. **Same inputs → same ID.** The ID is a pure function of the input bytes: no
   timestamps, no status files, no per-invocation state. Reproducible and
   remote-cache friendly.
4. **Dev/unstamped builds keep working** — better than before, since they now get
   real IDs rather than a byte-identical copy of the constant-ID binary.

## CI guards

- **`//tools/buildid:release_build_ids`** (inverted from #652, which asserted each
  ID *equals* the stamp — precisely the condition that guaranteed the collision).
  It now asserts, over the six released Go ELFs (agent, mesh-dns, cni-install, the
  `aether-cni` plugin, controller, registrar): every note present and 20 bytes;
  every note equal to the SHA-1 recomputed from that binary's own content
  (self-verification); and all notes pairwise distinct. It needs no `--stamp`, so
  it holds in every configuration, is part of `bazel build //...` (hence
  bazel-diff on PRs), and is re-stated by `publish.yaml`.
- **`//integration:build_id_test`** (proxy) — was "equals the ldscript"; now
  asserts the shipped Envoy carries a `.note.gnu.build-id`, that its descriptor is
  exactly 20 bytes (the SHA-1 shape: the toolchain's md5 is 16, `fast` is 8), and
  that it is not all-zero. It deliberately does not recompute the digest: lld's
  `--build-id=sha1` is a tree hash over its output buffer — an internal linker
  detail, not a published function of the file — so recomputing it in a shell test
  would pin an lld implementation detail. (I confirmed that empirically against
  the hermetic lld 18.1.8 before deciding.)
- **`proxy-release.yml`** — the ldscript grep is replaced by an analysis-only
  `bazel aquery 'mnemonic("CppLink", //:envoy)'` assertion that the *last*
  `--build-id` on the link command line is `--build-id=sha1`. Composed with the
  test above, that pins the published binary's note to lld's content hash. No
  extra compile; the ~150 MB binary never leaves the executor.
- `make check-build-id` for the same report locally.

## Validation

**Go side — fully validated locally.** Six released ELFs, one build, `readelf -n`:

```
agent_image_buildid_binary              e33c395749ca00cf140a8d0f09a5a66755c8b9a8
mesh-dns_image_buildid_binary           c7ea4d0cf85deb4cf50322c98785b9d5ec531aa6
cni-install_image_buildid_binary        629c246b1109e4d3281e5a5ccf545597383f89cc
cni-install_image_buildid_extra_0       3c8197e6cbd646b923e6ffa0f9ba07a9d83f8c62   (aether-cni)
controller_image_buildid_binary         f9a4af2f1cc6b584ae1fadda98d6901ce33a6989
registrar_image_buildid_binary          3c10db027c918d27177267eea95a112851cde984
```

Six binaries, six distinct IDs (the plain `go_binary` alongside them still reads
`498919af…`). Self-verification recomputed **independently of the tool** (a
throwaway Python script re-deriving `sha1(image with the descriptor zeroed)` from
each shipped file): all six match their note.

- *Property 2*: changing one live string in `cni/internal/cmd/root.go` moved
  `cni-install` from `629c246b…` to `e37d2e04…`; reverting restored `629c246b…`
  exactly (which is also property 3).
- *Property 3*: `--stamp` and `--nostamp` builds both self-verify and are both
  pairwise distinct. Interesting and correct: under `--stamp` the four binaries
  that embed x_defs version data get different IDs (their bytes differ), while
  `cni-install` and `aether-cni`, which embed none, keep the identical ID. That is
  property 2's honest caveat, visible in miniature.
- *Idempotence on a real 25 MB binary*: `buildid set` run twice more over an
  already-written ELF produced byte-identical files and the same ID all three
  times.
- The guard's collision detection was exercised for real: `buildid verify` on two
  copies of the same binary fails with
  `build-ID 629c246b… is shared by 2 binaries: …`.

`bazel test //...` green (89 tests). `--config=ci` lint green. `make gazelle` and
`make format` clean.

**Proxy side — validated structurally; no full Envoy compile** (multi-hour;
deliberately not run):

- `bazel aquery 'mnemonic("CppLink", //:envoy)'` shows `'-Wl,--build-id=sha1'` on
  the link command line, **after** the toolchain's `'-Wl,--build-id=md5'`, with
  Envoy's own defaults intact (`-Wl,-z,relro,-z,now`, `'-Wl,--hash-style=gnu'`,
  `-pie`) and the `gnu_build_id.ldscript` gone. This is what proves both that the
  flag reaches the link and that dropping `stamped = True` did not disturb the
  rest of the link.
- lld semantics confirmed independently against the hermetic clang/lld 18.1.8 from
  this workspace: `--build-id=sha1` yields a 20-byte note; a later `--build-id=sha1`
  overrides an earlier `--build-id=md5` and produces the identical id; relinking
  identical input reproduces the id; a different program gets a different id.
- `check_build_id.sh` was exercised against real lld output for every branch:
  `sha1` (pass), `md5` (fails, "16-byte descriptor"), `fast` (fails, "8-byte"),
  no `--build-id` (fails, "carries no .note.gnu.build-id"), an all-zero hexstring
  id (fails), a missing file, and a non-ELF.
- The `--build-id` ordering assertion the release workflow runs was verified
  against the real aquery output.

**Awaits the proxy CI leg:** the end-to-end assertion on a compiled Envoy —
`//integration:build_id_test` plus the aquery check — which runs on the first
proxy PR/release build. It is gated, not assumed.

## Operational note (Pyroscope)

After this lands, **all seven binaries are individually uploadable** — each one's
debuginfo resolves only its own samples.

- **No stale `4aabff2`-era upload exists and none must ever be made.** We
  deliberately withheld the `4aabff2` artifacts precisely because of this
  collision; the earlier poisoned `498919af…` upload was already deleted. Uploading
  a `4aabff2`-era binary now would install one symbol table for all seven ELFs.
- The still-valid `15e3b073…` proxy upload predates the stamp and is unaffected;
  the proxy's ID changes on its next publish, so it will need re-uploading then.
- Per the standing procedure, re-upload a binary only when its image **digest**
  moves, keying off the chart's pinned digest rather than the tag. Because the ID
  is now content-derived, an unchanged binary keeps its ID and the upload dedupes.
- The agent, mesh-dns, cni-install, `aether-cni`, controller and registrar are six
  separate ELFs with six separate IDs; upload each one whose native frames matter.

## Not touched

No `charts/` changes, so no chart version bump. The cluster was not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
