### PR TITLE
fix(ci): serialise publishes and give the aether chart a commit-pinned tag (#692)

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -28,6 +28,13 @@ name: main-post-merge
 # Integration and e2e are not repeated here: `e2e.yaml` already covers `main`
 # pushes, and the integration leg is bounded by the same PR scope this job
 # re-derives.
+#
+# Deliberately NO `concurrency` group (unlike `publish.yaml`/`proxy-release.yml`,
+# serialised in #692). Those race because they write shared mutable state — a
+# registry tag, a rolling branch. This workflow only reads: each run validates its
+# own commit against its own first parent and writes nothing outside its own run.
+# Serialising it would delay the detection it exists to provide, and a queued-run
+# eviction would silently skip a commit's validation.
 on:
   push:
     branches:

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -16,6 +16,18 @@ on:
 permissions:
   contents: read
 
+# Serialise proxy releases for the same reason as `publish` (#692): the
+# `bump-chart` job rewrites `charts/aether/values.yaml` on top of whatever `main`
+# is at checkout time and force-pushes the single rolling `chore/proxy-image-bump`
+# branch, so two overlapping runs race on that shared branch and the loser's image
+# pin is silently dropped. `cancel-in-progress: false` because each run publishes
+# a distinct, commit-SHA-tagged multi-arch image that nothing else will republish;
+# cancelling one would leave per-arch blobs pushed with no manifest referencing
+# them.
+concurrency:
+  group: proxy-release-main
+  cancel-in-progress: false
+
 # No CARGO_BAZEL_REPIN. Under WORKSPACE it was unavoidable — @envoy's
 # bazel/dependency_imports_extra.bzl has a top-level
 # `load("@envoy_rust_crate_index//:defs.bzl", ...)`, so WORKSPACE evaluation

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,6 +10,19 @@ permissions:
   contents: read
   packages: write
 
+# Serialise publishes (#692). Every run pushes the *same* mutable chart tags
+# (`charts/aether:<Chart.yaml version>` in particular, which does not change per
+# commit), so two runs overlapping — a publish takes ~4 minutes, merges can be
+# closer than that — race on the registry and the loser is whichever finishes
+# first, not the older commit. On 2026-09-05 the older of two runs (77a7d45) won
+# over the newer (95b158e) and a deploy silently shipped without #689.
+# `cancel-in-progress: false` because a publish is not a redundant check to be
+# superseded: cancelling one mid-push would leave the images pushed and the chart
+# not (or the chart pushed against a half-published image set).
+concurrency:
+  group: publish-main
+  cancel-in-progress: false
+
 env:
   IMAGE_REGISTRY: ghcr.io/bpalermo/aether
 
@@ -63,6 +76,11 @@ jobs:
         run: |
           bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/crds:crds.push
           bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/aether:aether.push
+          # …and the same chart again under `charts/aether:<version>-<full sha>`
+          # (#692). The bare `<version>` tag above does not change per commit, so
+          # it alone cannot tell you which commit is deployed; this one can never
+          # be reused. Chart only — the images were just pushed by digest above.
+          bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/aether:aether_commit.push_registry
           bazel run --stamp --config=remote --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_ORG_API_KEY }} //charts/prober:prober.push
           # udsecho: UDS validation workloads (proposal 034 PR 3b) — chart + image
           # bundle like prober; the chart pins the image digest at package time.

--- a/charts/README.md
+++ b/charts/README.md
@@ -43,7 +43,7 @@ substitutes at package time, so packaged charts are pinned to a concrete digest.
 
 | Field | Value | Notes |
 | --- | --- | --- |
-| Chart `version` | e.g. `0.8.0-{GIT_COMMIT}` (crds), `0.2.0-{GIT_COMMIT}` (prober) | SemVer pre-release; commit becomes the OCI tag (dash-separated — `+build` metadata would be rewritten to `_` by helm). The `aether` chart is the exception: it carries a plain version (e.g. `0.90.1`) with no `{GIT_COMMIT}` suffix. Bump the chart's `version:` on any change to its templates/values (enforced in CI). |
+| Chart `version` | e.g. `0.8.0-{GIT_COMMIT}` (crds), `0.2.0-{GIT_COMMIT}` (prober) | SemVer pre-release; commit becomes the OCI tag (dash-separated — `+build` metadata would be rewritten to `_` by helm). The `aether` chart is published **twice**: under its plain `Chart.yaml` version (e.g. `0.92.4`, what Flux and the deploy procedure consume) *and* — via `:aether_commit`, whose `Chart.yaml` is derived from the same file — under `0.92.4-{GIT_COMMIT}`, so every commit's chart stays addressable after the mutable bare tag has moved on (#692). Bump the chart's `version:` on any change to its templates/values (enforced in CI). |
 | Chart `appVersion` | `{STABLE_GIT_VERSION}` | `git describe` value — matches the binaries' embedded `Version`. |
 | Image refs | `repo@sha256:…` | Pinned to the exact built digest (strongest form). |
 
@@ -85,8 +85,10 @@ helm maps it to the dash-separated tag):
 ```bash
 helm install aether-crds oci://ghcr.io/bpalermo/aether/charts/crds \
   --version 0.8.0-<git-commit>
+# Prefer the commit-pinned tag; `--version 0.92.4` also resolves, but that tag is
+# mutable and re-pushed by every release.
 helm install aether oci://ghcr.io/bpalermo/aether/charts/aether \
-  --version 0.90.1 -n aether-system --create-namespace
+  --version 0.92.4-<git-commit> -n aether-system --create-namespace
 ```
 
 ## Multiple instances & labels
@@ -130,6 +132,10 @@ bazel run //charts/aether:aether.push
 
 # Push only the chart (skip images):
 bazel run //charts/aether:aether.push_registry
+
+# Push the same chart again under `<version>-<git-commit>` (chart only — the
+# images are already up as digests). CI does both (#692).
+bazel run //charts/aether:aether_commit.push_registry
 ```
 
 The push target performs `helm registry login` automatically when the

--- a/charts/aether/BUILD.bazel
+++ b/charts/aether/BUILD.bazel
@@ -5,6 +5,18 @@ load("@rules_helm//helm:defs.bzl", "helm_chart", "helm_lint_test", "helm_templat
 # ship here are an input to //agent/internal/proxy/hotrestart (#666).
 exports_files(["values.yaml"])
 
+# Shared by both packagings below (see :aether_commit). `images` is what makes the
+# `{@//...:image_push.digest}` placeholders in values.yaml resolve at package time,
+# so both packages must declare it even though only `:aether.push` publishes the
+# images.
+AETHER_IMAGES = [
+    "//agent/cmd/agent:image_push",
+    "//agent/cmd/mesh-dns:image_push",
+    "//cni/cmd/cni-install:image_push",
+    "//registrar/cmd/registrar:image_push",
+    "//controller/cmd/controller:image_push",
+]
+
 # aether Helm chart (published as ghcr.io/bpalermo/aether/charts/aether).
 #
 # The whole system in one chart: agent + cni-install + per-node proxy, registrar,
@@ -22,13 +34,7 @@ exports_files(["values.yaml"])
 helm_chart(
     name = "aether",
     chart = "Chart.yaml",
-    images = [
-        "//agent/cmd/agent:image_push",
-        "//agent/cmd/mesh-dns:image_push",
-        "//cni/cmd/cni-install:image_push",
-        "//registrar/cmd/registrar:image_push",
-        "//controller/cmd/controller:image_push",
-    ],
+    images = AETHER_IMAGES,
     login_url = "ghcr.io",
     registry_url = "oci://ghcr.io/bpalermo/aether/charts",
     values = "values.yaml",
@@ -43,4 +49,49 @@ helm_lint_test(
 helm_template_test(
     name = "aether_template_test",
     chart = ":aether",
+)
+
+# Commit-pinned second packaging of the SAME chart (#692).
+#
+# `helm push` derives the OCI tag from the packaged chart's `version:`, so the
+# chart above publishes under the bare `charts/aether:<X.Y.Z>` tag — a tag that
+# does not change per commit. Two publish runs therefore used to write it in
+# whatever order they finished, and on 2026-09-05 the older commit's chart won.
+# `publish.yaml` is now serialised, which makes the bare tag last-writer-correct;
+# this target additionally makes every commit's chart addressable by a tag that
+# can never be reused: `charts/aether:<X.Y.Z>-<full git sha>`, the same scheme the
+# crds/prober/udsecho charts already carry in their own `Chart.yaml`.
+#
+# The version suffix is *derived* from Chart.yaml rather than duplicated, so the
+# bare tag and the commit tag can never disagree about X.Y.Z.
+#
+# Only `:aether_commit.push_registry` (chart, no images) is published — the images
+# are byte-identical to the ones `:aether.push` already pushed by digest.
+genrule(
+    name = "chart_commit_yaml",
+    srcs = ["Chart.yaml"],
+    outs = ["Chart.commit.yaml"],
+    # `{GIT_COMMIT}` is a workspace-status placeholder that rules_helm substitutes
+    # at package time on --stamp builds (bazel/workspace_status.sh: full 40-char
+    # sha). Emitting it literally here is the point.
+    # The trailing `grep` fails the build if Chart.yaml's version line ever stops
+    # matching the pattern, rather than silently republishing the bare version
+    # under a second name.
+    cmd = "sed -E 's/^(version:[[:space:]]*\"[0-9]+\\.[0-9]+\\.[0-9]+)\"$$/\\1-{GIT_COMMIT}\"/'" +
+          " $(location Chart.yaml) > $@ && grep -q -- '-{GIT_COMMIT}\"$$' $@",
+)
+
+helm_chart(
+    name = "aether_commit",
+    chart = ":Chart.commit.yaml",
+    images = AETHER_IMAGES,
+    login_url = "ghcr.io",
+    registry_url = "oci://ghcr.io/bpalermo/aether/charts",
+    values = "values.yaml",
+    visibility = ["//visibility:public"],
+)
+
+helm_lint_test(
+    name = "aether_commit_lint_test",
+    chart = ":aether_commit",
 )

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.3"
+version: "0.92.4"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.4"
+version: "0.92.5"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,8 +97,11 @@ Aether ships **two** charts. Install the CRDs first (they are standalone so they
 can be upgraded independently), then the system chart.
 
 ```bash
-# Pick the published version (chart version == git commit of the release).
-VERSION=0.x.0-<commit>
+# Pick the published version. Every chart is published under a commit-pinned tag
+# `<X.Y.Z>-<full git sha>` — use it, not the `aether` chart's bare `<X.Y.Z>` tag,
+# which is mutable and re-pushed by every release (#692).
+COMMIT=<full 40-char git sha>
+VERSION=0.x.0-$COMMIT
 
 # 1) CRDs (MeshConfig, HTTPFilter, EdgeConfig, EndpointPolicy) — install/upgrade first.
 helm upgrade --install aether-crds \
@@ -125,6 +128,15 @@ Resource names derive from the **release** name — installing as `aether` yield
 Verify:
 
 ```bash
+# What actually landed — the chart's appVersion is the commit that built it.
+# Never skip this: a chart tag can serve a different build than you asked for
+# (#692), and this is the only check that catches it.
+got="$(helm get metadata -n aether-system aether -o json | jq -r .appVersion)"
+case "$got" in
+  *"$COMMIT"*) echo "deployed $got — OK" ;;
+  *) echo "DEPLOY MISMATCH: appVersion=$got, expected $COMMIT" >&2; exit 1 ;;
+esac
+
 kubectl -n aether-system get pods         # agent + proxy + mesh-dns per node, registrar ×2, controller
 kubectl -n aether-system get meshconfig   # the seeded "default" MeshConfig CR
 ```

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -202,15 +202,40 @@ the `HTTPFilter` CRD exists** (it watches that type at startup); installing the
 `crds` chart first avoids the race (see #453).
 
 ```bash
+# The commit you intend to deploy (the `publish` run that built it), plus each
+# chart's X.Y.Z from its charts/<name>/Chart.yaml at that commit.
+COMMIT=<full 40-char git sha>
+CRDS_VERSION=<X.Y.Z>-$COMMIT
+AETHER_VERSION=<X.Y.Z>-$COMMIT
+
 # 1) CRDs first
 helm upgrade --install aether-crds oci://ghcr.io/bpalermo/aether/charts/crds \
-  --version "$VERSION"
+  --version "$CRDS_VERSION"
 
-# 2) then the system
+# 2) then the system. Prefer this commit-pinned chart tag over the bare
+#    `--version <X.Y.Z>`: the bare tag is mutable and re-pushed by every publish,
+#    the commit tag never is (#692).
 helm upgrade --install aether oci://ghcr.io/bpalermo/aether/charts/aether \
-  --version "$VERSION" -n aether-system --create-namespace \
+  --version "$AETHER_VERSION" -n aether-system --create-namespace \
   --set clusterName=my-cluster --set meshDomain=aether.internal
+
+# 3) ALWAYS assert what actually landed. The chart's appVersion is the commit
+#    that built it, so this is the only check that catches a chart tag serving
+#    a different build than you asked for — which happened on 2026-09-05, when
+#    two racing publishes wrote the same bare tag and the older build won,
+#    silently deploying a release without #689 in it (#692).
+got="$(helm get metadata -n aether-system aether -o json | jq -r .appVersion)"
+case "$got" in
+  *"$COMMIT"*) echo "deployed $got — OK" ;;
+  *) echo "DEPLOY MISMATCH: appVersion=$got, expected $COMMIT" >&2; exit 1 ;;
+esac
 ```
+
+`appVersion` is the chart's `{STABLE_GIT_VERSION}` — `git describe --tags --always
+--long --dirty --abbrev=40` — so the full sha is embedded in it but may carry a
+`v1.2.3-N-g` prefix or a `-dirty` suffix; hence the substring match rather than
+string equality. If it fails, the chart tag you pulled was built from a different
+commit: re-run that commit's `publish` workflow and upgrade again.
 
 From a checkout, the Bazel install targets do the same in order:
 


### PR DESCRIPTION
Fixes #692.

On 2026-09-05 two `publish` runs for consecutive merges raced on the same chart
tag and **the older build won**: `charts/aether:0.92.1` was pushed by the newer
commit (`95b158e`, #689) at 13:15:59Z and overwritten by the older one
(`77a7d45`) four seconds later. The 13:16:27Z deploy therefore shipped a release
that was believed to contain #689 and did not. Both of the issue's fixes are
here, plus the deploy-side guard.

## 1. Serialise the workflows that write shared mutable state

| workflow | concurrency group | why |
| --- | --- | --- |
| `publish.yaml` | `publish-main`, `cancel-in-progress: false` | Every run pushes the same mutable chart tags; a publish takes ~4 min and merges can be closer than that. `cancel-in-progress: false` because a publish is not a redundant check to be superseded — cancelling one mid-push leaves the images pushed and the chart not. |
| `proxy-release.yml` | `proxy-release-main`, `cancel-in-progress: false` | Same class of bug: `bump-chart` rewrites `charts/aether/values.yaml` on top of whatever `main` is at checkout time and force-pushes the single rolling `chore/proxy-image-bump` branch, so two overlapping runs drop one run's image pin. Cancelling would strand per-arch blobs with no manifest referencing them. |
| `main.yaml` (main-post-merge) | **none, deliberately** — now documented in the file | It writes nothing shared: each run validates its own commit against its own first parent. Serialising it would delay the detection it exists to provide, and queued-run eviction would silently skip a commit's validation. |

## 2. Publish the aether chart under a commit-pinned tag too

`helm push` derives the OCI tag from the packaged chart's `version:`, and the
`aether` chart carried a bare `X.Y.Z` that does not change per commit — unlike
`crds`/`prober`/`udsecho`, which already suffix `-{GIT_COMMIT}`.

The chart is now published **twice**, from two packagings of the same sources:

- `ghcr.io/bpalermo/aether/charts/aether:0.92.4` — unchanged, kept because Flux
  and the deploy procedure consume it, and now safe thanks to (1).
- `ghcr.io/bpalermo/aether/charts/aether:0.92.4-<full 40-char git sha>` — new,
  via `//charts/aether:aether_commit.push_registry` (chart only; the images went
  up by digest with the bare push).

The second packaging's `Chart.yaml` is *derived* from the first by a genrule that
appends `-{GIT_COMMIT}` to the version line, so the two tags can never disagree
about `X.Y.Z`, and the genrule fails the build if that line ever stops matching
the expected shape. Chart version bumped `0.92.3` → `0.92.4` (CI-enforced for any
`charts/` change).

## 3. Post-upgrade guard in the deploy procedure

There is no deploy script, so this went into the two documented procedures
(`docs/runbook.md` §7, `docs/getting-started.md`). Both now pin the commit tag and
end with:

```bash
got="$(helm get metadata -n aether-system aether -o json | jq -r .appVersion)"
case "$got" in
  *"$COMMIT"*) echo "deployed $got — OK" ;;
  *) echo "DEPLOY MISMATCH: appVersion=$got, expected $COMMIT" >&2; exit 1 ;;
esac
```

Substring rather than equality: `appVersion` is `{STABLE_GIT_VERSION}` =
`git describe --tags --always --long --dirty --abbrev=40`, so the sha may carry a
`v1.2.3-N-g` prefix or a `-dirty` suffix. `charts/README.md` documents the new
tag and push target.

## Validation

- `bazel build --stamp //charts/aether:aether //charts/aether:aether_commit` →
  the packaged charts carry `version: 0.92.4` and
  `version: 0.92.4-82ac16c4b3c2ffa61603a12ec596e91ebc13159a` respectively, with
  the same `appVersion`. Non-stamped builds degrade to `0.92.4-GIT-COMMIT` and
  still lint, exactly like the sibling charts.
- `bazel test //charts/...` → 9/9 pass, including the new
  `//charts/aether:aether_commit_lint_test`.
- `bazel build --config=lint //charts/...` clean; `bazel run //:format` clean.
- `scripts/check-chart-version-bump.sh origin/main` → `0.92.3 -> 0.92.4` OK.
- All three edited workflows parse (`yaml.safe_load`); `actionlint` is not
  installed on this machine.

Note on behaviour: with `cancel-in-progress: false`, a run queued behind another
is evicted if a third arrives — so a middle commit's chart may never be
published. That is the intended trade (the issue accepts it), and it now fails
*loudly*: the deploy guard rejects a tag whose `appVersion` is not the commit
asked for, instead of silently deploying the wrong build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
