### PR TITLE
fix(security): stop trusting the aether.io/spiffe-id pod annotation as a mesh-identity override (#669)

### DIFF
--- a/agent/internal/cni/server/BUILD.bazel
+++ b/agent/internal/cni/server/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//agent/internal/xds/ack",
         "//agent/internal/xds/cache",
         "//agent/internal/xds/proxy",
+        "//agent/internal/xds/xdsconst",
         "//agent/storage",
         "//agent/types",
         "//api/aether/cni/v1:cni",
@@ -55,6 +56,7 @@ go_test(
     name = "server_test",
     srcs = [
         "ghostsweep_test.go",
+        "identity_test.go",
         "liveness_test.go",
         "metrics_test.go",
         "pod_test.go",
@@ -69,6 +71,7 @@ go_test(
         "//agent/internal/xds/ack",
         "//agent/internal/xds/cache",
         "//agent/internal/xds/proxy",
+        "//agent/internal/xds/xdsconst",
         "//agent/storage",
         "//agent/types",
         "//api/aether/cni/v1:cni",

--- a/agent/internal/cni/server/identity_test.go
+++ b/agent/internal/cni/server/identity_test.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	xdsconst "aethermesh.dev/agent/internal/xds/xdsconst"
+	cniv1 "aethermesh.dev/api/aether/cni/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const spiffeIDOverrideMetric = "aether.agent.identity.spiffe_id_override_rejected"
+
+// TestReportRejectedSpiffeIDOverride is the observability half of #669: the
+// annotation is ignored, but never silently — a pod carrying it must produce a
+// WARN carrying both the requested and the actually-used identity, plus one
+// counter increment.
+func TestReportRejectedSpiffeIDOverride(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantLog     bool
+		wantCount   int64
+	}{
+		{name: "no annotations"},
+		{name: "unrelated annotation", annotations: map[string]string{"config.aether.io/upstreams": "svc-a"}},
+		{name: "empty annotation", annotations: map[string]string{xdsconst.AnnotationSpiffeID: ""}},
+		{
+			name:        "override rejected",
+			annotations: map[string]string{xdsconst.AnnotationSpiffeID: "spiffe://example.org/ns/prod/sa/payments"},
+			wantLog:     true,
+			wantCount:   1,
+		},
+		{
+			name:        "override restating the derived value is still reported",
+			annotations: map[string]string{xdsconst.AnnotationSpiffeID: "spiffe://example.org/ns/tenant-a/sa/worker"},
+			wantLog:     true,
+			wantCount:   1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			metrics, reader := newTestCNIMetrics(t)
+			s := &CNIServer{
+				log:         slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+				trustDomain: "example.org",
+				metrics:     metrics,
+			}
+			pod := &cniv1.CNIPod{
+				Name:           "worker-0",
+				Namespace:      "tenant-a",
+				ServiceAccount: "worker",
+				Annotations:    tt.annotations,
+			}
+
+			s.reportRejectedSpiffeIDOverride(context.Background(), s.log, pod)
+
+			got, found := metricSum(t, reader, spiffeIDOverrideMetric)
+			if !tt.wantLog {
+				assert.Empty(t, buf.String(), "no annotation must produce no log line")
+				assert.False(t, found, "no annotation must not touch the counter")
+				return
+			}
+
+			line := buf.String()
+			require.NotEmpty(t, line, "a rejected override must be logged")
+			assert.Contains(t, line, `"level":"WARN"`, "the rejection must be at WARN")
+			assert.Contains(t, line, tt.annotations[xdsconst.AnnotationSpiffeID], "the requested identity is logged for attribution")
+			assert.Contains(t, line, "spiffe://example.org/ns/tenant-a/sa/worker", "the identity actually used is logged")
+			assert.Contains(t, line, xdsconst.AnnotationSpiffeID)
+			assert.True(t, strings.Contains(line, "rejected"), "the message must say the override was rejected")
+			assert.Equal(t, tt.wantCount, got, "%s", spiffeIDOverrideMetric)
+		})
+	}
+}
+
+// TestReportRejectedSpiffeIDOverride_NilMetrics covers the telemetry-disabled
+// build: the report path must not panic without instruments.
+func TestReportRejectedSpiffeIDOverride_NilMetrics(t *testing.T) {
+	s := &CNIServer{log: slog.New(slog.DiscardHandler), trustDomain: "example.org"}
+	s.reportRejectedSpiffeIDOverride(context.Background(), s.log, &cniv1.CNIPod{
+		Namespace:      "tenant-a",
+		ServiceAccount: "worker",
+		Annotations:    map[string]string{xdsconst.AnnotationSpiffeID: "spiffe://evil.example/ns/prod/sa/payments"},
+	})
+}

--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -37,6 +37,7 @@ type cniMetrics struct {
 	storagePods        metric.Int64Gauge
 	healthTransitions  metric.Int64Counter
 	promotionDelay     metric.Float64Histogram
+	spiffeIDOverrides  metric.Int64Counter
 }
 
 // newCNIMetrics registers the reconciliation instruments on the given meter.
@@ -97,8 +98,22 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 		metric.WithUnit("s")); err != nil {
 		return nil, fmt.Errorf("promotion delay: %w", err)
 	}
+	if m.spiffeIDOverrides, err = meter.Int64Counter("aether.agent.identity.spiffe_id_override_rejected",
+		metric.WithDescription("Pods carrying the rejected aether.io/spiffe-id annotation, whose mesh identity was derived from the pod's own namespace/ServiceAccount instead (#669); nonzero means someone is trying to choose a workload identity by annotation")); err != nil {
+		return nil, fmt.Errorf("spiffe id overrides: %w", err)
+	}
 
 	return m, nil
+}
+
+// spiffeIDOverrideRejected records one pod whose aether.io/spiffe-id annotation
+// was ignored. Counted per pod-lifecycle event that reads the pod's identity (a
+// CNI ADD, or an agent-restart resubscribe), not per config push.
+func (m *cniMetrics) spiffeIDOverrideRejected(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.spiffeIDOverrides.Add(ctx, 1)
 }
 
 func (m *cniMetrics) sweepCompleted(ctx context.Context, ghostsRemoved, missingRegistered, stalePruned, orphansPruned, missingStorage, staleRunning, storedPods int, err error) {

--- a/agent/internal/cni/server/pod.go
+++ b/agent/internal/cni/server/pod.go
@@ -3,11 +3,13 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
 	"aethermesh.dev/agent/internal/spire"
 	"aethermesh.dev/agent/internal/xds/proxy"
+	xdsconst "aethermesh.dev/agent/internal/xds/xdsconst"
 	"aethermesh.dev/agent/types"
 	cniv1 "aethermesh.dev/api/aether/cni/v1"
 	registryv1 "aethermesh.dev/api/aether/registry/v1"
@@ -39,6 +41,24 @@ const unregisterTimeout = 5 * time.Second
 // span itself comes from the otelgrpc stats handler; spans started here break
 // the pod lifecycle down into its API-server / registry / xDS / Envoy steps.
 const tracerName = "aether/agent-cni-server"
+
+// reportRejectedSpiffeIDOverride surfaces a pod carrying the rejected
+// aether.io/spiffe-id annotation: WARN plus a counter, so an attempt to choose a
+// workload identity by annotation is never silent (#669). The pod's mesh
+// identity is always derived from the trust domain and its own
+// namespace/ServiceAccount (proxy.SpiffeIDFromPod); the annotation value is
+// logged for attribution only. No-op for pods without the annotation.
+func (s *CNIServer) reportRejectedSpiffeIDOverride(ctx context.Context, log *slog.Logger, cniPod *cniv1.CNIPod) {
+	requested, present := proxy.SpiffeIDOverrideAnnotation(cniPod)
+	if !present {
+		return
+	}
+	s.metrics.spiffeIDOverrideRejected(ctx)
+	log.WarnContext(ctx, "rejected pod SPIFFE ID override; mesh identity is derived from the pod's namespace and ServiceAccount",
+		"annotation", xdsconst.AnnotationSpiffeID,
+		"requestedSpiffeID", requested,
+		"spiffeID", proxy.SpiffeIDFromPod(cniPod, s.trustDomain))
+}
 
 // startStepSpan starts a child span for one step of a pod lifecycle operation.
 func startStepSpan(ctx context.Context, name string, pod *cniv1.CNIPod) (context.Context, trace.Span) {
@@ -76,6 +96,9 @@ func (s *CNIServer) AddPod(ctx context.Context, req *cniv1.AddPodRequest) (*cniv
 		log.DebugContext(ctx, "ignoring pod")
 		return &cniv1.AddPodResponse{Result: cniv1.AddPodResponse_RESULT_IGNORED}, nil
 	}
+
+	// A pod-chosen mesh identity is never honoured; make the attempt loud (#669).
+	s.reportRejectedSpiffeIDOverride(ctx, log, cniPod)
 
 	// Store in the local storage. Whether this container was already known
 	// distinguishes a fresh CNI ADD from an idempotent re-add (CNI CHECK).

--- a/agent/internal/cni/server/resubscribe.go
+++ b/agent/internal/cni/server/resubscribe.go
@@ -55,6 +55,11 @@ func (s *CNIServer) runResubscribeStoredPods(ctx context.Context) {
 			continue
 		}
 
+		// Re-report the rejected override on restart: the CNI ADD that first
+		// logged it may be long gone, and a stored pod still carrying the
+		// annotation is still an attempt worth seeing (#669).
+		s.reportRejectedSpiffeIDOverride(ctx, log, pod)
+
 		spiffeID := proxy.SpiffeIDFromPod(pod, s.trustDomain)
 		selectors := spire.PodSelectors(pod.GetNamespace(), pod.GetServiceAccount(), pod.GetName(), string(k8sPod.UID))
 		if err := s.spireBridge.SubscribePod(pod.GetNetworkNamespace(), spiffeID, selectors); err != nil {

--- a/agent/internal/xds/proxy/BUILD.bazel
+++ b/agent/internal/xds/proxy/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "networkfilter.go",
         "projection.go",
         "route.go",
+        "spiffe.go",
         "stats_filter.go",
         "subset.go",
         "tracing.go",

--- a/agent/internal/xds/proxy/egress.go
+++ b/agent/internal/xds/proxy/egress.go
@@ -534,16 +534,27 @@ func localityPriority(localRegion, localZone string, endpoint *registryv1.Servic
 func ServiceLocalityLbEndpointFromRegistryEndpoint(endpoint *registryv1.ServiceEndpoint, localRegion, localZone string, wp WaypointRewrite) *endpointv3.LocalityLbEndpoints {
 	viaWaypoint := wp.viaWaypoint(endpoint)
 
-	subsetKeys := map[string]string{
-		subsetClusterKey: endpoint.GetClusterName(),
-		subsetIPKey:      endpoint.GetIp(),
+	// Provider-defined subset keys go in FIRST, and reserved system keys are
+	// dropped from them: endpoint metadata comes from the workload's own
+	// metadata.endpoint.aether.io/* annotations (registry.NewServiceEndpointFromCNIPod),
+	// i.e. pod-supplied input, and used to be applied AFTER the built-ins — so a
+	// pod could overwrite the ip/pod/namespace/cluster envoy.lb fields that back
+	// the NO_FALLBACK x-aether-ip / x-aether-pod pins (answering for another
+	// pod), or stamp the waypoint tag and steer the cluster's transport-socket
+	// matcher onto the waypoint SNI (#669). The registration facts the control
+	// plane derives always win now.
+	subsetKeys := make(map[string]string, len(endpoint.GetMetadata())+5)
+	for k, v := range endpoint.GetMetadata() {
+		if _, reserved := reservedSubsetKeys[k]; reserved {
+			continue
+		}
+		subsetKeys[k] = v
 	}
+	subsetKeys[subsetClusterKey] = endpoint.GetClusterName()
+	subsetKeys[subsetIPKey] = endpoint.GetIp()
 	if endpoint.GetKubernetesMetadata() != nil {
 		subsetKeys[subsetPodNamespaceKey] = endpoint.GetKubernetesMetadata().GetNamespace()
 		subsetKeys[subsetPodNameKey] = endpoint.GetKubernetesMetadata().GetPodName()
-	}
-	for k, v := range endpoint.GetMetadata() {
-		subsetKeys[k] = v
 	}
 	if viaWaypoint {
 		// Tag the endpoint so the cluster's transport-socket matcher selects the

--- a/agent/internal/xds/proxy/egress_test.go
+++ b/agent/internal/xds/proxy/egress_test.go
@@ -173,6 +173,50 @@ func TestServiceLocalityLbEndpointFromRegistryEndpoint_EDSMode(t *testing.T) {
 		"EDS-mode endpoints opt out of active health checking and rely on EDS health")
 }
 
+// TestServiceLocalityLbEndpointFromRegistryEndpoint_MetadataCannotForgeBuiltins
+// is the #669 regression: endpoint metadata is pod-supplied (the
+// metadata.endpoint.aether.io/* annotations), so it must never overwrite the
+// built-in envoy.lb keys the control plane derives — ip/pod back the
+// NO_FALLBACK x-aether-ip / x-aether-pod pins, and waypoint steers the
+// cluster's transport-socket matcher.
+func TestServiceLocalityLbEndpointFromRegistryEndpoint_MetadataCannotForgeBuiltins(t *testing.T) {
+	ep := &registryv1.ServiceEndpoint{
+		Ip:          "10.0.0.5",
+		ClusterName: "svc-a",
+		KubernetesMetadata: &registryv1.ServiceEndpoint_KubernetesMetadata{
+			Namespace: "tenant-a",
+			PodName:   "svc-a-1",
+			NodeIp:    "192.168.1.10",
+		},
+		Metadata: map[string]string{
+			subsetIPKey:           "10.9.9.9",
+			subsetPodNameKey:      "payments-0",
+			subsetPodNamespaceKey: "prod",
+			subsetClusterKey:      "other-cluster",
+			subsetWaypointKey:     subsetWaypointValue,
+			"version":             "v2",
+		},
+	}
+
+	lb := ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "", "", WaypointRewrite{}).
+		GetLbEndpoints()[0].GetMetadata().GetFilterMetadata()[envoyFilterMetadataSubsetNamespace].GetFields()
+
+	assert.Equal(t, "10.0.0.5", lb[subsetIPKey].GetStringValue(), "pod-supplied metadata must not forge the endpoint IP")
+	assert.Equal(t, "svc-a-1", lb[subsetPodNameKey].GetStringValue(), "pod-supplied metadata must not forge the pod name")
+	assert.Equal(t, "tenant-a", lb[subsetPodNamespaceKey].GetStringValue(), "pod-supplied metadata must not forge the namespace")
+	assert.Equal(t, "svc-a", lb[subsetClusterKey].GetStringValue(), "pod-supplied metadata must not forge the cluster")
+	assert.NotContains(t, lb, subsetWaypointKey, "pod-supplied metadata must not stamp the waypoint tag")
+	// Provider-defined (non-reserved) keys still travel.
+	assert.Equal(t, "v2", lb["version"].GetStringValue())
+
+	// The control plane's own waypoint tag is still stamped when it decides the
+	// endpoint is reached through the node waypoint.
+	wp := WaypointRewrite{Enabled: true, TunnelPort: 18021, LocalCluster: "local"}
+	lb = ServiceLocalityLbEndpointFromRegistryEndpoint(ep, "", "", wp).
+		GetLbEndpoints()[0].GetMetadata().GetFilterMetadata()[envoyFilterMetadataSubsetNamespace].GetFields()
+	assert.Equal(t, subsetWaypointValue, lb[subsetWaypointKey].GetStringValue())
+}
+
 func TestEndpointHealthStatus(t *testing.T) {
 	assert.Equal(t, corev3.HealthStatus_UNHEALTHY,
 		endpointHealthStatus(&registryv1.ServiceEndpoint{Health: registryv1.ServiceEndpoint_HEALTH_UNHEALTHY}))

--- a/agent/internal/xds/proxy/ingress_test.go
+++ b/agent/internal/xds/proxy/ingress_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	xdsconst "aethermesh.dev/agent/internal/xds/xdsconst"
 	cniv1 "aethermesh.dev/api/aether/cni/v1"
 	aetherannotations "aethermesh.dev/common/constants/annotations"
 	xdstypev3 "github.com/cncf/xds/go/xds/type/v3"
@@ -12,6 +13,7 @@ import (
 	healthcheckv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/health_check/v3"
 	http_connection_managerv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	tcp_proxyv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,6 +79,40 @@ func TestNewInboundListener(t *testing.T) {
 	vh := rc.GetVirtualHosts()[0]
 	assert.Equal(t, []string{"*"}, vh.GetDomains())
 	assert.Equal(t, AppClusterName(pod, AppPortFromPod(pod)), vh.GetRoutes()[0].GetRoute().GetCluster())
+}
+
+// TestNewInboundListener_IgnoresSpiffeIDAnnotation is the #669 regression at the
+// config level: the SDS certificate secret every mTLS chain presents is named by
+// the DERIVED identity, so an annotated pod cannot make its inbound listener
+// present (or be validated as) another workload's SVID.
+func TestNewInboundListener_IgnoresSpiffeIDAnnotation(t *testing.T) {
+	pod := &cniv1.CNIPod{
+		Name:             "pod-a",
+		Namespace:        "tenant-a",
+		ServiceAccount:   "worker",
+		NetworkNamespace: "/var/run/netns/cni-a",
+		Ips:              []string{"10.0.0.1"},
+		Annotations: map[string]string{
+			xdsconst.AnnotationSpiffeID: "spiffe://example.org/ns/prod/sa/payments",
+		},
+	}
+
+	l, err := NewInboundListener(pod, "example.org", false, false, nil, nil)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, l.GetFilterChains())
+	for _, fc := range l.GetFilterChains() {
+		ts := fc.GetTransportSocket()
+		require.NotNil(t, ts, "chain %s must terminate mTLS", fc.GetName())
+		tlsCtx := &tlsv3.DownstreamTlsContext{}
+		require.NoError(t, ts.GetTypedConfig().UnmarshalTo(tlsCtx))
+		certs := tlsCtx.GetCommonTlsContext().GetTlsCertificateSdsSecretConfigs()
+		require.Len(t, certs, 1)
+		assert.Equal(t, "spiffe://example.org/ns/tenant-a/sa/worker", certs[0].GetName(),
+			"chain %s must present the derived SVID, not the annotated one", fc.GetName())
+		assert.Equal(t, "spiffe://example.org",
+			tlsCtx.GetCommonTlsContext().GetValidationContextSdsSecretConfig().GetName())
+	}
 }
 
 // TestNewInboundListenerCleartext verifies the SPIRE-off inbound listener: a

--- a/agent/internal/xds/proxy/listener.go
+++ b/agent/internal/xds/proxy/listener.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"fmt"
 
-	xdsconst "aethermesh.dev/agent/internal/xds/xdsconst"
 	cniv1 "aethermesh.dev/api/aether/cni/v1"
 	aetherannotations "aethermesh.dev/common/constants/annotations"
 	meshconst "aethermesh.dev/common/constants/mesh"
@@ -105,17 +104,6 @@ func NewAppDeliveryClusters(cniPod *cniv1.CNIPod, udsSocketPath string) (appClus
 	healthCluster = NewAppHealthProbeCluster(HealthProbeClusterName(cniPod), appAddr, primary, AppHealthPathFromPod(cniPod), isTCP)
 
 	return appClusters, healthCluster
-}
-
-// SpiffeIDFromPod returns the SPIFFE ID for the pod. It first checks the
-// aether.io/spiffe-id annotation. If not set, it constructs the SPIFFE ID
-// from the trust domain, namespace, and service account using the standard
-// SPIRE convention: spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>.
-func SpiffeIDFromPod(cniPod *cniv1.CNIPod, trustDomain string) string {
-	if id, ok := cniPod.GetAnnotations()[xdsconst.AnnotationSpiffeID]; ok && id != "" {
-		return id
-	}
-	return fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, cniPod.GetNamespace(), cniPod.GetServiceAccount())
 }
 
 func GenerateOutboundHTTPListener(cniPod *cniv1.CNIPod, meshDomain string, emitStatsPod bool, extensionFilters []*http_connection_managerv3.HttpFilter) (*listenerv3.Listener, error) {

--- a/agent/internal/xds/proxy/spiffe.go
+++ b/agent/internal/xds/proxy/spiffe.go
@@ -1,0 +1,41 @@
+package proxy
+
+import (
+	"fmt"
+
+	xdsconst "aethermesh.dev/agent/internal/xds/xdsconst"
+	cniv1 "aethermesh.dev/api/aether/cni/v1"
+)
+
+// SpiffeIDFromPod returns the mesh SPIFFE ID of a local pod, derived — and only
+// ever derived — from the mesh trust domain and the pod's own namespace and
+// ServiceAccount, following the SPIRE convention
+// spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>. It matches the
+// identity SPIRE issues for the pod's k8s selectors, so the SDS secret it names
+// is the one the SPIRE bridge serves for that pod.
+//
+// This value is trusted input to the data plane: it names the SDS secret the
+// pod's inbound listener presents, the client certificate the pod's egress
+// presents (the per-netns transport-socket matcher), and the identity stamped
+// into the aether.source authz metadata. It is therefore derived from
+// API-server facts only.
+//
+// It used to honour the aether.io/spiffe-id pod annotation as an override
+// (#669). Annotations reach the agent verbatim over the CNI ADD path, so any
+// principal able to create a pod could choose the identity that pod's proxy
+// config presents — and because the bridge's SDS secrets are node-wide, a pod
+// naming a co-located workload's SPIFFE ID had that workload's SVID presented
+// on its behalf. The override is gone; SpiffeIDOverrideAnnotation reports the
+// annotation so its presence can be logged and counted.
+func SpiffeIDFromPod(cniPod *cniv1.CNIPod, trustDomain string) string {
+	return fmt.Sprintf("spiffe://%s/ns/%s/sa/%s", trustDomain, cniPod.GetNamespace(), cniPod.GetServiceAccount())
+}
+
+// SpiffeIDOverrideAnnotation returns the pod's aether.io/spiffe-id annotation
+// value and whether a non-empty one is present. The value is never honoured
+// (see SpiffeIDFromPod); callers use it to surface the rejected override — WARN
+// log plus a counter — so an attempted identity override is never silent.
+func SpiffeIDOverrideAnnotation(cniPod *cniv1.CNIPod) (string, bool) {
+	id := cniPod.GetAnnotations()[xdsconst.AnnotationSpiffeID]
+	return id, id != ""
+}

--- a/agent/internal/xds/proxy/spiffe_test.go
+++ b/agent/internal/xds/proxy/spiffe_test.go
@@ -8,7 +8,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestSpiffeIDFromPod pins the #669 invariant: a pod's mesh identity is derived
+// from the trust domain and the pod's OWN namespace/ServiceAccount, whatever the
+// (attacker-controllable) aether.io/spiffe-id annotation says. Every annotated
+// case below must produce exactly the same ID as the unannotated one.
 func TestSpiffeIDFromPod(t *testing.T) {
+	// The pod under test: namespace tenant-a, ServiceAccount worker.
+	pod := func(annotation *string) *cniv1.CNIPod {
+		p := &cniv1.CNIPod{
+			Namespace:      "tenant-a",
+			ServiceAccount: "worker",
+		}
+		if annotation != nil {
+			p.Annotations = map[string]string{xdsconst.AnnotationSpiffeID: *annotation}
+		}
+		return p
+	}
+	annotated := func(v string) *cniv1.CNIPod { return pod(&v) }
+
+	const derived = "spiffe://example.org/ns/tenant-a/sa/worker"
+
 	tests := []struct {
 		name        string
 		cniPod      *cniv1.CNIPod
@@ -16,53 +35,94 @@ func TestSpiffeIDFromPod(t *testing.T) {
 		expected    string
 	}{
 		{
-			name: "annotation override",
-			cniPod: &cniv1.CNIPod{
-				Annotations: map[string]string{
-					xdsconst.AnnotationSpiffeID: "spiffe://custom.domain/custom-id",
-				},
-				Namespace:      "default",
-				ServiceAccount: "my-sa",
-			},
+			name:        "no annotation derives from namespace and service account",
+			cniPod:      pod(nil),
 			trustDomain: "example.org",
-			expected:    "spiffe://custom.domain/custom-id",
+			expected:    derived,
 		},
 		{
-			name: "constructed from pod metadata",
-			cniPod: &cniv1.CNIPod{
-				Namespace:      "production",
-				ServiceAccount: "api-server",
-			},
-			trustDomain: "example.org",
-			expected:    "spiffe://example.org/ns/production/sa/api-server",
-		},
-		{
-			name: "empty annotation falls back to constructed",
-			cniPod: &cniv1.CNIPod{
-				Annotations: map[string]string{
-					xdsconst.AnnotationSpiffeID: "",
-				},
-				Namespace:      "staging",
-				ServiceAccount: "worker",
-			},
-			trustDomain: "test.domain",
-			expected:    "spiffe://test.domain/ns/staging/sa/worker",
-		},
-		{
-			name: "no annotations",
-			cniPod: &cniv1.CNIPod{
-				Namespace:      "kube-system",
-				ServiceAccount: "default",
-			},
+			name:        "no annotations map at all",
+			cniPod:      &cniv1.CNIPod{Namespace: "kube-system", ServiceAccount: "default"},
 			trustDomain: "cluster.local",
 			expected:    "spiffe://cluster.local/ns/kube-system/sa/default",
+		},
+		{
+			name:        "empty annotation",
+			cniPod:      annotated(""),
+			trustDomain: "example.org",
+			expected:    derived,
+		},
+		{
+			name:        "annotation restating the derived value",
+			cniPod:      annotated(derived),
+			trustDomain: "example.org",
+			expected:    derived,
+		},
+		{
+			name:        "annotation naming another service account",
+			cniPod:      annotated("spiffe://example.org/ns/tenant-a/sa/payments"),
+			trustDomain: "example.org",
+			expected:    derived,
+		},
+		{
+			name:        "annotation naming another namespace",
+			cniPod:      annotated("spiffe://example.org/ns/prod/sa/payments"),
+			trustDomain: "example.org",
+			expected:    derived,
+		},
+		{
+			name:        "annotation naming another trust domain",
+			cniPod:      annotated("spiffe://evil.example/ns/tenant-a/sa/worker"),
+			trustDomain: "example.org",
+			expected:    derived,
+		},
+		{
+			name:        "malformed annotation URI",
+			cniPod:      annotated("not-a-spiffe-uri"),
+			trustDomain: "example.org",
+			expected:    derived,
+		},
+		{
+			name:        "annotation naming the node/edge identity shape",
+			cniPod:      annotated("spiffe://example.org/ns/aether-system/sa/aether-agent"),
+			trustDomain: "example.org",
+			expected:    derived,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := SpiffeIDFromPod(tt.cniPod, tt.trustDomain)
-			assert.Equal(t, tt.expected, result)
+			assert.Equal(t, tt.expected, SpiffeIDFromPod(tt.cniPod, tt.trustDomain),
+				"the aether.io/spiffe-id annotation must never influence the derived identity")
+		})
+	}
+}
+
+// TestSpiffeIDOverrideAnnotation covers the reporting hook: the rejected
+// annotation must still be observable so the agent can log and count it.
+func TestSpiffeIDOverrideAnnotation(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantValue   string
+		wantPresent bool
+	}{
+		{name: "no annotations"},
+		{name: "unrelated annotation", annotations: map[string]string{"config.aether.io/upstreams": "svc-a"}},
+		{name: "empty value is not an override", annotations: map[string]string{xdsconst.AnnotationSpiffeID: ""}},
+		{
+			name:        "override present",
+			annotations: map[string]string{xdsconst.AnnotationSpiffeID: "spiffe://example.org/ns/prod/sa/payments"},
+			wantValue:   "spiffe://example.org/ns/prod/sa/payments",
+			wantPresent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			value, present := SpiffeIDOverrideAnnotation(&cniv1.CNIPod{Annotations: tt.annotations})
+			assert.Equal(t, tt.wantPresent, present)
+			assert.Equal(t, tt.wantValue, value)
 		})
 	}
 }

--- a/agent/internal/xds/proxy/subset.go
+++ b/agent/internal/xds/proxy/subset.go
@@ -39,13 +39,19 @@ const (
 var subsetKeyPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
 
 // reservedSubsetKeys are the built-in envoy.lb keys that cannot be redefined
-// by endpoint metadata annotations: ip/pod have fixed headers, and
-// cluster/namespace are registration facts, not routing dimensions.
+// by endpoint metadata annotations: ip/pod have fixed headers, cluster/namespace
+// are registration facts, not routing dimensions, and waypoint is the system tag
+// the cluster's transport-socket matcher branches on (proposal 019). Endpoint
+// metadata carrying one of these is dropped, both as a subset selector
+// (ValidSubsetKey) and from the endpoint's envoy.lb metadata itself
+// (ServiceLocalityLbEndpointFromRegistryEndpoint) — pod-supplied annotations
+// must not be able to forge a control-plane fact (#669).
 var reservedSubsetKeys = map[string]struct{}{
 	subsetIPKey:           {},
 	subsetPodNameKey:      {},
 	subsetClusterKey:      {},
 	subsetPodNamespaceKey: {},
+	subsetWaypointKey:     {},
 }
 
 // ValidSubsetKey reports whether a provider-defined metadata key may be used

--- a/agent/internal/xds/proxy/subset_test.go
+++ b/agent/internal/xds/proxy/subset_test.go
@@ -15,7 +15,7 @@ import (
 func TestValidSubsetKey(t *testing.T) {
 	for key, want := range map[string]bool{
 		"version": true, "shard-id": true, "v2": true,
-		"ip": false, "pod": false, "cluster": false, "namespace": false, // reserved
+		"ip": false, "pod": false, "cluster": false, "namespace": false, "waypoint": false, // reserved
 		"": false, "-x": false, "x-": false, "UPPER": false, "a.b": false, "a_b": false,
 	} {
 		assert.Equal(t, want, ValidSubsetKey(key), "key %q", key)

--- a/agent/internal/xds/xdsconst/xdsconst.go
+++ b/agent/internal/xds/xdsconst/xdsconst.go
@@ -14,8 +14,14 @@ const (
 	// round-trip of first-request latency.
 	AnnotationConfigUpstreams = "config.aether.io/upstreams"
 
-	// AnnotationSpiffeID is the pod annotation key for specifying the workload's SPIFFE ID.
-	// When set, this is used as the SDS secret name for the workload's TLS certificate.
+	// AnnotationSpiffeID is a REJECTED pod annotation, retained only so the agent
+	// can detect and report it (#669). It once overrode the workload's SPIFFE ID
+	// — the SDS secret name for the pod's TLS certificate — but pod annotations
+	// are attacker-controlled input on the CNI ADD path, so honouring it let any
+	// principal who can create a pod choose the mesh identity that pod's proxy
+	// config presents. A pod's identity is now derived from the trust domain and
+	// its own namespace/ServiceAccount, always (proxy.SpiffeIDFromPod). Setting
+	// this annotation has no effect beyond a WARN log and a counter.
 	AnnotationSpiffeID = "aether.io/spiffe-id"
 
 	// AnnotationEndpointHealthPath is the pod annotation key for the HTTP path the

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -361,7 +361,7 @@ Defined in [`common/constants/`](../common/constants). Prefixes:
 | edge GatewayClass controller | `gateway.aether.io/edge` | `controllerName` of the edge GatewayClass. |
 | mesh (GAMMA) controller | `gateway.aether.io/mesh` | `controllerName` for Service-parented route status. |
 | Gateway HTTP redirect | `gateway.aether.io/http-redirect: "true"` | Opt a Gateway's plain-HTTP listener into HTTP→HTTPS 301. |
-| workload SPIFFE ID | `aether.io/spiffe-id` | Workload SPIFFE ID (SDS secret name for the pod's TLS cert). |
+| workload SPIFFE ID | `aether.io/spiffe-id` | **Rejected and ignored** (#669). A pod's mesh identity is always `spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>`, derived from the API server. A pod carrying this annotation is logged at WARN and counted by `aether.agent.identity.spiffe_id_override_rejected`. |
 
 ### Always-ignored namespaces
 


### PR DESCRIPTION
Fixes #669.

## What the annotation actually controlled (call-site analysis)

`SpiffeIDFromPod` had five call sites; the value is *trusted input to the data plane* at four of them:

| Call site | What the returned ID becomes |
|---|---|
| `proxy/ingress.go:75` (`NewInboundListener`) | `tlsCertificateSecretName` — the SDS secret **every inbound mTLS chain presents** (TCP floor + no-SNI h2 chain + one per served port). The validation context is separate and derived from the trust domain flag, so the annotation could not widen who is *accepted*. |
| `xds/cache/listener.go:141` / `:413` | `localWorkloads[netns]` — consumed by `cache/mtls.go` → `proxy.InjectUpstreamMTLS`, which builds the per-netns `TransportSocketMatcher` and one `TransportSocketMatch` per local ID. That names **the client certificate the pod's egress presents** (capture + outbound), for both HTTP and TCP-floor clusters. |
| `cni/server/pod.go:123`, `cni/server/resubscribe.go:58` | The `spiffeID` argument to `spire.Bridge.SubscribePod`. Bookkeeping only for issuance (selectors are the real ones), but it is also the key `UnsubscribePod` deletes from the node-wide secret map and the key its shared-identity refcount compares. |
| `proxy/authz.go:70` | `spiffeId` in the `aether.source` dynamic-metadata namespace, forwarded to the ext_authz sidecar as the calling workload's identity (027). |

## Real blast radius, as traced (not as assumed)

The SVID *material* does come from SPIRE, and `SubscribePod` passes the pod's real k8s selectors (`spire.PodSelectors(ns, sa, name, uid)`), so SPIRE never mints a forged identity. But the annotation does not have to make SPIRE issue anything — it only has to **name a secret that already exists in the snapshot**:

* `spire/converter.go` names each SDS secret from the SPIFFE ID of the SVID SPIRE actually returned (`spiffe://<td><path>`), and `bridge.handleSVIDUpdate` stores it as `b.secrets[secret.Name]`.
* `bridge.pushSecrets` pushes **every** secret in that map into the single snapshot served to the node proxy. Secrets are node-wide, not scoped per pod or per netns.

So:

1. **Co-located victim → real impersonation, fails OPEN.** A pod annotated with the SPIFFE ID of any workload that happens to run on the same node gets that identity's SDS secret name in its own inbound listener *and* in its egress transport-socket match. Its egress then presents the victim's SVID; peers' SAN pinning (`cache/mtls.go`), inbound RBAC, and the XFCC/`aether.source` caller identity (025/027, #476/#477) all see the victim. This is cross-namespace impersonation obtainable with "create a pod in my own namespace" — the weakest common Kubernetes permission.
2. **No co-located holder → fails CLOSED, noisily-ish.** The listener/cluster references an SDS secret that is never served, so those chains never warm; the effect is a self-inflicted outage for that pod, not an identity gain.
3. **Client side / EDS: unaffected.** What peers pin is derived in `cache/mtls.go` from the registry service name (`spiffe://<td>/ns/<ns>/sa/<service>`), never from the annotation. The annotation changed only what the annotated pod's own config presents — which is exactly what makes case 1 exploitable rather than self-defeating.
4. **Secondary, same mechanism:** `UnsubscribePod` deletes `b.secrets[sub.spiffeID]` using the annotated key, and its "another pod still uses this identity" refcount compares annotated keys. An attacker pod that borrowed a co-located identity could, on its own deletion, **evict the victim's SVID from the node snapshot** — a co-tenant data-plane outage — and conversely leak its own.

So the honest summary is: *not* uniformly fail-closed. Fail-closed on an unpopulated identity, fail-open (full impersonation, both directions) on any identity already present on the node — which an attacker can arrange by scheduling next to the target.

## Fix chosen

**Removal**, per the issue's preference — validation could only ever permit the annotation to restate the derived value.

* `proxy.SpiffeIDFromPod` now always returns `spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>` (moved to a new `proxy/spiffe.go` next to its test).
* `proxy.SpiffeIDOverrideAnnotation` reports the annotation so its presence is observable.
* `CNIServer.reportRejectedSpiffeIDOverride` logs **WARN** (`annotation`, `requestedSpiffeID`, the `spiffeID` actually used) and increments **`aether.agent.identity.spiffe_id_override_rejected`**. Called on the CNI ADD path and again from the restart resubscribe replay, so a pod that still carries the annotation is re-reported after an agent restart rather than going quiet.
* `xdsconst.AnnotationSpiffeID` is kept, documented as rejected — it is now only a detection key.
* A genuine cross-identity need, should one appear, belongs behind a cluster-scoped object a namespace user cannot create (as #669 says), not this annotation.

### Also in scope: endpoint metadata ordering

`ServiceLocalityLbEndpointFromRegistryEndpoint` applied pod-supplied `metadata.endpoint.aether.io/*` keys **after** the built-in `envoy.lb` keys. Those built-ins are not decoration: `ip`/`pod` back the **NO_FALLBACK** `x-aether-ip` / `x-aether-pod` pinning selectors, and `waypoint` steers the cluster's transport-socket matcher onto the structured waypoint SNI (019). A pod could therefore claim another pod's name/IP for pinned traffic, or forge the waypoint tag. Pod metadata is now applied first *and* filtered against the reserved key set, with the control-plane facts written last. `waypoint` was additionally added to `reservedSubsetKeys` (it passed `ValidSubsetKey`'s pattern, so it was also usable as a provider subset key).

## Test evidence

`bazel test //agent/... //common/... //registry/... //controller/... //registrar/... //cni/... --test_output=errors` → all green (68 targets). `bazel build --config=ci //agent/...` green (gocognit 15). `make gazelle`, `make format` run.

New/changed tests, none weakened:

* `proxy.TestSpiffeIDFromPod` — table-driven over: no annotation, no annotations map, empty string, annotation restating the derived value, wrong ServiceAccount, wrong namespace, wrong trust domain, malformed URI, control-plane-identity shape. Every case must equal the derived ID.
* `proxy.TestSpiffeIDOverrideAnnotation` — the detection hook (absent / unrelated / empty / present).
* `proxy.TestNewInboundListener_IgnoresSpiffeIDAnnotation` — config-level regression: for **every** filter chain of an annotated pod's inbound listener, the `DownstreamTlsContext` cert SDS name is the derived ID and the validation context is the trust domain.
* `server.TestReportRejectedSpiffeIDOverride` — asserts the WARN record carries the requested *and* the used identity and that the counter increments exactly once; asserts no log and no counter touch when the annotation is absent or empty. Plus a nil-metrics (telemetry-off) case.
* `proxy.TestServiceLocalityLbEndpointFromRegistryEndpoint_MetadataCannotForgeBuiltins` — forged `ip`/`pod`/`namespace`/`cluster`/`waypoint` metadata is dropped, non-reserved keys still travel, and the control plane's own waypoint tag is still stamped when it decides the endpoint is remote.
* `proxy.TestValidSubsetKey` — `waypoint` now rejected as a provider subset key.

## Operator-visible behaviour change

* **`aether.io/spiffe-id` no longer does anything.** Any workload that relied on it to present a non-derived identity will now present `spiffe://<td>/ns/<ns>/sa/<sa>`; if a peer pins the old value, that hop breaks. Nothing in this repo (charts, e2e, conformance, proposals) set the annotation — only `docs/configuration.md`, updated here — so no in-tree consumer changes.
* Watch `aether.agent.identity.spiffe_id_override_rejected` after rollout: any nonzero value is a pod trying to choose its own identity and is worth investigating, benign or not.
* Endpoint metadata annotations named `ip`, `pod`, `namespace`, `cluster` or `waypoint` are now dropped from the endpoint's `envoy.lb` metadata (they were already excluded from subset *selectors*). Subset routing on such a key was never functional; the only change is that the forged value no longer lands in the endpoint metadata.

## Not fixed here

The other identity-enforcement gap #669 mentions — `proxy/transportsocket.go` silently omitting SAN pinning when `sanURIs` is empty, leaving the handshake proving only trust-domain membership — is untouched. It is a distinct fail-open path (empty `sanNamespaces` on a service entry) and deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
