### PR TITLE
fix(agent): stop logging the startup watch-stream handoff as an ERROR (#700)

### DIFF
--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     srcs = [
         "metrics_test.go",
         "registrar_test.go",
+        "watch_startup_test.go",
     ],
     embed = [":registrar"],
     deps = [
@@ -37,7 +38,10 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",
         "@io_opentelemetry_go_otel_sdk_metric//metricdata",
+        "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//credentials/insecure",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_grpc//test/bufconn",
     ],
 )

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -421,10 +421,20 @@ func (r *RegistrarRegistry) listAllEndpointsFromServer(ctx context.Context, prot
 // was earned on, the token is cleared so the registrar resends the full
 // (re-filtered) snapshot — newly in-scope services were never delivered to
 // the old stream, so resuming by version would silently skip them.
+//
+// A stream the loop itself lost to a filter re-assert or to shutdown is not a
+// failure: it is classified out of the error path (no ERROR, no backoff, no
+// watch_errors count) so the only ERROR here is a registrar that would not
+// serve the stream (issue #700).
 func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 	backoff := initialBackoff
 	lastVersion := ""
 	lastFilterGen := uint64(0)
+	// The process's first stream is opened by Initialize, before the node's
+	// dependency set exists, so it is routinely superseded by the startup
+	// filter assert (issue #700). The marker keeps that expected handoff
+	// distinguishable from a mid-life filter change in the log.
+	firstStream := true
 
 	for {
 		select {
@@ -456,19 +466,19 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 
 		stream, err := r.client.WatchEndpoints(streamCtx, req)
 		if err != nil {
+			// Classify BEFORE cancelling: while the call is in flight the only
+			// thing that cancels streamCtx is SetServiceFilter re-asserting a
+			// changed filter (or the parent context ending) — never this loop.
+			cancelled := streamCtx.Err() != nil
 			streamCancel()
-			r.metrics.streamFailed(ctx)
-			jitter := time.Duration(float64(backoff) * jitterFraction * rand.Float64())
-			wait := backoff + jitter
-			r.log.ErrorContext(ctx, "failed to start watch stream, retrying", "error", err, "backoff", wait)
-			select {
-			case <-ctx.Done():
+			keepWatching := r.recoverStreamOpen(ctx, err, cancelled, firstStream, &backoff)
+			firstStream = false
+			if !keepWatching {
 				return
-			case <-time.After(wait):
 			}
-			backoff = min(backoff*2, maxBackoff)
 			continue
 		}
+		firstStream = false
 
 		// Reset backoff on successful connection.
 		backoff = initialBackoff
@@ -479,6 +489,47 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 		lastVersion = r.processStream(ctx, stream, lastVersion)
 		streamCancel()
 	}
+}
+
+// recoverStreamOpen applies the recovery for a watch stream that would not
+// open, and reports whether the loop should keep watching (false = shut down).
+// cancelled says whether the per-stream context was already cancelled when the
+// call returned; firstStream whether this was the process's first stream.
+//
+// Opening a server-streaming RPC blocks in the gRPC picker until the
+// connection is READY, so on a clean start that call is in flight across the
+// whole dial + mTLS handshake — and the agent's startup filter assert lands
+// inside that window (issue #700). Neither that handoff nor a shutdown is a
+// stream failure, so neither takes the error path.
+func (r *RegistrarRegistry) recoverStreamOpen(ctx context.Context, err error, cancelled, firstStream bool, backoff *time.Duration) bool {
+	if ctx.Err() != nil {
+		// Shutting down: the cancellation IS the shutdown.
+		r.log.DebugContext(ctx, "watch stream cancelled by shutdown")
+		return false
+	}
+	if cancelled && status.Code(err) == codes.Canceled {
+		// Expected, not a failure: Initialize opens the unfiltered stream
+		// before the node's dependency set exists, then the agent's xDS
+		// PreListen asserts the demand-scoped filter as soon as the local pod
+		// set is known (agent/internal/xds/server/server.go), cancelling the
+		// in-flight dial. Reconnect immediately with the new filter — backing
+		// off here would only delay the filtered snapshot.
+		r.log.InfoContext(ctx, "watch stream superseded by a service-filter change before it connected; reconnecting",
+			"startup", firstStream)
+		return true
+	}
+
+	r.metrics.streamFailed(ctx)
+	jitter := time.Duration(float64(*backoff) * jitterFraction * rand.Float64())
+	wait := *backoff + jitter
+	r.log.ErrorContext(ctx, "failed to start watch stream, retrying", "error", err, "backoff", wait)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(wait):
+	}
+	*backoff = min(*backoff*2, maxBackoff)
+	return true
 }
 
 // processStream reads events from the stream and updates the local cache.

--- a/registry/internal/registrar/watch_startup_test.go
+++ b/registry/internal/registrar/watch_startup_test.go
@@ -1,0 +1,204 @@
+package registrar
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	registrarv1 "aethermesh.dev/api/aether/registrar/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// lockedBuffer is a concurrency-safe sink for the slog handler: the watch loop
+// writes from its own goroutine while the test reads.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// fakeWatchServer is an in-process RegistrarService that answers WatchEndpoints
+// with an immediate SNAPSHOT_COMPLETE and then holds the stream open, recording
+// every request it received so a test can assert which filter was asserted.
+type fakeWatchServer struct {
+	registrarv1.UnimplementedRegistrarServiceServer
+
+	active atomic.Int64
+
+	mu       sync.Mutex
+	requests []*registrarv1.WatchEndpointsRequest
+}
+
+func (s *fakeWatchServer) WatchEndpoints(req *registrarv1.WatchEndpointsRequest, stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse]) error {
+	s.mu.Lock()
+	s.requests = append(s.requests, req)
+	s.mu.Unlock()
+
+	s.active.Add(1)
+	defer s.active.Add(-1)
+
+	if err := stream.Send(&registrarv1.WatchEndpointsResponse{
+		Type:    registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE,
+		Version: "1",
+	}); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (s *fakeWatchServer) lastRequest() *registrarv1.WatchEndpointsRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.requests) == 0 {
+		return nil
+	}
+	return s.requests[len(s.requests)-1]
+}
+
+func (s *fakeWatchServer) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests)
+}
+
+// startFakeRegistrar serves fakeWatchServer over a bufconn listener and returns
+// a dial option set whose dialer blocks until gate is closed (nil gate = dial
+// immediately). Gating the dial is what makes the startup race deterministic:
+// opening a stream blocks in the gRPC picker until the connection is READY, so
+// the first WatchEndpoints call is still in flight when the test asserts the
+// service filter — exactly what the agent does on a clean start.
+func startFakeRegistrar(t *testing.T, gate <-chan struct{}) (*fakeWatchServer, []grpc.DialOption) {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	grpcSrv := grpc.NewServer()
+	fake := &fakeWatchServer{}
+	registrarv1.RegisterRegistrarServiceServer(grpcSrv, fake)
+	go func() { _ = grpcSrv.Serve(lis) }()
+	t.Cleanup(grpcSrv.Stop)
+
+	dialer := func(ctx context.Context, _ string) (net.Conn, error) {
+		if gate != nil {
+			select {
+			case <-gate:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		return lis.DialContext(ctx)
+	}
+
+	return fake, []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(dialer),
+	}
+}
+
+func newLoggingRegistry(t *testing.T, opts []grpc.DialOption) (*RegistrarRegistry, *lockedBuffer) {
+	t.Helper()
+
+	logs := &lockedBuffer{}
+	log := slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	return NewRegistrarRegistry(log, Config{
+		// passthrough so the custom dialer (bufconn) is used verbatim.
+		Address:     "passthrough:///registrar-test",
+		ClusterName: "test-cluster",
+		NodeName:    "test-node",
+		DialOptions: opts,
+	}), logs
+}
+
+// TestWatchLoop_StartupFilterAssertIsNotAnError mirrors the agent's real startup
+// sequence — Initialize opens the unfiltered watch, then the xDS PreListen
+// asserts the node's demand-scoped filter while the first stream is still
+// dialing — and asserts the client logs nothing at ERROR on that clean start
+// (issue #700).
+func TestWatchLoop_StartupFilterAssertIsNotAnError(t *testing.T) {
+	gate := make(chan struct{})
+	fake, dialOpts := startFakeRegistrar(t, gate)
+	r, logs := newLoggingRegistry(t, dialOpts)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, r.Initialize(ctx))
+	defer func() { _ = r.Close() }()
+
+	// Wait until the loop published its per-stream cancel: the first
+	// WatchEndpoints is now in flight against the still-gated connection.
+	require.Eventually(t, func() bool {
+		r.filterMu.Lock()
+		defer r.filterMu.Unlock()
+		return r.streamCancel != nil
+	}, 5*time.Second, time.Millisecond)
+
+	// The startup filter assert (agent/internal/xds/server/server.go PreListen).
+	r.SetServiceFilter([]string{"default/svc-a"})
+
+	// Let the dial complete; the loop must reconnect with the new filter.
+	close(gate)
+
+	readyCtx, readyCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer readyCancel()
+	require.NoError(t, r.WaitReady(readyCtx))
+
+	out := logs.String()
+	require.NotContains(t, out, `"level":"ERROR"`, "clean start must not log at ERROR; got:\n%s", out)
+	require.Contains(t, out, "watch stream superseded by a service-filter change",
+		"the superseded first stream must be announced, not swallowed; got:\n%s", out)
+	require.Contains(t, out, `"startup":true`,
+		"the first stream's handoff must carry the startup marker; got:\n%s", out)
+
+	// The reconnect asserted the new filter, and it happened without paying the
+	// reconnect backoff (the backoff path logs at ERROR, asserted absent above).
+	last := fake.lastRequest()
+	require.NotNil(t, last)
+	require.Equal(t, []string{"default/svc-a"}, last.GetFilter().GetServices())
+	require.Equal(t, 1, fake.requestCount(), "the superseded stream never reached the server")
+}
+
+// TestWatchLoop_ShutdownIsNotAnError asserts that tearing the client down
+// (Close cancels the watch context) leaves no ERROR behind either: the
+// cancellation is the shutdown, not a stream failure.
+func TestWatchLoop_ShutdownIsNotAnError(t *testing.T) {
+	fake, dialOpts := startFakeRegistrar(t, nil)
+	r, logs := newLoggingRegistry(t, dialOpts)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, r.Initialize(ctx))
+
+	readyCtx, readyCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer readyCancel()
+	require.NoError(t, r.WaitReady(readyCtx))
+
+	require.NoError(t, r.Close())
+
+	require.Eventually(t, func() bool { return fake.active.Load() == 0 }, 10*time.Second, 5*time.Millisecond)
+
+	out := logs.String()
+	require.NotContains(t, out, `"level":"ERROR"`, "shutdown must not log at ERROR; got:\n%s", out)
+}


### PR DESCRIPTION
Fixes #700.

## Root cause

The cancelled context is the agent's own, and the cancellation is deliberate — it is the demand-scoped filter assert racing the very first watch stream's dial.

1. `registry/internal/registrar/registrar.go:282` — `Initialize` starts `watchLoop` immediately. The agent calls it from `agent/internal/cmd/root.go:251`, long before it knows which services this node depends on, so the first stream is opened **unfiltered** (`filterServices == nil`).
2. Opening a server-streaming RPC blocks in the gRPC picker until the connection is READY, so that first `WatchEndpoints` call is still in flight across the whole dial + SPIRE mTLS handshake to the registrar. That is the ~0.6s window in the issue, right after `resolved workload trust domain from SPIRE`.
3. Inside that window the xDS server's `PreListen` asserts the node's dependency set: `agent/internal/xds/server/server.go:104` → `AssertWatchFilter` → `SetServiceFilter` → `registrar.go:222 cancelStream()`. `nil` → `[]string{...}` is always a filter change on a clean start, so the in-flight dial's per-stream context is cancelled.
4. The in-flight call returns `code = Canceled`. The **established-stream** path already classified exactly this case as benign (`handleStreamError`, "watch stream ended for filter re-assertion", Debug), but the **pre-connection** path did not — it fell straight through to the generic branch at the old `registrar.go:463`: ERROR, an `aether.agent.registry.watch_errors` count, and a 1s+jitter backoff before the filtered stream could even be attempted.

So: one ERROR per agent start, one wasted reconnect, and ~1s of avoidable delay before the demand-scoped snapshot arrives (#612's reconnect-doubling concern).

## Fix

Classify the failure *before* cancelling the per-stream context — while the call is in flight, only `SetServiceFilter` or the parent context can have cancelled it, never the loop itself:

- parent context done → shutting down, return quietly (this also removes a spurious ERROR on every agent **shutdown**, which took the same branch);
- per-stream context cancelled with `codes.Canceled` → a filter re-assert superseded the dial. Log at **INFO** with a `startup` marker (`true` for the process's first stream) and reconnect **immediately** — the backoff only delayed the filtered snapshot.

Real stream-open failures keep ERROR, the `watch_errors` metric and the exponential backoff, unchanged.

## What an operator now sees

On a clean start, in place of the ERROR:

```
INFO registrar-registry watch stream superseded by a service-filter change before it connected; reconnecting startup=true
```

(`startup=false` if the same handoff ever happens mid-life, on a dependency-set change.) Nothing at all on shutdown. A registrar that genuinely will not serve the stream still logs the original ERROR line.

## Validation

- New `registry/internal/registrar/watch_startup_test.go`: an in-process registrar (`bufconn`) with a **gated dialer** makes the race deterministic — the first `WatchEndpoints` is provably blocked in the picker when `SetServiceFilter` lands — mirroring the agent's real sequence (`Initialize` → filter assert → `WaitReady`). It captures all records through a `slog` JSON handler into a buffer and asserts **zero `"level":"ERROR"`**, the INFO supersede line with `startup=true`, and that the reconnect carried the new filter (`filter.services == ["default/svc-a"]`) with the superseded stream never reaching the server. A second test asserts a clean shutdown logs no ERROR.
- Verified the test **fails without the production change**, with the issue's exact line:
  `ERROR failed to start watch stream, retrying error="rpc error: code = Canceled desc = context canceled while waiting for connections to become ready" backoff=1018846651`
- `bazel test --test_arg=-test.short //registry/... //agent/...` → 39/39 pass; `registrar_test` also green at `--runs_per_test=3`.
- `make gazelle`, `make format-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr