### PR TITLE
fix(soak): make the mesh_dns SLI target repo-owned, replicated and spread

### DIFF
--- a/docs/observability/profiling-symbols.md
+++ b/docs/observability/profiling-symbols.md
@@ -1,0 +1,111 @@
+# Profiling symbols: why flame graphs go blank after a release
+
+Continuous profiling on `talos-main` comes from the **OpenTelemetry eBPF profiler**,
+which reports native stack frames by **GNU build ID** and nothing else. Pyroscope can
+only turn those frames into function names if a *debuginfo* blob carrying the **same**
+build ID has been uploaded to it.
+
+Every aether release produces new binaries, therefore new build IDs, therefore a
+Pyroscope that no longer knows how to symbolise them.
+
+## The failure is silent, and that is the point
+
+When symbols are missing, **nothing breaks and nothing alerts**:
+
+- profiles keep arriving and keep being stored;
+- CPU/memory totals stay correct;
+- no error is logged anywhere;
+- the flame graph simply renders hex addresses instead of function names.
+
+You normally discover it at the worst possible moment — in the middle of an
+investigation, on the one build you actually needed to read. Treat "the flame graph is
+full of `0x...`" as a *symbol* problem, never as a profiler problem.
+
+## How to tell
+
+Ask Pyroscope what it knows:
+
+```bash
+kubectl -n o11y port-forward svc/pyroscope 4040:4040 &
+profilecli debuginfo list --url http://127.0.0.1:4040
+```
+
+Each line looks like:
+
+```
+build_id=897d73e8b1684754d0cd127f021725619b6379db name=agent \
+  type=TYPE_EXECUTABLE_FULL state=STATE_UPLOADED size=60.2 MiB uploaded_at=2026-09-01T23:35:56Z
+```
+
+Then get the build ID of the binary actually running, and compare:
+
+```bash
+crane export --platform linux/arm64 \
+  "$(kubectl -n aether-system get ds aether-agent \
+       -o jsonpath='{.spec.template.spec.containers[0].image}')" - \
+  | tar -x -O agent > /tmp/agent
+readelf -n /tmp/agent | grep 'Build ID'
+```
+
+If that ID is not in the list, that component's frames will not symbolise.
+
+> **`--platform linux/arm64` is not optional.** Every node on `talos-main` is arm64, and
+> the images are multi-arch. Omitting it silently gives you the amd64 binary, whose build
+> ID differs completely (`897d73e8…` vs `da9ce3fa…` for the same image) — so you will
+> compare the wrong ID, or worse, upload symbols that match nothing and appear to have
+> worked.
+
+## Who keeps this in sync
+
+Nobody, by hand — this is automated **outside this repo**, in the GitOps cluster
+repository:
+
+> `bpalermo/k8s-talos-main` → `clusters/talos-main/pyroscope-debuginfo/`
+
+An hourly CronJob in the `o11y` namespace reconciles Pyroscope's debuginfo store against
+the image digests **actually running** in `aether-system` and `aether-ingress`. It
+extracts the binaries with `crane`, uploads any build ID Pyroscope is missing, and
+re-uploads anything that disappears from the store. Steady state is a no-op.
+
+That directory's `README.md` is the operational reference: rollout, GC interlocks, alerts
+and known risks all live there.
+
+### Why it is not in this repo
+
+The job needs cluster knowledge — namespaces, registry, Pyroscope's address, the node
+architecture. Only one thing about it is aether knowledge: **where each binary sits inside
+each image**. That table is `targets.tsv`, and it is the piece that changes when this repo
+changes:
+
+| image | binary path in image | defined by |
+|---|---|---|
+| `aether-proxy` | `/usr/local/bin/envoy` | `proxy/BUILD.bazel` |
+| `agent`, `mesh-dns`, `registrar`, `controller`, `cni-install` | `/<name>` (Go binaries land at the image root) | `bazel/img/go_multi_arch_image.bzl` |
+| `cni-install` | `/opt/cni/bin/aether-cni` | `cni/cmd/cni-install/BUILD.bazel` |
+
+Deployment is also decisive: the `aether` chart is installed by hand, so a job living here
+would only refresh symbols when a human ran `helm upgrade` — which is exactly the manual
+step the automation removes.
+
+**If you move or rename a binary inside an image, update `targets.tsv` in the GitOps
+repo.** Nothing in this repo's CI will catch it; the symptom is one component's frames
+going hex while every other component stays fine. The sync job alerts on this
+(`DebuginfoSyncMissingSymbols`).
+
+## Adding a new binary to the mesh
+
+A new component only gets symbolised profiles once it is added there:
+
+1. Add a row to `clusters/talos-main/pyroscope-debuginfo/targets.tsv`:
+   `<image>` ⇥ `<artifact>` ⇥ `<tar-relative path>` ⇥ `executable-full` ⇥ `true`
+   (the path has **no leading slash**, and `<artifact>` must be unique in that file).
+2. Make sure the workload runs in a namespace the job discovers (`aether-system` or
+   `aether-ingress`) from a **digest-pinned** `ghcr.io/bpalermo/aether/*` reference.
+
+The next hourly tick picks it up.
+
+## Related
+
+- Alert rules: group `debuginfo-sync` in the cluster repo's `prometheus/values.yaml`.
+- [`README.md`](./README.md) — the mesh-DNS alerting rules and how alerts are delivered
+  on `talos-main` (helm values, not a `PrometheusRule` CRD).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -232,3 +232,9 @@ continuous mesh traffic.
 See [`charts/README.md`](../charts/README.md) for chart layout, image mirroring,
 and the `--stamp` versioning scheme, and [`getting-started.md`](./getting-started.md)
 for the full install + onboarding walkthrough.
+
+> Moving or renaming a binary **inside** an image (the Bazel image rules, `proxy/`, or
+> `cni/cmd/cni-install/`) breaks profile symbolisation, silently — flame graphs decay to
+> hex addresses with no error and no failing test. See
+> [`observability/profiling-symbols.md`](./observability/profiling-symbols.md) for the
+> path table that has to be updated alongside it.

--- a/e2e/soak/README.md
+++ b/e2e/soak/README.md
@@ -17,6 +17,13 @@ the very churn being tested. Never grade a soak on mesh self-SLI alone.
 ## Run
 
 ```bash
+# 0. The mesh_dns SLI target. Only needed once (and after any change to it), but
+#    CHECK IT before a run: the prober resolves echo.<ns>.aether.internal on every
+#    node, so if this is a single replica the mesh_dns tier measures that one pod's
+#    node instead of the mesh. See the gotcha below.
+kubectl apply -n aether-test -f e2e/soak/echo.yaml
+kubectl -n aether-test get pods -l app=echo -o wide   # expect 3, on 3 different nodes
+
 # 1. Load the k6 script as a ConfigMap (source of truth is the .js file here).
 kubectl create configmap k6-soak-script -n aether-test \
   --from-file=test.js=e2e/soak/k6-mesh-soak.js \
@@ -70,9 +77,21 @@ Each of these invalidated a real run:
    digest. Use `helm get values <rel> -n <ns> -o yaml > /tmp/v.yaml` then `-f /tmp/v.yaml`.
 6. **k6 needs 1Gi.** At 256Mi runners OOM-restart ~3-5h into the 7h40m run, fragmenting
    the summary.
+7. **`echo` must be multi-replica and spread, or the mesh_dns tier is not a mesh
+   signal.** It is the *only* target of that tier, so its own health is
+   indistinguishable from the mesh's. On 2026-09-02 it was a single replica that
+   happened to sit on the node hosting the entire o11y stack, with a 10m CPU request;
+   when that node saturated, echo starved and mesh_dns reported ~30% errors fleet-wide
+   (66% on the co-located prober) while the mesh itself was fine — and the run was
+   ungradeable. It had no repo-owned definition at all, so there was nowhere to fix
+   it; `e2e/soak/echo.yaml` now owns it with 3 replicas, a soft hostname spread, and
+   honest requests. It is deliberately NOT `test/e2e/testdata/echo.yaml`, which the
+   CNI e2e tests apply on single-node kind and must stay minimal.
 
 ## Files
 
+- `echo.yaml` — the mesh_dns SLI target (3 replicas, soft hostname spread). Apply before
+  a run; it is the workload the mesh_dns tier actually measures.
 - `k6-mesh-soak.js` — load script (constant-arrival-rate, qualified mesh names, no OTLP).
 - `k6-runner.yaml` — the 5-node runner DaemonSet.
 - `churn.sh` — the 30-roll churn driver; takes a build label for the log header.

--- a/e2e/soak/echo.yaml
+++ b/e2e/soak/echo.yaml
@@ -1,0 +1,135 @@
+# The soak harness's mesh_dns target.
+#
+# The external prober resolves `echo.<ns>.aether.internal` through the mesh DNS path
+# on every node, so THIS is the workload the mesh_dns SLI tier actually measures. It
+# is deliberately separate from `test/e2e/testdata/echo.yaml`, which is a fixture the
+# CNI e2e tests apply on a single-node kind cluster and must stay minimal.
+#
+# Why it is here at all (2026-09-02): during the aborted soak this service ran as a
+# SINGLE replica pinned by chance to main-worker-01 — the node hosting the whole o11y
+# stack — with a 10m CPU request and no repo-owned definition. When that node
+# saturated, echo starved, and the mesh_dns tier reported ~30% errors fleet-wide
+# (66% on worker-01's own prober). The SLI was measuring one starved pod rather than
+# the mesh. Nothing in either repo defined it, so there was no place to fix it.
+#
+#   kubectl apply -n aether-test -f e2e/soak/echo.yaml
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: echo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: echo
+  labels:
+    # Marks the Service for mesh projection; the agent generates the
+    # <svc>.<ns>.aether.internal record from it, which is what the prober resolves.
+    aether.io/mesh-service: "true"
+  annotations:
+    aether.io/service: echo
+    # The application's own listener. The Service port below is the mesh inbound
+    # port; the proxy forwards to this port inside the pod.
+    aether.io/port: "8080"
+    aether.io/app-protocol: http
+spec:
+  type: ClusterIP
+  selector:
+    app: echo
+  ports:
+    - name: mesh
+      port: 18081
+      targetPort: 18081
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo
+  labels:
+    app: echo
+spec:
+  # THREE replicas, not one. The prober's mesh_dns tier is only a mesh signal if a
+  # single busy node cannot dominate it: with one replica the tier degrades to a
+  # health check of whichever node that pod landed on.
+  replicas: 3
+  # Surge a new Ready pod before terminating the old one so a rollout never leaves
+  # the Service with zero ready endpoints (the source of the transient 503s seen on
+  # echo during the 2026-06-29 redirect-all soak). The mesh drains the terminating
+  # pod via its deletionTimestamp watch.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: echo
+  template:
+    metadata:
+      labels:
+        app: echo
+        # Without this the CNI installs no capture/DNS redirect and the pod is
+        # invisible to the mesh — a harness bug that reads as a mesh outage.
+        aether.io/managed: "true"
+    spec:
+      serviceAccountName: echo
+      # Spread the replicas across nodes. SOFT (ScheduleAnyway): on a single-node
+      # kind cluster, or when a node is cordoned, scheduling must still succeed —
+      # a DoNotSchedule constraint would leave replicas Pending and take the SLI
+      # target down entirely, which is worse than an uneven spread.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: echo
+      # Hold the pod briefly after deletion is requested so endpoint deregistration
+      # (mesh EDS DRAINING) and in-flight requests settle before SIGTERM. Native
+      # sleep preStop (k8s >= 1.29) — the distroless echo-basic image has no shell.
+      terminationGracePeriodSeconds: 30
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: echo
+          image: gcr.io/k8s-staging-gateway-api/echo-basic@sha256:eb7396722956640221e856b8e8cf44179da131d5bd6fc27a4f0cb91f60c237c3
+          env:
+            - name: HTTP_PORT
+              value: "8080"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 8080
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 5
+          # Sized from the soak's actual load, not copied from the e2e fixture's
+          # 10m. Each replica serves its share of the prober's ~50 req/s plus the
+          # k6 load; a 10m request makes the scheduler treat this as free and lets
+          # it be starved first on a busy node, which is exactly what happened.
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+            limits:
+              memory: 256Mi
+          securityContext:
+            privileged: false
+            runAsNonRoot: true
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL


### PR DESCRIPTION
## The problem

The external prober resolves `echo.<ns>.aether.internal` on every node, so **`echo` is the workload the mesh_dns SLI tier actually measures**. It was:

- a **single replica**, so its own health was indistinguishable from the mesh's;
- requesting **10m CPU**, which makes the scheduler treat it as free and lets it be starved first on a busy node;
- **not defined in either repo** — the Deployment was hand-applied from `test/e2e/testdata/echo.yaml` and the Service existed only in the cluster (`kubectl apply` warns it is missing `last-applied-configuration`, i.e. it was created imperatively and never managed).

On 2026-09-02 that replica happened to sit on the node hosting the entire o11y stack. When the node saturated, echo starved and the mesh_dns tier reported **~30% errors fleet-wide** (66% on the co-located prober) **while the mesh itself was healthy**. The soak was ungradeable, and there was nowhere in either repo to fix the harness.

## The change

`e2e/soak/echo.yaml` now owns the ServiceAccount, Service and Deployment together:

| | before | after |
|---|---|---|
| replicas | 1 | **3** |
| spread | none | soft hostname `topologySpreadConstraint` |
| cpu request | 10m | 100m (+ 64Mi/256Mi memory) |
| ownership | hand-applied, Service unmanaged | repo-owned |

**The spread is deliberately soft (`ScheduleAnyway`).** A `DoNotSchedule` constraint would leave replicas Pending on single-node kind or when a node is cordoned — taking the SLI target down entirely, which is worse than an uneven spread. (This is the same trap that makes spread constraints useless for the node-pinned o11y PVCs.)

**Deliberately not `test/e2e/testdata/echo.yaml`**: that fixture is applied by the CNI e2e tests (`test/e2e/cni_test.go`) on a single-node kind cluster and must stay minimal. Changing it to 3 replicas would alter unrelated conformance tests.

## Verified on talos-main

Applied **hitlessly** — `maxSurge: 1` / `maxUnavailable: 0` plus the mesh's deletionTimestamp drain meant the Service never had zero ready endpoints:

- replicas landed on **worker-03, worker-04, worker-05** — off the hot node;
- both prober tiers held at **24.94 / 49.87 rps success with zero errors** in every class across the rollout.

Documented in the harness README as step 0 with a pre-run check, plus a gotcha explaining why a single-replica target makes the tier meaningless.

Refs #629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr