### PR TITLE
chore(charts): pin aether-proxy to 4212e13 (tag + digest)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.91.2"
+version: "0.91.3"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -234,10 +234,10 @@ proxy:
   # commit SHA. Mirror by overriding `repository`.
   image:
     repository: ghcr.io/bpalermo/aether/aether-proxy
-    tag: c2ecdabaa5edfde7ffca4704248af0c8d7794ac8
+    tag: 4212e13aa585add5d3884903e32a3c85cac796c5
     # Digest-pinned (option A): content-addressed, tamper-proof. The aether.image
     # helper prefers digest over tag. Envoy v1.39.0 multi-arch index (#534).
-    digest: "sha256:27db36ed2407991b9dfc4440ee7d75225d63ebd63459a4a077893a548c9c049c"
+    digest: "sha256:a749fcce573a1d93822dc9f36a6e287e30a01fbaed6eaca8f2aaa30b91a74924"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application logs as one JSON object per line (bootstrap


### PR DESCRIPTION
Hand-rolled replacement for the `bump-chart` job, which has now failed on two consecutive proxy publishes with:

```
GitHub Actions is not permitted to create or approve pull requests.
```

Repo state: `default_workflow_permissions=read`, `can_approve_pull_request_reviews=false`. The image build and push themselves succeeded both times — only PR creation is blocked.

## What this does

| field | before | after |
|---|---|---|
| `proxy.image.tag` | `c2ecdaba…` (Jul, #534) | `4212e13a…` |
| `proxy.image.digest` | `sha256:27db36ed…` | `sha256:a749fcce…` |

Updates **both**, which is the substance of #648: `aether.image` prefers `digest`, so the auto-bump's tag-only rewrite would have left the fleet on the old build regardless.

The new Envoy carries the content-derived build-ID from #653/#654: `6342923f432ff9f342bd8dd349577c8fa80b4745` — 20 bytes, distinct from all six control-plane binaries. That completes the seven-way distinctness check and unblocks per-binary symbol upload to Pyroscope.

Chart 0.91.2 → 0.91.3.

## Making the automation work again (your call, not done here)

Either flip **Settings → Actions → General → Workflow permissions → "Allow GitHub Actions to create and approve pull requests"** (and grant write), or give the job a PAT. Both are permissions decisions, so I left them alone. #648 tracks teaching the job to rewrite the digest too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr