### PR TITLE
chore: retire the aether_stats stats_tags regex workaround (#695 step 4)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.2"
+version: "0.92.3"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-proxy-configmap.yaml
+++ b/charts/aether/templates/agent-proxy-configmap.yaml
@@ -146,35 +146,19 @@ data:
         # collapse to listener.{inbound,out_http}.* labeled by aether.pod.
         - tag_name: aether.pod
           regex: "^listener\\.(?:inbound|out_http)(_([^.]+))\\."
-        # aether_stats (proposal 012) records via counterFromStatNameWithTags,
-        # which inlines the tag VALUES into the full stat name
-        # (aether.requests_total.reporter.<v>.source_service.<v>.…). On the
-        # filter's own write path those values are real Stats tags — but the
-        # node proxy hot-restarts on every config change (talos-main hit epoch
-        # 53), and Envoy's StatMerger re-creates each counter across a restart
-        # via counterFromStatName() with NO tags
-        # ("TODO(snowp): Propagate tag values during hot restarts" in
-        # stat_merger.cc). After the first restart the programmatic tags are
-        # gone and the values collapse into the metric name with empty labels
-        # (the talos-main symptom). These regexes re-derive the six tags from
-        # the name exactly the way aether.cluster survives — tag_name MUST match
-        # the seven programmatic keys in aether_stats.cc so fresh and merged
-        # counters export identical labels. Values are dot-free, so [^.]* is exact.
-        # Guarded by //source/extensions/filters/http/aether_stats:tag_extraction_test.
-        - tag_name: reporter
-          regex: "(\\.reporter\\.([^.]*))"
-        - tag_name: source_service
-          regex: "(\\.source_service\\.([^.]*))"
-        - tag_name: source_pod
-          regex: "(\\.source_pod\\.([^.]*))"
-        - tag_name: destination_service
-          regex: "(\\.destination_service\\.([^.]*))"
-        - tag_name: destination_pod
-          regex: "(\\.destination_pod\\.([^.]*))"
-        - tag_name: response_code
-          regex: "(\\.response_code\\.([^.]*))"
-        - tag_name: response_flags
-          regex: "(\\.response_flags\\.([^.]*))"
+        # NOTE: aether_stats (proposal 012) records via
+        # counterFromStatNameWithTags. There is deliberately NO regex here for
+        # its programmatic keys (reporter/source_service/source_pod/
+        # destination_service/destination_pod/response_code/response_flags):
+        # since envoyproxy/envoy#45674 — in the pinned proxy snapshot, runtime
+        # flag envoy.reloadable_features.hot_restart_propagate_stat_tags
+        # default on — the hot restart parent transmits the tag metadata and
+        # the child re-creates the counter with its tags, so they survive a
+        # restart natively (they used to be dropped by StatMerger and had to be
+        # re-derived from the stat name here). The no-regex invariant is
+        # guarded by
+        # //source/extensions/filters/http/aether_stats:tag_extraction_test in
+        # the proxy workspace.
       stats_matcher:
         exclusion_list:
           patterns:

--- a/proxy/source/extensions/filters/http/aether_stats/BUILD
+++ b/proxy/source/extensions/filters/http/aether_stats/BUILD
@@ -62,14 +62,29 @@ envoy_cc_test(
     ],
 )
 
-# Guards the stats_tags regexes in charts/agent/templates/configmap.yaml that let
-# the aether_stats tags survive a hot restart (StatMerger drops programmatic tags).
+# Guards the no-regex invariant behind aether#695: a counter the filter writes
+# with programmatic tags keeps those tags when StatMerger merges it across a hot
+# restart (envoyproxy/envoy#45674), with NO aether_stats stats_tags regexes in
+# charts/aether/templates/agent-proxy-configmap.yaml. Also pins the pre-fix
+# behaviour (propagation runtime guard off) and the two chart regexes that stay.
 envoy_cc_test(
     name = "tag_extraction_test",
     srcs = ["tag_extraction_test.cc"],
     repository = "@envoy",
     deps = [
+        ":aether_stats_lib",
+        ":pkg_cc_proto",
+        "@abseil-cpp//absl/strings",
+        "@envoy//source/common/runtime:runtime_features_lib",
+        "@envoy//source/common/stats:allocator_lib",
+        "@envoy//source/common/stats:stat_merger_lib",
+        "@envoy//source/common/stats:symbol_table_lib",
         "@envoy//source/common/stats:tag_producer_lib",
+        "@envoy//source/common/stats:thread_local_store_lib",
+        "@envoy//test/mocks/server:server_factory_context_mocks",
+        "@envoy//test/mocks/stream_info:stream_info_mocks",
+        "@envoy//test/mocks/upstream:cluster_info_mocks",
+        "@envoy//test/test_common:utility_lib",
         "@envoy_api//envoy/config/metrics/v3:pkg_cc_proto",
     ],
 )

--- a/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
@@ -3,108 +3,301 @@
 
 #include "envoy/config/metrics/v3/stats.pb.h"
 
+#include "source/common/protobuf/protobuf.h"
+#include "source/common/runtime/runtime_features.h"
+#include "source/common/stats/allocator.h"
+#include "source/common/stats/stat_merger.h"
+#include "source/common/stats/symbol_table.h"
 #include "source/common/stats/tag_producer_impl.h"
+#include "source/common/stats/thread_local_store.h"
+#include "source/extensions/filters/http/aether_stats/aether_stats.h"
 
+#include "test/mocks/server/server_factory_context.h"
+#include "test/mocks/stream_info/mocks.h"
+#include "test/mocks/upstream/cluster_info.h"
+#include "test/test_common/utility.h"
+
+#include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+// Guards the invariant that replaced the chart's stats_tags regex workaround
+// (aether#695).
+//
+// History: aether_stats (proposal 012) records via counterFromStatNameWithTags,
+// which inlines the tag VALUES into the full stat name
+// (aether.requests_total.reporter.<v>.source_service.<v>....). The node proxy
+// hot-restarts on every config change (talos-main hit epoch 53), and Envoy's
+// StatMerger used to re-create every merged counter via counterFromStatName()
+// with NO tags ("TODO(snowp): Propagate tag values during hot restarts"). After
+// the first restart the programmatic tags were gone and their values collapsed
+// into the metric name with empty labels. charts/aether papered over that with
+// one stats_tags regex per programmatic key, re-deriving the tags from the name.
+//
+// envoyproxy/envoy#45674 (in the pinned Envoy snapshot) makes the hot restart
+// parent transmit the tag metadata (hot_restart.proto TaggedMetric /
+// counter_tags) and the child re-create the counter via
+// counterFromMergedStatName, so the tags survive natively. This test asserts
+// exactly that, with NO aether_stats stats_tags regexes configured: what the
+// child gets back must be indistinguishable from the fresh, filter-written
+// counter. The negative test pins the pre-fix behaviour so the difference the
+// propagation makes stays explicit.
 namespace Envoy {
-namespace Stats {
+namespace Extensions {
+namespace HttpFilters {
+namespace AetherStats {
 namespace {
 
-// Builds the production stats tag producer (mirrors the stats_tags in
-// charts/agent/templates/configmap.yaml) and asserts the aether_stats tags are
-// recovered by regex from the full counter name.
-//
-// Why this matters: the aether_stats filter records via
-// counterFromStatNameWithTags, which inlines the tag VALUES into the full stat
-// name. Across a hot restart (the node proxy hot-restarts on every config
-// change — talos-main was at epoch 53), Envoy's StatMerger re-materialises the
-// counter via counterFromStatName(full_name) with NO tags
-// ("TODO(snowp): Propagate tag values during hot restarts" in stat_merger.cc).
-// The only thing that then recovers reporter/source_service/... as real tags is
-// regex extraction — exactly how aether.cluster already survives. Without these
-// regexes the tags collapse into the metric name with empty labels, which is the
-// talos-main symptom.
-TagProducerPtr prodTagProducer() {
+using testing::NiceMock;
+using testing::ReturnRef;
+
+// The child gates the tag metadata on this guard (hot_restarting_child.cc). It
+// is a default-true RUNTIME_GUARD in the pinned snapshot. When upstream retires
+// the guard, `runtimeFeatureEnabled` will ENVOY_BUG on the unknown name — at
+// that point drop TagsLostWhenPropagationDisabled and the RuntimeGuard helper.
+constexpr absl::string_view kPropagateTagsFlag =
+    "envoy.reloadable_features.hot_restart_propagate_stat_tags";
+
+// Flips a runtime guard for the duration of a test and restores it.
+class RuntimeGuard {
+public:
+  RuntimeGuard(absl::string_view name, bool value)
+      : name_(name), previous_(Runtime::runtimeFeatureEnabled(name)) {
+    Runtime::maybeSetRuntimeGuard(name_, value);
+  }
+  ~RuntimeGuard() { Runtime::maybeSetRuntimeGuard(name_, previous_); }
+
+private:
+  const absl::string_view name_;
+  const bool previous_;
+};
+
+// The stats_tags the chart keeps after aether#695: aether.cluster and
+// aether.pod only, both extracted from Envoy's OWN stat names. Deliberately no
+// regex for any aether_stats programmatic key — that is the invariant under
+// test. Envoy tag semantics: the first capture group is removed from the stat
+// name, the tag value is the second group.
+Stats::TagProducerPtr productionTagProducer() {
   envoy::config::metrics::v3::StatsConfig config;
   config.mutable_use_all_default_tags()->set_value(false);
-  const auto add = [&](absl::string_view name, absl::string_view re) {
-    auto* t = config.add_stats_tags();
-    t->set_tag_name(std::string(name));
-    t->set_regex(std::string(re));
+  const auto add = [&](absl::string_view name, absl::string_view regex) {
+    auto* tag = config.add_stats_tags();
+    tag->set_tag_name(std::string(name));
+    tag->set_regex(std::string(regex));
   };
-  // Pre-existing tags.
   add("aether.cluster", "^cluster\\.(([^.]+)\\.)");
   add("aether.pod", "^listener\\.(?:inbound|out_http)(_([^.]+))\\.");
-  // aether_stats tags — names MUST match the programmatic tag keys in
-  // aether_stats.cc so a fresh (epoch-0) counter and a hot-restart-merged
-  // counter export identical labels.
-  add("reporter", "(\\.reporter\\.([^.]*))");
-  add("source_service", "(\\.source_service\\.([^.]*))");
-  add("source_pod", "(\\.source_pod\\.([^.]*))");
-  add("destination_service", "(\\.destination_service\\.([^.]*))");
-  add("destination_pod", "(\\.destination_pod\\.([^.]*))");
-  add("response_code", "(\\.response_code\\.([^.]*))");
-  add("response_flags", "(\\.response_flags\\.([^.]*))");
-  return TagProducerImpl::createTagProducer(config, {}).value();
+  return Stats::TagProducerImpl::createTagProducer(config, {}).value();
 }
 
-std::map<std::string, std::string> extract(const std::string& name, std::string& tag_extracted) {
-  TagVector tags;
-  tag_extracted = prodTagProducer()->produceTags(name, tags);
-  std::map<std::string, std::string> m;
-  for (const auto& t : tags) {
-    m[t.name_] = t.value_;
+// One Envoy process' stats plane: a real thread-local store carrying the
+// production tag producer, plus the factory-context mock the filter reads its
+// scope from.
+struct StatsProcess {
+  StatsProcess() {
+    store_.setTagProducer(productionTagProducer());
+    ON_CALL(context_, scope()).WillByDefault(ReturnRef(*store_.rootScope()));
   }
-  return m;
+
+  Stats::SymbolTableImpl symbol_table_;
+  Stats::Allocator alloc_{symbol_table_};
+  Stats::ThreadLocalStoreImpl store_{alloc_};
+  NiceMock<Server::Configuration::MockServerFactoryContext> context_;
+};
+
+class HotRestartTagPropagationTest : public testing::Test {
+protected:
+  HotRestartTagPropagationTest() {
+    stream_info_.response_code_ = 200;
+    auto cluster = std::make_shared<NiceMock<Upstream::MockClusterInfo>>();
+    cluster->name_ = "payments.aether.internal:8080";
+    stream_info_.upstream_cluster_info_ = cluster;
+  }
+
+  static ProtoConfig sourceConfig() {
+    ProtoConfig proto;
+    proto.set_reporter("source");
+    proto.set_source_service("checkout");
+    proto.set_source_pod("checkout-abc123");
+    proto.set_emit_pod(true);
+    proto.set_mesh_domain("aether.internal");
+    return proto;
+  }
+
+  // Records one request through the real filter into `process` and returns the
+  // resulting counter. The store starts empty and every call here uses the same
+  // tag set, so there is exactly one aether.requests_total counter.
+  Stats::CounterSharedPtr record(StatsProcess& process) {
+    FilterConfig config(sourceConfig(), process.context_);
+    config.record(stream_info_);
+    Stats::CounterSharedPtr found;
+    for (const auto& counter : process.store_.counters()) {
+      if (absl::StrContains(counter->name(), "aether.requests_total")) {
+        EXPECT_EQ(found, nullptr) << "more than one aether.requests_total counter";
+        found = counter;
+      }
+    }
+    return found;
+  }
+
+  static std::map<std::string, std::string> tagsOf(const Stats::Metric& metric) {
+    std::map<std::string, std::string> tags;
+    for (const auto& tag : metric.tags()) {
+      tags[tag.name_] = tag.value_;
+    }
+    return tags;
+  }
+
+  // Builds the hot restart payload the parent sends for `counter` and merges it
+  // into the child store, exactly as HotRestartingParent::exportStatsToChild and
+  // HotRestartingChild::mergeParentStats do — the flat name and its delta, the
+  // dynamic spans, and (gated on the runtime guard) the tag metadata.
+  //
+  // The dynamic spans matter here: the filter interns tag VALUES through a
+  // StatNameDynamicPool, so the counter's StatName is a mix of symbolic and
+  // dynamic segments. Merging the flat name without the spans would build an
+  // all-symbolic StatName, which is a different stat from the one the filter
+  // writes — the child would end up with two counters.
+  void mergeIntoChild(Stats::StatMerger& merger, const Stats::Counter& counter,
+                      const std::string& full_name) {
+    Protobuf::Map<std::string, uint64_t> counter_deltas;
+    counter_deltas[full_name] = counter.value();
+
+    Stats::StatMerger::DynamicsMap dynamics;
+    dynamics[full_name] = parent_.store_.symbolTable().getDynamicSpans(counter.statName());
+
+    Stats::StatMerger::TagsMap counter_tags;
+    if (Runtime::runtimeFeatureEnabled(kPropagateTagsFlag)) {
+      Stats::StatMerger::ParentTags& parent_tags = counter_tags[full_name];
+      parent_tags.base_name_ = counter.tagExtractedName();
+      for (const auto& tag : counter.tags()) {
+        parent_tags.tags_.emplace_back(tag.name_, tag.value_);
+      }
+    }
+
+    merger.mergeStats(counter_deltas, Protobuf::Map<std::string, uint64_t>(), dynamics,
+                      counter_tags, Stats::StatMerger::TagsMap());
+  }
+
+  StatsProcess parent_;
+  StatsProcess child_;
+  NiceMock<StreamInfo::MockStreamInfo> stream_info_;
+};
+
+// The counter the filter writes is clean to begin with: the tags are labels, the
+// metric name is the bare aether.requests_total, and the values are only
+// inlined into the full (flat) name.
+TEST_F(HotRestartTagPropagationTest, FreshCounterIsTagged) {
+  Stats::CounterSharedPtr fresh = record(parent_);
+  ASSERT_NE(fresh, nullptr);
+  EXPECT_EQ(fresh->tagExtractedName(), "aether.requests_total");
+
+  const auto tags = tagsOf(*fresh);
+  EXPECT_EQ(tags.size(), 7);
+  EXPECT_EQ(tags.at("reporter"), "source");
+  EXPECT_EQ(tags.at("source_service"), "checkout");
+  EXPECT_EQ(tags.at("source_pod"), "checkout-abc123");
+  EXPECT_EQ(tags.at("destination_service"), "payments");
+  EXPECT_EQ(tags.at("destination_pod"), "");
+  EXPECT_EQ(tags.at("response_code"), "200");
+  EXPECT_EQ(tags.count("response_flags"), 1);
+
+  // The flat name still carries the values — that inlining is what used to be
+  // all that was left after a merge.
+  EXPECT_TRUE(absl::StrContains(fresh->name(), ".reporter.source"));
 }
 
-// Inbound (destination reporter): empty source_pod, populated destination_pod
-// (the local pod), response_flags "-".
-TEST(AetherStatsTagExtraction, RecoversDestinationTags) {
-  std::string extracted;
-  auto m = extract("aether.requests_total.reporter.destination.source_service.loadgen.source_pod."
-                   ".destination_service.svc-1.destination_pod.svc-1-abc123.response_code.200."
-                   "response_flags.-",
-                   extracted);
-  EXPECT_EQ(extracted, "aether.requests_total");
-  EXPECT_EQ(m["reporter"], "destination");
-  EXPECT_EQ(m["source_service"], "loadgen");
-  EXPECT_EQ(m["source_pod"], "");
-  EXPECT_EQ(m["destination_service"], "svc-1");
-  EXPECT_EQ(m["destination_pod"], "svc-1-abc123");
-  EXPECT_EQ(m["response_code"], "200");
-  EXPECT_EQ(m["response_flags"], "-");
+// THE invariant: with the tag metadata propagated (guard on by default) and no
+// aether_stats stats_tags regexes anywhere, a counter merged across a hot
+// restart is indistinguishable from the fresh one — same tag-extracted name,
+// same tags — and the child's own write lands on that same counter instead of
+// creating a mangled twin.
+TEST_F(HotRestartTagPropagationTest, TagsSurviveHotRestartWithoutRegexes) {
+  // The pinned snapshot ships the propagation on by default; a re-pin that
+  // flipped it would silently reinstate the collapse.
+  EXPECT_TRUE(Runtime::runtimeFeatureEnabled(kPropagateTagsFlag));
+
+  Stats::CounterSharedPtr fresh = record(parent_);
+  ASSERT_NE(fresh, nullptr);
+  const std::string full_name = fresh->name();
+
+  // The merger owns the merged stat until the child touches it, so it has to
+  // outlive the assertions below.
+  Stats::StatMerger merger(child_.store_);
+  mergeIntoChild(merger, *fresh, full_name);
+
+  Stats::CounterSharedPtr merged = TestUtility::findCounter(child_.store_, full_name);
+  ASSERT_NE(merged, nullptr);
+  EXPECT_EQ(merged->value(), fresh->value());
+  EXPECT_EQ(merged->tagExtractedName(), fresh->tagExtractedName());
+  EXPECT_EQ(tagsOf(*merged), tagsOf(*fresh));
+
+  // The post-restart write from the child's own filter resolves to the merged
+  // counter (no poisoned central-cache slot) and keeps the labels.
+  Stats::CounterSharedPtr after_restart = record(child_);
+  ASSERT_NE(after_restart, nullptr);
+  EXPECT_EQ(after_restart.get(), merged.get());
+  EXPECT_EQ(after_restart->tagExtractedName(), "aether.requests_total");
+  EXPECT_EQ(tagsOf(*after_restart), tagsOf(*fresh));
+  EXPECT_EQ(after_restart->value(), 2); // 1 merged from the parent + 1 local
 }
 
-// Outbound (source reporter): populated source_pod, empty destination_pod (the
-// peer's pod is not known from the routed cluster name).
-TEST(AetherStatsTagExtraction, RecoversSourceTags) {
-  std::string extracted;
-  auto m = extract("aether.requests_total.reporter.source.source_service.checkout.source_pod."
-                   "checkout-abc123.destination_service.payments.destination_pod..response_code.503."
-                   "response_flags.UF",
-                   extracted);
-  EXPECT_EQ(extracted, "aether.requests_total");
-  EXPECT_EQ(m["reporter"], "source");
-  EXPECT_EQ(m["source_service"], "checkout");
-  EXPECT_EQ(m["source_pod"], "checkout-abc123");
-  EXPECT_EQ(m["destination_service"], "payments");
-  EXPECT_EQ(m["destination_pod"], "");
-  EXPECT_EQ(m["response_code"], "503");
-  EXPECT_EQ(m["response_flags"], "UF");
+// What the chart regexes used to compensate for: with the propagation disabled
+// the parent sends no tag metadata, the merged counter has no tags at all, and
+// every tag value stays welded into the metric name (the talos-main symptom —
+// series named ...aether.requests_total.reporter.source....).
+TEST_F(HotRestartTagPropagationTest, TagsLostWhenPropagationDisabled) {
+  RuntimeGuard disabled(kPropagateTagsFlag, false);
+
+  Stats::CounterSharedPtr fresh = record(parent_);
+  ASSERT_NE(fresh, nullptr);
+  const std::string full_name = fresh->name();
+
+  Stats::StatMerger merger(child_.store_);
+  mergeIntoChild(merger, *fresh, full_name);
+
+  Stats::CounterSharedPtr merged = TestUtility::findCounter(child_.store_, full_name);
+  ASSERT_NE(merged, nullptr);
+  EXPECT_TRUE(merged->tags().empty());
+  EXPECT_EQ(merged->tagExtractedName(), full_name);
+  EXPECT_TRUE(absl::StrContains(merged->tagExtractedName(), ".reporter."));
 }
 
-// The new regexes must not perturb unrelated stats (e.g. the cluster path that
-// already works) — aether.cluster still extracts and nothing else matches.
-TEST(AetherStatsTagExtraction, LeavesClusterStatsIntact) {
-  std::string extracted;
-  auto m = extract("cluster.svc-1.upstream_rq_total", extracted);
-  EXPECT_EQ(extracted, "cluster.upstream_rq_total");
-  EXPECT_EQ(m["aether.cluster"], "svc-1");
-  EXPECT_EQ(m.count("reporter"), 0);
+// The two stats_tags the chart keeps are unrelated to aether_stats: they lift
+// Envoy's own cluster/listener name segments out of the stat name. They must
+// keep working, and they must NOT touch aether.requests_total.
+TEST_F(HotRestartTagPropagationTest, RetainedChartRegexesStillExtract) {
+  Stats::TagProducerPtr producer = productionTagProducer();
+
+  Stats::TagVector cluster_tags;
+  const std::string cluster_extracted =
+      producer->produceTags("cluster.svc-1.upstream_rq_total", cluster_tags);
+  EXPECT_EQ(cluster_extracted, "cluster.upstream_rq_total");
+  ASSERT_EQ(cluster_tags.size(), 1);
+  EXPECT_EQ(cluster_tags[0].name_, "aether.cluster");
+  EXPECT_EQ(cluster_tags[0].value_, "svc-1");
+
+  Stats::TagVector listener_tags;
+  const std::string listener_extracted =
+      producer->produceTags("listener.inbound_svc-1-abc123.downstream_cx_total", listener_tags);
+  EXPECT_EQ(listener_extracted, "listener.inbound.downstream_cx_total");
+  ASSERT_EQ(listener_tags.size(), 1);
+  EXPECT_EQ(listener_tags[0].name_, "aether.pod");
+  EXPECT_EQ(listener_tags[0].value_, "svc-1-abc123");
+
+  // No regex re-derives the programmatic keys any more: extraction alone leaves
+  // the mangled name untouched. Propagation, not regex, is what recovers them.
+  Stats::TagVector request_tags;
+  const std::string mangled = "aether.requests_total.reporter.source.source_service.checkout."
+                              "source_pod.checkout-abc123.destination_service.payments."
+                              "destination_pod..response_code.200.response_flags.-";
+  EXPECT_EQ(producer->produceTags(mangled, request_tags), mangled);
+  EXPECT_TRUE(request_tags.empty());
 }
 
 } // namespace
-} // namespace Stats
+} // namespace AetherStats
+} // namespace HttpFilters
+} // namespace Extensions
 } // namespace Envoy


### PR DESCRIPTION
## Why the regexes existed

`aether_stats` (proposal 012) records one counter per request via
`counterFromStatNameWithTags`, which inlines the tag **values** into the full
stat name (`aether.requests_total.reporter.<v>.source_service.<v>.…`). On the
filter's write path those are real Stats tags — but the node proxy hot-restarts
on every config change (talos-main reached epoch 53), and Envoy's `StatMerger`
re-created every merged counter via `counterFromStatName()` with **no** tags
("TODO(snowp): Propagate tag values during hot restarts"). After the first
restart the programmatic tags were gone and their values collapsed into the
metric name with empty labels — the talos-main symptom: series *named*
`…aether.requests_total.reporter.source.…` instead of one metric with labels.

The workaround was seven `stats_tags` regexes in the proxy bootstrap, one per
programmatic key, re-deriving the tags from the mangled name.

## Why they can go now

The proxy is built from the Envoy `main` snapshot pinned in #697, which contains
envoyproxy/envoy#45674 *"hot restart: propagate programmatic stat tags across
restart"*. The parent now transmits each tagged stat's metadata
(`hot_restart.proto` `TaggedMetric` / `counter_tags`) and the child re-creates
the counter through `counterFromMergedStatName`, so the tags survive natively.
Its runtime guard `envoy.reloadable_features.hot_restart_propagate_stat_tags` is
a default-**true** `RUNTIME_GUARD` at the pinned commit (13144fb).

## What changed

- `charts/aether/templates/agent-proxy-configmap.yaml`: the seven programmatic
  regexes (`reporter`, `source_service`, `source_pod`, `destination_service`,
  `destination_pod`, `response_code`, `response_flags`) are gone, replaced by a
  short note pointing at envoy#45674 and the guarding test. **`aether.cluster`
  and `aether.pod` stay** — those extract from Envoy's own `cluster.*` /
  `listener.*` stat names and were never part of the workaround.
  `helm template charts/aether` now renders exactly two `tag_name` entries.
- `charts/aether/Chart.yaml`: 0.92.2 → 0.92.3.
- `proxy/.../aether_stats/tag_extraction_test.cc`: rewritten around the new
  invariant instead of the regex list.

## What the new test guards

With **no** `aether_stats` `stats_tags` regexes configured anywhere:

1. `FreshCounterIsTagged` — the filter's own counter is clean: tag-extracted name
   `aether.requests_total` plus seven label tags; the values are only inlined in
   the flat name.
2. `TagsSurviveHotRestartWithoutRegexes` — a real `FilterConfig::record()` into a
   "parent" `ThreadLocalStoreImpl`, then a `StatMerger` merge into a "child"
   store built exactly as `HotRestartingChild::mergeParentStats` builds it
   (counter delta + `StatMerger::TagsMap` `ParentTags{base_name_, tags_}`,
   gated on the runtime guard). The merged counter has the *same*
   `tagExtractedName` and the *same* tag set as the fresh one, and the child's
   own post-restart write resolves to that same counter (value 2, no poisoned
   central-cache slot / mangled twin). It also asserts the guard is on by
   default, so a future re-pin that flipped it fails here rather than on talos.
3. `TagsLostWhenPropagationDisabled` — the negative case that makes the above
   meaningful: with the guard forced off, no metadata is sent, the merged counter
   has zero tags and `tagExtractedName` is the full mangled name containing
   `.reporter.`.
4. `RetainedChartRegexesStillExtract` — the two kept chart regexes still lift
   `aether.cluster` / `aether.pod` out of Envoy's stat names, and extraction
   alone no longer recovers any programmatic key (propagation, not regex, is what
   recovers them).

One thing the first CI run surfaced and the test now pins: the filter interns tag
**values** through a `StatNameDynamicPool`, so the counter's `StatName` mixes
symbolic and dynamic segments. The merge therefore has to carry the parent's
dynamic spans (`SymbolTable::getDynamicSpans`, which
`HotRestartingParent::exportStatsToChild` transmits) alongside the tag metadata —
without them the child rebuilds an all-symbolic name and ends up with *two*
counters. Tags alone are not sufficient for the post-restart write to land on the
merged counter, and the test now proves both halves.

Upstream templates: `ProgrammaticTagsSurviveMerge` /
`ProgrammaticTagsLostWithoutMetadata` in `test/common/stats/stat_merger_test.cc`.

## talos validation recipe (for the main session)

```bash
# deploy 0.92.3, then force a hot restart on every node with NO regexes present
kubectl -n aether-system rollout restart ds/aether-proxy
kubectl -n aether-system rollout status ds/aether-proxy
```

After the roll, in Grafana / Prometheus:

```promql
# every series must still carry the programmatic labels
count(aether_requests_total{reporter!="",source_service!=""}) == count(aether_requests_total)
```

and assert the historical collapse symptom is absent — no series whose **name**
contains `.reporter.` (e.g. `count({__name__=~".*\\.reporter\\..*"})` is empty).

Refs #695 — deliberately not closing it: the re-pin to a `1.40.0.envoy` module
and the root `@envoy_binary_linux_*` bump remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
