### PR TITLE
fix(agent): decouple startup from OTel export so a shedding collector cannot crash-loop agents (#662)

### DIFF
--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -126,7 +126,7 @@ func runEdge(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	result, err := manager.Bootstrap(ctx, cfg.Config, edgeName, Version, func(o *ctrl.Options) {
+	result, err := manager.Bootstrap(ctx, cfg.Config, edgeName, Version, l, func(o *ctrl.Options) {
 		o.Scheme = scheme
 	})
 	if err != nil {

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -95,8 +95,8 @@ var rootCmd = &cobra.Command{
 		}
 		applyMeshConfig(mc)
 
-		l, logShutdown, err = manager.SetupManagerLogging(cmd.Context(), cfg.Config, name, Version)
-		return err
+		l, logShutdown = manager.SetupManagerLogging(cmd.Context(), cfg.Config, name, Version)
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, _ []string) (err error) {
 		return runAgent(cmd.Context())
@@ -226,7 +226,7 @@ func runAgent(ctx context.Context) (retErr error) {
 		},
 	}
 
-	result, err := manager.Bootstrap(ctx, cfg.Config, name, Version)
+	result, err := manager.Bootstrap(ctx, cfg.Config, name, Version, l)
 	if err != nil {
 		return err
 	}

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -329,6 +329,13 @@ func setupSpireSource(ctx context.Context) (*commonspire.Source, string, error) 
 	// match the secrets the SPIRE bridge delivers. Peer authorization uses the
 	// mesh domain — addressing (<svc>.<mesh-domain>) and identity
 	// (spiffe://<mesh-domain>/...) are one domain by design, never split.
+	//
+	// This wait is on the startup path, before the manager serves /healthz, so it
+	// is bounded (commonspire.SourceTimeout) and announced: an unattested agent
+	// used to stall here with no log line at all until the liveness probe killed
+	// it (issue #662).
+	l.InfoContext(ctx, "waiting for the SPIRE Workload API to issue this agent's SVID",
+		"socket", cfg.SpireWorkloadSocketPath, "timeout", commonspire.SourceTimeout)
 	spireSource, err := commonspire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
 	if err != nil {
 		return nil, "", err

--- a/common/manager/BUILD.bazel
+++ b/common/manager/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "manager",
@@ -19,5 +19,17 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/cache",
         "@io_k8s_sigs_controller_runtime//pkg/healthz",
         "@io_opentelemetry_go_contrib_bridges_otelslog//:otelslog",
+    ],
+)
+
+go_test(
+    name = "manager_test",
+    srcs = ["telemetry_test.go"],
+    embed = [":manager"],
+    deps = [
+        "//common/telemetry/setup",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )

--- a/common/manager/logging.go
+++ b/common/manager/logging.go
@@ -2,7 +2,6 @@ package manager
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 
 	"aethermesh.dev/common/log"
@@ -28,22 +27,34 @@ func SetupLogging(debug bool, name string) *slog.Logger {
 // ctx passed to the *Context log methods. controller-runtime is wired via the
 // logr→slog bridge over the same handler. The returned shutdown flushes and stops
 // the LoggerProvider; it is nil when OTLP logging is disabled.
-func SetupManagerLogging(ctx context.Context, cfg Config, name, version string) (*slog.Logger, func(context.Context) error, error) {
+//
+// It returns no error by design (issue #662): OTLP log export is best-effort, so
+// a collector that is missing, unreachable or shedding degrades the component to
+// stderr-only logging with a WARN rather than killing the process. Setup runs on
+// a detached, bounded context so it can neither spend the caller's startup budget
+// nor observe a cancellation of the caller's context, and the returned shutdown
+// flushes on its own detached context so the final flush still runs after SIGTERM.
+func SetupManagerLogging(ctx context.Context, cfg Config, name, version string) (*slog.Logger, func(context.Context) error) {
 	if !cfg.LogsEnabled || cfg.OTLPEndpoint == "" {
-		return SetupLogging(cfg.Debug, name), nil, nil
+		return SetupLogging(cfg.Debug, name), nil
 	}
 
-	provider, shutdown, err := setup.SetupLogs(ctx, setup.Config{
+	setupCtx, cancel := setup.DetachedTimeout(ctx, setup.SetupTimeout)
+	defer cancel()
+
+	provider, shutdown, err := setup.SetupLogs(setupCtx, setup.Config{
 		ServiceName:    name,
 		ServiceVersion: version,
 		OTLPEndpoint:   cfg.OTLPEndpoint,
 	})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to setup OTel logs: %w", err)
+		l := SetupLogging(cfg.Debug, name)
+		l.WarnContext(ctx, "failed to set up OTel log export; logging to stderr only", "error", err)
+		return l, nil
 	}
 
 	otelHandler := otelslog.NewHandler(name, otelslog.WithLoggerProvider(provider))
 	l := log.Named(log.NewLoggerWithHandler(cfg.Debug, otelHandler), name)
 	ctrl.SetLogger(logr.FromSlogHandler(l.Handler()))
-	return l, shutdown, nil
+	return l, setup.BestEffortShutdown(shutdown)
 }

--- a/common/manager/manager.go
+++ b/common/manager/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"aethermesh.dev/common/telemetry/setup"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,47 +17,14 @@ type Result struct {
 	Shutdown func(context.Context) error // nil if neither OTel metrics nor tracing enabled
 }
 
-// Bootstrap sets up telemetry (if enabled), creates a controller-runtime Manager,
+// Bootstrap sets up telemetry (best-effort), creates a controller-runtime Manager,
 // and registers the standard health and readiness probes. Optional opts mutate
 // the ctrl.Options before the manager is built (e.g. to supply a custom webhook
 // server backed by SPIRE).
-func Bootstrap(ctx context.Context, cfg Config, serviceName, serviceVersion string, optFns ...func(*ctrl.Options)) (*Result, error) {
-	telemetryCfg := setup.Config{
-		ServiceName:     serviceName,
-		ServiceVersion:  serviceVersion,
-		OTLPEndpoint:    cfg.OTLPEndpoint,
-		TraceSampleRate: cfg.TraceSampleRate,
-		TraceExport:     cfg.TracingExport,
-	}
-
-	var shutdowns []func(context.Context) error
-	if cfg.OTelEnabled {
-		metricsShutdown, err := setup.Setup(ctx, telemetryCfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to setup telemetry: %w", err)
-		}
-		shutdowns = append(shutdowns, metricsShutdown)
-	}
-	// Tracing is always installed: a TracerProvider issues the span contexts that
-	// give logs their trace_id/span_id (the slog/otelslog correlation), which is
-	// useful regardless of other telemetry. Span EXPORT stays opt-in (TraceExport)
-	// — see SetupTracing.
-	tracingShutdown, err := setup.SetupTracing(ctx, telemetryCfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to setup tracing: %w", err)
-	}
-	shutdowns = append(shutdowns, tracingShutdown)
-
-	var shutdown func(context.Context) error
-	if len(shutdowns) > 0 {
-		shutdown = func(ctx context.Context) error {
-			var errs []error
-			for _, fn := range shutdowns {
-				errs = append(errs, fn(ctx))
-			}
-			return errors.Join(errs...)
-		}
-	}
+//
+// Telemetry never fails the bootstrap: see setupTelemetry.
+func Bootstrap(ctx context.Context, cfg Config, serviceName, serviceVersion string, l *slog.Logger, optFns ...func(*ctrl.Options)) (*Result, error) {
+	shutdown := setupTelemetry(ctx, cfg, serviceName, serviceVersion, l)
 
 	opts := ctrl.Options{
 		HealthProbeBindAddress: cfg.HealthProbeBindAddress,
@@ -89,4 +57,73 @@ func Bootstrap(ctx context.Context, cfg Config, serviceName, serviceVersion stri
 		Manager:  m,
 		Shutdown: shutdown,
 	}, nil
+}
+
+// setupTelemetry installs the MeterProvider (when OTel is enabled) and the
+// always-on TracerProvider, and returns a combined shutdown (nil when nothing
+// was installed).
+//
+// Telemetry is best-effort by construction — it CANNOT fail the caller's startup
+// and it CANNOT touch the caller's context (issue #662):
+//
+//   - Provider construction runs on a detached, bounded context, so a wedged
+//     collector or resource detector can neither consume the caller's startup
+//     budget (the binary's health probes do not answer until initialization
+//     finishes, so spending it means a kubelet liveness kill and a crash loop)
+//     nor observe a cancellation of the caller's context.
+//   - A setup error degrades the component to no telemetry with a WARN instead
+//     of returning an error that exits the process. An agent that programs Envoy
+//     but cannot export metrics is degraded, not dead; making an observability
+//     backend a hard dependency of the data plane also makes the failure
+//     fleet-correlated, since every instance exports to the same collector.
+//   - Each shutdown flushes on a detached, bounded context, so the final flush
+//     still runs after SIGTERM has cancelled the caller's context.
+func setupTelemetry(ctx context.Context, cfg Config, serviceName, serviceVersion string, l *slog.Logger) func(context.Context) error {
+	// Degrading gracefully is this function's whole job, so it must not itself
+	// nil-panic on the very path that reports the degradation.
+	if l == nil {
+		l = slog.Default()
+	}
+
+	telemetryCfg := setup.Config{
+		ServiceName:     serviceName,
+		ServiceVersion:  serviceVersion,
+		OTLPEndpoint:    cfg.OTLPEndpoint,
+		TraceSampleRate: cfg.TraceSampleRate,
+		TraceExport:     cfg.TracingExport,
+	}
+
+	setupCtx, cancel := setup.DetachedTimeout(ctx, setup.SetupTimeout)
+	defer cancel()
+
+	var shutdowns []func(context.Context) error
+	if cfg.OTelEnabled {
+		metricsShutdown, err := setup.Setup(setupCtx, telemetryCfg)
+		if err != nil {
+			l.WarnContext(ctx, "failed to set up OTel metrics; continuing without them", "error", err)
+		} else {
+			shutdowns = append(shutdowns, setup.BestEffortShutdown(metricsShutdown))
+		}
+	}
+	// Tracing is always installed: a TracerProvider issues the span contexts that
+	// give logs their trace_id/span_id (the slog/otelslog correlation), which is
+	// useful regardless of other telemetry. Span EXPORT stays opt-in (TraceExport)
+	// — see SetupTracing.
+	tracingShutdown, err := setup.SetupTracing(setupCtx, telemetryCfg)
+	if err != nil {
+		l.WarnContext(ctx, "failed to set up OTel tracing; continuing without it", "error", err)
+	} else {
+		shutdowns = append(shutdowns, setup.BestEffortShutdown(tracingShutdown))
+	}
+
+	if len(shutdowns) == 0 {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		var errs []error
+		for _, fn := range shutdowns {
+			errs = append(errs, fn(ctx))
+		}
+		return errors.Join(errs...)
+	}
 }

--- a/common/manager/telemetry_test.go
+++ b/common/manager/telemetry_test.go
@@ -1,0 +1,241 @@
+package manager
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"aethermesh.dev/common/telemetry/setup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// shedddingCollector starts a gRPC server on loopback that answers every RPC the
+// way a saturated otel-collector does — the exact status the memory_limiter
+// processor returns when it sheds (issue #662). It needs no OTLP protos: the
+// unknown-service handler covers every method.
+func shedddingCollector(t *testing.T) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer(grpc.UnknownServiceHandler(func(any, grpc.ServerStream) error {
+		return status.Error(codes.ResourceExhausted, "data refused due to high memory usage")
+	}))
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// blackHoleCollector starts a listener that accepts connections and then says
+// nothing at all — a collector that is reachable but never answers.
+func blackHoleCollector(t *testing.T) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, acceptErr := lis.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go func() { _, _ = io.Copy(io.Discard, conn) }()
+		}
+	}()
+	t.Cleanup(func() {
+		_ = lis.Close()
+		<-done
+	})
+	return lis.Addr().String()
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func telemetryConfig(endpoint string) Config {
+	return Config{
+		OTelEnabled:     true,
+		LogsEnabled:     true,
+		OTLPEndpoint:    endpoint,
+		TraceSampleRate: 1.0,
+		TracingExport:   true,
+	}
+}
+
+// TestSetupTelemetry_SheddingCollectorDoesNotFailStartup is the core regression
+// test for issue #662: a collector refusing data must leave the caller with a
+// working (if degraded) component and an untouched startup context.
+func TestSetupTelemetry_SheddingCollectorDoesNotFailStartup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	start := time.Now()
+	shutdown := setupTelemetry(ctx, telemetryConfig(shedddingCollector(t)), "test-service", "v0.0.1", discardLogger())
+	elapsed := time.Since(start)
+
+	if shutdown == nil {
+		t.Fatal("setupTelemetry() returned no shutdown; telemetry was not installed")
+	}
+	if elapsed > setup.SetupTimeout {
+		t.Fatalf("setup took %s, want < %s", elapsed, setup.SetupTimeout)
+	}
+	// The startup context must be untouched: SPIRE, xDS and CNI initialization
+	// all hang off it, and a cancelled one is what killed the agent.
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("telemetry setup disturbed the caller's context: %v", err)
+	}
+
+	// The final flush must still run after SIGTERM has cancelled the caller's
+	// context: an export failure is fine here, "context canceled" is not.
+	cancel()
+	if err := shutdown(ctx); errors.Is(err, context.Canceled) {
+		t.Fatalf("shutdown() returned %v; the flush ran on the caller's dead context", err)
+	}
+}
+
+func TestSetupTelemetry_BlackHoleCollectorDoesNotBlockStartup(t *testing.T) {
+	ctx := context.Background()
+
+	start := time.Now()
+	shutdown := setupTelemetry(ctx, telemetryConfig(blackHoleCollector(t)), "test-service", "v0.0.1", discardLogger())
+	elapsed := time.Since(start)
+
+	if shutdown == nil {
+		t.Fatal("setupTelemetry() returned no shutdown; telemetry was not installed")
+	}
+	if elapsed > setup.SetupTimeout {
+		t.Fatalf("setup took %s, want < %s", elapsed, setup.SetupTimeout)
+	}
+}
+
+// TestSetupTelemetry_DetachedFromCallerContext proves the two contexts are
+// separated: telemetry setup completes even when the caller's context is already
+// dead, so telemetry can neither be killed by nor kill the startup sequence.
+func TestSetupTelemetry_DetachedFromCallerContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	shutdown := setupTelemetry(ctx, telemetryConfig(shedddingCollector(t)), "test-service", "v0.0.1", discardLogger())
+	if shutdown == nil {
+		t.Fatal("setupTelemetry() returned no shutdown for an already-cancelled caller context")
+	}
+	if err := shutdown(ctx); errors.Is(err, context.Canceled) {
+		t.Fatalf("shutdown() returned %v; the flush ran on the caller's dead context", err)
+	}
+}
+
+// TestSetupTelemetry_Disabled keeps --otel-enabled=false behaving exactly as
+// before: no MeterProvider, but the always-on TracerProvider is still installed
+// (it is what stamps trace_id onto logs), so a shutdown is still returned.
+func TestSetupTelemetry_Disabled(t *testing.T) {
+	cfg := Config{OTelEnabled: false, TraceSampleRate: 1.0}
+
+	shutdown := setupTelemetry(context.Background(), cfg, "test-service", "v0.0.1", discardLogger())
+	if shutdown == nil {
+		t.Fatal("setupTelemetry() should still install the TracerProvider when OTel is disabled")
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown() error = %v", err)
+	}
+}
+
+// badEndpoint is an OTLP endpoint the gRPC exporters cannot even parse, so
+// provider construction fails outright — the case that used to abort Bootstrap
+// with "failed to setup telemetry" and exit the process.
+const badEndpoint = "%%%"
+
+func TestSetupTelemetry_SetupFailureIsNotFatal(t *testing.T) {
+	var buf bytes.Buffer
+	l := slog.New(slog.NewTextHandler(&buf, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	shutdown := setupTelemetry(ctx, telemetryConfig(badEndpoint), "test-service", "v0.0.1", l)
+
+	// No telemetry could be installed, so there is nothing to flush — but the
+	// caller gets control back with a live context instead of a fatal error.
+	if shutdown != nil {
+		t.Fatal("setupTelemetry() installed telemetry against an unusable endpoint")
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("telemetry setup disturbed the caller's context: %v", err)
+	}
+	for _, want := range []string{"failed to set up OTel metrics", "failed to set up OTel tracing"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("log = %q, want it to contain %q", buf.String(), want)
+		}
+	}
+}
+
+func TestSetupManagerLogging_SetupFailureFallsBackToStderr(t *testing.T) {
+	l, shutdown := SetupManagerLogging(context.Background(), telemetryConfig(badEndpoint), "test-service", "v0.0.1")
+	if l == nil {
+		t.Fatal("SetupManagerLogging() returned a nil logger for an unusable endpoint")
+	}
+	if shutdown != nil {
+		t.Fatal("SetupManagerLogging() returned a shutdown though no provider was created")
+	}
+	// The logger must still work: stderr logging is unaffected by OTLP export.
+	l.Info("component continues with stderr-only logging")
+}
+
+// TestSetupManagerLogging_SheddingCollector asserts the logging half of the same
+// property: the logger is usable, emitting records does not block on the dead
+// collector, and the final flush is not defeated by a cancelled caller context.
+func TestSetupManagerLogging_SheddingCollector(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	l, shutdown := SetupManagerLogging(ctx, telemetryConfig(shedddingCollector(t)), "test-service", "v0.0.1")
+	if l == nil {
+		t.Fatal("SetupManagerLogging() returned a nil logger")
+	}
+	if shutdown == nil {
+		t.Fatal("SetupManagerLogging() returned no shutdown; OTLP logging was not installed")
+	}
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("log setup disturbed the caller's context: %v", err)
+	}
+
+	logged := make(chan struct{})
+	go func() {
+		defer close(logged)
+		l.InfoContext(ctx, "hello from a component whose collector is shedding")
+	}()
+	select {
+	case <-logged:
+	case <-time.After(5 * time.Second):
+		t.Fatal("emitting a log record blocked on the shedding collector")
+	}
+
+	cancel()
+	if err := shutdown(ctx); errors.Is(err, context.Canceled) {
+		t.Fatalf("shutdown() returned %v; the flush ran on the caller's dead context", err)
+	}
+}
+
+// TestSetupManagerLogging_Disabled keeps the OTLP-off path unchanged: a plain
+// stderr logger and no shutdown.
+func TestSetupManagerLogging_Disabled(t *testing.T) {
+	l, shutdown := SetupManagerLogging(context.Background(), Config{}, "test-service", "v0.0.1")
+	if l == nil {
+		t.Fatal("SetupManagerLogging() returned a nil logger")
+	}
+	if shutdown != nil {
+		t.Fatal("SetupManagerLogging() returned a shutdown with OTLP logging disabled")
+	}
+}

--- a/common/spire/BUILD.bazel
+++ b/common/spire/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_library")
+load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "spire",
@@ -10,4 +10,10 @@ go_library(
         "@com_github_spiffe_go_spiffe_v2//spiffetls/tlsconfig",
         "@com_github_spiffe_go_spiffe_v2//workloadapi",
     ],
+)
+
+go_test(
+    name = "spire_test",
+    srcs = ["tls_test.go"],
+    embed = [":spire"],
 )

--- a/common/spire/tls.go
+++ b/common/spire/tls.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
@@ -19,15 +20,47 @@ import (
 // Callers own the returned source and must Close it on shutdown.
 type Source = workloadapi.X509Source
 
+// SourceTimeout bounds how long NewSource waits for the Workload API to issue
+// this workload's first SVID.
+//
+// The wait used to be unbounded, which made an unavailable SPIRE agent (or a
+// SPIRE server that cannot attest it) a silent, indefinite stall on the startup
+// path. Every binary here initializes its dependencies BEFORE starting the
+// controller-runtime manager, and the manager is what starts answering /healthz
+// and /readyz — so a stall here is invisible to the process but fatal to it: the
+// chart's liveness probe (10s period, default 3 failures) kills the container
+// after roughly 35s, the signal handler cancels the shared startup context, and
+// the wait aborts with the misleading "context canceled". That is the crash loop
+// in issue #662. Failing fast, below the liveness budget, restarts on an accurate
+// error instead of an opaque probe kill.
+const SourceTimeout = 25 * time.Second
+
 // NewSource connects to the SPIRE Workload API at socketPath and returns an
-// X.509 SVID source that watches for rotations. socketPath may be a filesystem
-// path to the agent UDS (e.g. /run/secrets/workload-spiffe-uds/socket) or a
-// full endpoint address (unix://… / tcp://…).
+// X.509 SVID source that watches for rotations, waiting up to SourceTimeout for
+// the first SVID. socketPath may be a filesystem path to the agent UDS
+// (e.g. /run/secrets/workload-spiffe-uds/socket) or a full endpoint address
+// (unix://… / tcp://…).
 func NewSource(ctx context.Context, socketPath string) (*Source, error) {
+	return NewSourceWithTimeout(ctx, socketPath, SourceTimeout)
+}
+
+// NewSourceWithTimeout is NewSource with an explicit bound on the first-SVID
+// wait. A non-positive timeout waits as long as ctx allows.
+//
+// The bound applies to the initial wait only: go-spiffe derives the rotation
+// watcher's context from context.Background() (workloadapi.newWatcher), so the
+// returned source keeps refreshing SVIDs for its whole lifetime regardless of
+// this timeout. Callers still own the source and must Close it.
+func NewSourceWithTimeout(ctx context.Context, socketPath string, timeout time.Duration) (*Source, error) {
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 	src, err := workloadapi.NewX509Source(ctx,
 		workloadapi.WithClientOptions(workloadapi.WithAddr(socketAddr(socketPath))))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create SPIRE Workload API source: %w", err)
+		return nil, fmt.Errorf("failed to create SPIRE Workload API source (socket %s): %w", socketPath, err)
 	}
 	return src, nil
 }

--- a/common/spire/tls_test.go
+++ b/common/spire/tls_test.go
@@ -1,0 +1,100 @@
+package spire
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNewSourceWithTimeout_BoundsFirstSVIDWait is the regression test for the
+// startup stall in issue #662: the Workload API client retries an unreachable
+// agent forever, so without a bound the first-SVID wait never returns and the
+// binary is killed by its liveness probe before it ever serves /healthz.
+func TestNewSourceWithTimeout_BoundsFirstSVIDWait(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "nothing-listens-here.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		src, err := NewSourceWithTimeout(ctx, socket, 200*time.Millisecond)
+		if src != nil {
+			_ = src.Close()
+		}
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("NewSourceWithTimeout() succeeded against a socket nobody serves")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want a deadline-exceeded error", err)
+		}
+		// The error must name the socket: the old one said only
+		// "context canceled", which pointed at the wrong subsystem entirely.
+		if !strings.Contains(err.Error(), socket) {
+			t.Fatalf("err = %v, want it to name the socket %q", err, socket)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("NewSourceWithTimeout() did not honour its timeout")
+	}
+
+	// The caller's context must survive the failure: it is the startup context
+	// the rest of the binary hangs off.
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("NewSourceWithTimeout() disturbed the caller's context: %v", err)
+	}
+}
+
+// TestNewSourceWithTimeout_HonoursCallerCancellation keeps the pre-existing
+// behaviour: a cancelled caller context still aborts the wait.
+func TestNewSourceWithTimeout_HonoursCallerCancellation(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "nothing-listens-here.sock")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		src, err := NewSourceWithTimeout(ctx, socket, time.Minute)
+		if src != nil {
+			_ = src.Close()
+		}
+		done <- err
+	}()
+
+	time.AfterFunc(50*time.Millisecond, cancel)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err = %v, want a cancellation error", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("NewSourceWithTimeout() ignored the caller's cancellation")
+	}
+}
+
+func TestSocketAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "bare path", path: "/run/spire/socket", want: "unix:///run/spire/socket"},
+		{name: "unix endpoint", path: "unix:///run/spire/socket", want: "unix:///run/spire/socket"},
+		{name: "tcp endpoint", path: "tcp://127.0.0.1:8081", want: "tcp://127.0.0.1:8081"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := socketAddr(tt.path); got != tt.want {
+				t.Errorf("socketAddr(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/common/telemetry/setup/BUILD.bazel
+++ b/common/telemetry/setup/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "setup",
     srcs = [
         "healthz.go",
+        "lifecycle.go",
         "logs.go",
         "options.go",
         "setup.go",
@@ -34,6 +35,7 @@ go_library(
 go_test(
     name = "setup_test",
     srcs = [
+        "lifecycle_test.go",
         "logs_test.go",
         "setup_test.go",
         "tracing_test.go",

--- a/common/telemetry/setup/healthz.go
+++ b/common/telemetry/setup/healthz.go
@@ -1,18 +1,31 @@
 package setup
 
 import (
+	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 )
 
+// cacheSyncCheckTimeout bounds the readiness check's wait for the informer
+// cache. WaitForCacheSync blocks until the cache syncs or the request context
+// ends, so an unsynced cache used to hang the probe until the kubelet's own
+// 1s timeout expired — reported as "Readiness probe failed: context deadline
+// exceeded", which is indistinguishable from a wedged process (issue #662).
+// Answering below the probe timeout turns that into an honest "not synced yet".
+const cacheSyncCheckTimeout = 500 * time.Millisecond
+
 // CacheSyncChecker returns a healthz.Checker that reports healthy once the
-// controller-runtime informer cache has synced.
+// controller-runtime informer cache has synced, and reports unready promptly
+// (rather than hanging the probe) while it has not.
 func CacheSyncChecker(mgr ctrl.Manager) healthz.Checker {
 	return func(req *http.Request) error {
-		if !mgr.GetCache().WaitForCacheSync(req.Context()) {
+		ctx, cancel := context.WithTimeout(req.Context(), cacheSyncCheckTimeout)
+		defer cancel()
+		if !mgr.GetCache().WaitForCacheSync(ctx) {
 			return errors.New("informer cache not synced")
 		}
 		return nil

--- a/common/telemetry/setup/lifecycle.go
+++ b/common/telemetry/setup/lifecycle.go
@@ -1,0 +1,43 @@
+package setup
+
+import (
+	"context"
+	"time"
+)
+
+// SetupTimeout bounds telemetry provider construction. Nothing in the current
+// provider wiring dials a collector eagerly (the OTLP gRPC clients are lazy),
+// but resource detection and any future exporter option could block, and
+// telemetry must never be able to spend the caller's startup budget: a binary
+// whose health probes only start answering after initialization is killed by
+// the kubelet long before it serves anything (issue #662).
+const SetupTimeout = 5 * time.Second
+
+// FlushTimeout bounds the final flush of a telemetry provider on shutdown.
+const FlushTimeout = 5 * time.Second
+
+// DetachedTimeout returns a context that keeps parent's values but neither
+// observes its cancellation nor propagates cancellation back to it, bounded by
+// d. Use it for telemetry work that must be immune to — and invisible to — the
+// caller's lifecycle context.
+func DetachedTimeout(parent context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(parent), d)
+}
+
+// BestEffortShutdown wraps a provider shutdown so the flush always runs on a
+// detached, bounded context, and returns nil when fn is nil.
+//
+// On SIGTERM the caller's context is ALREADY cancelled by the signal handler, so
+// passing it straight through made every final flush a guaranteed no-op that
+// failed with "context canceled" — the last records of a terminating process,
+// which are exactly the ones worth having, were always dropped (issue #662).
+func BestEffortShutdown(fn func(context.Context) error) func(context.Context) error {
+	if fn == nil {
+		return nil
+	}
+	return func(ctx context.Context) error {
+		flushCtx, cancel := DetachedTimeout(ctx, FlushTimeout)
+		defer cancel()
+		return fn(flushCtx)
+	}
+}

--- a/common/telemetry/setup/lifecycle_test.go
+++ b/common/telemetry/setup/lifecycle_test.go
@@ -1,0 +1,88 @@
+package setup
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDetachedTimeout_SurvivesParentCancellation(t *testing.T) {
+	parent, cancel := context.WithCancel(context.Background())
+	ctx, cancelDetached := DetachedTimeout(parent, time.Minute)
+	defer cancelDetached()
+
+	cancel()
+
+	if err := ctx.Err(); err != nil {
+		t.Fatalf("detached context observed the parent's cancellation: %v", err)
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("detached context was done after the parent was cancelled")
+	default:
+	}
+}
+
+func TestDetachedTimeout_KeepsParentValues(t *testing.T) {
+	type key struct{}
+	parent := context.WithValue(context.Background(), key{}, "value")
+
+	ctx, cancel := DetachedTimeout(parent, time.Minute)
+	defer cancel()
+
+	if got := ctx.Value(key{}); got != "value" {
+		t.Fatalf("value = %v, want %q", got, "value")
+	}
+}
+
+func TestDetachedTimeout_IsBounded(t *testing.T) {
+	ctx, cancel := DetachedTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("err = %v, want DeadlineExceeded", ctx.Err())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("detached context was not bounded by its timeout")
+	}
+}
+
+// TestBestEffortShutdown_RunsWithCancelledCaller is the regression test for the
+// "failed to shutdown telemetry: context canceled" / "failed to flush OTel logs:
+// context canceled" pair in issue #662: on SIGTERM the caller's context is
+// already cancelled, and the flush must still get a live context.
+func TestBestEffortShutdown_RunsWithCancelledCaller(t *testing.T) {
+	var got error
+	fn := BestEffortShutdown(func(ctx context.Context) error {
+		got = ctx.Err()
+		return nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := fn(ctx); err != nil {
+		t.Fatalf("shutdown() error = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("flush ran on a dead context: %v", got)
+	}
+}
+
+func TestBestEffortShutdown_NilPassesThrough(t *testing.T) {
+	if fn := BestEffortShutdown(nil); fn != nil {
+		t.Fatal("BestEffortShutdown(nil) should return nil")
+	}
+}
+
+func TestBestEffortShutdown_PropagatesError(t *testing.T) {
+	want := errors.New("export failed")
+	fn := BestEffortShutdown(func(context.Context) error { return want })
+
+	if err := fn(context.Background()); !errors.Is(err, want) {
+		t.Fatalf("err = %v, want %v", err, want)
+	}
+}

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -61,8 +61,8 @@ var rootCmd = &cobra.Command{
 	Long:         "Runs the aether-controller: the MeshConfig validating webhook and the reconciler that projects the MeshConfig CR into a ConfigMap.",
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) (err error) {
-		l, logShutdown, err = manager.SetupManagerLogging(cmd.Context(), cfg.Config, name, Version)
-		return err
+		l, logShutdown = manager.SetupManagerLogging(cmd.Context(), cfg.Config, name, Version)
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runController(cmd.Context())
@@ -110,7 +110,7 @@ func runController(ctx context.Context) (retErr error) {
 		defer func() { retErr = errors.Join(retErr, spireSource.Close()) }()
 	}
 
-	result, err := manager.Bootstrap(ctx, cfg.Config, name, Version, bootstrapOpts...)
+	result, err := manager.Bootstrap(ctx, cfg.Config, name, Version, l, bootstrapOpts...)
 	if err != nil {
 		return err
 	}

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -50,8 +50,8 @@ var rootCmd = &cobra.Command{
 	Long:         "Runs the Aether registrar that proxies registry operations, caches endpoints, and streams changes to agents.",
 	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, _ []string) (err error) {
-		l, logShutdown, err = manager.SetupManagerLogging(cmd.Context(), cfg.Config, name, Version)
-		return err
+		l, logShutdown = manager.SetupManagerLogging(cmd.Context(), cfg.Config, name, Version)
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runRegistrar(cmd.Context())
@@ -164,7 +164,7 @@ func bootstrapManager(ctx context.Context) (ctrl.Manager, func(context.Context) 
 	if err != nil {
 		return nil, nil, err
 	}
-	result, err := manager.Bootstrap(ctx, cfg.Config, name, Version, bootstrapOpts...)
+	result, err := manager.Bootstrap(ctx, cfg.Config, name, Version, l, bootstrapOpts...)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Closes #662.

## The mechanism, as found in the code

Every one of these binaries initializes its dependencies **before** starting the
controller-runtime manager — and the manager is what begins answering `/healthz`
and `/readyz`. So the whole initialization sequence runs inside the kubelet's
liveness budget while the probe endpoint is silent, and everything in it shares
one context: `ctrl.SetupSignalHandler()`, threaded from `main` through
`runAgent` into telemetry, storage, SPIRE and the registrar client.

That gives the observed failure a precise shape:

1. `commonspire.NewSource` → `workloadapi.NewX509Source` waits for the first SVID
   **without any bound** (`common/spire/tls.go:26` before this PR). The Workload
   API client treats `Unavailable` as retryable and retries forever, so an
   unreachable or non-attesting SPIRE agent parks the agent here — silently,
   with no log line at all.
2. `/healthz` never answers, because `m.Start(ctx)` is the last statement of
   `runAgent` (`agent/internal/cmd/root.go:316`). At 10s period × 3 failures the
   kubelet kills the container at ~35s.
3. SIGTERM cancels the one shared context. The in-flight first-SVID wait aborts
   with `failed to create SPIRE Workload API source: context canceled` —
   attributing a probe kill to SPIRE.
4. The deferred flushes then run on that same, already-cancelled context
   (`deferTelemetryShutdown`/`deferLogShutdown`), which is exactly why both
   reported `context canceled` and exported nothing. That was true of **every**
   SIGTERM, not just this incident: the last records of a terminating process
   were always dropped.
5. Exit 1 → CrashLoopBackOff.

The `exporter export timeout: ... data refused due to high memory usage` line is
emitted by the periodic reader's background goroutine through OTel's global
error handler. It is a symptom of the same saturation, not the thing that
blocked startup — the OTLP gRPC clients are lazy (`grpc.NewClient`), so exporter
construction never dials.

But the coupling the issue names is real, just in a different direction than the
log ordering suggests: **telemetry could kill the process outright.**
`manager.Bootstrap` returned an error if the metric or trace provider failed to
build, and `SetupManagerLogging` returned one if the OTLP log exporter did — and
both errors exit(1). An observability backend was a hard dependency of the data
plane.

## Why that matters

Telemetry is best-effort by definition; the data plane is not.

1. **It makes an o11y component a hard dependency of the data plane.** If the
   agent can't start, that node's mesh config goes stale and new pods there get
   no listeners. An agent that programs Envoy but cannot export metrics is
   *degraded*, not dead.
2. **The failure is fleet-correlated.** Every agent exports to the same
   collector and every agent attests against the same SPIRE server, so one
   saturated dependency can take out *every* node's agent simultaneously — most
   likely during a rolling restart, when they all start at once. Same class as
   #566/#640. On 2026-09-02 that was 3 of 5 nodes, with worker-02 at 5 restarts
   and still CrashLoopBackOff.
3. **It converts back-pressure into a crash loop.** Shedding is `memory_limiter`
   working correctly. The right response is degraded telemetry, not death.

## What changed

**`common/telemetry/setup/lifecycle.go` (new)** — two helpers that make the
context separation explicit:

- `DetachedTimeout(parent, d)` keeps the parent's values but drops its
  cancellation and bounds the work. Telemetry can neither spend the caller's
  startup budget nor observe a cancellation of the caller's context.
- `BestEffortShutdown(fn)` runs a provider's final flush on such a context, so
  the flush still works after SIGTERM has cancelled the caller's context.

**`common/manager`** — telemetry is now best-effort by construction:

- `setupTelemetry` (extracted from `Bootstrap`) builds the providers on a
  detached, bounded context; a failure logs a WARN and continues with less
  telemetry instead of returning an error that exits the process.
- `SetupManagerLogging` **drops its error return entirely** — an OTLP log
  exporter that cannot be built degrades to stderr-only logging with a WARN. The
  "telemetry cannot fail startup" property is now enforced by the type, not by
  convention.
- Every returned shutdown is wrapped in `BestEffortShutdown`, which fixes the
  `failed to shutdown telemetry: context canceled` /
  `failed to flush OTel logs: context canceled` pair for all four binaries at
  once (agent, edge, registrar, controller) with no change at the call sites.
- `Bootstrap` takes the component's logger so it can report the degradation.

**`common/spire/tls.go`** — `NewSource` bounds the first-SVID wait at 25s
(`SourceTimeout`, deliberately below the ~35s liveness budget) and names the
socket in the error; `NewSourceWithTimeout` exposes the bound for tests. The
agent logs the wait before entering it, so the next incident has a breadcrumb.

The bound is safe for rotation: go-spiffe derives the rotation watcher's context
from `context.Background()` in `workloadapi.newWatcher`, not from the one passed
in, so the returned source keeps refreshing SVIDs for its whole lifetime. This
turns an opaque 35s probe kill into a fast restart with an accurate error — it
does not make an unavailable SPIRE survivable, which it isn't: the agent cannot
serve mTLS xDS without an SVID.

**`common/telemetry/setup/healthz.go`** — the readiness cache-sync check is
bounded at 500ms. `WaitForCacheSync` blocks until the cache syncs or the request
ends, so an unsynced cache hung the probe until the kubelet's own timeout
expired and was reported as `Readiness probe failed: context deadline
exceeded` — indistinguishable from a wedged process. It now answers below the
probe timeout with an honest `informer cache not synced`.

`--otel-enabled=false` is unchanged: no MeterProvider, TracerProvider still
installed (it is what stamps `trace_id` onto logs), same shutdown shape.

## The readyz decision

**`readyz` should not depend on telemetry, and after this PR it structurally
cannot.**

An agent that can program Envoy but cannot export metrics is degraded, not
unready. Gating readiness on telemetry would make a saturated collector
*mark every agent in the fleet unready at once* — turning a metrics outage into
a data-plane outage, which is the same correlation failure this PR removes, just
one layer up. Readiness should describe what the node's consumers depend on:
Envoy getting its config.

Concretely, `readyz` keeps its two existing checks (`healthz.Ping` and
`cache-sync`) and gains none. Telemetry can no longer influence readiness even
indirectly, because it can no longer fail the bootstrap that installs those
checks. Export health stays observable where it belongs — the collector's own
`otelcol_*` metrics and the `OtelCollectorRefusingData` alert, which did fire
correctly here.

## Test evidence

New tests, all verified to **fail without the fix** (negative controls run by
reverting each fix in place):

| Test | Asserts | Without fix |
|---|---|---|
| `TestSetupTelemetry_SheddingCollectorDoesNotFailStartup` | setup completes under budget against a collector answering `ResourceExhausted: data refused due to high memory usage`; caller's context untouched; flush after SIGTERM is not `context canceled` | FAILED |
| `TestSetupTelemetry_BlackHoleCollectorDoesNotBlockStartup` | a reachable-but-silent collector does not block setup | — |
| `TestSetupTelemetry_DetachedFromCallerContext` | setup succeeds with an already-cancelled caller context | FAILED |
| `TestSetupTelemetry_SetupFailureIsNotFatal` | an unbuildable exporter degrades with a WARN instead of erroring out | FAILED (was a fatal error return) |
| `TestSetupManagerLogging_SheddingCollector` | logger usable, emitting a record does not block, flush not defeated by a cancelled caller | FAILED |
| `TestSetupManagerLogging_SetupFailureFallsBackToStderr` | stderr-only fallback, no fatal | FAILED |
| `TestSetupTelemetry_Disabled` / `TestSetupManagerLogging_Disabled` | `--otel-enabled=false` behaves exactly as before | — |
| `TestNewSourceWithTimeout_BoundsFirstSVIDWait` | bounded wait against a socket nobody serves; error names the socket | **TIMEOUT at 10.1s** (the hang, reproduced) |
| `TestNewSourceWithTimeout_HonoursCallerCancellation` | caller cancellation still aborts the wait | — |
| `TestBestEffortShutdown_RunsWithCancelledCaller` | the flush gets a live context when the caller's is dead | FAILED |

The fake collector needs no OTLP protos: a `grpc.UnknownServiceHandler`
returning `ResourceExhausted` reproduces the shed exactly (and is correctly
non-retryable per the OTLP spec, so the test is fast and deterministic).

```
bazel test //agent/... //common/... //registrar/... //controller/...  → 60 tests pass
bazel build --config=ci //agent/... //common/... //registrar/... //controller/...  → OK
make format-check  → clean
```

No dependency, proto, or chart changes.

## How to verify on-cluster

1. Point an agent at a collector that sheds (or scale the collector's memory
   limit down until `OtelCollectorRefusingData` fires) and
   `kubectl rollout restart ds/aether-agent`. Expect the agents to start,
   serve xDS, and log at most a telemetry WARN — no `Error: failed to create
   SPIRE Workload API source`, no restarts.
2. `kubectl delete pod` an agent and check its final log lines: the flush should
   no longer report `failed to shutdown telemetry: context canceled`, and the
   last records should reach the collector.
3. To exercise the startup bound, cordon the SPIRE agent on one node and restart
   the aether agent there: expect one clean exit at ~25s naming the workload
   socket, preceded by `waiting for the SPIRE Workload API to issue this agent's
   SVID`, instead of a silent 35s liveness kill.

Not deployed — a soak is being scheduled on talos-main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
