### PR TITLE
fix(xds): alias the ODCDS authority on the mesh port, and re-seed the demand set on a fresh xDS stream (#682)

### DIFF
--- a/agent/internal/xds/cache/cachemetrics/cachemetrics.go
+++ b/agent/internal/xds/cache/cachemetrics/cachemetrics.go
@@ -40,6 +40,14 @@ type Metrics struct {
 	// dependency set — each is an undeclared upstream that should be
 	// promoted to a config.aether.io/upstreams annotation.
 	upstreamsMiss metric.Int64Counter
+	// upstreamsTTLRefreshed counts observed dependencies that crossed the idle
+	// TTL but were REFRESHED instead of expired because the node's proxy still
+	// holds a live on-demand subscription for them (issue #682). It is the only
+	// external evidence that the in-use exemption is doing anything: the
+	// exemption's whole effect is that nothing happens — no expiry, no cluster
+	// drop, no ODCDS re-warm — so without this counter a validator cannot tell
+	// a working exemption from a demand set that simply never aged.
+	upstreamsTTLRefreshed metric.Int64Counter
 	// bindingMismatch counts local source pods whose outbound clusters are
 	// bound to an SDS client-certificate secret that is NOT that pod's own
 	// SPIFFE ID (issue #638). Non-zero means the node's egress would present a
@@ -85,6 +93,10 @@ func New(meter metric.Meter) (*Metrics, error) {
 		metric.WithDescription("ODCDS requests for services outside the node dependency set (undeclared upstreams; promote to annotations)")); err != nil {
 		return nil, fmt.Errorf("upstreams miss: %w", err)
 	}
+	if m.upstreamsTTLRefreshed, err = meter.Int64Counter("aether.agent.upstreams.ttl_refreshed",
+		metric.WithDescription("Observed dependencies past the idle TTL kept in the node dependency set because the proxy still holds a live on-demand subscription")); err != nil {
+		return nil, fmt.Errorf("upstreams ttl refreshed: %w", err)
+	}
 	if m.bindingMismatch, err = meter.Int64Counter("aether.agent.identity.outbound_binding_mismatch",
 		metric.WithDescription("Local source pods whose outbound clusters are bound to another workload's SDS client-certificate secret")); err != nil {
 		return nil, fmt.Errorf("outbound binding mismatch: %w", err)
@@ -121,6 +133,17 @@ func (m *Metrics) UpstreamMiss(ctx context.Context, _ string) {
 		return
 	}
 	m.upstreamsMiss.Add(ctx, 1)
+}
+
+// UpstreamTTLRefreshed counts n observed dependencies exempted from idle expiry
+// in one prune pass by a live on-demand subscription (issue #682). Service names
+// are deliberately NOT attributes (unbounded cardinality). A no-op for n <= 0 so
+// the steady state — nothing near its TTL — records nothing.
+func (m *Metrics) UpstreamTTLRefreshed(ctx context.Context, n int64) {
+	if m == nil || n <= 0 {
+		return
+	}
+	m.upstreamsTTLRefreshed.Add(ctx, n)
 }
 
 // Generated records the outcome of one snapshot generation.

--- a/agent/internal/xds/cache/cachemetrics/cachemetrics_test.go
+++ b/agent/internal/xds/cache/cachemetrics/cachemetrics_test.go
@@ -55,6 +55,25 @@ func TestCacheMetrics_NilReceiverSafe(t *testing.T) {
 	var m *Metrics
 	m.Generated(context.Background(), 0.01, 1, nil)
 	m.Generated(context.Background(), 0.01, 1, errors.New("boom"))
+	m.UpstreamTTLRefreshed(context.Background(), 3)
+}
+
+// TestCacheMetrics_UpstreamTTLRefreshed verifies the in-use exemption counter
+// sums across prune passes and records nothing when no entry was exempted.
+func TestCacheMetrics_UpstreamTTLRefreshed(t *testing.T) {
+	m, reader := newTestMetrics(t)
+	ctx := context.Background()
+
+	m.UpstreamTTLRefreshed(ctx, 0)
+	if _, found := metricValue(t, reader, "aether.agent.upstreams.ttl_refreshed"); found {
+		t.Error("a prune pass that exempted nothing must record nothing")
+	}
+
+	m.UpstreamTTLRefreshed(ctx, 2)
+	m.UpstreamTTLRefreshed(ctx, 3)
+	if got, _ := metricValue(t, reader, "aether.agent.upstreams.ttl_refreshed"); got != 5 {
+		t.Errorf("ttl_refreshed = %d, want 5", got)
+	}
 }
 
 func TestCacheMetrics_GeneratedSuccess(t *testing.T) {

--- a/agent/internal/xds/cache/cluster.go
+++ b/agent/internal/xds/cache/cluster.go
@@ -3,12 +3,14 @@ package cache
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
 
 	"aethermesh.dev/agent/internal/xds/proxy"
 	registryv1 "aethermesh.dev/api/aether/registry/v1"
+	meshconst "aethermesh.dev/common/constants/mesh"
 	"aethermesh.dev/registry"
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -333,7 +335,7 @@ func (c *SnapshotCache) buildHTTPServiceEntryLocked(serviceName string, endpoint
 		sni:            strconv.Itoa(int(defaultPort)),
 	}
 
-	c.buildDefaultPortAliasLocked(serviceName, fqdn, defaultPort, sanNamespaces, sortedKeys)
+	c.buildPortAliasesLocked(serviceName, fqdn, defaultPort, sanNamespaces, sortedKeys, buckets)
 
 	// One cluster per non-default advertised port.
 	for port, b := range buckets {
@@ -353,16 +355,30 @@ func (c *SnapshotCache) buildHTTPServiceEntryLocked(serviceName string, endpoint
 	}
 }
 
-// buildDefaultPortAliasLocked stores the cold-path alias cluster for a service's
-// DEFAULT port: "<fqdn>:<defaultPort>". Caller must hold clusterMu.
+// buildPortAliasesLocked stores the cold-path alias clusters for the ports an
+// ODCDS ":authority" can legitimately carry for a service but that have no
+// per-port cluster of their own: "<fqdn>:<port>". Caller must hold clusterMu.
 //
 // The ODCDS catch-all resolves its cluster from the request :authority
 // (onDemandClusterHeader), and a client addressing a service on a non-80 port
-// sends "<fqdn>:<port>" as the authority. For every NON-default port that name
-// is a real per-port cluster; for the default port it was nothing at all — the
-// portless "<fqdn>" cluster carries the traffic and buildHTTPEndpointBuckets
-// deliberately skips the default port. So an on-demand request for a
-// default-port authority named a cluster the agent could never publish.
+// sends "<fqdn>:<port>" as the authority. For every NON-default advertised port
+// that name is a real per-port cluster; for the two ports below it was nothing
+// at all, so an on-demand request for them named a cluster the agent could
+// never publish:
+//
+//   - The MESH port (meshconst.ProxyOutboundPort, 18081). This is the port every
+//     mesh VIP Service advertises — the registrar's Service generator writes
+//     exactly one ServicePort, MeshPort, on every generated Service — so it is
+//     the port a client resolving through mesh DNS actually dials, and therefore
+//     the authority the catch-all sees in production. It is NOT in the registry
+//     endpoints at all: registryv1.ServiceEndpoint.port is the APPLICATION port
+//     (endpoint.aether.io/port, projected onto the Service as the aether.io/port
+//     annotation), which for the soak's echo is 8080 while the dialed Service
+//     port is 18081. Deriving the alias from endpoints[0].GetPort() alone
+//     therefore published ":8080" and left ":18081" — the name that actually
+//     wedged for 5m10s on 2026-09-05 — unpublished on every node.
+//   - The DEFAULT/application port, which the default entry's own vhost claims
+//     as a host-match domain, so a client that dials it must find a cluster too.
 //
 // That is not merely a slow cold path, it is a permanent wedge (issue #682):
 // go-control-plane only lists a name in a wildcard delta response's
@@ -373,31 +389,54 @@ func (c *SnapshotCache) buildHTTPServiceEntryLocked(serviceName string, endpoint
 // its vhost disappears, no ODCDS request ever reaches the agent again: every
 // request to that authority fails until the ADS stream resets.
 //
-// The alias fixes the name gap at the source — every mesh authority the
-// catch-all can produce for an in-scope service now resolves to a real cluster,
-// and an ODCDS miss is answered by the very next snapshot push. It shares the
-// default cluster's bare-service EDS (same endpoints, same SAN pinning, same
-// SNI) and carries NO vhost of its own: the default entry's vhost already
-// claims the "<fqdn>:<port>" domain, and a second vhost with that domain would
-// be a duplicate-domain RDS reject. Node proxies only — the edge serves an
-// explicit exposed set with no ODCDS catch-all (see BuildEdgeRouteConfiguration).
-func (c *SnapshotCache) buildDefaultPortAliasLocked(serviceName, fqdn string, defaultPort uint32, sanNamespaces, sortedKeys []string) {
+// An alias shares the default cluster's bare-service EDS (same endpoints, same
+// SAN pinning, same SNI) and carries NO vhost of its own: the default entry's
+// vhost already claims the "<fqdn>:<defaultPort>" domain and the capture route
+// domains already claim the mesh-port spelling, and a second vhost with either
+// domain would be a duplicate-domain RDS reject. A port that has a real per-port
+// cluster is skipped — that cluster is the authoritative, port-filtered EDS
+// membership and must not be shadowed by a whole-service alias. Node proxies
+// only: the edge serves an explicit exposed set with no ODCDS catch-all (see
+// BuildEdgeRouteConfiguration).
+func (c *SnapshotCache) buildPortAliasesLocked(serviceName, fqdn string, defaultPort uint32, sanNamespaces, sortedKeys []string, buckets map[uint32]*portBucket) {
 	if c.edge || fqdn == "" {
 		return
 	}
-	alias := proxy.PortClusterName(serviceName, c.meshDomain, defaultPort)
-	if alias == "" {
-		return
+	for _, port := range aliasAuthorityPorts(defaultPort, buckets) {
+		alias := proxy.PortClusterName(serviceName, c.meshDomain, port)
+		if alias == "" {
+			continue
+		}
+		c.clusters[alias] = clusterEntry{
+			// EDS resource name is the BARE service (not the alias): the alias is the
+			// same endpoint set as the default cluster, so it must not publish a
+			// second, duplicate load assignment.
+			cluster:       proxy.NewServiceCluster(alias, serviceName, serviceName, sortedKeys, c.perDownstreamConnectionPool()),
+			sanNamespaces: sanNamespaces,
+			service:       serviceName,
+			sni:           strconv.Itoa(int(port)),
+		}
 	}
-	c.clusters[alias] = clusterEntry{
-		// EDS resource name is the BARE service (not the alias): the alias is the
-		// same endpoint set as the default cluster, so it must not publish a
-		// second, duplicate load assignment.
-		cluster:       proxy.NewServiceCluster(alias, serviceName, serviceName, sortedKeys, c.perDownstreamConnectionPool()),
-		sanNamespaces: sanNamespaces,
-		service:       serviceName,
-		sni:           strconv.Itoa(int(defaultPort)),
+}
+
+// aliasAuthorityPorts returns the ports needing an alias cluster: the mesh VIP
+// Service port every client dials through mesh DNS, plus the service's default
+// (application) port, minus any port that already has its own per-port cluster
+// and minus 0 (an endpoint with no port). Deterministic order — the mesh port
+// first — so two rebuilds of the same input write the same entries (map order
+// is protocol-visible, see #135).
+func aliasAuthorityPorts(defaultPort uint32, buckets map[uint32]*portBucket) []uint32 {
+	ports := make([]uint32, 0, 2)
+	for _, p := range [...]uint32{meshconst.ProxyOutboundPort, defaultPort} {
+		if p == 0 || slices.Contains(ports, p) {
+			continue // 0 = unset; already emitted (the default port IS the mesh port)
+		}
+		if _, real := buckets[p]; real {
+			continue // a real per-port cluster owns this name
+		}
+		ports = append(ports, p)
 	}
+	return ports
 }
 
 // portBucket accumulates per-port endpoints for a service.

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -90,20 +90,7 @@ func (c *SnapshotCache) removePodDependencies(netns string) {
 // request arrived on is what keeps the entry alive past the idle TTL while the
 // proxy is still routing to it (issue #682).
 func (c *SnapshotCache) ObserveDependency(ctx context.Context, service string) bool {
-	if service == "" {
-		return false
-	}
-
-	c.depMu.Lock()
-	_, known := c.dependencySetLocked()[service]
-	c.observedDeps[service] = time.Now()
-	// Bump even on a pure timestamp refresh: the memoized expiry horizon
-	// (depSetExpiry) may extend, and a stale horizon would expire this
-	// entry from the served set too early.
-	c.bumpDepGenLocked()
-	c.depMu.Unlock()
-
-	if known {
+	if known, recorded := c.recordObservation(service); !recorded || known {
 		return false
 	}
 
@@ -112,6 +99,65 @@ func (c *SnapshotCache) ObserveDependency(ctx context.Context, service string) b
 	c.metrics.UpstreamMiss(ctx, service)
 	c.signalDependencyChange()
 	return true
+}
+
+// RestoreDependency re-admits a service the node's proxy ALREADY holds a cluster
+// for, as reported in the initial_resource_versions of the first delta request
+// on a fresh xDS stream. Returns true when the dependency is new to this
+// process. Same TTL'd membership as an observation, but it is deliberately NOT a
+// miss: the proxy is not asking for something new, the agent is recovering
+// demand it had already granted.
+//
+// Why this exists (issue #682, the ~20s post-restart echo outage on nodes with
+// no local replica, 2026-09-05 rev194): the observed half of the dependency set
+// is process-local memory, so a restarted agent's first snapshot legitimately
+// drops every ODCDS-acquired upstream, and Envoy 503s (NC) on the next request.
+// The cold path is supposed to repair that in one round trip — except a
+// reconnecting Envoy never re-asks. On a fresh stream Envoy marks every
+// requested resource "waiting for server", and its first request carries
+// initial_resource_versions for the resources it HOLDS plus
+// resource_names_subscribe for names newly added since — which, after
+// markStreamFresh clears the pending-add set, is nothing. A name it is still
+// waiting on appears in NEITHER field, and its on_demand filter dedupes every
+// later re-subscribe for a name already in that state, so no ODCDS request
+// reaches the new agent at all. On talos the outage ended only when Envoy's
+// 15s init-fetch timeout tore that subscription state down and the next request
+// re-subscribed from scratch: 14.05s (w01) / 14.67s (w03) of 503s, ~7 rounds of
+// the 2s on-demand timeout, with the agent logging nothing.
+//
+// The held-resource inventory is the evidence the agent was missing: it is the
+// proxy stating, in the protocol, exactly which clusters it is still running on.
+// Restoring from it re-seeds the demand set in the first request of the stream —
+// before the first snapshot push — so the upstream never leaves the snapshot.
+// Restored entries are plain observations, NOT live-subscription pins: anything
+// the proxy no longer routes to decays on the ordinary idle TTL, so demand
+// scoping still shrinks after a restart.
+func (c *SnapshotCache) RestoreDependency(ctx context.Context, service string) bool {
+	if known, recorded := c.recordObservation(service); !recorded || known {
+		return false
+	}
+
+	c.log.DebugContext(ctx, "restored observed upstream from the proxy's held clusters", "service", service)
+	c.signalDependencyChange()
+	return true
+}
+
+// recordObservation stamps an observation for service, reporting whether the
+// service was already in the dependency set and whether anything was recorded
+// at all (an empty name records nothing).
+func (c *SnapshotCache) recordObservation(service string) (known, recorded bool) {
+	if service == "" {
+		return false, false
+	}
+	c.depMu.Lock()
+	defer c.depMu.Unlock()
+	_, known = c.dependencySetLocked()[service]
+	c.observedDeps[service] = time.Now()
+	// Bump even on a pure timestamp refresh: the memoized expiry horizon
+	// (depSetExpiry) may extend, and a stale horizon would expire this
+	// entry from the served set too early.
+	c.bumpDepGenLocked()
+	return known, true
 }
 
 // TrackOnDemandCluster records a live on-demand (ODCDS) cluster subscription

--- a/agent/internal/xds/cache/dependencies.go
+++ b/agent/internal/xds/cache/dependencies.go
@@ -268,7 +268,13 @@ func (c *SnapshotCache) PruneObservedDependencies() {
 	c.depMu.Unlock()
 
 	if refreshed > 0 {
-		c.log.Debug("refreshed in-use observed upstreams (live on-demand subscription)", "count", refreshed)
+		// Info, not Debug: this is the only trace the in-use exemption leaves.
+		// Its entire effect is that nothing happens, so at Debug an operator
+		// cannot distinguish a working exemption from a demand set that never
+		// aged (issue #682 deployment validation). It fires at most once per
+		// prune tick, and only when an entry actually crossed its TTL.
+		c.log.Info("refreshed in-use observed upstreams (live on-demand subscription)", "count", refreshed)
+		c.metrics.UpstreamTTLRefreshed(context.Background(), int64(refreshed))
 	}
 	if expired > 0 {
 		c.log.Info("expired observed upstreams from node dependency set", "count", expired)

--- a/agent/internal/xds/cache/dependencies_test.go
+++ b/agent/internal/xds/cache/dependencies_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	xdsconst "aethermesh.dev/agent/internal/xds/xdsconst"
 	cniv1 "aethermesh.dev/api/aether/cni/v1"
 	registryv1 "aethermesh.dev/api/aether/registry/v1"
+	meshconst "aethermesh.dev/common/constants/mesh"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -450,6 +452,49 @@ func TestLoadClustersFromRegistry_MultiPort(t *testing.T) {
 	assert.Nil(t, alias.loadAssignment, "the alias publishes no second load assignment")
 	assert.Equal(t, "ns/svc-mp", alias.service, "the alias maps back to the service key (SAN/retention)")
 	assert.Equal(t, "8080", alias.sni)
+
+	// The MESH port gets an alias too, and it is the one that matters in
+	// production: every mesh VIP Service advertises exactly ProxyOutboundPort,
+	// so ":18081" — not the application port — is the authority a client
+	// resolving through mesh DNS dials, and the name the ODCDS catch-all
+	// requests. It is not in the registry endpoints at all (those carry
+	// application ports), so it must come from the mesh constant.
+	meshAlias, hasMeshAlias := c.clusters[fmt.Sprintf("svc-mp.ns.aether.internal:%d", meshconst.ProxyOutboundPort)]
+	require.True(t, hasMeshAlias, "the mesh Service port authority must resolve to a cluster (ODCDS cold path)")
+	assert.Equal(t, "ns/svc-mp", meshAlias.cluster.GetEdsClusterConfig().GetServiceName(),
+		"the mesh-port alias shares the default cluster's bare-service EDS")
+	assert.Nil(t, meshAlias.vhost, "the cap_http route domains already own the :18081 spelling")
+	assert.Nil(t, meshAlias.loadAssignment, "the alias publishes no second load assignment")
+	assert.Equal(t, "ns/svc-mp", meshAlias.service)
+}
+
+// TestLoadClustersFromRegistry_MeshPortServedAsRealPort verifies a service that
+// genuinely ADVERTISES the mesh port keeps its real, port-filtered per-port
+// cluster: the whole-service alias must never shadow it.
+func TestLoadClustersFromRegistry_MeshPortServedAsRealPort(t *testing.T) {
+	c := newTestCache("node-1")
+	c.SetMeshDomain("aether.internal")
+	declareDeps(c, "ns/svc-mp")
+	ctx := context.Background()
+
+	// ep1 serves 8080 (default) + the mesh port; ep2 only 8080.
+	ep1 := makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)
+	ep1.Ports = []uint32{8080, meshconst.ProxyOutboundPort}
+	ep2 := makeEndpoint("10.0.0.2", "cluster-1", "node-3", 8080)
+	ep2.Ports = []uint32{8080}
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			return map[string][]*registryv1.ServiceEndpoint{"ns/svc-mp": {ep1, ep2}}, nil
+		},
+	}
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+
+	real, ok := c.clusters[fmt.Sprintf("svc-mp.ns.aether.internal:%d", meshconst.ProxyOutboundPort)]
+	require.True(t, ok)
+	require.NotNil(t, real.loadAssignment, "the real per-port cluster keeps its own port-filtered EDS")
+	require.Len(t, real.loadAssignment.GetEndpoints(), 1, "only the pod advertising the port is a member")
+	assert.Equal(t, []string{fmt.Sprintf("svc-mp.ns.aether.internal:%d", meshconst.ProxyOutboundPort)},
+		real.vhost.GetDomains(), "the real per-port cluster keeps its vhost")
 }
 
 // TestDependencySet_IncludesGammaRouteTargets verifies a GAMMA route TARGET (an

--- a/agent/internal/xds/cache/odcds_test.go
+++ b/agent/internal/xds/cache/odcds_test.go
@@ -185,3 +185,51 @@ func TestObservedDependency_UnsubscribeReleasesTheTTLExemption(t *testing.T) {
 	c.PruneObservedDependencies()
 	assert.NotContains(t, c.DependencySet(), service)
 }
+
+// TestRestoreDependency_AnsweredInTheFirstPushAndStillDecays covers the
+// post-restart repair (#682): a fresh cache with an EMPTY dependency set,
+// re-seeded from the clusters the proxy reports it holds, must serve the
+// requested authority in its FIRST snapshot push — no ODCDS round trip, no
+// waiting for a periodic tick. And because a restored entry is an ordinary
+// TTL'd observation rather than a live-subscription pin, an upstream the proxy
+// has stopped using still ages out: the restore repairs demand scoping's blind
+// spot without disabling it.
+func TestRestoreDependency_AnsweredInTheFirstPushAndStillDecays(t *testing.T) {
+	const (
+		service   = "aether-test/echo"
+		fqdn      = "echo.aether-test.aether.internal"
+		authority = fqdn + ":18081"
+	)
+
+	ctx := context.Background()
+	c := newTestCache("node-1")
+	c.SetMeshDomain("aether.internal")
+	c.observedTTL = 30 * time.Millisecond
+
+	reg := &catalogListerRegistry{
+		mockRegistry: &mockRegistry{
+			listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+				return map[string][]*registryv1.ServiceEndpoint{
+					// The production shape: the registry carries the APPLICATION port.
+					service: {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 8080)},
+				}, nil
+			},
+		},
+		known: map[string]bool{service: true},
+	}
+
+	require.Empty(t, c.DependencySet(), "a restarted agent starts with nothing observed")
+	require.True(t, c.RestoreDependency(ctx, service), "the held cluster re-seeds the dependency set")
+
+	// ONE reload, and the authority the proxy is running on is already served.
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "node-1", reg))
+	first := snapshotClusterNames(t, c)
+	assert.Contains(t, first, authority, "the proxy's held authority must be in the FIRST push after a restart")
+	assert.Contains(t, first, fqdn)
+
+	// Not a pin: the restored entry is still subject to the idle TTL.
+	assert.Empty(t, c.OnDemandServices(), "a restored dependency is an observation, not a live subscription")
+	time.Sleep(40 * time.Millisecond)
+	c.PruneObservedDependencies()
+	assert.NotContains(t, c.DependencySet(), service, "a restored upstream nobody uses still ages out")
+}

--- a/agent/internal/xds/cache/odcds_test.go
+++ b/agent/internal/xds/cache/odcds_test.go
@@ -36,11 +36,33 @@ func snapshotClusterNames(t *testing.T, c *SnapshotCache) map[string]types.Resou
 // The assertion that matters: after the service is dropped from the dependency
 // set, ONE on-demand observation plus ONE reload must put the requested name
 // back in the published snapshot — no stream reset, no second round trip.
+//
+// Both port spellings the catch-all can produce are covered. The second case is
+// the production shape and the follow-up fix: the registry endpoint port is the
+// APPLICATION port (echo: 8080) while the mesh VIP Service — the only thing a
+// client can dial after mesh DNS hands it a portless A record — advertises
+// ProxyOutboundPort (18081). Deriving the alias from endpoints[0].GetPort()
+// alone published ":8080" and left ":18081" unpublished on every node, which is
+// exactly the authority that wedged for 5m10s on 2026-09-05; the first case
+// passed only because its app port happened to equal the dialed port.
 func TestODCDS_DefaultPortAuthorityIsAnsweredInOnePush(t *testing.T) {
+	t.Run("app port is the dialed port", func(t *testing.T) {
+		assertODCDSAuthorityAnsweredInOnePush(t, 18081, "echo.aether-test.aether.internal:18081")
+	})
+	t.Run("mesh Service port differs from the app port", func(t *testing.T) {
+		assertODCDSAuthorityAnsweredInOnePush(t, 8080, "echo.aether-test.aether.internal:18081")
+	})
+}
+
+// assertODCDSAuthorityAnsweredInOnePush warms a service whose endpoints
+// advertise appPort, drops it out of the demand set, then asserts that a single
+// on-demand observation of authority (the delta subscribe the proxy re-issues on
+// the SAME stream) plus a single reload republishes that exact name.
+func assertODCDSAuthorityAnsweredInOnePush(t *testing.T, appPort uint32, authority string) {
+	t.Helper()
 	const (
-		service   = "aether-test/echo"
-		fqdn      = "echo.aether-test.aether.internal"
-		authority = fqdn + ":18081"
+		service = "aether-test/echo"
+		fqdn    = "echo.aether-test.aether.internal"
 	)
 
 	ctx := context.Background()
@@ -53,7 +75,7 @@ func TestODCDS_DefaultPortAuthorityIsAnsweredInOnePush(t *testing.T) {
 		mockRegistry: &mockRegistry{
 			listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
 				return map[string][]*registryv1.ServiceEndpoint{
-					service: {makeEndpoint("10.0.0.1", "cluster-1", "node-2", 18081)},
+					service: {makeEndpoint("10.0.0.1", "cluster-1", "node-2", appPort)},
 				}, nil
 			},
 		},

--- a/agent/internal/xds/server/odcds.go
+++ b/agent/internal/xds/server/odcds.go
@@ -3,6 +3,9 @@ package server
 import (
 	"context"
 	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
 
 	"aethermesh.dev/agent/internal/xds/cache"
 	"aethermesh.dev/agent/internal/xds/proxy"
@@ -81,6 +84,7 @@ func (o *onDemandObserver) onDeltaRequest(streamID int64, req *discoveryv3.Delta
 	if req.GetTypeUrl() != resourcev3.ClusterType {
 		return nil
 	}
+	o.resumeHeldClusters(streamID, req.GetInitialResourceVersions())
 	for _, name := range req.GetResourceNamesUnsubscribe() {
 		o.cache.UntrackOnDemandCluster(streamID, name)
 	}
@@ -91,6 +95,93 @@ func (o *onDemandObserver) onDeltaRequest(streamID int64, req *discoveryv3.Delta
 		o.observeSubscription(streamID, name)
 	}
 	return nil
+}
+
+// resumeHeldClusters re-seeds the node dependency set from the clusters the
+// proxy reports it already HOLDS — the initial_resource_versions map, which the
+// delta protocol requires on the first request of every stream and which is
+// therefore empty on every subsequent one.
+//
+// This is what makes a fresh agent answer the proxy's live demand in its FIRST
+// push instead of ~15s later (issue #682; see SnapshotCache.RestoreDependency
+// for the full mechanism). The short version: a restarted agent starts with an
+// empty observed-dependency set and drops every ODCDS-acquired upstream from
+// its first snapshot, and a reconnecting Envoy will not re-ask for them — a name
+// it is still "waiting for server" on is in neither initial_resource_versions
+// nor resource_names_subscribe, and its on_demand filter dedupes every later
+// re-subscribe. On talos (rev194, 2026-09-05) that cost 14.05s of 503s on w01
+// and 14.67s on w03, ending only when Envoy's init-fetch timeout reset the
+// subscription state. The held inventory is the proxy telling the agent, in the
+// protocol, which clusters it is still running on; the agent simply has to read
+// it.
+//
+// Restored entries are ordinary TTL'd observations, never live-subscription
+// pins, so an upstream the proxy has stopped using still ages out of the demand
+// set. A held name whose service is gone from the catalog is skipped silently —
+// unlike an on-demand REQUEST, a stale held resource is not a client asking for
+// a ghost, so it is neither logged nor counted as a rejection.
+func (o *onDemandObserver) resumeHeldClusters(streamID int64, held map[string]string) {
+	if len(held) == 0 {
+		return
+	}
+	names := make([]string, 0, len(held))
+	for name := range held {
+		names = append(names, name)
+	}
+	// Deterministic order so the restore is reproducible across runs (map order
+	// is protocol-visible on the push that follows, see #135).
+	sort.Strings(names)
+
+	ctx := context.Background()
+	restored := 0
+	for _, name := range names {
+		service, ok := o.meshServiceKey(name)
+		if !ok {
+			continue
+		}
+		if cat, hasCatalog := o.registry.(registry.ServiceCatalog); hasCatalog && !cat.HasService(service) {
+			continue
+		}
+		if o.cache.RestoreDependency(ctx, service) {
+			restored++
+		}
+	}
+	if restored > 0 {
+		o.log.InfoContext(ctx, "restored node dependency set from the clusters the proxy still holds (fresh delta stream)",
+			"stream", streamID, "services", restored, "held", len(held))
+	}
+}
+
+// meshServiceKey maps a held cluster resource name to its dependency-set service
+// key, accepting ONLY a plain mesh service cluster: "<svc>.<ns>.<meshDomain>"
+// with an optional ":<port>" authority suffix. Everything else the proxy holds
+// is not a demand-set entry — per-pod app_/health_ clusters, the "tcp:" floor
+// clusters (whose service is pinned by captureTCPDeps anyway), the passthrough
+// cluster — and a lenient match would mint bogus keys like "ns/tcp:svc".
+func (o *onDemandObserver) meshServiceKey(name string) (string, bool) {
+	if name == "" || name == "*" || proxy.IsPerPodClusterName(name) {
+		return "", false
+	}
+	meshDomain := o.cache.MeshDomain()
+	service, ok := proxy.ServiceFromClusterName(name, meshDomain)
+	if !ok {
+		return "", false
+	}
+	base := proxy.ServiceClusterName(service, meshDomain)
+	if base == "" {
+		return "", false
+	}
+	if name == base {
+		return service, true
+	}
+	port, isPortSuffixed := strings.CutPrefix(name, base+":")
+	if !isPortSuffixed {
+		return "", false
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return "", false
+	}
+	return service, true
 }
 
 // observeSubscription maps one named delta CDS subscription to its service key,

--- a/agent/internal/xds/server/odcds_test.go
+++ b/agent/internal/xds/server/odcds_test.go
@@ -139,3 +139,79 @@ func TestOnDemandObserver_TracksLiveSubscriptionsForTTLExemption(t *testing.T) {
 	}))
 	assert.Empty(t, c.OnDemandServices(), "a ghost service can never pin a dependency")
 }
+
+// TestOnDemandObserver_ResumesHeldClustersOnAFreshStream is the #682
+// post-restart regression test.
+//
+// The observed half of the node dependency set is process-local memory, so a
+// restarted agent starts empty and its first snapshot drops every
+// ODCDS-acquired upstream — and a reconnecting Envoy never re-asks for them: a
+// name it is still "waiting for server" on appears in neither
+// initial_resource_versions nor resource_names_subscribe (markStreamFresh
+// clears the pending-add set), and the on_demand filter dedupes every later
+// re-subscribe. On talos (rev194, 2026-09-05) that was 14.05s of 503s on w01
+// and 14.67s on w03 with the agent logging nothing, ending only when Envoy's
+// init-fetch timeout reset its subscription state.
+//
+// The clusters the proxy reports it HOLDS are the evidence: the first request
+// of the stream must re-seed the dependency set from them, with no named
+// subscribe at all.
+func TestOnDemandObserver_ResumesHeldClustersOnAFreshStream(t *testing.T) {
+	c := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
+	reg := &catalogRegistry{mockRegistry: &mockRegistry{}, known: map[string]bool{
+		"aether-test/echo": true,
+		"team-a/svc-tcp":   true,
+	}}
+	o := newOnDemandObserver(c, reg, slog.New(slog.DiscardHandler))
+
+	// The reconnect handshake: everything the proxy still holds, NOTHING newly
+	// subscribed — exactly what Envoy sends after the agent restarts.
+	require.NoError(t, o.Callbacks().OnStreamDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl: resourcev3.ClusterType,
+		InitialResourceVersions: map[string]string{
+			"echo.aether-test.aether.internal":       "v7",
+			"echo.aether-test.aether.internal:18081": "v7",
+			"app_pod-1_8080":                         "v7",
+			"health_pod-1":                           "v7",
+			"tcp:svc-tcp.team-a.aether.internal":     "v7",
+			"ghost.team-a.aether.internal":           "v7",
+			"passthrough":                            "v7",
+		},
+	}))
+
+	deps := c.DependencySet()
+	assert.Contains(t, deps, "aether-test/echo",
+		"a held cluster re-seeds the dependency set on the first request of the stream")
+	assert.NotContains(t, deps, "team-a/svc-tcp",
+		"the tcp: floor cluster is not a mesh service authority (it must not mint 'team-a/tcp:svc-tcp' either)")
+	assert.NotContains(t, deps, "team-a/tcp:svc-tcp")
+	assert.NotContains(t, deps, "team-a/ghost", "a held cluster whose service left the catalog is not restored")
+	assert.Len(t, deps, 1, "per-pod and non-mesh names are ignored; both echo spellings collapse to one key")
+
+	// Restored entries are observations, not live-subscription pins: an upstream
+	// the proxy has stopped using must still age out of the demand set.
+	assert.Empty(t, c.OnDemandServices(), "a held resource is not a live on-demand subscription")
+}
+
+// TestOnDemandObserver_ResumeIsIdempotentAndFirstRequestOnly verifies the resume
+// pass costs nothing on the steady-state requests of a stream (Envoy sends
+// initial_resource_versions only on the first request of each stream) and never
+// resurrects a service the demand set has deliberately dropped since.
+func TestOnDemandObserver_ResumeIsIdempotentAndFirstRequestOnly(t *testing.T) {
+	c := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
+	reg := &catalogRegistry{mockRegistry: &mockRegistry{}, known: map[string]bool{"aether-test/echo": true}}
+	o := newOnDemandObserver(c, reg, slog.New(slog.DiscardHandler))
+
+	held := &discoveryv3.DeltaDiscoveryRequest{
+		TypeUrl:                 resourcev3.ClusterType,
+		InitialResourceVersions: map[string]string{"echo.aether-test.aether.internal:18081": "v7"},
+	}
+	require.NoError(t, o.onDeltaRequest(1, held))
+	require.Contains(t, c.DependencySet(), "aether-test/echo")
+	require.NoError(t, o.onDeltaRequest(1, held))
+	assert.Len(t, c.DependencySet(), 1, "re-running the resume pass is idempotent")
+
+	// A steady-state ACK carries no held inventory and changes nothing.
+	require.NoError(t, o.onDeltaRequest(1, &discoveryv3.DeltaDiscoveryRequest{TypeUrl: resourcev3.ClusterType}))
+	assert.Len(t, c.DependencySet(), 1)
+}


### PR DESCRIPTION
Follow-up to #691. Deployment validation on talos-main (rev194, 2026-09-05 13:34Z) confirmed the stall fix works — two deliberate demand-set shrinks produced **0 ODCDS stalls and 0 prober errors** on the two no-local-replica nodes (w01/w03), against **+133/+134** at the 09-05 teardown — but surfaced two defects. Both are fixed here, one commit each, plus the observability gap that made the TTL half unverifiable.

## Commit 1 — the alias was built from the wrong port

`buildDefaultPortAliasLocked` derived the alias port from `endpoints[0].GetPort()`: the **registry endpoint port**, which is the **application** port (`endpoint.aether.io/port`, default 8080). That is not a port any client dials.

Mesh DNS answers a portless A record for the mesh VIP Service, and every mesh VIP Service advertises exactly one port — `meshconst.ProxyOutboundPort` (18081), synthesized by the registrar's Service generator (`MeshPort`), matched by the CNI's capture `dport` rule, and claimed by the `cap_http` route domains. So the authority the ODCDS catch-all actually sees in production is `<fqdn>:18081`.

Validation found exactly that: the only port-suffixed echo cluster present on w01 was `echo.aether-test.aether.internal:8080`, and **no `:18081` cluster existed on any node** — the exact name that stalled for 5m10s on 09-05:

```
cm odcds: on-demand discovery for cluster echo.aether-test.aether.internal:18081 timed out
```

The shrink test passed only because commit 2 of #691 (the TTL exemption) kept echo in the dependency set, so the `:18081` path was never exercised.

Publish an alias for every port an ODCDS authority can legitimately carry that has no per-port cluster of its own: the **mesh port** and the **default/application port** (the default entry's own vhost claims the latter as a host-match domain). A port that IS a real advertised port keeps its own port-filtered per-port cluster — the whole-service alias never shadows it. Alias order is deterministic because map order is protocol-visible (#135).

`TestODCDS_DefaultPortAuthorityIsAnsweredInOnePush` now covers both spellings. The new *"mesh Service port differs from the app port"* case reproduces production (app port 8080, dialed port 18081) and fails on the pre-fix tree with the deployment symptom:

```
map[...]{"echo.aether-test.aether.internal", "…:8080"}
  does not contain "echo.aether-test.aether.internal:18081"
```

`TestLoadClustersFromRegistry_MultiPort` gains the mesh-port alias assertions, and `TestLoadClustersFromRegistry_MeshPortServedAsRealPort` pins the no-shadowing rule.

## Commit 2 — the ~20s echo outage after every agent restart

### Before-state (talos-main, rev194, 2026-09-05)

```
w01: CNI conflist re-assert loop started            13:34:46.317Z
     observed undeclared upstream (ODCDS miss) echo 13:35:05.052Z   (+19s)
w03: CNI conflist re-assert loop started            13:35:11.650Z
     observed undeclared upstream (ODCDS miss) echo 13:35:31.669Z   (+20s)
```

Prober `http_error` **+130 (w01) / +127 (w03)** inside those windows, then flat; the new `AetherProberHTTPErrorBurst` alert fired and resolved. On the 09-05 soak (rev192) the agent roll at 02:35:51Z produced **zero** `http_error` at the next checkpoint.

### The agent is not slow

The xDS socket was accepting **1.8s** after the anchor (13:34:48.125Z). PreListen did not stall — no `registry watch cache not complete in time`, no `registry unavailable for initial snapshot`. The catalog was healthy — no `rejecting on-demand request for unknown service`. No TTL expiry fired — no `expired observed upstreams`, and `service left dependency set` appears only for an unrelated service outside the window.

The access logs pin the outage exactly:

* exactly **133 × 503 `cluster_not_found` / `NC`** per node, **echo only** (`uds-echo` and `uds-cr-echo` served 200 throughout the same window, so the proxy, its mTLS and its other clusters were fine);
* echo at 10 rps up to 13:34:50, **zero 13:34:51 → 13:35:04**, back to 10 rps at 13:35:05;
* NC request durations min 2ms / avg 1014ms / **max 2003ms** — precisely `onDemandClusterTimeout = 2s`, with releases batched every 2s, ~7 rounds.

So Envoy's `on_demand` filter **was** engaging and timing out, while the agent's `onDeltaRequest` callback — which logs synchronously on any named delta-CDS subscribe — logged nothing for **14.05s (w01) / 14.67s (w03)**.

### Mechanism

The observed half of the dependency set is process-local memory, so a restarted agent's first snapshot legitimately drops every ODCDS-acquired upstream. That is meant to cost one round trip — except **a reconnecting Envoy never re-asks**:

* `markStreamFresh()` puts every requested resource back into *waiting for server* and **clears the pending-add set**;
* the first request of the new stream carries `initial_resource_versions` only for resources it **holds**, and `resource_names_subscribe` only for names added **since**;
* a name it is still waiting on is in **neither** field, and `updateSubscriptionInterest` dedupes every later re-subscribe for a name already in `requested_resource_state_`.

So nothing reaches the new agent at all until Envoy's 15s init-fetch timeout tears that subscription state down and the next request re-subscribes from scratch — hence 14–15s, hence the total silence on the agent side, and hence why this is invisible on a node where echo is a *declared* upstream (a pod annotation survives the restart; an observation does not).

### The fix

`initial_resource_versions` is the evidence the agent was ignoring: it is the proxy stating, in the protocol, exactly which clusters it is still running on. `resumeHeldClusters` re-seeds the node dependency set from it on the first request of every delta CDS stream — **before** the first snapshot push — so the upstream never leaves the snapshot at all.

Restored entries are ordinary **TTL'd observations, not live-subscription pins**: an upstream the proxy has stopped using still ages out, so demand scoping still shrinks after a restart. They are also **not counted as ODCDS misses** — the proxy is not asking for something new, the agent is recovering demand it had already granted, and counting them would drown the miss metric (the signal to promote an upstream to an annotation) in one burst per restart. Only plain mesh service clusters are accepted, `<svc>.<ns>.<domain>` with an optional `:<port>` suffix: per-pod `app_`/`health_` clusters, the `tcp:` floor clusters (a lenient match would mint keys like `ns/tcp:svc`) and the passthrough cluster are not demand-set entries, and a held name whose service has left the catalog is skipped silently rather than counted as a rejection.

Tests — all three fail with the resume pass stubbed out:

* `TestOnDemandObserver_ResumesHeldClustersOnAFreshStream` — the reconnect handshake with **no named subscribe at all**, plus the name filtering and the no-pin rule;
* `TestOnDemandObserver_ResumeIsIdempotentAndFirstRequestOnly`;
* `TestRestoreDependency_AnsweredInTheFirstPushAndStillDecays` — fresh cache, empty dependency set, registry loaded: the requested authority is in the **first** push, and still decays.

## Commit 3 — observability for the TTL half

The in-use exemption's entire effect is that nothing happens, and its only trace was a Debug line, so the validator could not observe it working. Add `aether.agent.upstreams.ttl_refreshed`, incremented per exempted entry per prune pass alongside the existing `aether.agent.upstreams.*` instruments and nil-receiver-safe like the rest of `cachemetrics` (a no-op for `n <= 0`). The accompanying log moves to Info for the same reason — it fires at most once per prune tick and only when an entry actually crossed its TTL.

## Validation

`make format`, `bazel test //...` (96/96 pass), lint with `--config=lint --@aspect_rules_lint//lint:fail_on_violation` on the touched packages. No chart change.

Not covered here: re-running the shrink test with the `:18081` alias actually present (the path that was never exercised), and confirming the post-restart gap is gone on the next roll — both belong to the next deployment validation.

Refs #682

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
