### PR TITLE
docs(proxy): counters transfer as deltas across hot restart, not absolutes (#708)

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.3"
+version: "0.92.4"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-proxy-configmap.yaml
+++ b/charts/aether/templates/agent-proxy-configmap.yaml
@@ -159,6 +159,30 @@ data:
         # guarded by
         # //source/extensions/filters/http/aether_stats:tag_extraction_test in
         # the proxy workspace.
+      #
+      # ⚠ COUNTER VALUES ARE PER-GENERATION — labels survive a hot restart, the
+      # absolute value does not, and that is by design (aether#708, measured
+      # 2026-09-05).
+      #   * The hot restart parent ships `counter.latch()` — the increment
+      #     PENDING since its last stats flush — and StatMerger `.add()`s it.
+      #     Gauges transfer absolute; counters transfer as DELTAS.
+      #   * The parent has been latching that pending increment away every
+      #     `stats_flush_interval` for its whole life (5s default; deliberately
+      #     unset here), so the child inherits only the last ≤5s of the
+      #     parent's traffic — on talos-main every first post-restart sample
+      #     was < 1 minute of that node's rate.
+      #   * The OTel sink then exports `counter.value()` as CUMULATIVE with
+      #     `start_time_unix_nano` = THIS process's start, i.e. an honest new
+      #     cumulative series per Envoy generation. Plain
+      #     `envoy_cluster_upstream_cx_total` resets in exactly the same
+      #     buckets — this is not aether_stats-specific.
+      # RULE for every dashboard, alert, query and soak script: NEVER read a
+      # raw counter value (no `sum(aether_requests_total)`); always
+      # `rate(...[5m])` / `increase(...[$__range])`, which are correct across
+      # the reset. Making values continuous was rejected: `report_counters_as_
+      # deltas` is sink-wide and the collector runs 2 replicas behind one
+      # Service, so two stateful delta→cumulative converters would each see
+      # half of a series.
       stats_matcher:
         exclusion_list:
           patterns:

--- a/docs/proposals/001_proxy-hot-restart.md
+++ b/docs/proposals/001_proxy-hot-restart.md
@@ -46,7 +46,7 @@ Keep **one long-lived proxy Pod** whose supervisor is the stable entrypoint, and
 
 - **Pros:** simplest possible — textbook hot restart, no Kubernetes surgery, no surge scheduling.
 - **Cons:** upgrades only the **Envoy binary + bootstrap config**, not the proxy container image (base-layer CVEs, supervisor changes still need a real roll).
-- **Why we spike this first:** it is the minimal proof that the supervisor + hot-restart handoff actually works (epoch increments, zero dropped connections, stat continuity). The binary-delivery-without-pod-replacement mechanism (a host-local push of a versioned binary that the supervisor watches) is **production-A** and is *not* part of the spike — the spike triggers the handoff via a watched bootstrap-config change / SIGHUP, which exercises the identical code path.
+- **Why we spike this first:** it is the minimal proof that the supervisor + hot-restart handoff actually works (epoch increments, zero dropped connections, dip-free stat *rates* across the handoff). The binary-delivery-without-pod-replacement mechanism (a host-local push of a versioned binary that the supervisor watches) is **production-A** and is *not* part of the spike — the spike triggers the handoff via a watched bootstrap-config change / SIGHUP, which exercises the identical code path.
 
 ### Spike packaging (A)
 
@@ -82,10 +82,27 @@ node, before:   [old Pod: supervisor → envoy epoch 5]   serving, listeners bou
 4. envoy(6) pulls listen-socket FDs + stats from envoy(5), starts listening, signals envoy(5) to drain.
 5. new Pod becomes Ready (readiness gate fires only after handoff completes).
 6. DaemonSet, seeing new Ready, deletes old Pod; old supervisor SIGTERMs envoy(5) after drain, exits 0.
-node, after:    [new Pod: supervisor → envoy epoch 6]   no dropped connection, stats carried over
+node, after:    [new Pod: supervisor → envoy epoch 6]   no dropped connection, listen FDs + gauges carried over
 ```
 
-- **Pros:** real container-image upgrade, zero dropped connections, stat continuity, **native rollout, no standing extra cost**.
+> **What "carried over" means for stats.** Listen-socket FDs and **gauges**
+> transfer with their absolute values. **Counters do not**: the parent ships
+> `counter.latch()` — the increment *pending since its last stats flush* — and
+> `StatMerger::mergeCounters` `.add()`s that delta onto the child's counter.
+> Since the parent has been latching every `stats_flush_interval` (5s default;
+> `charts/aether` sets none) for its whole life, the child inherits only the
+> last ≤5s of traffic. Measured on talos-main 2026-09-05 across one
+> `rollout restart ds/aether-proxy`: per node `139047→683`, `266735→1559`,
+> `131812→339`, `259710→379`, `266301→1147`, each then resuming at its exact
+> prior slope — every first post-restart sample is **< 1 minute of that node's
+> traffic**, i.e. delta semantics exactly (a merge that was *not* running would
+> floor at 0 with no residual). Plain `envoy_cluster_upstream_cx_total` resets
+> in the same buckets, so this is generic Envoy behaviour, not `aether_stats`.
+> With a cumulative OTLP exporter each Envoy generation is an honest new
+> cumulative series: **never read a raw counter across a roll — `rate()` /
+> `increase()` only** (aether#708).
+
+- **Pros:** real container-image upgrade, zero dropped connections, delta-preserving stats handoff, **native rollout, no standing extra cost**.
 - **Cons / spike-must-prove:**
   - **Admin port handoff** — both Envoys want `127.0.0.1:9901` in host netns; Envoy passes the admin listener FD via the same transfer, but verify.
   - **Epoch edge case** — if the predecessor is gone (reboot/crash), the file says `5` but no epoch-5 process exists; starting at `6` hangs waiting for a parent. The supervisor must probe for a live predecessor and **reset to epoch 0** when absent.
@@ -126,7 +143,7 @@ C is the end state once an Istio-grade proxy-upgrade operator is justified — n
 
 ## Validation (talos-main)
 
-- **Stats proof:** after a trigger, `server.hot_restart_generation` / `server.hot_restarts` increments and counters carry over (`curl :9901/stats`).
+- **Stats proof:** after a trigger, `server.hot_restart_generation` / `server.hot_restarts` increments, gauges carry over with their absolute values, and counters carry over **as deltas only** — the child starts from the parent's post-flush residual (≤ one `stats_flush_interval` of traffic), not its lifetime total (`curl :9901/stats`). Assert *rate* continuity (`sum(rate(aether_requests_total[5m]))` shows no dip and no spike through the roll), never value monotonicity.
 - **Zero-drop proof:** hold a long-lived streaming request through the mesh across a triggered restart; assert no reset. Re-run the mesh e2e (200 + XFCC URI SAN) against epoch *N+1*.
 - **Binary-upgrade proof (A):** swap the Envoy binary on the shared volume and trigger; new epoch serves, old drains.
 - **Image-upgrade proof (B):** roll the DaemonSet image with `maxSurge=1`; confirm overlap + handoff + zero drop.
@@ -174,4 +191,4 @@ Production binary-delivery for A, the Strategy C operator, agent→supervisor RP
 
 ## Exit Criteria → Decision
 
-**A is GREEN** if a triggered hot restart shows an incremented `hot_restart_generation`, zero dropped in-flight connections, and stat continuity on talos-main. That unblocks building **B**, whose own exit criterion is a connection-preserving DaemonSet image roll. Go/no-go on the whole effort: does bootstrap-change + image-upgrade continuity justify the supervisor (A) and the surge/coordination machinery (B)?
+**A is GREEN** if a triggered hot restart shows an incremented `hot_restart_generation`, zero dropped in-flight connections, and *rate* continuity of the stats on talos-main (gauges carry over absolute; counters carry over as deltas, so the criterion is a dip-free `rate()`/`increase()` across the handoff, not an unbroken counter value — see the note under Strategy B). That unblocks building **B**, whose own exit criterion is a connection-preserving DaemonSet image roll. Go/no-go on the whole effort: does bootstrap-change + image-upgrade continuity justify the supervisor (A) and the surge/coordination machinery (B)?

--- a/docs/proposals/012_aether_stats_cpp_extension.md
+++ b/docs/proposals/012_aether_stats_cpp_extension.md
@@ -95,6 +95,20 @@ Stats::StatNameTagVector tags{{reporter_, reporter_val}, /* … */};
 config_->scope_.counterFromStatNameWithTags(config_->requests_total_, tags).inc();
 ```
 
+> **`aether_requests_total` values are per-Envoy-generation.** This is an Envoy
+> counter, and the node proxy hot-restarts on every config change and every
+> DaemonSet roll. A hot restart transfers gauges absolute but counters as
+> **deltas** (`counter.latch()`, the increment pending since the parent's last
+> `stats_flush_interval` — 5s by default), so the child inherits ≤5s of the
+> parent's traffic, and the OTLP sink exports `counter.value()` as CUMULATIVE
+> from *this process's* start. The series therefore restarts near zero on every
+> roll (measured on talos-main 2026-09-05; plain
+> `envoy_cluster_upstream_cx_total` resets in the same buckets). Since #45674 the
+> **labels** survive natively — only the value is per-generation. Rule for every
+> dashboard, alert and query: **never read a raw counter value; use
+> `rate(...[5m])` / `increase(...[$__range])`**, which are correct across the
+> reset. See aether#708 and proposal 001.
+
 ### Registration + linking
 
 `REGISTER_FACTORY(Factory, NamedHttpFilterConfigFactory)` with name
@@ -144,7 +158,8 @@ config encoding change. The `DynamicModuleConfig` wiring is removed.
 2. **Agent**: switch the generated filter from `dynamic_modules` to
    `aether.filters.http.aether_stats`; delete the Rust module + its wiring.
 3. **Dashboards**: rename `dynamicmodulescustom.aether_requests_total` →
-   `aether.requests_total`.
+   `aether.requests_total`, and express every panel as `rate()`/`increase()` —
+   the counter's value is per-Envoy-generation (see the caveat above).
 
 The net result: full `StreamInfo` access, real response flags with no workaround,
 native stat naming, and a single self-contained Envoy binary.

--- a/docs/proposals/013_mesh-availability-prober.md
+++ b/docs/proposals/013_mesh-availability-prober.md
@@ -20,6 +20,16 @@ events we want an SLO for:
 - mid-flight resets when the source proxy is itself the component restarting,
 - anything that produces no HTTP response → no access-log/stat.
 
+On top of that bias, the metric's **values are per-Envoy-generation**: a hot
+restart transfers counters as *deltas* (`counter.latch()`, the increment pending
+since the parent's last 5s stats flush), and the OTLP sink exports each process's
+counter as CUMULATIVE from its own start — so `aether_requests_total` restarts
+near zero on every proxy roll, exactly the events a churn soak is grading. This
+is by design, not a defect (aether#708, proposal 001); any read of it must be
+`rate()`/`increase()`, never a raw value. The prober's own
+`aether_probe_requests_total` lives in a separate, non-hot-restarting process and
+has no such discontinuity — one more reason it, not `aether_stats`, is the SLI.
+
 The self-reported number is thus **biased high precisely during hot-restarts and
 rollouts**. The 2026-06-17 soak quantified it: a single-source run saw **~501,502**
 client failures during churn while the mesh metric recorded **9** (0.0018%). This
@@ -225,8 +235,10 @@ supervisor metrics = **when/where** churn happened.
 
 Reproduce the soak: enable the prober (liveness tier), run a proxy hot-restart
 (`kubectl rollout restart ds/aether-proxy`) and confirm the prober records
-`connection_error` on the rolling node while `aether_requests_total` shows ~0 infra
-failures — i.e., the prober sees what the mesh cannot. Confirm per-node attribution
+`connection_error` on the rolling node while
+`sum(increase(aether_requests_total{response_flags!="-"}[5m]))` shows ~0 infra
+failures (`increase()`, not a raw read — the counter restarts per Envoy
+generation across exactly this roll) — i.e., the prober sees what the mesh cannot. Confirm per-node attribution
 (only the rolling node's prober dips) and steady-state ~100%. With the reachability
 tier enabled, a service deploy should dip reachability (EDS/propagation) while
 liveness stays flat.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -341,7 +341,9 @@ Note: the stream labels on these logs are the dotted OTel resource fields (`serv
 returns a FALSE ZERO — control-test any negative by dropping the selector.
 
 # Same, as a counter: zero at steady state, any increase is the #638 defect.
-sum by (k8s_node_name) (aether_agent_identity_outbound_binding_mismatch_total)
+# increase(), never a raw read — the raw value is per-process (an agent restart
+# resets it) and an instant query lands between samples and false-zeroes.
+sum by (k8s_node_name) (increase(aether_agent_identity_outbound_binding_mismatch_total[1h]))
 ```
 
 Join the `snapshot_version` on the WARN with the first

--- a/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
+++ b/proxy/source/extensions/filters/http/aether_stats/tag_extraction_test.cc
@@ -43,6 +43,11 @@
 // child gets back must be indistinguishable from the fresh, filter-written
 // counter. The negative test pins the pre-fix behaviour so the difference the
 // propagation makes stays explicit.
+//
+// The file also pins the *other* half of the hot restart contract, which the
+// tag fix does not change and which aether#708 mistook for a regression:
+// counters transfer as DELTAS (`counter.latch()`), so a child's counter value
+// is per-generation by design. See CountersTransferAsDeltasNotAbsoluteValues.
 namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
@@ -154,15 +159,19 @@ protected:
   // HotRestartingChild::mergeParentStats do — the flat name and its delta, the
   // dynamic spans, and (gated on the runtime guard) the tag metadata.
   //
+  // The delta is `counter.latch()`, not `counter.value()`: the parent ships the
+  // increment pending since its last stats flush, and StatMerger .add()s it.
+  // (The real parent additionally skips counters whose latched value is 0.)
+  //
   // The dynamic spans matter here: the filter interns tag VALUES through a
   // StatNameDynamicPool, so the counter's StatName is a mix of symbolic and
   // dynamic segments. Merging the flat name without the spans would build an
   // all-symbolic StatName, which is a different stat from the one the filter
   // writes — the child would end up with two counters.
-  void mergeIntoChild(Stats::StatMerger& merger, const Stats::Counter& counter,
+  void mergeIntoChild(Stats::StatMerger& merger, Stats::Counter& counter,
                       const std::string& full_name) {
     Protobuf::Map<std::string, uint64_t> counter_deltas;
-    counter_deltas[full_name] = counter.value();
+    counter_deltas[full_name] = counter.latch();
 
     Stats::StatMerger::DynamicsMap dynamics;
     dynamics[full_name] = parent_.store_.symbolTable().getDynamicSpans(counter.statName());
@@ -241,6 +250,66 @@ TEST_F(HotRestartTagPropagationTest, TagsSurviveHotRestartWithoutRegexes) {
   EXPECT_EQ(after_restart->tagExtractedName(), "aether.requests_total");
   EXPECT_EQ(tagsOf(*after_restart), tagsOf(*fresh));
   EXPECT_EQ(after_restart->value(), 2); // 1 merged from the parent + 1 local
+}
+
+// The other half of the hot restart contract, and the one that surprises
+// readers of `aether_requests_total` (aether#708): counters transfer as
+// DELTAS, never as absolute values.
+//
+// HotRestartingParent::exportStatsToChild sends `counter.latch()` — the
+// increment pending since the parent's last stats flush — and
+// StatMerger::mergeCounters `.add()`s it onto the child's counter. The parent
+// has been latching that pending increment away every `stats_flush_interval`
+// for its whole life (5s default; charts/aether sets none), so the child
+// inherits only the residual of the last flush window, not the parent's
+// lifetime total. Combined with an OTLP sink that exports `counter.value()` as
+// CUMULATIVE from *this process's* start, every aether_stats series restarts
+// near zero on each hot restart. That is Envoy behaving correctly, so the rule
+// for consumers is: never read a raw counter value across a roll —
+// rate()/increase() only.
+//
+// If this ever fails because the child inherited the parent's full value,
+// something started shipping absolute counters and the delta-consuming sinks
+// (statsd, metrics_service) are being double-counted.
+TEST_F(HotRestartTagPropagationTest, CountersTransferAsDeltasNotAbsoluteValues) {
+  // The parent serves a long life of traffic (the filter's own .inc(), just
+  // more of it).
+  Stats::CounterSharedPtr fresh = record(parent_);
+  ASSERT_NE(fresh, nullptr);
+  fresh->add(2);
+  ASSERT_EQ(fresh->value(), 3UL);
+
+  // The parent's periodic flush (MetricSnapshotImpl, every
+  // stats_flush_interval) latches the pending increment away. flushMetricsToSinks
+  // even notes that hot restart depends on this latching.
+  EXPECT_EQ(fresh->latch(), 3UL);
+
+  // One more request accrues *after* that flush: this is all the parent still
+  // has pending when the child asks for its stats.
+  fresh->inc();
+  ASSERT_EQ(fresh->value(), 4UL);
+
+  const std::string full_name = fresh->name();
+  Stats::StatMerger merger(child_.store_);
+  mergeIntoChild(merger, *fresh, full_name);
+
+  Stats::CounterSharedPtr merged = TestUtility::findCounter(child_.store_, full_name);
+  ASSERT_NE(merged, nullptr);
+  // The post-latch residual only — NOT the parent's 4.
+  EXPECT_EQ(merged->value(), 1UL);
+  EXPECT_LT(merged->value(), fresh->value());
+
+  // Delta semantics are orthogonal to tag propagation: the labels still survive.
+  EXPECT_EQ(merged->tagExtractedName(), "aether.requests_total");
+  EXPECT_EQ(tagsOf(*merged), tagsOf(*fresh));
+
+  // And the child's own traffic keeps accumulating on that same counter, from
+  // the inherited residual — which is why rate()/increase() over the child's
+  // series is correct even though its absolute value is meaningless.
+  Stats::CounterSharedPtr after_restart = record(child_);
+  ASSERT_NE(after_restart, nullptr);
+  EXPECT_EQ(after_restart.get(), merged.get());
+  EXPECT_EQ(after_restart->value(), 2);
 }
 
 // What the chart regexes used to compensate for: with the propagation disabled


### PR DESCRIPTION
Closes #708 — not a bug.

`HotRestartingParent::exportStatsToChild` sends `counter.latch()` (the increment *pending* since the parent's last stats flush) and `StatMerger::mergeCounters` `.add()`s it: gauges transfer absolute, **counters transfer as deltas**.
The parent has been latching that pending increment away every `stats_flush_interval` (5s default; `charts/aether` sets none) for its whole life, so the child inherits only the last ≤5s of the parent's traffic.
The OTLP sink then exports `counter.value()` as CUMULATIVE with `start_time_unix_nano` = *this process's* start — an honest new cumulative series per Envoy generation, which is why `sum(aether_requests_total)` looks like it resets. Measured on talos-main 2026-09-05: every first post-restart sample was < 1 minute of that node's traffic, and plain `envoy_cluster_upstream_cx_total` resets in exactly the same buckets.

## Changes

- **`charts/aether/templates/agent-proxy-configmap.yaml`** — a "counter values are per-generation" note beside the existing tag-propagation note (it lives inside the rendered `envoy.yaml`), stating the mechanism, the consumer rule (**never read a raw counter; `rate()`/`increase()` only**) and why making the values continuous was rejected (`report_counters_as_deltas` is sink-wide, and the collector runs 2 replicas behind one Service). Chart `0.92.3` → `0.92.4`.
- **`docs/proposals/001_proxy-hot-restart.md`** — corrects the three over-stated claims ("stats carried over", "counters carry over", the "stat continuity" exit criterion): listen FDs and gauges carry over, counters as deltas only; the exit criterion becomes dip-free *rate* continuity. Cites the 2026-09-05 measurement.
- **`docs/proposals/012_aether_stats_cpp_extension.md`**, **`013_mesh-availability-prober.md`** — the per-generation caveat made explicit where `aether_requests_total` is described (013 also notes the prober's own counter has no such discontinuity, reinforcing why it is the SLI).
- **`docs/runbook.md`** — the #638 mismatch-counter query converted to `increase(...[1h])`.
- **`proxy/.../aether_stats/tag_extraction_test.cc`** — `mergeIntoChild` now ships `counter.latch()` (what the parent actually sends), and a new `CountersTransferAsDeltasNotAbsoluteValues` case latches the parent counter (simulating the periodic flush), merges, and asserts the child holds **only the post-latch residual** — pinning delta transfer as an intentional invariant rather than a defect someone "fixes" later.

Query sites audited: the only raw-counter reads in scope were `docs/runbook.md:344` and the validation snippet in `013`. Repo has no Grafana dashboard JSON — the panels live in the GitOps repo (`bpalermo/k8s-talos-main`), out of scope here; `docs/proposals/013` references the "Mesh Availability (synthetic)" row and the "Mesh Request Success Rate" panel, which are the ones to convert there. `e2e/soak/README.md` and `e2e/pressure/run.sh` already use `rate()`/`increase()` or before/after baselines on non-hot-restarting processes and were left alone.

`helm lint charts/aether` passes and `helm template charts/aether` still renders a parseable `envoy.yaml`; `make format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr