### PR TITLE
ci: validate main after every merge and require branches up to date before merging (#679)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,148 @@
+name: main-post-merge
+
+# Post-merge validation of `main` (issue #679).
+#
+# `ci.yaml` validates a PR *head* against that PR's merge-base. That is the right
+# scope for the PR's own change, but it is structurally blind to the combination
+# of two concurrently-open PRs: the combined state does not exist anywhere until
+# the second merge creates it, and until this workflow existed nothing looked at
+# it. (Instance: #671 and #672 each registered CNI metrics against a base that
+# did not contain the other; the squash of the second put `newCNIMetrics` at
+# gocognit 16 against a limit of 15 on `main`, and the violation only surfaced
+# days later on the unrelated PRs #676/#677.)
+#
+# So: on every push to `main`, re-run the same build+lint+unit-test leg `ci.yaml`
+# runs, with the impact set computed as **the merge commit vs its first parent**
+# (`HEAD^`) — i.e. exactly what this merge added to `main`, evaluated against the
+# tree that now exists. `scripts/ci-impacted-targets.sh` falls back to a full
+# `//...` build+test whenever bazel-diff cannot compute the set (no parent,
+# unreachable base, tool failure), so `main` is never silently under-validated.
+#
+# This is a detector, not a preventer: it turns the skew into a red `main` run
+# instead of a mystery failure on a bystander PR. Branch protection's
+# `required_status_checks.strict` (require branches up to date before merging) is
+# what actually prevents the bad merge.
+#
+# Nothing here is a required status check — `ci` (from `ci.yaml`) remains the only
+# one, and this workflow deliberately does not touch the pull_request path.
+# Integration and e2e are not repeated here: `e2e.yaml` already covers `main`
+# pushes, and the integration leg is bounded by the same PR scope this job
+# re-derives.
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  # Same bazel-diff analysis as ci.yaml's `diff` job, but based on the merge
+  # commit's first parent instead of a PR merge-base. Analysis only — no
+  # BuildBuddy key needed here.
+  #
+  # No coarse `paths-filter` scoping (unlike ci.yaml): there is no required check
+  # to keep reporting here, and a proxy-only merge naturally yields an empty
+  # impact set, because proxy/ is a sibling Bazel workspace outside `//...`.
+  diff:
+    runs-on: ubuntu-latest
+    outputs:
+      has_any: ${{ steps.impacted.outputs.has_any }}
+      has_unit: ${{ steps.impacted.outputs.has_unit }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+          # Full history so the first parent is reachable for the diff.
+          fetch-depth: 0
+      - name: Resolve first parent
+        id: base
+        run: |
+          # A merge/squash commit's first parent is the previous tip of main, so
+          # HEAD^..HEAD is precisely what this merge introduced. An empty value
+          # makes the script fall back to a full run (root commit, shallow clone).
+          if base="$(git rev-parse --verify -q 'HEAD^')"; then
+            echo "sha=$base" >>"$GITHUB_OUTPUT"
+          else
+            echo "::warning::HEAD has no first parent; falling back to a full //... run"
+            echo "sha=" >>"$GITHUB_OUTPUT"
+          fi
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+          repository-cache: true
+      - name: Download bazel-diff
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/bazel-diff.jar" \
+            https://github.com/Tinder/bazel-diff/releases/download/v26.0.1/bazel-diff_deploy.jar
+      - name: Compute impacted targets
+        id: impacted
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          BAZEL_DIFF_JAR: ${{ runner.temp }}/bazel-diff.jar
+          OUT_DIR: ${{ runner.temp }}/bazel-diff-out
+        run: |
+          # Run from a copy outside the tree: the script git-checkouts the base and
+          # head revisions, which would otherwise swap the script file mid-run.
+          cp scripts/ci-impacted-targets.sh "$RUNNER_TEMP/impacted.sh"
+          bash "$RUNNER_TEMP/impacted.sh"
+      - name: Upload impacted target lists
+        uses: actions/upload-artifact@v7
+        with:
+          name: impacted-targets-main
+          path: ${{ runner.temp }}/bazel-diff-out/impacted_*.txt
+          if-no-files-found: error
+
+  # Byte-for-byte the same legs as ci.yaml's `test` job: build every impacted
+  # target (compile + lint on BuildBuddy RBE), run the impacted unit tests
+  # (--config=ci implies --config=remote, which pins TestRunner to the local
+  # strategy — tests must NOT run remotely), then the proxy-ready linkage guard.
+  test:
+    needs: diff
+    if: needs.diff.outputs.has_any == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.19.0
+        with:
+          bazelisk-cache: true
+      - name: Download impacted target lists
+        uses: actions/download-artifact@v7
+        with:
+          name: impacted-targets-main
+          path: ${{ runner.temp }}/impacted
+      - name: Build impacted targets
+        run: |
+          bazel build --config=ci \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            --build_metadata=COMMIT_SHA=${{ github.sha }} \
+            --build_metadata=REPO_URL=https://github.com/${{ github.repository }} \
+            --build_metadata=BRANCH_NAME=${{ github.ref_name }} \
+            --target_pattern_file=${{ runner.temp }}/impacted/impacted_build.txt
+      - name: Unit tests
+        if: needs.diff.outputs.has_unit == 'true'
+        run: |
+          bazel test --config=ci \
+            --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} \
+            --target_pattern_file=${{ runner.temp }}/impacted/impacted_unit.txt
+      # #673: the aether-proxy readiness probe must stay a stdlib-only binary —
+      # its entire value is what it does NOT link (package init() runs before
+      # main(), so a heavy import costs every pod every 2s and no argv check can
+      # avoid it). //agent/cmd/proxy-ready:deps_test asserts this on the linked
+      # ELF; this is the build-graph half, which fails on a forbidden dependency
+      # even before the linker drops it as unreachable. Analysis-only and cheap —
+      # the query runs against the cache the build step above just warmed.
+      - name: Guard proxy-ready linkage
+        run: scripts/check-proxy-ready-deps.sh --config=ci

--- a/scripts/ci-impacted-targets.sh
+++ b/scripts/ci-impacted-targets.sh
@@ -1,16 +1,22 @@
 #!/usr/bin/env bash
-# Computes the Bazel targets impacted by a PR with Tinder/bazel-diff and splits
-# the impacted TEST targets into unit / integration / e2e so CI builds and tests
-# only what changed. Falls back to "everything impacted" on any error or when the
-# base revision is unavailable, so CI never silently under-tests.
+# Computes the Bazel targets impacted by a revision range with Tinder/bazel-diff
+# and splits the impacted TEST targets into unit / integration / e2e so CI builds
+# and tests only what changed. Falls back to "everything impacted" on any error or
+# when the base revision is unavailable, so CI never silently under-tests.
+#
+# The range is whatever the caller passes; nothing here assumes a PR. Two callers:
+#   .github/workflows/ci.yaml   BASE_SHA = the PR's merge-base, HEAD_SHA = PR head
+#   .github/workflows/main.yaml BASE_SHA = HEAD^ (a merge commit's first parent),
+#                               HEAD_SHA = the merge commit — i.e. post-merge
+#                               validation of what a merge added to main (#679)
 #
 # Runs bazel-diff at both the base and head revisions (it git-checkouts them), so
 # the workflow MUST run this from a copy outside the repo tree (e.g. $RUNNER_TEMP)
 # — otherwise the checkout could swap the script file out from under bash.
 #
 # Env:
-#   BASE_SHA        merge-base commit to diff against (empty -> full fallback)
-#   HEAD_SHA        PR head commit (default: current HEAD)
+#   BASE_SHA        base commit to diff against (empty -> full fallback)
+#   HEAD_SHA        head commit to diff (default: current HEAD)
 #   BAZEL_DIFF_JAR  path to bazel-diff_deploy.jar (missing -> full fallback)
 #   OUT_DIR         output dir for the target lists (default: $PWD/.bazel-diff-out)
 #   GITHUB_OUTPUT   if set, has_any/has_unit/has_integration/has_e2e are appended
@@ -60,6 +66,7 @@ SEED="$OUT_DIR/seed.txt"
 cat >"$SEED" <<'EOF'
 .bazelrc
 .github/workflows/ci.yaml
+.github/workflows/main.yaml
 scripts/ci-impacted-targets.sh
 MODULE.bazel
 MODULE.bazel.lock


### PR DESCRIPTION
## The merge-skew instance

PR CI validates a PR **head** against that PR's **merge-base**. Nothing validated `main` after a merge. Two PRs that each pass against their own base can therefore combine into a state neither was ever tested in:

| commit | change | registrations at CI time | CI |
|---|---|---|---|
| #671 `763f5b3` | +1 (`spiffe_id_override_rejected`) | 15 | pass |
| #672 head `f5d540a` | branched **before** #671 merged; +2 onto a file at 13 | 15 | pass |
| #672 squash `cf68f1b` | main = #671 + #672 | **16** (limit 15) | **never run** |

`newCNIMetrics` landed on `main` at gocognit 16/15 and no PR ever failed for it. It surfaced days later on two *unrelated* PRs — #676 (mesh-dns forward pool) and #677 — because `//agent/internal/cni/server:server` is in their reverse-transitive impact set via `xds/cache`. Cleared by #678; the class remained.

## What this PR adds — `main-post-merge` (the detector)

New `.github/workflows/main.yaml`, workflow name `main-post-merge`, jobs `diff` + `test`. On every push to `main` it runs the *same* legs `ci.yaml`'s `test` job runs:

- `bazel build --config=ci` over the impacted build set (compile + the `--config=lint` aspects, `--fail_on_violation` — this is the leg that catches gocognit),
- `bazel test --config=ci` over the impacted unit set,
- `scripts/check-proxy-ready-deps.sh --config=ci` (#673 linkage guard).

Impact set = **the merge commit vs its first parent** (`HEAD^`), i.e. exactly what the merge added to `main`, evaluated against the tree that now exists. `scripts/ci-impacted-targets.sh` already falls back to a full `//...` build+test whenever bazel-diff cannot compute a set (no first parent, unreachable base, tool failure), so `main` is never silently under-validated.

Constraints preserved:
- RBE via BuildBuddy: `--config=ci` → `--config=remote`; the same `--remote_header=x-buildbuddy-api-key` is passed on build and test.
- **Tests stay local** — unchanged mechanism: `build:remote --strategy=TestRunner=local` in `.bazelrc`. Nothing here overrides it.
- The `pull_request` path is untouched. `ci` remains the only required status check; this workflow reports nothing required, so a red `main-post-merge` is a red `main`, not a blocked PR.
- No coarse `paths-filter` job: there is no required check to keep reporting on this trigger, and a proxy-only merge yields an empty impact set anyway (`proxy/` is a sibling workspace outside `//...`), so `test` just skips.
- `integration` / `e2e` are not repeated: `e2e.yaml` already covers `main` pushes.

### `scripts/ci-impacted-targets.sh`

Read it — it takes `BASE_SHA`/`HEAD_SHA` from the environment and never computes a merge-base itself, so there was no functional PR assumption to fix. Its *docs* did assume one; retitled for the two callers. One real fix: `.github/workflows/main.yaml` added to the seed-file list, so editing the new workflow forces a full run, same as `ci.yaml`.

### Dry run

`BASE_SHA=a3cde6c^ HEAD_SHA=a3cde6c` (the squash of #681) against the modified script:

```
  output: has_any=true
  output: has_unit=true
  output: has_integration=true
  output: has_e2e=false
>> impacted: build=33 unit=8 integration=1 e2e=false
```

The build set is exactly the packages #681 touched plus their reverse deps:

```
//agent/internal/cmd:cmd            //agent/internal/cni/server:server
//agent/internal/cniconflist:...    //agent/internal/node:node
//agent/cmd/agent:agent (+ image targets)
//charts/aether:...  //website:site  //:website_docs
```

unit = `agent/internal/{cmd,cniconflist,cni/server,node}` tests + `agent/cmd/agent:image_test` + chart lint/template + `website:site_test`; integration = `//agent/internal/cni/server:server_integration_test`.

`actionlint` v1.7.7 on the new file: clean (exit 0). Over all workflows it reports only the two pre-existing `github.head_ref` findings in `ci.yaml` and `proxy.yml`, untouched here.

## Part B — branch protection (settings change, not code)

The issue's recommended fix is `required_status_checks.strict = true` ("require branches up to date before merging"). Findings:

- `repos/bpalermo/aether/branches/main/protection` returns **404 Branch not protected** — `main` is guarded by a **repository ruleset** (`main`, id `12650911`, `~DEFAULT_BRANCH`, enforcement `active`), not legacy branch protection. The PATCH in the issue therefore 404s.
- In the ruleset, the equivalent field **is already set**: `required_status_checks.strict_required_status_checks_policy: true`, with contexts `ci` and `proxy` (unchanged, not touched). Also `do_not_enforce_on_create: true`, plus `deletion`, `non_fast_forward`, `required_linear_history`, and `pull_request` (1 approval, code-owner review, squash only).
- **So why did the skew still happen?** `bypass_actors: [{actor_id: 5 (RepositoryRole = admin), bypass_mode: "always"}]`, and `current_user_can_bypass: "always"`. Rule-suite history confirms it: every recent push to `refs/heads/main`, including `a3cde6c`, `e1b6557`, `623c254`, is recorded with `result: bypass`. The strict up-to-date requirement is configured but never evaluated for the only person who merges.

No protection field was changed: `strict` was already `true`, and narrowing `bypass_actors` is a different field and a policy call for the repo owner. **To actually close the class**, the admin bypass has to go (Settings → Rules → `main` → Bypass list → remove "Repository admin", or set its mode to "Pull requests only"); until then this PR's `main-post-merge` job is the working half — it turns the skew into an unmistakable red run on `main` instead of a mystery failure on a bystander PR days later.

Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
