### PR TITLE
test(soak): add a no-roll window + demand-set shrink so #682 is visible, and an age-matched proxy RSS sampler for #628

### DIFF
--- a/e2e/soak/README.md
+++ b/e2e/soak/README.md
@@ -9,7 +9,7 @@ Three components run together:
 |---|---|
 | **External prober** (`//prober`, DaemonSet, already deployed) | the availability SLI — **authoritative for PASS/FAIL** |
 | **k6 runners** (`k6-runner.yaml`) | mesh load by NAME (~300/s) so DNS + cross-node paths are exercised |
-| **Churn driver** (`churn.sh`) | 30 rolling restarts incl. mesh-dns/agent/proxy/edge + a concurrent triple |
+| **Churn driver** (`churn.sh`) | 31 rolling restarts incl. mesh-dns/agent/proxy/edge + a concurrent triple, then a 90-minute no-roll window and a demand-set shrink |
 
 The prober is external **on purpose**: the mesh's own self-reported metrics are blind to
 the very churn being tested. Never grade a soak on mesh self-SLI alone.
@@ -35,14 +35,105 @@ kubectl get pods -n aether-system
 #   sum by (tier) (rate(aether_probe_requests_total{result="success"}[3m]))   -> ~25/s
 #   sum by (tier) (rate(aether_probe_requests_total{result!="success"}[5m]))  -> 0
 
-# 3. Start load, then churn (detached — churn sleeps ~7h15m).
+# 3. Start load, then churn. Detached — churn sleeps ~7h32m, and `nohup setsid` is
+#    mandatory: on 2026-09-03 the harness reaped a plain `&` job at T0+75m.
 kubectl apply -f e2e/soak/k6-runner.yaml
-bash e2e/soak/churn.sh "rev183/0.86.0" &
+nohup setsid bash e2e/soak/churn.sh "rev192/0.92.0" >/dev/null 2>&1 &
 
-# 4. Teardown at T0+8h.
+# 4. Age-matched proxy RSS baseline at T0+30m (churn.sh takes the rest itself).
+bash e2e/soak/sample-proxy-rss.sh --at-age 1800
+
+# 5. Teardown at T0+8h.
 kubectl delete -f e2e/soak/k6-runner.yaml
-grep -c ROLLED /tmp/soak-churn.log      # expect 30
+grep -c ROLLED /tmp/soak-churn.log      # expect 31
+grep -E "no-roll window|SHRINK" /tmp/soak-churn.log
+column -t /tmp/soak-proxy-rss.tsv       # the #628 age-matched series
 ```
+
+## The churn schedule
+
+29 schedule entries; the TRIPLE fires three rolls at once, so `grep -c ROLLED` is
+**31** (6 proxy, 2 agent, 3 mesh-dns, 2 edge, 18 svc). The older footer said 30 — it
+forgot the TRIPLE's proxy. The set of rolls has not changed, only the tally.
+
+| T0+ (min) | Roll | | T0+ (min) | Roll |
+|---|---|---|---|---|
+| 12 | svc-1 | | 24 | svc-2 |
+| 36 | **proxy** \* | | 48 | svc-3 |
+| 60 | mesh-dns | | 72 | **agent** |
+| 84 | svc-5 | | 96 | **proxy** \* |
+| 108 | svc-1 | | 120 | edge |
+| 132 | svc-2 | | 144 | mesh-dns |
+| 156 | svc-3 | | 168 | svc-4 |
+| 180 | svc-5 | | 192 | svc-1 |
+| 204 | edge | | 216 | **proxy** \* |
+| 228 | svc-2 | | 240 | svc-4 |
+| 252 | **proxy** \* | | 264 | svc-3 |
+| 276 | svc-1 | | 300 | **TRIPLE** \* — agent + proxy + svc-3, the stress peak **and the last agent roll** |
+| 312 | mesh-dns | | 324 | svc-4 |
+| 336 | **proxy** \* | | 348 | svc-2 |
+| 360 | svc-1 — the last roll of any kind | | | |
+| **360 → 450** | **NO-ROLL WINDOW** — nothing is rolled for 90 minutes | | | |
+| 450 | **SHRINK** — `svc-5` scaled to 0 for 90s, then restored | | | |
+| ~452 | `churn driver complete` (k6 runs 7h40m, so both land under load) | | | |
+
+\* = 30 minutes after that proxy roll an age-matched RSS sample is taken in the
+background (`sample-proxy-rss.sh --at-age 1800`), for #628. Six samples per run.
+
+### The no-roll window (#682)
+
+The node agent's demand-scoped dependency set holds each observed upstream for **1h**,
+and rolling `aether-agent` rebuilds that set with a fresh TTL. The old schedule rolled
+the agent at T0+90m and again at T0+300m, so **the TTL could never expire inside a
+soak**: for its entire history this harness was *structurally blind* to the whole
+TTL-expiry → ODCDS-stall class, which surfaced only in the quiet hours between runs
+(#682). The window sits after the last agent roll and outlasts the TTL, so the expiry
+now happens under load, inside the graded window, on the nodes that have no local
+replica of the upstream (w01/w03 in the current `echo` placement).
+
+Opt out with `SOAK_NO_ROLL_WINDOW=0` (default on). `SOAK_NO_ROLL_END_MIN` moves the end.
+
+### The demand-set shrink (#682)
+
+Grading the 2026-09-05 run found a much cheaper trigger: **any** demand-set shrink —
+not the 1h TTL specifically — drops the cluster on a node with no local replica and
+exposes the same ODCDS stall, in seconds instead of an hour. So after the window the
+driver scales `deploy/svc-5` to 0 for 90s and restores it to **whatever replica count
+it read first** (never a hard-coded number; an EXIT/INT/TERM trap restores it even if
+the driver is killed mid-shrink).
+
+`svc-5` is the target on purpose: it is the one service the k6 script declares as an
+upstream but never actually drives, so bouncing it cannot pollute the k6 error rate or
+the prober SLI. The observable is the log pair — `service left dependency set` in the
+agent log, `cm odcds: ... timed out` in the proxy log.
+
+Opt out with `SOAK_SHRINK=0` (default on); `SOAK_SHRINK_TARGET` / `SOAK_SHRINK_SECONDS`
+retarget it.
+
+**Authorization:** rolling these shared `talos-main` workloads for soak validation is
+standing-authorized, and scaling `svc-5` down and back up for 90s is the same class of
+action on the same harness namespace.
+
+## Proxy RSS sampling (#628)
+
+`sample-proxy-rss.sh` prints one row per `aether-proxy` pod:
+
+```
+timestamp             node            pod                 age_seconds  working_set_mi
+2026-09-05T01:35:04Z  main-worker-01  aether-proxy-abcde  1803         241
+```
+
+Rows are appended to `/tmp/soak-proxy-rss.tsv` (header written once) and echoed to
+stdout. `--at-age SECONDS` polls every 15s (max 20 min) until the **youngest** proxy
+pod reaches that age and then samples once, so every checkpoint reads the same
+generation age.
+
+**Run it at T0+30m, and 30 minutes after each proxy roll** (`churn.sh` logs
+`ROLLED aether-system/daemonset/aether-proxy`, and queues those samples itself).
+
+Why the age match: #628 has never had two age-matched samples. Churn recycles the proxy
+every ~30-90 minutes, so a "higher" node is usually just an older incarnation, and
+ramp-then-plateau (born-hot) cannot be told from a leak without holding age fixed.
 
 ## Grading
 
@@ -56,6 +147,8 @@ sum by (tier, result) (increase(aether_probe_requests_total[8h]))
 - **mesh_dns** tier (resolves a real FQDN) — DNS + cross-node SLI. Target: `dns_error`,
   `dns_nxdomain`, `dns_timeout` **all zero**. A residual `http_error` (~0.02%) is the
   known cross-node drain path, tracked separately.
+- **#682 episodes during the no-roll window or SHRINK are the harness working, not a
+  regression** — attribute via the agent log line `service left dependency set`.
 
 ## Hard-won gotchas
 
@@ -87,6 +180,15 @@ Each of these invalidated a real run:
    it; `e2e/soak/echo.yaml` now owns it with 3 replicas, a soft hostname spread, and
    honest requests. It is deliberately NOT `test/e2e/testdata/echo.yaml`, which the
    CNI e2e tests apply on single-node kind and must stay minimal.
+8. **A churn schedule can hide a whole defect class.** Until 2026-09-05 the driver
+   rolled `aether-agent` every ~15 minutes for the entire run, and every agent roll
+   rebuilds the demand-scoped dependency set with a fresh 1h TTL. The soak therefore
+   *could not* observe a TTL expiry, and #682 — 5-minute per-node outages on nodes
+   with no local replica — lived undetected in the quiet hours between runs for the
+   harness's whole history while every soak reported PASS. The no-roll window and the
+   shrink exist to close that hole; a repeat of this shape (a churn step that resets
+   the very state a defect needs to age) is worth looking for whenever a bug is only
+   ever seen *between* soaks.
 
 ## Files
 
@@ -94,4 +196,7 @@ Each of these invalidated a real run:
   a run; it is the workload the mesh_dns tier actually measures.
 - `k6-mesh-soak.js` — load script (constant-arrival-rate, qualified mesh names, no OTLP).
 - `k6-runner.yaml` — the 5-node runner DaemonSet.
-- `churn.sh` — the 30-roll churn driver; takes a build label for the log header.
+- `churn.sh` — the 31-roll churn driver plus the no-roll window and the demand-set
+  shrink; takes a build label for the log header.
+- `sample-proxy-rss.sh` — age-matched `aether-proxy` working-set sampler for #628.
+  Standalone, and queued automatically by `churn.sh` after each proxy roll.

--- a/e2e/soak/churn.sh
+++ b/e2e/soak/churn.sh
@@ -1,27 +1,111 @@
 #!/usr/bin/env bash
-# 8-hour soak churn driver: 30 rolling restarts on a ~15-minute cadence, including
-# three aether-mesh-dns DaemonSet rolls (surge + SO_REUSEPORT handoff) and one
-# CONCURRENT triple (agent + proxy + svc at the same instant) as the stress peak.
+# 8-hour soak churn driver: 31 rolling restarts (29 schedule entries; the TRIPLE
+# fires three at once), including three aether-mesh-dns DaemonSet rolls (surge +
+# SO_REUSEPORT handoff) and one CONCURRENT triple (agent + proxy + svc at the same
+# instant) as the stress peak -- followed by a deliberate 90-minute NO-ROLL WINDOW
+# and a demand-set SHRINK.
 #
-# Run detached — it sleeps between rolls for ~7h15m:
-#   bash e2e/soak/churn.sh "rev183/0.86.0" &
+# Run detached -- it sleeps between rolls for ~7h32m:
+#   nohup setsid bash e2e/soak/churn.sh "rev192/0.92.0" >/dev/null 2>&1 &
 #
 # Progress is appended to $LOG with UTC timestamps; grep ROLLED to count.
+#
+# ---------------------------------------------------------------- the schedule
+#
+#   T0+   what                       why
+#   ----  -------------------------  --------------------------------------------
+#   12    svc-1        24  svc-2
+#   36    proxy  *     48  svc-3
+#   60    mesh-dns     72  agent      the ONLY scheduled agent roll besides TRIPLE
+#   84    svc-5        96  proxy  *
+#   108   svc-1        120 edge
+#   132   svc-2        144 mesh-dns
+#   156   svc-3        168 svc-4
+#   180   svc-5        192 svc-1
+#   204   edge         216 proxy  *
+#   228   svc-2        240 svc-4
+#   252   proxy  *     264 svc-3
+#   276   svc-1
+#   300   TRIPLE *     agent + proxy + svc-3 concurrently -- the stress peak, and
+#                      the LAST agent roll of the run (see the no-roll window)
+#   312   mesh-dns     324 svc-4
+#   336   proxy  *     348 svc-2
+#   360   svc-1        the last roll of any kind
+#   ----  -------------------------  --------------------------------------------
+#   360   NO-ROLL WINDOW BEGIN       nothing is rolled for 90 minutes
+#   450   NO-ROLL WINDOW END
+#   450   SHRINK                     svc-5 -> 0 replicas for 90s, then restored
+#   ~452  churn driver complete      (k6 runs 7h40m, so both land under load)
+#
+#   * = 30 minutes later an age-matched proxy RSS sample is taken in the
+#       background (sample-proxy-rss.sh --at-age 1800), for #628.
+#
+# ------------------------------------------------ why the window and the shrink
+#
+# #682: the node agent's demand-scoped dependency set holds each observed upstream
+# for 1h, and rolling aether-agent rebuilds that set with a fresh TTL. The old
+# schedule rolled the agent at T0+90m and again at T0+300m, so the TTL could never
+# expire inside a soak -- the harness was STRUCTURALLY BLIND to the whole
+# TTL-expiry -> ODCDS-stall class for its entire history, and the defect only ever
+# surfaced in the quiet hours between runs. The no-roll window sits after the last
+# agent roll and lasts longer than the TTL, so the expiry now happens under load,
+# inside the graded window, on the nodes with no local replica of the upstream.
+#
+# The SHRINK is the cheap second trigger the 2026-09-05 grading found: ANY demand-set
+# shrink -- not the 1h TTL specifically -- drops the cluster on a node with no local
+# replica and exposes the ODCDS stall, in seconds instead of an hour. svc-5 is the
+# target on purpose: it is the one service k6 declares as an upstream but never
+# actually drives, so bouncing it cannot pollute the k6 error rate or the prober SLI.
+#
+# Both steps are opt-out (default ON):  SOAK_NO_ROLL_WINDOW=0   SOAK_SHRINK=0
 set -uo pipefail
 
 BUILD_LABEL="${1:-unspecified-build}"
 LOG="${SOAK_CHURN_LOG:-/tmp/soak-churn.log}"
 T0=$(date +%s)
 
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SAMPLER="${SOAK_PROXY_RSS_SAMPLER:-$HERE/sample-proxy-rss.sh}"
+
+# Age-matched proxy RSS sampling (#628): sleep 28 minutes after a proxy roll, then
+# let the sampler poll the last couple of minutes until the youngest proxy pod is
+# exactly 30 minutes old. Without the age match, a "higher" node is usually just an
+# older incarnation.
+PROXY_RSS_AGE="${SOAK_PROXY_RSS_AGE:-1800}"
+PROXY_RSS_DELAY="${SOAK_PROXY_RSS_DELAY:-1680}"
+
+# No-roll window (#682). Begins when the last scheduled roll returns.
+NO_ROLL_END_MIN="${SOAK_NO_ROLL_END_MIN:-450}"
+
+# Demand-set shrink (#682).
+SHRINK_NS="${SOAK_SHRINK_NS:-aether-test}"
+SHRINK_TARGET="${SOAK_SHRINK_TARGET:-deployment/svc-5}"
+SHRINK_SECONDS="${SOAK_SHRINK_SECONDS:-90}"
+SHRINK_PREV=""
+
 # Start a FRESH log, archiving any previous run alongside it. Without this the driver
 # appends to the last soak's file, and `grep -c ROLLED` -- which teardown uses to confirm
-# 30 rolls -- silently double-counts, so a run looks complete when it is not.
+# 31 rolls -- silently double-counts, so a run looks complete when it is not.
 if [ -s "$LOG" ]; then
 	mv -f "$LOG" "$LOG.$(date -u +%Y%m%dT%H%M%SZ).prev"
 fi
 : >"$LOG"
 
 log() { echo "$(date -u +%FT%TZ) $*" >>"$LOG"; }
+
+# Never leave the shrink target scaled to zero, even if the driver is killed mid-shrink.
+restore_shrink() {
+	if [ -n "$SHRINK_PREV" ]; then
+		local prev="$SHRINK_PREV"
+		SHRINK_PREV=""
+		if kubectl -n "$SHRINK_NS" scale "$SHRINK_TARGET" --replicas="$prev" >>"$LOG" 2>&1; then
+			log "SHRINK done $SHRINK_NS/$SHRINK_TARGET restored to replicas=$prev"
+		else
+			log "SHRINK FAILED to restore $SHRINK_NS/$SHRINK_TARGET to replicas=$prev -- RESTORE BY HAND"
+		fi
+	fi
+}
+trap restore_shrink EXIT INT TERM
 
 # Sleep until T0 + $1 minutes.
 waituntil() {
@@ -40,16 +124,53 @@ roll() {
 	fi
 }
 
+# Queue an age-matched proxy RSS sample 30 minutes from now, detached, so it can
+# never delay the schedule.
+schedule_rss_sample() {
+	if [ "${SOAK_PROXY_RSS:-1}" = "0" ]; then return; fi
+	if [ ! -r "$SAMPLER" ]; then
+		log "RSS SAMPLE skipped: no sampler at $SAMPLER"
+		return
+	fi
+	(
+		sleep "$PROXY_RSS_DELAY"
+		bash "$SAMPLER" --at-age "$PROXY_RSS_AGE"
+	) >>"$LOG" 2>&1 &
+	log "RSS SAMPLE queued for T+${PROXY_RSS_AGE}s after this aether-proxy roll (#628)"
+}
+
+roll_proxy() {
+	roll aether-system daemonset/aether-proxy
+	schedule_rss_sample
+}
+
+shrink() {
+	local prev
+	prev=$(kubectl -n "$SHRINK_NS" get "$SHRINK_TARGET" -o jsonpath='{.spec.replicas}' 2>>"$LOG")
+	if ! [[ "$prev" =~ ^[0-9]+$ ]] || [ "$prev" -eq 0 ]; then
+		log "SHRINK skipped: cannot read a non-zero .spec.replicas from $SHRINK_NS/$SHRINK_TARGET (got '${prev}')"
+		return
+	fi
+	log "SHRINK begin $SHRINK_NS/$SHRINK_TARGET replicas=$prev -> 0 for ${SHRINK_SECONDS}s (demand-set shrink, #682)"
+	if ! kubectl -n "$SHRINK_NS" scale "$SHRINK_TARGET" --replicas=0 >>"$LOG" 2>&1; then
+		log "SHRINK FAILED to scale $SHRINK_NS/$SHRINK_TARGET down; leaving it at $prev"
+		return
+	fi
+	SHRINK_PREV="$prev"
+	sleep "$SHRINK_SECONDS"
+	restore_shrink
+}
+
 log "churn driver start T0=$(date -u +%FT%TZ) build=$BUILD_LABEL"
 
 # "<offset-minutes> <kind> [name]"
 SCHED=(
-	"15 svc svc-1" "30 svc svc-2" "45 proxy" "60 svc svc-3" "75 meshdns"
-	"90 agent" "105 svc svc-5" "120 proxy" "135 svc svc-1" "150 edge"
-	"165 svc svc-2" "180 meshdns" "195 svc svc-3" "210 svc svc-4" "225 svc svc-5"
-	"240 svc svc-1" "255 edge" "270 proxy" "285 svc svc-2" "300 TRIPLE"
-	"315 svc svc-4" "330 proxy" "345 meshdns" "360 svc svc-1" "375 svc svc-2"
-	"390 svc svc-3" "405 svc svc-4" "420 proxy" "435 svc svc-1"
+	"12 svc svc-1" "24 svc svc-2" "36 proxy" "48 svc svc-3" "60 meshdns"
+	"72 agent" "84 svc svc-5" "96 proxy" "108 svc svc-1" "120 edge"
+	"132 svc svc-2" "144 meshdns" "156 svc svc-3" "168 svc svc-4" "180 svc svc-5"
+	"192 svc svc-1" "204 edge" "216 proxy" "228 svc svc-2" "240 svc svc-4"
+	"252 proxy" "264 svc svc-3" "276 svc svc-1" "300 TRIPLE" "312 meshdns"
+	"324 svc svc-4" "336 proxy" "348 svc svc-2" "360 svc svc-1"
 )
 
 for entry in "${SCHED[@]}"; do
@@ -57,20 +178,47 @@ for entry in "${SCHED[@]}"; do
 	waituntil "$off"
 	case "$kind" in
 	svc) roll aether-test "deployment/$name" ;;
-	proxy) roll aether-system daemonset/aether-proxy ;;
+	proxy) roll_proxy ;;
 	agent) roll aether-system daemonset/aether-agent ;;
 	meshdns) roll aether-system daemonset/aether-mesh-dns ;;
 	edge) roll aether-ingress deployment/aether-edge ;;
 	TRIPLE)
 		log "CONCURRENT triple begin"
+		# Wait on these three PIDs specifically: a bare `wait` would also block on
+		# any RSS sampler still parked in its --at-age poll, delaying the log.
 		roll aether-system daemonset/aether-agent &
+		t_agent=$!
 		roll aether-system daemonset/aether-proxy &
+		t_proxy=$!
 		roll aether-test deployment/svc-3 &
-		wait
+		t_svc=$!
+		wait "$t_agent" "$t_proxy" "$t_svc"
 		log "CONCURRENT triple done"
+		# The TRIPLE-fresh proxy incarnation is #628's worst observed data point
+		# (316Mi in 9 minutes on 08-03), so age-match it too.
+		schedule_rss_sample
 		;;
 	*) log "UNKNOWN kind $kind" ;;
 	esac
 done
 
-log "churn driver complete (30 rolls: 5 proxy, 2 agent incl triple, 2 edge, 3 meshdns, 18 svc)"
+# The no-roll window: the 1h demand-scoped TTL expires under load, with no agent or
+# proxy roll to reset it. See the header. Nothing is rolled until NO_ROLL_END_MIN.
+if [ "${SOAK_NO_ROLL_WINDOW:-1}" = "0" ]; then
+	log "no-roll window SKIPPED (SOAK_NO_ROLL_WINDOW=0)"
+else
+	log "no-roll window begin T0+360m; nothing is rolled until T0+${NO_ROLL_END_MIN}m (#682 TTL expiry under load)"
+	waituntil "$NO_ROLL_END_MIN"
+	log "no-roll window end T0+${NO_ROLL_END_MIN}m"
+fi
+
+if [ "${SOAK_SHRINK:-1}" = "0" ]; then
+	log "SHRINK skipped (SOAK_SHRINK=0)"
+else
+	shrink
+fi
+
+# 29 schedule entries, but the TRIPLE logs its three concurrent rolls separately, so
+# `grep -c ROLLED` is 31. (The old footer said 30: it forgot the TRIPLE's proxy. The
+# set of rolls is unchanged -- only the tally is now honest.)
+log "churn driver complete (31 rolls: 6 proxy incl triple, 2 agent incl triple, 2 edge, 3 meshdns, 18 svc incl triple)"

--- a/e2e/soak/sample-proxy-rss.sh
+++ b/e2e/soak/sample-proxy-rss.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Age-matched aether-proxy RSS sampler (#628).
+#
+# #628 -- "Envoy proxy heap growth under load" -- has never had two AGE-MATCHED
+# samples. Every reading so far was taken at whatever age the pods happened to be,
+# and since the churn driver recycles the proxy every ~30-90 minutes, a "higher"
+# reading on one node is usually just an older incarnation. Without a fixed age the
+# ramp-then-plateau question (born-hot vs leak) cannot be answered.
+#
+# This samples the proxy container's working set together with the pod's age, so
+# rows are comparable across nodes, generations and runs.
+#
+# Usage:
+#   e2e/soak/sample-proxy-rss.sh                 # sample right now, whatever the ages
+#   e2e/soak/sample-proxy-rss.sh --at-age 1800   # wait until the YOUNGEST proxy pod
+#                                                # is 1800s old, then sample once
+#
+# --at-age polls every 15s for at most 20 minutes. If the deadline passes it samples
+# anyway and warns on stderr -- a row with an honest age_seconds beats no row at all.
+#
+# Rows are appended to /tmp/soak-proxy-rss.tsv (header written once) and echoed to
+# stdout:
+#
+#   timestamp             node            pod                age_seconds  working_set_mi
+#   2026-09-05T01:35:04Z  main-worker-01  aether-proxy-abcde  1803         241
+#
+# Requires metrics-server (`kubectl top`), which talos-main runs.
+set -uo pipefail
+
+NS="${SOAK_PROXY_NS:-aether-system}"
+SELECTOR="${SOAK_PROXY_SELECTOR:-app.kubernetes.io/name=aether-proxy}"
+CONTAINER="${SOAK_PROXY_CONTAINER:-proxy}"
+OUT="${SOAK_PROXY_RSS_TSV:-/tmp/soak-proxy-rss.tsv}"
+POLL_SECONDS="${SOAK_PROXY_RSS_POLL:-15}"
+MAX_WAIT_SECONDS="${SOAK_PROXY_RSS_MAX_WAIT:-1200}"
+
+AT_AGE=""
+
+usage() {
+	sed -n '2,30p' "$0"
+	exit "${1:-0}"
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--at-age)
+		AT_AGE="${2:-}"
+		if ! [[ "$AT_AGE" =~ ^[0-9]+$ ]]; then
+			echo "sample-proxy-rss: --at-age needs a whole number of seconds" >&2
+			exit 2
+		fi
+		shift 2
+		;;
+	-h | --help) usage 0 ;;
+	*)
+		echo "sample-proxy-rss: unknown argument '$1'" >&2
+		usage 2
+		;;
+	esac
+done
+
+# "<pod> <node> <startTime>" per Running proxy pod. startTime is the incarnation's
+# birth, which is what makes a reading age-matched rather than node-matched.
+pod_table() {
+	kubectl get pods -n "$NS" -l "$SELECTOR" \
+		--field-selector=status.phase=Running \
+		-o go-template='{{range .items}}{{.metadata.name}} {{.spec.nodeName}} {{.status.startTime}}{{"\n"}}{{end}}' \
+		2>/dev/null | grep -v '<no value>'
+}
+
+# Age in seconds of the youngest Running proxy pod; empty if there are none.
+youngest_age() {
+	local now pod node start age min=""
+	now=$(date -u +%s)
+	while read -r pod node start; do
+		[ -n "$start" ] || continue
+		age=$(date -u -d "$start" +%s 2>/dev/null) || continue
+		age=$((now - age))
+		if [ -z "$min" ] || [ "$age" -lt "$min" ]; then min="$age"; fi
+	done < <(pod_table)
+	printf '%s' "$min"
+}
+
+# Working set of the proxy container, in Mi, keyed by pod name. `kubectl top
+# --containers` prints POD NAME CPU MEMORY; the proxy pod also runs an `authz`
+# container, so filtering on the container name is mandatory.
+mem_table() {
+	kubectl top pods -n "$NS" -l "$SELECTOR" --containers --no-headers 2>/dev/null |
+		awk -v c="$CONTAINER" '$2 == c { print $1, $4 }'
+}
+
+# Normalise a kubectl quantity (Ki/Mi/Gi, or bare bytes) to whole Mi.
+to_mi() {
+	local v="$1"
+	case "$v" in
+	*Ki) echo $((${v%Ki} / 1024)) ;;
+	*Mi) echo "${v%Mi}" ;;
+	*Gi) echo $((${v%Gi} * 1024)) ;;
+	*[!0-9]*) echo "NA" ;;
+	*) echo $((v / 1024 / 1024)) ;;
+	esac
+}
+
+sample_once() {
+	local now ts pod node start age mem mi
+	now=$(date -u +%s)
+	ts=$(date -u +%FT%TZ)
+
+	local mems
+	mems=$(mem_table)
+	if [ -z "$mems" ]; then
+		echo "sample-proxy-rss: no '$CONTAINER' rows from 'kubectl top pods -n $NS -l $SELECTOR --containers'" >&2
+	fi
+
+	if [ ! -s "$OUT" ]; then
+		printf 'timestamp\tnode\tpod\tage_seconds\tworking_set_mi\n' >>"$OUT"
+	fi
+
+	while read -r pod node start; do
+		[ -n "$start" ] || continue
+		age=$(date -u -d "$start" +%s 2>/dev/null) || continue
+		age=$((now - age))
+		mem=$(printf '%s\n' "$mems" | awk -v p="$pod" '$1 == p { print $2; exit }')
+		if [ -z "$mem" ]; then
+			mi="NA"
+		else
+			mi=$(to_mi "$mem")
+		fi
+		printf '%s\t%s\t%s\t%s\t%s\n' "$ts" "$node" "$pod" "$age" "$mi" | tee -a "$OUT"
+	done < <(pod_table | sort -k2,2)
+}
+
+if [ -n "$AT_AGE" ]; then
+	waited=0
+	while :; do
+		age=$(youngest_age)
+		if [ -z "$age" ]; then
+			echo "sample-proxy-rss: no Running proxy pods yet (waited ${waited}s)" >&2
+		elif [ "$age" -ge "$AT_AGE" ]; then
+			break
+		fi
+		if [ "$waited" -ge "$MAX_WAIT_SECONDS" ]; then
+			echo "sample-proxy-rss: youngest proxy pod still ${age:-?}s < ${AT_AGE}s after ${waited}s; sampling anyway" >&2
+			break
+		fi
+		sleep "$POLL_SECONDS"
+		waited=$((waited + POLL_SECONDS))
+	done
+fi
+
+sample_once


### PR DESCRIPTION
Two soak-harness changes, both confined to `e2e/soak/`. No Go, no chart.

## 1. The soak was structurally blind to #682 for its entire history

The node agent's demand-scoped dependency set holds each observed upstream for **1h**,
and rolling `aether-agent` rebuilds that set with a fresh TTL. The old churn schedule
rolled the agent at T0+90m and again at T0+300m (the TRIPLE), so **the TTL could never
expire inside a soak**. #682 — a TTL expiry that drops the cluster on a node with no
local replica and then stalls ODCDS re-discovery for ~5 minutes — only ever surfaced in
the quiet hours *between* runs, while every soak reported PASS. Grading the 2026-09-05
run confirmed it quantitatively: all 13 `service left dependency set` lines across the
five agents were timestamped 09:06:17Z, one second after the k6 DaemonSet was deleted at
teardown. Not one fell inside the graded window.

Two fixes, both opt-out (`SOAK_NO_ROLL_WINDOW=0`, `SOAK_SHRINK=0`), default ON:

- **A 90-minute no-roll window** at T0+360 → T0+450, placed after the last agent roll
  (the TRIPLE) and after the last roll of any kind. Nothing is rolled: no agent, proxy,
  mesh-dns, edge or svc. The last proxy roll is at T0+336, so the 1h TTL expires at
  roughly T0+396 — under load, inside the graded window, on the nodes with no local
  `echo` replica. Logged as `no-roll window begin` / `no-roll window end`.
- **A demand-set shrink** at T0+450, after the window and before
  `churn driver complete`: `deploy/svc-5` is scaled to 0 for 90s and restored to
  **whatever replica count was read first** (never hard-coded; an EXIT/INT/TERM trap
  restores it even if the driver is killed mid-shrink). This is the cheap trigger the
  #682 grade comment found — *any* demand-set shrink, not the 1h TTL specifically,
  reproduces the ODCDS stall in seconds. Logged as `SHRINK begin` / `SHRINK done`.
  `svc-5` is the target on purpose: it is the one service the k6 script declares as an
  upstream but never actually drives, so bouncing it cannot pollute the k6 error rate or
  the prober SLI.

The roll count and the roll composition are unchanged — the other rolls were re-spaced
from a 15-minute to a 12-minute cadence to buy the window without extending the run.
Churn now ends at ~T0+7h32m; k6 still runs 7h40m, so both new steps land under load.

### The new schedule

| T0+ (min) | Roll | | T0+ (min) | Roll |
|---|---|---|---|---|
| 12 | svc-1 | | 24 | svc-2 |
| 36 | **proxy** \* | | 48 | svc-3 |
| 60 | mesh-dns | | 72 | **agent** |
| 84 | svc-5 | | 96 | **proxy** \* |
| 108 | svc-1 | | 120 | edge |
| 132 | svc-2 | | 144 | mesh-dns |
| 156 | svc-3 | | 168 | svc-4 |
| 180 | svc-5 | | 192 | svc-1 |
| 204 | edge | | 216 | **proxy** \* |
| 228 | svc-2 | | 240 | svc-4 |
| 252 | **proxy** \* | | 264 | svc-3 |
| 276 | svc-1 | | 300 | **TRIPLE** \* — agent + proxy + svc-3, the stress peak **and the last agent roll** |
| 312 | mesh-dns | | 324 | svc-4 |
| 336 | **proxy** \* | | 348 | svc-2 |
| 360 | svc-1 — the last roll of any kind | | | |
| **360 → 450** | **NO-ROLL WINDOW** — nothing is rolled for 90 minutes | | | |
| 450 | **SHRINK** — `svc-5` → 0 for 90s, then restored | | | |
| ~452 | `churn driver complete` | | | |

\* = 30 minutes later an age-matched proxy RSS sample is taken in the background.

## 2. Age-matched proxy RSS sampler for #628

`e2e/soak/sample-proxy-rss.sh` prints one row per `aether-proxy` pod from
`kubectl top pods -n aether-system --containers` joined with the pod's `startTime`:

```
timestamp             node            pod                 age_seconds  working_set_mi
2026-09-05T01:35:04Z  main-worker-01  aether-proxy-abcde  1803         241
```

Rows are appended to `/tmp/soak-proxy-rss.tsv` (header written once) and echoed to
stdout. `--at-age SECONDS` polls every 15s (max 20 min) until the **youngest** proxy pod
reaches that age and then samples once, so every checkpoint reads the same generation
age. It filters on the `proxy` container (the pod also runs `authz`), skips pods with no
`startTime`, and normalises Ki/Mi/Gi to whole Mi.

Usage:

```bash
bash e2e/soak/sample-proxy-rss.sh                # sample now, whatever the ages
bash e2e/soak/sample-proxy-rss.sh --at-age 1800  # a 30-min-old generation, every time
```

Run it at T0+30m; `churn.sh` queues the rest itself — 28 minutes after each proxy roll it
backgrounds `sample-proxy-rss.sh --at-age 1800`, which polls the last couple of minutes
until the youngest pod is exactly 30 minutes old. Six samples per run (the five scheduled
proxy rolls plus the TRIPLE's, since the TRIPLE-fresh incarnation is #628's worst
observed data point). The samplers are detached and can never delay the schedule; the
TRIPLE now waits on its three roll PIDs specifically rather than a bare `wait`, so a
parked sampler cannot hold up the `CONCURRENT triple done` log.

Why this matters: #628 has never had two age-matched samples. Churn recycles the proxy
every ~30-90 minutes, so a "higher" node is usually just an older incarnation, and
ramp-then-plateau (born-hot) cannot be told from a leak without holding age fixed.

## Also

- `README.md`: the schedule table, both new steps with their env opt-outs, the sampler
  usage, a note that scaling `svc-5` for 90s falls under the same standing authorization
  as rolling these shared `talos-main` workloads, and a new gotcha #8 on the blind spot
  itself.
- A grading line: **#682 episodes during the no-roll window or SHRINK are the harness
  working, not a regression** — attribute via the agent log line
  `service left dependency set`.
- Corrected the roll tally. The footer claimed 30 rolls but omitted the TRIPLE's proxy;
  `grep -c ROLLED` has always printed 31. The set of rolls is unchanged, only the tally
  and the README's `# expect` are now honest.

## Testing

- `shellcheck` (0.11.0, via `@aspect_rules_lint`) clean on both scripts; `bazel run
  //:format` (shfmt) clean. There is no BUILD target under `e2e/soak/`, so the lint
  aspect does not cover these files — shellcheck was run directly.
- Sampler exercised against a stub `kubectl`: header written once, Ki→Mi conversion,
  `<no value>` startTime skipped, `--at-age` deadline warns and samples anyway.
- Churn driver smoke-run with `T0` shifted back 450 minutes and a stub `kubectl`: 31
  `ROLLED` lines in the right order, six RSS samplers fired, window logged, shrink read
  `.spec.replicas` dynamically and restored it — including on `SIGTERM` mid-shrink.

Refs #682 #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
