### PR TITLE
test(proxy): guard the shipped Envoy's symbol table, correct the "stripped" docs

### DIFF
--- a/proxy/.bazelrc
+++ b/proxy/.bazelrc
@@ -27,14 +27,26 @@ build:linux --config=clang
 # passes -fuse-ld=lld the same way.
 build --linkopt=-Wl,--build-id=sha1
 
-# Optimized, stripped release build — the binary baked into the proxy image.
-# Plain `bazel build //:image` is fastbuild (dev); image build paths (CI, the
-# Makefile load/push targets, the README) pass --config=release to bake the
-# optimized binary.
+# Optimized release build — the binary baked into the proxy image. Plain
+# `bazel build //:image` is fastbuild (dev); image build paths (CI, the Makefile
+# load/push targets, the README) pass --config=release to bake the optimized
+# binary.
+#
+# `--strip=always` is NOT a full strip, despite the name: Bazel maps it to the
+# linker's `--strip-debug`, so it removes DWARF and KEEPS `.symtab` (~22 MB,
+# ~944k symbols here). DWARF is redundant anyway — envoy.bazelrc sets
+# `--fission=dbg,opt`, which parks it in .dwo files that never enter the image.
+#
+# Keeping the symbol table is deliberate and load-bearing (aether #651): the
+# OpenTelemetry eBPF profiler does not symbolize native frames in-agent, so
+# Pyroscope needs this build's symbols to name the ~1 core of CPU the proxy
+# fleet burns. Do not "finish the job" with `-Wl,-s` / `--strip-all` — it saves
+# ~10 MiB compressed and silently turns every Envoy flamegraph back into hex
+# addresses. //integration:symtab_test fails the build if that happens.
 build:release -c opt
 build:release --strip=always
 
-# Release build: optimized, stripped (used by CI to produce the image binary).
+# Release build: optimized, DWARF-stripped (used by CI to produce the image binary).
 build:ci --config=release
 # BuildBuddy invocation metadata (https://www.buildbuddy.io/docs/guide-metadata).
 # Dynamic metadata (COMMIT_SHA/REPO_URL/BRANCH_NAME) is passed by the CI workflow.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -21,8 +21,8 @@ cd proxy
 bazel build //:envoy
 
 # Build + load the custom aether-proxy image into the local Docker daemon.
-# --config=release bakes the optimized, stripped Envoy (plain builds are
-# fastbuild/dev). The Makefile `load-proxy-image` target does this for you.
+# --config=release bakes the optimized Envoy (plain builds are fastbuild/dev).
+# The Makefile `load-proxy-image` target does this for you.
 bazel build --config=release //:image
 bazel run --config=release //:load   # ghcr.io/bpalermo/aether/aether-proxy:latest
 
@@ -32,8 +32,15 @@ bazel test //:image_test
 
 The image is `distroless/cc` base + the custom `//:envoy` binary at
 `/usr/local/bin/envoy`. Plain `bazel build //:image` produces a **fastbuild**
-(unoptimized, unstripped) binary — always pass `--config=release` (CI and the
-Makefile targets do) to bake the production binary.
+(unoptimized) binary — always pass `--config=release` (CI and the Makefile
+targets do) to bake the production binary.
+
+The released binary is **not** fully stripped, on purpose. `--strip=always`
+removes DWARF but keeps `.symtab` (~22 MB, ~944k symbols), which is what lets
+Pyroscope put names on the proxy fleet's native frames — the profiler itself
+symbolizes nothing native (aether #651). `//integration:symtab_test` guards it,
+and `//integration:build_id_test` guards the content-derived GNU build-ID the
+symbol upload is keyed by (#653).
 
 > **`aether_stats` is a compiled-in C++ extension** (proposal 012), built into
 > `//:envoy` via `AETHER_EXTENSIONS` in `BUILD.bazel`. It records

--- a/proxy/integration/BUILD.bazel
+++ b/proxy/integration/BUILD.bazel
@@ -22,3 +22,24 @@ sh_test(
     args = ["$(rootpath //:envoy)"],
     data = ["//:envoy"],
 )
+
+# aether #651: assert the shipped Envoy still carries `.symtab`. The eBPF
+# profiler resolves no native frame itself — it emits (build-ID, offset) and
+# Pyroscope's symbolizer needs this build's symbol table to produce names. A
+# build-ID alone is a key to nothing if the symbols are gone.
+#
+# Worth a gate because the regression is silent and the trap is subtle: Bazel's
+# `--strip=always` sounds like it strips everything but passes the linker
+# `--strip-debug`, which drops DWARF and KEEPS `.symtab` (~22 MB, ~944k symbols
+# on this binary — the reason the proxy is symbolizable at all). A future move to
+# a real strip would read as a size win and would quietly cost the fleet its
+# flamegraph names.
+#
+# No extra build cost: //:envoy is already compiled for //:image_test.
+sh_test(
+    name = "symtab_test",
+    size = "small",
+    srcs = ["check_symtab.sh"],
+    args = ["$(rootpath //:envoy)"],
+    data = ["//:envoy"],
+)

--- a/proxy/integration/check_symtab.sh
+++ b/proxy/integration/check_symtab.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Assert the shipped custom Envoy still carries a symbol table (aether #651/#653).
+#
+# Usage:
+#   check_symtab.sh <binary>
+#
+# Why this is a release gate and not a nicety:
+#
+# The OpenTelemetry eBPF profiler never symbolizes native frames in-agent — it
+# reports (build-ID, file offset) and leaves naming to the backend. Pyroscope's
+# symbolizer then needs a symbol table for *this* build to turn those offsets
+# into names. If `.symtab` ever disappears from the shipped binary, the ~1 core
+# of fleet CPU the proxy burns silently goes back to `envoy!0x52e4c6f` hex
+# frames — with no build error, no failing test, and nothing in the flamegraph
+# to explain why. This test is the tripwire for that.
+#
+# The failure is easy to introduce by accident, because Bazel's strip semantics
+# are not what the name suggests: `--strip=always` passes the linker
+# `--strip-debug`, which removes DWARF but KEEPS `.symtab`. A future change to a
+# real strip (`-Wl,-s` / `--strip-all`, or `objcopy --strip-all` in an image
+# rule) would look like a harmless size optimisation and would cost the fleet
+# its symbols. See the comment on `build:release --strip=always` in
+# proxy/.bazelrc.
+#
+# Dependency-free on purpose: `od` + `awk` are POSIX, so this runs unchanged on a
+# GitHub runner and inside a BuildBuddy RBE executor image, neither of which is
+# guaranteed to ship binutils `readelf`/`nm`.
+set -euo pipefail
+
+binary=${1:?usage: check_symtab.sh <binary>}
+
+if [ ! -f "$binary" ]; then
+	echo "FAIL: $binary does not exist" >&2
+	exit 1
+fi
+
+# le <hex-string-of-little-endian-bytes> -> decimal.
+# od prints bytes in file order, so a little-endian field arrives reversed.
+le() {
+	local hex=$1 out="" i
+	for ((i = ${#hex} - 2; i >= 0; i -= 2)); do out+=${hex:i:2}; done
+	echo $((16#$out))
+}
+
+# read_at <offset> <count> -> contiguous lowercase hex of those bytes.
+read_at() {
+	od -An -v -tx1 -j "$1" -N "$2" "$binary" | tr -d ' \n'
+}
+
+# ELF64 header fields we need (all little-endian):
+#   e_shoff     0x28, 8 bytes — section header table offset
+#   e_shentsize 0x3a, 2 bytes — bytes per section header
+#   e_shnum     0x3c, 2 bytes — number of section headers
+header=$(read_at 0 64)
+if [ "${header:0:8}" != "7f454c46" ]; then
+	echo "FAIL: $binary is not an ELF file" >&2
+	exit 1
+fi
+if [ "${header:8:2}" != "02" ]; then
+	echo "FAIL: $binary is not ELF64 (ei_class=${header:8:2})" >&2
+	exit 1
+fi
+
+shoff=$(le "${header:80:16}")
+shentsize=$(le "${header:116:4}")
+shnum=$(le "${header:120:4}")
+
+if [ "$shoff" -eq 0 ] || [ "$shnum" -eq 0 ]; then
+	echo "FAIL: $binary has no section header table — it has been fully stripped" >&2
+	echo "      (aether #651: the shipped Envoy must retain .symtab so Pyroscope can" >&2
+	echo "       symbolize native frames; see proxy/.bazelrc)" >&2
+	exit 1
+fi
+
+# Walk the section headers looking for SHT_SYMTAB (sh_type == 2), which is what
+# `.symtab` is by definition — matching on the type rather than the section name
+# avoids a second read of the section-name string table. Each ELF64 section
+# header is: sh_name(4) sh_type(4) sh_flags(8) sh_addr(8) sh_offset(8)
+# sh_size(8) sh_link(4) sh_info(4) sh_addralign(8) sh_entsize(8).
+table=$(read_at "$shoff" $((shnum * shentsize)))
+
+symtab_size=0
+symtab_entsize=0
+for ((i = 0; i < shnum; i++)); do
+	entry=${table:$((i * shentsize * 2)):$((shentsize * 2))}
+	[ "$(le "${entry:8:8}")" -eq 2 ] || continue
+	symtab_size=$(le "${entry:64:16}")
+	symtab_entsize=$(le "${entry:112:16}")
+	break
+done
+
+if [ "$symtab_size" -eq 0 ]; then
+	echo "FAIL: $binary carries no .symtab (SHT_SYMTAB) section" >&2
+	echo "      Native frames in Pyroscope will render as hex addresses." >&2
+	echo "      (aether #651. Bazel's --strip=always keeps .symtab; something in the" >&2
+	echo "       build has moved to a full strip — see proxy/.bazelrc)" >&2
+	exit 1
+fi
+
+# An ELF64 symbol is 24 bytes; guard against a degenerate table that exists but
+# holds nothing useful.
+symbols=0
+if [ "$symtab_entsize" -gt 0 ]; then
+	symbols=$((symtab_size / symtab_entsize))
+fi
+if [ "$symbols" -lt 1000 ]; then
+	echo "FAIL: $binary has only $symbols symbols in .symtab — expected a full Envoy table" >&2
+	exit 1
+fi
+
+echo "OK: $binary retains .symtab ($symbols symbols, $symtab_size bytes)"


### PR DESCRIPTION
Last of the Phase 4 items from the symbolization work (#651) — the two that were left open after #652/#654.

## The docs were wrong, and the wrongness is load-bearing

`proxy/.bazelrc` and `proxy/README.md` both described the release binary as **stripped**. It isn't. Bazel maps `--strip=always` to the linker's `--strip-debug`: DWARF goes, `.symtab` stays — ~22 MB, ~944k symbols on this binary. (DWARF is redundant regardless: `envoy.bazelrc` sets `--fission=dbg,opt`, parking it in .dwo files that never enter the image.)

That misconception is what sent the original symbolization investigation down a blind alley — "the binary is stripped, so we need to ship symbols separately" — when in fact the symbols were in the image the whole time and the missing piece was Pyroscope's backend symbolizer.

## Why a CI gate, not just a comment fix

The eBPF profiler symbolizes **no** native frame in-agent; it emits (build-ID, file offset). Pyroscope needs this build's symbol table to produce names. So `.symtab` disappearing costs the fleet every Envoy frame name — silently, with no build error, no failing test, and nothing in the flamegraph to explain it. And the change that would cause it looks entirely reasonable: switching to a real strip (`-Wl,-s`, `--strip-all`, an `objcopy` in an image rule) reads as a ~10 MiB size win.

`//integration:symtab_test` now fails the build if `.symtab` goes missing, if the section header table is gone entirely, or if the table exists but is degenerate.

## Implementation notes

- Dependency-free (`od` + `awk`, POSIX), same rationale as `check_build_id.sh`: RBE executors aren't guaranteed to ship binutils `readelf`/`nm`.
- Walks ELF64 section headers for `SHT_SYMTAB` (type 2) rather than matching the section *name*, which avoids a second read of the section-name string table.
- No extra build cost — `//:envoy` is already compiled for `//:image_test`.

## Validation

Run against the **real published binaries**, not fixtures:

| binary | result |
|---|---|
| `envoy` from `aether-proxy@27db36ed` (deployed fleet) | OK — 944,013 symbols, 22,656,312 bytes |
| `envoy` from `aether-proxy:4212e13` (new build) | OK — identical counts |

Negatives, each crafted from the real binary and each failing with the diagnostic that names the cause:
- `SHT_SYMTAB` retyped to `SHT_NULL` → "carries no .symtab (SHT_SYMTAB) section"
- `e_shnum` zeroed → "no section header table — it has been fully stripped"
- non-ELF input → "is not an ELF file"

`bazel build --nobuild //integration:symtab_test` analyzes clean (no Envoy compile needed to verify wiring); `--config=ci` lint (shellcheck) clean; `make format` clean. The PR's own proxy legs run the test for real against a freshly compiled Envoy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr