### PR TITLE
fix(agent): seed the #638 identity mismatch counters at zero (false-zero in Prometheus)

### DIFF
--- a/agent/internal/xds/cache/cachemetrics/cachemetrics.go
+++ b/agent/internal/xds/cache/cachemetrics/cachemetrics.go
@@ -122,6 +122,16 @@ func New(meter metric.Meter) (*Metrics, error) {
 		return nil, fmt.Errorf("inbound binding mismatch: %w", err)
 	}
 
+	// Seed the two #638 discriminator counters at zero. The OTel SDK exports a
+	// counter only after its first Add, so a counter that is never incremented
+	// (the healthy case for both of these) never appears in Prometheus at all —
+	// and "no series" is indistinguishable from "zero" to a grading query.
+	// Seeding makes a live zero visible and lets increase()/rate() work from
+	// process start. Observed on talos-main rev200: neither series existed.
+	ctx := context.Background()
+	m.bindingMismatch.Add(ctx, 0)
+	m.inboundBindingMismatch.Add(ctx, 0)
+
 	return m, nil
 }
 

--- a/agent/internal/xds/cache/cachemetrics/cachemetrics_test.go
+++ b/agent/internal/xds/cache/cachemetrics/cachemetrics_test.go
@@ -129,3 +129,21 @@ func TestCacheMetrics_GeneratedFailure(t *testing.T) {
 		t.Error("version recorded on failure")
 	}
 }
+
+// The #638 discriminator counters must exist (at zero) before anything is ever
+// counted; otherwise their absence in Prometheus reads as a false zero.
+func TestCacheMetrics_IdentityCountersSeededAtZero(t *testing.T) {
+	_, reader := newTestMetrics(t)
+	for _, name := range []string{
+		"aether.agent.identity.outbound_binding_mismatch",
+		"aether.agent.identity.inbound_binding_mismatch",
+	} {
+		v, ok := metricValue(t, reader, name)
+		if !ok {
+			t.Fatalf("%s not exported before first increment", name)
+		}
+		if v != 0 {
+			t.Fatalf("%s = %d, want 0", name, v)
+		}
+	}
+}


### PR DESCRIPTION
Found validating rev200 (#715) on talos-main: `sum by (k8s_node_name)(aether_agent_identity_inbound_binding_mismatch_total)` returned **no series** — and so did the outbound counter from #686, which has been deployed for days. The OTel SDK only exports a counter after its first `Add`, and both counters are never incremented in the healthy case, so "0" and "never registered" were indistinguishable to the soak's `increase(...[1h])` grading queries.

Fix: `Add(ctx, 0)` on both counters at registration; `TestCacheMetrics_IdentityCountersSeededAtZero` pins that both are exported at zero before any increment. No behaviour change otherwise.

Validation plan on talos-main: after deploy, both `aether_agent_identity_{inbound,outbound}_binding_mismatch_total` must return five series reading 0.

Refs #638, #686, #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr