### PR TITLE
chore(proxy): pin aether chart to aether-proxy:51ba129 (first bzlmod build, Envoy main snapshot) (#697)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.1"
+version: "0.92.2"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -281,10 +281,10 @@ proxy:
   # commit SHA. Mirror by overriding `repository`.
   image:
     repository: ghcr.io/bpalermo/aether/aether-proxy
-    tag: 4212e13aa585add5d3884903e32a3c85cac796c5
+    tag: 51ba12979d545bcde021d81ef9151355db7c6a07
     # Digest-pinned (option A): content-addressed, tamper-proof. The aether.image
-    # helper prefers digest over tag. Envoy v1.39.0 multi-arch index (#534).
-    digest: "sha256:a749fcce573a1d93822dc9f36a6e287e30a01fbaed6eaca8f2aaa30b91a74924"
+    # helper prefers digest over tag. Multi-arch index for 51ba12979d545bcde021d81ef9151355db7c6a07.
+    digest: "sha256:9e401334408d8f87d59d0c409d957553d56938fb373b258eab002d3e655bd8a3"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application logs as one JSON object per line (bootstrap


### PR DESCRIPTION
Opened by hand from the branch `proxy-release` run 33985382585 pushed: the workflow's `bump-chart` job (rewritten in #705 to update `digest:` as well as `tag:`, per #703) produced this exact diff and then failed only at PR creation — the repository's Actions permission "allow GitHub Actions to create and approve pull requests" is off (#703).

Pins `aether-proxy` to the first bzlmod-built image (`51ba129`, envoyproxy `1.40.0-dev.20260904.13144fb.envoy`, registry `bed06c78`, wasm + dynamic modules + hickory trimmed):

- `tag:` `4212e13…` → `51ba129…`
- `digest:` `sha256:a749fcce…` (v1.39.0 index, #534) → `sha256:9e401334…` (verified: `docker buildx imagetools inspect --raw … | sha256sum` on the multi-arch index, amd64 + arm64)
- `Chart.yaml` 0.92.1 → 0.92.2

This is the first time the automated pin changes the deployed image, since `aether.image` prefers `digest:` (#703).

Post-merge on talos: `helm upgrade` to 0.92.2, roll the proxy DaemonSet to force a hot restart, and assert `aether_requests_total{reporter,source_service,…}` labels survive on the merged counters (envoy#45674 is in this snapshot) — then #695 step 4 (retire the `stats_tags` regexes) becomes a follow-up.

Refs #697 #703 #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr