### PR TITLE
fix(agent): exempt API-confirmed orphans from the prune circuit breaker (#670)

### DIFF
--- a/agent/internal/cni/server/ghostsweep.go
+++ b/agent/internal/cni/server/ghostsweep.go
@@ -56,17 +56,33 @@ const (
 	// gated by this — the API is ground truth.
 	ghostNetnsFailThreshold = 3
 
-	// pruneBreakerFraction is the fraction of stored pods a single pass may prune
-	// before the mass-delete breaker refuses the whole prune. Correlated
-	// netns-check failure (the incident) trips it; genuine churn does not (truly
-	// gone pods are gone from the API too and the API cross-check keeps a Running
-	// pod out of the prune set regardless of a netns stat failure).
+	// pruneBreakerFraction is the fraction of the NETNS-DERIVED class a single
+	// pass may prune before the mass-delete breaker refuses that half of the
+	// prune. Correlated netns-check failure (the incident) trips it; genuine churn
+	// does not (truly gone pods are gone from the API too and the API cross-check
+	// keeps a Running pod out of the prune set regardless of a netns stat
+	// failure).
+	//
+	// The fraction deliberately excludes API-confirmed orphans, in both numerator
+	// and denominator (#670). Measuring it over the combined set made the breaker
+	// self-reinforcing: once a node's orphan backlog crossed 30% of storage every
+	// pass was refused, so the backlog could only grow. Observed on talos-main
+	// 2026-09-03 — 92 storage records for 39 live pods fleet-wide (57.6% stale;
+	// worker-01 at 66%) with one refusal per sweep pass on every node, standing
+	// for weeks and surviving agent rolls because the staleness lives on disk.
 	pruneBreakerFraction = 0.30
 
 	// pruneBreakerMinPods is the absolute floor below which the fraction breaker
 	// does not apply — on a near-empty node pruning 1 of 2 pods is normal, not a
 	// mass event.
 	pruneBreakerMinPods = 2
+
+	// pruneBreakerRelogPasses rate-limits the breaker's ERROR line while it stays
+	// tripped: loud on the transition into the tripped state, then once every this
+	// many passes (sweeps are 60s apart, so ~30 minutes). Before #670 it logged
+	// every pass on every node for weeks, which read as ordinary sweep chatter and
+	// nobody noticed.
+	pruneBreakerRelogPasses = 30
 )
 
 // Lost-CNI-ADD self-heal guards (#567).
@@ -293,7 +309,8 @@ type staleRunningPod struct {
 // gone or whose Kubernetes pod no longer exists. Returns the surviving pods, the
 // counts of stale and orphaned pods pruned, the stale-while-Running detection
 // count and ripe eviction set (#640), and whether the mass-delete circuit
-// breaker refused the pass (#566, which the self-heal evictions interlock on).
+// breaker withheld the netns-derived candidates (#566, which the self-heal
+// evictions interlock on).
 func (s *CNIServer) pruneStaleStoragePods(ctx context.Context, pods []*cniv1.CNIPod, nodePods map[string]*corev1.Pod, nodePodsOK bool) ([]*cniv1.CNIPod, int, int, int, []staleRunningPod, bool) {
 	// Prune storage entries that no longer correspond to a live pod: a missed CNI
 	// DEL left the file behind. Keeping it both re-registers a dead endpoint (the
@@ -314,17 +331,65 @@ func (s *CNIServer) pruneStaleStoragePods(ctx context.Context, pods []*cniv1.CNI
 	// persistent storage with no self-recovery. Three guards now bound that:
 	// netns-only classification needs ghostNetnsFailThreshold consecutive failures
 	// (hysteresis), a pod the API still reports Running is never a ghost regardless
-	// of netns (cross-check), and a pass that would prune too large a fraction is
-	// refused wholesale (mass breaker).
+	// of netns (cross-check), and a pass that would prune too large a fraction of
+	// the netns-derived class is refused (mass breaker).
+	//
+	// The breaker covers the netns-derived class ONLY (#670). An API-confirmed
+	// orphan is ground truth — the node-scoped List says the pod does not exist
+	// here — and cannot be the correlated netns-stat false positive the breaker
+	// guards against, so it prunes whether or not the breaker trips. The real
+	// protection against a bad API read is nodePodsOK: a failed List classifies no
+	// orphan at all, so no pod-absence pruning happens in that pass.
 	candidates, staleRunningDetected, staleRunningRipe := s.classifyPruneCandidates(ctx, pods, nodePods, nodePodsOK)
-	if s.pruneBreakerTrips(ctx, len(pods), len(candidates)) {
-		// Refuse the whole pass. Keep every pod: truly-gone pods are also gone
-		// from the API, which the orphan cross-check catches once the correlated
-		// netns failure clears, so nothing is leaked permanently.
-		return pods, 0, 0, staleRunningDetected, staleRunningRipe, true
+	netnsCandidates, netnsEligible, orphanEntries := pruneCounts(pods, candidates)
+	if nodePodsOK {
+		// Only meaningful when the API answered; a failed List must not be
+		// reported as "zero stale entries".
+		s.metrics.staleStorageEntriesObserved(ctx, orphanEntries)
+	}
+
+	breakerTripped := s.pruneBreakerTrips(ctx, netnsEligible, netnsCandidates)
+	if breakerTripped {
+		// Withhold the netns-derived candidates only. They are the class that can
+		// be a correlated-stat false positive, and truly-gone pods among them are
+		// gone from the API too, so the orphan path reaps them on a later pass.
+		candidates = orphanCandidates(candidates)
 	}
 	fresh, stalePruned, orphansPruned := s.applyPrune(ctx, pods, candidates)
-	return fresh, stalePruned, orphansPruned, staleRunningDetected, staleRunningRipe, false
+	return fresh, stalePruned, orphansPruned, staleRunningDetected, staleRunningRipe, breakerTripped
+}
+
+// pruneCounts summarizes a classified prune set for the circuit breaker (#670):
+// netnsCandidates is the number of candidates the netns check produced
+// (stale-netns and superseded entries), netnsEligible the size of the class they
+// are drawn from — every stored entry the API did not confirm orphaned — and
+// orphanEntries the API-confirmed orphans, which the breaker ignores in both
+// numerator and denominator.
+func pruneCounts(pods []*cniv1.CNIPod, candidates map[string]pruneCandidate) (netnsCandidates, netnsEligible, orphanEntries int) {
+	for _, p := range pods {
+		cand, isCandidate := candidates[p.GetContainerId()]
+		if isCandidate && cand.orphaned {
+			orphanEntries++
+			continue
+		}
+		netnsEligible++
+		if isCandidate {
+			netnsCandidates++
+		}
+	}
+	return netnsCandidates, netnsEligible, orphanEntries
+}
+
+// orphanCandidates narrows a classified prune set to its API-confirmed orphans —
+// what still prunes when the netns circuit breaker trips (#670).
+func orphanCandidates(candidates map[string]pruneCandidate) map[string]pruneCandidate {
+	orphans := make(map[string]pruneCandidate, len(candidates))
+	for id, cand := range candidates {
+		if cand.orphaned {
+			orphans[id] = cand
+		}
+	}
+	return orphans
 }
 
 // pruneCandidate marks a stored pod for pruning and why, routing the log line:
@@ -474,21 +539,55 @@ func (s *CNIServer) pruneVanishedNetnsStreaks(pods []*cniv1.CNIPod) {
 	}
 }
 
-// pruneBreakerTrips reports whether pruning candidateCount of storedCount pods in
-// one pass exceeds the mass-delete circuit breaker (#566). It logs at ERROR and
-// increments a metric when it trips.
-func (s *CNIServer) pruneBreakerTrips(ctx context.Context, storedCount, candidateCount int) bool {
-	if candidateCount <= pruneBreakerMinPods {
+// pruneBreakerTrips reports whether pruning candidateCount netns-derived
+// candidates out of eligibleCount netns-eligible entries in one pass exceeds the
+// mass-delete circuit breaker (#566). API-confirmed orphans are excluded from
+// both counts and prune regardless (#670).
+//
+// The engaged/clear state is recorded every pass: the trip counter alone proved
+// undetectable in practice — it climbed once a minute on every node for weeks and
+// read as ordinary sweep activity.
+func (s *CNIServer) pruneBreakerTrips(ctx context.Context, eligibleCount, candidateCount int) bool {
+	tripped := candidateCount > pruneBreakerMinPods &&
+		float64(candidateCount) > float64(eligibleCount)*pruneBreakerFraction
+	s.metrics.pruneBreakerState(ctx, tripped)
+	if !tripped {
+		s.clearPruneBreaker(ctx)
 		return false
 	}
-	if float64(candidateCount) <= float64(storedCount)*pruneBreakerFraction {
-		return false
-	}
-	s.log.ErrorContext(ctx, "ghost sweep: prune circuit breaker TRIPPED; refusing to prune (correlated netns-check failure suspected — fix storage cause, not mass-delete)",
-		"would_prune", candidateCount, "stored", storedCount,
-		"fraction_limit", pruneBreakerFraction, "min_pods", pruneBreakerMinPods)
 	s.metrics.pruneBreakerTripped(ctx)
+	s.logPruneBreakerTrip(ctx, eligibleCount, candidateCount)
 	return true
+}
+
+// clearPruneBreaker records the tripped -> clear transition once, so the recovery
+// is as visible in the log as the trip was.
+func (s *CNIServer) clearPruneBreaker(ctx context.Context) {
+	if s.pruneBreakerEngaged {
+		s.log.WarnContext(ctx, "ghost sweep: prune circuit breaker CLEARED; netns-derived pruning resumed",
+			"tripped_passes", s.pruneBreakerTrippedPasses)
+		s.pruneBreakerEngaged = false
+	}
+	s.pruneBreakerTrippedPasses = 0
+}
+
+// logPruneBreakerTrip emits the breaker's ERROR line on the transition into the
+// tripped state and then only once every pruneBreakerRelogPasses passes, so a
+// standing trip stays visible without drowning the log (#670).
+func (s *CNIServer) logPruneBreakerTrip(ctx context.Context, eligibleCount, candidateCount int) {
+	first := !s.pruneBreakerEngaged
+	s.pruneBreakerEngaged = true
+	s.pruneBreakerTrippedPasses++
+	if !first && s.pruneBreakerTrippedPasses%pruneBreakerRelogPasses != 1 {
+		s.log.DebugContext(ctx, "ghost sweep: prune circuit breaker still tripped; withholding netns-derived pruning",
+			"would_prune", candidateCount, "netns_eligible", eligibleCount,
+			"consecutive_passes", s.pruneBreakerTrippedPasses)
+		return
+	}
+	s.log.ErrorContext(ctx, "ghost sweep: prune circuit breaker TRIPPED; withholding netns-derived pruning (correlated netns-check failure suspected — fix the storage cause, not mass-delete). API-confirmed orphans still prune (#670)",
+		"first_trip", first, "consecutive_passes", s.pruneBreakerTrippedPasses,
+		"would_prune", candidateCount, "netns_eligible", eligibleCount,
+		"fraction_limit", pruneBreakerFraction, "min_pods", pruneBreakerMinPods)
 }
 
 // applyPrune removes the classified prune candidates from storage and drops

--- a/agent/internal/cni/server/ghostsweep_test.go
+++ b/agent/internal/cni/server/ghostsweep_test.go
@@ -3,6 +3,8 @@ package server
 import (
 	"context"
 	"log/slog"
+	"strconv"
+	"strings"
 	"testing"
 
 	"aethermesh.dev/agent/internal/xds/cache"
@@ -684,6 +686,219 @@ func TestSweepStaleRunningInterlockedOnBreaker(t *testing.T) {
 		s.sweepGhostEndpoints(ctx)
 	}
 	assert.Zero(t, evictions, "stale-running eviction interlocked off while the breaker trips")
+}
+
+// storeCNIPod adds a stored CNI pod with the given netns and IP, returning it.
+func storeCNIPod(t *testing.T, store *storage.MockStorage[*cniv1.CNIPod], name, id, netns, ip string) *cniv1.CNIPod {
+	t.Helper()
+	p := validCNIPod(name, "default", id)
+	p.NetworkNamespace = netns
+	p.Ips = []string{ip}
+	require.NoError(t, store.AddResource(t.Context(), types.ContainerID(id), p))
+	return p
+}
+
+// TestSweepPrunesMajorityOrphansDespiteBreaker (#670 regression): when most
+// stored entries are orphans per the Kubernetes API, they ARE pruned and the
+// breaker does not engage. Before the fix the fraction counted orphans, so any
+// node whose stale backlog crossed pruneBreakerFraction refused every pass
+// forever and the backlog could only grow — measured on talos-main 2026-09-03 at
+// 92 storage records for 39 live pods (57.6% stale) with one refusal per sweep
+// pass on every node.
+func TestSweepPrunesMajorityOrphansDespiteBreaker(t *testing.T) {
+	ctx := context.Background()
+	// netnsExists stays true (package init): the orphans' netns pins linger, so
+	// only the API cross-check can identify them — the talos-main signature.
+
+	const (
+		orphans   = 7
+		liveCount = 3
+	)
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	objs := make([]client.Object, 0, liveCount)
+	for i := range orphans {
+		n := strconv.Itoa(i)
+		storeCNIPod(t, store, "pod-orphan-"+n, "container-orphan-"+n, "/run/aether/netns/orphan-"+n, "10.0.6."+n)
+	}
+	for i := range liveCount {
+		n := strconv.Itoa(i)
+		ip := "10.0.7." + n
+		storeCNIPod(t, store, "pod-live-"+n, "container-live-"+n, "/run/aether/netns/live-"+n, ip)
+		objs = append(objs, runningK8sPod("pod-live-"+n, "default", ip))
+	}
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	k8s := fake.NewClientBuilder().WithObjects(objs...).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+	m, reader := newTestCNIMetrics(t)
+	s.metrics = m
+
+	s.sweepGhostEndpoints(ctx)
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, liveCount, "every API-confirmed orphan pruned in a single pass; live entries kept")
+
+	engaged, found := metricSum(t, reader, "aether.agent.ghost_sweep.prune_breaker_engaged")
+	require.True(t, found, "breaker state recorded every pass")
+	assert.Zero(t, engaged, "API-confirmed orphans never engage the breaker")
+
+	stale, found := metricSum(t, reader, "aether.agent.storage.stale_pods")
+	require.True(t, found, "the stale backlog is exposed directly")
+	assert.EqualValues(t, orphans, stale, "backlog reported as DETECTED, before any pruning")
+}
+
+// TestSweepBreakerStillRefusesCorrelatedNetnsFailure (#566, must survive #670):
+// every stored entry's netns check failing at once — the 2026-07-19 power-blip
+// signature — still engages the breaker and still prunes nothing. The API
+// confirms every pod exists on this node, so there is no orphan to exempt: the
+// #670 carve-out cannot reach this incident.
+func TestSweepBreakerStillRefusesCorrelatedNetnsFailure(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	netnsExists = func(string) bool { return false } // the correlated stat failure
+
+	const n = 10
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	objs := make([]client.Object, 0, n)
+	for i := range n {
+		s := strconv.Itoa(i)
+		storeCNIPod(t, store, "pod-"+s, "container-"+s, "/run/aether/netns/"+s, "10.0.8."+s)
+		// Running WITHOUT an IP: podRunningWithIP does not veto, so these stay
+		// netns-derived prune candidates — but the pod exists, so not orphans.
+		objs = append(objs, runningK8sPod("pod-"+s, "default", ""))
+	}
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	k8s := fake.NewClientBuilder().WithObjects(objs...).Build()
+	srv := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+	m, reader := newTestCNIMetrics(t)
+	srv.metrics = m
+
+	for range ghostNetnsFailThreshold + 1 {
+		srv.sweepGhostEndpoints(ctx)
+	}
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, n, "correlated netns failure prunes nothing")
+
+	engaged, found := metricSum(t, reader, "aether.agent.ghost_sweep.prune_breaker_engaged")
+	require.True(t, found)
+	assert.EqualValues(t, 1, engaged, "breaker reads engaged while it withholds pruning")
+	tripped, found := metricSum(t, reader, "aether.agent.ghost_sweep.prune_breaker_tripped")
+	require.True(t, found)
+	assert.Positive(t, tripped)
+	stale, found := metricSum(t, reader, "aether.agent.storage.stale_pods")
+	require.True(t, found)
+	assert.Zero(t, stale, "the API accounts for every entry; nothing is stale")
+}
+
+// TestSweepMixedOrphansAndNetnsStale (#670): the two candidate classes are judged
+// independently in one pass. API-confirmed orphans prune immediately, while the
+// netns-derived candidates stay gated by the fraction computed over their OWN
+// class — 4 of the 10 non-orphan entries here, above pruneBreakerFraction.
+func TestSweepMixedOrphansAndNetnsStale(t *testing.T) {
+	ctx := context.Background()
+
+	orig := netnsExists
+	defer func() { netnsExists = orig }()
+	// Only the "stale-" namespaces are gone; orphan and healthy pins linger.
+	netnsExists = func(path string) bool { return !strings.HasPrefix(path, "/run/aether/netns/stale-") }
+
+	const (
+		orphans   = 7
+		netnsGone = 4
+		netnsOK   = 6
+	)
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	objs := make([]client.Object, 0, netnsGone+netnsOK)
+	for i := range orphans {
+		n := strconv.Itoa(i)
+		// Absent from the API -> orphan, netns pin lingering.
+		storeCNIPod(t, store, "pod-orphan-"+n, "container-orphan-"+n, "/run/aether/netns/orphan-"+n, "10.0.9."+n)
+	}
+	for i := range netnsGone {
+		n := strconv.Itoa(i)
+		storeCNIPod(t, store, "pod-stale-"+n, "container-stale-"+n, "/run/aether/netns/stale-"+n, "10.0.10."+n)
+		objs = append(objs, runningK8sPod("pod-stale-"+n, "default", "")) // no IP: no cross-check veto
+	}
+	for i := range netnsOK {
+		n := strconv.Itoa(i)
+		ip := "10.0.11." + n
+		storeCNIPod(t, store, "pod-ok-"+n, "container-ok-"+n, "/run/aether/netns/ok-"+n, ip)
+		objs = append(objs, runningK8sPod("pod-ok-"+n, "default", ip))
+	}
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	k8s := fake.NewClientBuilder().WithObjects(objs...).Build()
+	s := newTestCNIServer(k8s, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+	m, reader := newTestCNIMetrics(t)
+	s.metrics = m
+
+	// Pass 1 prunes the orphans (no hysteresis); the netns candidates only ripen
+	// at ghostNetnsFailThreshold, and are then withheld by the breaker.
+	for range ghostNetnsFailThreshold + 1 {
+		s.sweepGhostEndpoints(ctx)
+	}
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, netnsGone+netnsOK, "orphans pruned; netns candidates withheld by the breaker")
+	for i := range orphans {
+		_, err := store.GetResource(ctx, types.ContainerID("container-orphan-"+strconv.Itoa(i)))
+		require.Error(t, err, "orphan %d pruned", i)
+	}
+	for i := range netnsGone {
+		_, err := store.GetResource(ctx, types.ContainerID("container-stale-"+strconv.Itoa(i)))
+		require.NoError(t, err, "netns-stale entry %d gated by its own class's fraction", i)
+	}
+
+	engaged, found := metricSum(t, reader, "aether.agent.ghost_sweep.prune_breaker_engaged")
+	require.True(t, found)
+	assert.EqualValues(t, 1, engaged, "breaker engaged on the netns class alone")
+}
+
+// TestSweepNoPodAbsencePruningWithoutNodePodList (#566/#670 invariant): with no
+// trustworthy node-pod list, NOTHING is pruned by pod absence — this is the guard
+// that makes exempting orphans from the breaker safe, and it must hold whatever
+// else is true of the pass. A failed List must also not be reported as "zero
+// stale entries".
+func TestSweepNoPodAbsencePruningWithoutNodePodList(t *testing.T) {
+	ctx := context.Background()
+	// netnsExists stays true: the netns path contributes no candidates either, so
+	// any prune here could only have come from (absent) pod-existence data.
+
+	const n = 5
+	store := storage.NewMockStorage[*cniv1.CNIPod]()
+	for i := range n {
+		s := strconv.Itoa(i)
+		storeCNIPod(t, store, "pod-"+s, "container-"+s, "/run/aether/netns/"+s, "10.0.12."+s)
+	}
+
+	reg := &sweepRegistry{listing: map[string][]*registryv1.ServiceEndpoint{}}
+	// Nil client -> listNodePods returns ok=false, exactly as a failed List does.
+	s := newTestCNIServer(nil, store, reg, cache.NewSnapshotCache("n", slog.New(slog.DiscardHandler)), "")
+	m, reader := newTestCNIMetrics(t)
+	s.metrics = m
+
+	evictions := 0
+	s.evictPod = func(context.Context, string, string) error { evictions++; return nil }
+
+	for range ghostNetnsFailThreshold + lostAddEvictThreshold + 2 {
+		s.sweepGhostEndpoints(ctx)
+	}
+
+	all, err := store.GetAll(ctx)
+	require.NoError(t, err)
+	assert.Len(t, all, n, "no pod-absence pruning without a trustworthy node-pod list")
+	assert.Zero(t, evictions, "no self-heal eviction without a trustworthy node-pod list")
+	assert.Empty(t, s.missingStorageStreaks, "streaks dropped so a list blip never accrues toward eviction")
+
+	_, found := metricSum(t, reader, "aether.agent.storage.stale_pods")
+	assert.False(t, found, "staleness is not claimed when the API did not answer")
 }
 
 // TestSweepLostAddStreakResetsOnRecovery (#567): once a missing pod appears in

--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -31,10 +31,12 @@ type cniMetrics struct {
 	missingStorage     metric.Int64Counter
 	sweepErrors        metric.Int64Counter
 	pruneBreaker       metric.Int64Counter
+	pruneBreakerOpen   metric.Int64Gauge
 	lostAddEvictions   metric.Int64Counter
 	staleRunningEvicts metric.Int64Counter
 	unmeshedPods       metric.Int64Gauge
 	storagePods        metric.Int64Gauge
+	staleStoragePods   metric.Int64Gauge
 	healthTransitions  metric.Int64Counter
 	promotionDelay     metric.Float64Histogram
 }
@@ -72,6 +74,10 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 		metric.WithDescription("Ghost sweep passes whose mass-delete circuit breaker refused to prune (correlated netns-check failure suspected)")); err != nil {
 		return nil, fmt.Errorf("prune breaker: %w", err)
 	}
+	if m.pruneBreakerOpen, err = meter.Int64Gauge("aether.agent.ghost_sweep.prune_breaker_engaged",
+		metric.WithDescription("1 while the ghost sweep's mass-delete circuit breaker is withholding netns-derived pruning on this node, 0 when clear; a standing 1 means stale storage cannot be cleaned and will grow (#670)")); err != nil {
+		return nil, fmt.Errorf("prune breaker engaged: %w", err)
+	}
 	if m.lostAddEvictions, err = meter.Int64Counter("aether.agent.ghost_sweep.lost_add_evictions",
 		metric.WithDescription("Pods evicted by the ghost sweep to force a fresh CNI ADD after a lost one left them with no mesh listener")); err != nil {
 		return nil, fmt.Errorf("lost add evictions: %w", err)
@@ -87,6 +93,10 @@ func newCNIMetrics(meter metric.Meter) (*cniMetrics, error) {
 	if m.storagePods, err = meter.Int64Gauge("aether.agent.storage.pods",
 		metric.WithDescription("Pods currently tracked in the agent's local file storage")); err != nil {
 		return nil, fmt.Errorf("storage pods: %w", err)
+	}
+	if m.staleStoragePods, err = meter.Int64Gauge("aether.agent.storage.stale_pods",
+		metric.WithDescription("Local storage pod entries this node's Kubernetes pod list does not account for (missed CNI DEL), whether or not they were prunable this pass; against aether.agent.storage.pods this is the direct stale-vs-live ratio (#670)")); err != nil {
+		return nil, fmt.Errorf("stale storage pods: %w", err)
 	}
 	if m.healthTransitions, err = meter.Int64Counter("aether.agent.liveness.health_transitions",
 		metric.WithDescription("Endpoint health transitions reflected into the registry by the liveness loop")); err != nil {
@@ -138,6 +148,33 @@ func (m *cniMetrics) pruneBreakerTripped(ctx context.Context) {
 		return
 	}
 	m.pruneBreaker.Add(ctx, 1)
+}
+
+// pruneBreakerState records whether the mass-delete circuit breaker is engaged
+// (1) or clear (0). Recorded every sweep pass, zero included, so "the breaker is
+// standing open" is a state an alert can match rather than a counter slope
+// somebody has to notice — the counter climbed once a minute on every node of
+// talos-main for weeks and went unremarked (#670).
+func (m *cniMetrics) pruneBreakerState(ctx context.Context, engaged bool) {
+	if m == nil {
+		return
+	}
+	var v int64
+	if engaged {
+		v = 1
+	}
+	m.pruneBreakerOpen.Record(ctx, v)
+}
+
+// staleStorageEntriesObserved records how many storage entries this pass had no
+// Kubernetes pod on this node — the stale backlog as DETECTED, independent of
+// whether it could be pruned. orphans_pruned reads zero both when there is no
+// staleness and when cleanup is blocked; this gauge tells those apart (#670).
+func (m *cniMetrics) staleStorageEntriesObserved(ctx context.Context, stale int) {
+	if m == nil {
+		return
+	}
+	m.staleStoragePods.Record(ctx, int64(stale))
 }
 
 // lostAddEvicted records a pod evicted to force a fresh CNI ADD (#567).

--- a/agent/internal/cni/server/server.go
+++ b/agent/internal/cni/server/server.go
@@ -111,6 +111,14 @@ type CNIServer struct {
 	// under lifecycleMu.
 	staleRunningStreaks map[string]int
 
+	// pruneBreakerEngaged and pruneBreakerTrippedPasses track the mass-delete
+	// circuit breaker across sweep passes so its ERROR line can be loud on the
+	// transition into (and out of) the tripped state and rate-limited while it
+	// stands (#670: it logged every pass on every node for weeks unnoticed).
+	// Accessed only under lifecycleMu.
+	pruneBreakerEngaged       bool
+	pruneBreakerTrippedPasses int
+
 	// evictPod evicts a pod via the Kubernetes Eviction API (policy/v1,
 	// PDB-respecting). Overridable in tests (the fake client has no eviction
 	// subresource). Nil disables self-heal eviction.


### PR DESCRIPTION
Fixes #670.

## Mechanism

`classifyPruneCandidates` builds one candidate set out of two classes that fail in completely different ways:

- **orphans** — `nodePodsOK && !podInNode(nodePods, p)`. The node-scoped Kubernetes pod List says the pod does not exist on this node. Ground truth, deliberately *not* gated by the netns hysteresis.
- **stale-netns** (and its `superseded` sibling from #650) — the netns path has been gone for `ghostNetnsFailThreshold` consecutive passes. This is the class that produced #566's false positives, when a transient fleet-wide `stat` failure made every pod look dead at once during the 2026-07-19 power blip.

`pruneStaleStoragePods` then applied the breaker to the **combined** set and refused the whole pass on a trip. So a large number of legitimately-orphaned records — records Kubernetes confirms are garbage — tripped a breaker built to guard a different failure mode, and because they were never removed, the next pass saw the same fraction and refused again. The protection had become a deadlock, and a self-reinforcing one: the backlog could only grow.

An agent roll resets the counter but not the condition. The staleness lives in on-disk storage the fresh process re-reads, so the breaker re-arms within ~60s on the new process.

## Live measurements (2026-09-03 soak, rev190/0.91.3-a14df22)

End of an 8h soak: **92 storage records for 39 live mesh-managed pods = 57.6% stale fleet-wide** (worker-01: 36 records / 14 pods). Every node above `pruneBreakerFraction = 0.30`:

| node | `aether_agent_storage_pods` | mesh-managed pods | stale % |
|---|---|---|---|
| main-worker-01 | 35 | 12 | 66% |
| main-worker-05 | 17 | 9 | 47% |
| main-worker-04 | 12 | 5 | 58% |
| main-worker-02 | 15 | 9 | 40% |
| main-worker-03 | 13 | 8 | 38% |

`aether_agent_ghost_sweep_prune_breaker_tripped_total` climbed **+15 per 15 minutes on every node — exactly one refusal per sweep pass, every pass**, perfectly linear for the full 170 minutes before an agent roll, then resumed the same cadence on the fresh pod.

## The fix

Compute the breaker fraction over **netns-derived candidates only**, in both numerator and denominator, and prune API-confirmed orphans unconditionally (still subject to the existing per-pass rate limiting and the `nodePodsOK` guard). On a trip, only the netns-derived candidates are withheld; the pass is no longer refused wholesale.

Two small pure helpers keep `classifyPruneCandidates` untouched and `pruneStaleStoragePods` under the gocognit-15 threshold:

- `pruneCounts(pods, candidates)` → `(netnsCandidates, netnsEligible, orphanEntries)`. `netnsEligible` is every stored entry the API did *not* confirm orphaned, so the fraction is measured over the class at risk of netns misclassification. This is **stricter** than the old whole-storage denominator, not looser.
- `orphanCandidates(candidates)` narrows the set to orphans when the breaker trips.

`breakerTripped` is still returned and still interlocks both self-heal eviction paths.

## #566 protections preserved, and how each is proven

| Protection | Preserved | Proven by |
|---|---|---|
| Netns hysteresis (`ghostNetnsFailThreshold` consecutive failures) | Untouched — `classifyPruneCandidates` is unchanged | `TestSweepHysteresisTransientNetnsFailure`, `TestSweepPrunesStalePods` (both unmodified) |
| API cross-check: a pod the API reports Running with an IP is never pruned regardless of netns (`podRunningWithIP`) | Untouched | `TestSweepAPICrossCheckVetoesPrune` (unmodified) |
| Breaker still trips and still prunes **nothing** under correlated netns-stat failure | Yes — with no orphans to exempt, the carve-out cannot reach this incident | **new** `TestSweepBreakerStillRefusesCorrelatedNetnsFailure` (10 pods, every `stat` fails, API confirms all 10 exist → 0 pruned, engaged gauge 1, trip counter positive); plus unmodified `TestSweepMassBreakerRefusesPrune`, `TestSweepMassBreakerMetricAndInterlock` |
| `nodePodsOK == false` → no pod-absence pruning at all | Untouched — a failed List classifies no orphan, so the exemption has nothing to act on | **new** `TestSweepNoPodAbsencePruningWithoutNodePodList` (0 pruned, 0 evicted, streaks dropped, `stale_pods` not even recorded) |
| #640 stale-while-Running eviction + shared per-pass eviction budget | Untouched, still interlocked on `breakerTripped` | `TestSweepEvictsStaleRunningPodAfterThreshold`, `TestSweepStaleRunningEvictionRateLimitedAndBudgetShared`, `TestSweepStaleRunningInterlockedOnBreaker` (all unmodified) |
| #650 superseded-entry path | Untouched, and counted in the netns class (it is netns-derived) | `TestSweepPrunesSupersededEntry` (unmodified) |

**New tests**

1. `TestSweepPrunesMajorityOrphansDespiteBreaker` — the regression test. 7 orphans + 3 live, netns pins all lingering (the talos signature): all 7 prune in one pass, breaker gauge reads 0.
2. `TestSweepBreakerStillRefusesCorrelatedNetnsFailure` — the #566 incident, must still block. It does.
3. `TestSweepMixedOrphansAndNetnsStale` — 7 orphans + 4 netns-stale + 6 healthy: orphans prune, the 4 netns candidates stay withheld because they are 4/10 of their own class, above the fraction.
4. `TestSweepNoPodAbsencePruningWithoutNodePodList` — the invariant.

Verified empirically that (1) and (3) **fail** against the pre-fix logic (`should have 3 item(s), but has 10`) while (2) and (4) pass on both — i.e. the new tests bracket exactly the behaviour change and nothing else. Every pre-existing test passes unmodified; none were weakened.

## Instrumentation decision

The breaker was **silent-by-log**: it fired every 60s on every node for weeks and nobody noticed, because a counter with no alert reads as ordinary sweep activity and an ERROR line that never stops is indistinguishable from wallpaper. A counter is not a detection mechanism for a *standing* condition. Three changes:

- **`aether.agent.ghost_sweep.prune_breaker_engaged`** (Int64Gauge, recorded every pass, zero included). Turns "the breaker is standing open" into a state an alert can match, rather than a slope someone has to notice. Recording zeros matters: the gauge falls back to 0 the moment the condition clears, so the alert self-resolves.
- **`aether.agent.storage.stale_pods`** (Int64Gauge) — storage entries with no Kubernetes pod on this node, as *detected*, whether or not they were prunable. `orphans_pruned` reads zero both when there is no staleness and when cleanup is blocked; this gauge tells those two apart, which is exactly the signal that was missing. Not recorded when `nodePodsOK` is false, so a failed List is never reported as "zero stale".
- The trip **ERROR line is now rate-limited**: loud on the transition into the tripped state (`first_trip=true`), then once every `pruneBreakerRelogPasses = 30` passes (~30 min) while it stands, DEBUG in between — plus a new WARN on the tripped→clear transition so recovery is as visible as the trip.

The existing `prune_breaker_tripped` counter is kept unchanged.

Alert rules I would write (GitOps repo, not here):

```yaml
- alert: AetherGhostSweepPruneBreakerStandingOpen
  expr: max_over_time(aether_agent_ghost_sweep_prune_breaker_engaged[15m]) == 1
  for: 30m
  labels: { severity: warning }
  annotations:
    summary: "Ghost-sweep prune breaker standing open on {{ $labels.k8s_node_name }}"
    description: "Stale storage cannot be cleaned on this node and will grow. Check for a correlated netns-stat failure; do not mass-delete."

- alert: AetherAgentStaleStorageBacklog
  expr: aether_agent_storage_stale_pods / clamp_min(aether_agent_storage_pods, 1) > 0.25
  for: 30m
  labels: { severity: warning }
  annotations:
    summary: "{{ $value | humanizePercentage }} of agent storage on {{ $labels.k8s_node_name }} has no live pod"
```

The second one is the load-bearing one — it would have caught this within half an hour of the backlog forming, independently of whether the breaker was the reason cleanup stalled.

## Verifying on-cluster after deploy

1. `aether_agent_ghost_sweep_prune_breaker_tripped_total` **stops climbing** on every node (it was exactly +1/pass).
2. `aether_agent_ghost_sweep_prune_breaker_engaged` reads **0** steadily.
3. `aether_agent_storage_pods` **converges down** toward each node's mesh-managed pod count — compare against `count(kube_pod_info{node="..."} and on(pod,namespace) kube_pod_labels{label_aether_io_managed="true"})`, or just `kubectl get pods -A -l aether.io/managed=true --field-selector spec.nodeName=main-worker-01 | wc -l`. Worker-01 should fall from ~35 toward ~12. Expect this within a few sweep passes: orphans are pruned per pass at whatever rate they classify, with no eviction involved.
4. `aether_agent_storage_stale_pods` (new) drops to ~0 and stays low; `aether_agent_ghost_sweep_orphans_pruned_total` shows the one-time catch-up burst then settles to churn rate.
5. Agent logs: a single `prune circuit breaker CLEARED` line per node, then silence.
6. Nothing else should move — no `lost_add_evictions` / `stale_running_evictions` burst (the eviction paths are untouched and still interlocked), no `unmeshed_pods` change.

## Note on #638

This plausibly removes the *substrate* of #638's H1, though not #638 itself. The chain is: stale storage record → the endpoint is never deregistered (etcd `Put` with no lease/TTL; deregistration is entirely agent-driven) → CNI IPAM recycles the dead pod's IP, during a roll overwhelmingly to a pod of the service being rolled → a client dials it, gets that pod's genuine SVID, and the SAN matcher rejects. Draining the stale-record backlog removes the ghost endpoints that recycled IP can collide with, and the correlation is suggestive: worker-01 carried by far the most stale records (23) and is the only node that has ever shown non-zero `envoy_cluster_ssl_fail_verify_san_total`.

Two caveats against calling #638 fixed here. First, #638's own separate defect — the ghost sweep matching ghosts to live pods **by IP alone, ignoring the service** — means a ghost whose IP has already been recycled stays un-reapable even with the breaker fixed; that needs its own change. Second, the 4.25s cross-wiring window observed at TRIPLE-cluster is short enough to be a genuine race rather than a standing-garbage effect. So: this should shrink #638's blast radius materially and is a prerequisite for testing H1 cleanly, but #638 should stay open and be re-measured on the next soak after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
