### PR TITLE
fix(agent): treat a registrar drain GOAWAY as a handoff, not a watch failure (#718)

### DIFF
--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     srcs = [
         "metrics_test.go",
         "registrar_test.go",
+        "watch_drain_test.go",
         "watch_startup_test.go",
     ],
     embed = [":registrar"],

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"math/rand/v2"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,6 +33,21 @@ const (
 	maxBackoff = 30 * time.Second
 	// jitterFraction is the fraction of backoff to randomize (0.0–1.0).
 	jitterFraction = 0.2
+	// goawayNoErrorDetail is how grpc-go renders a server-initiated, graceful
+	// HTTP/2 GOAWAY in the status message of the Unavailable error the stream
+	// dies with. From google.golang.org/grpc/internal/transport/http2_client.go:
+	//
+	//	status.Newf(codes.Unavailable, "closing transport due to: %v, received prior goaway: %v", err, goAwayDebugMessage)
+	//	goAwayDebugMessage = fmt.Sprintf("code: %s", f.ErrCode)          // no debug data
+	//	goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %q", …)  // with debug data
+	//
+	// grpc-go exposes the GOAWAY code nowhere structurally — the status carries
+	// no details, and internal/transport is not importable — so matching this
+	// substring on the status message is the discriminator. grpc-go's own
+	// test/goaway_test.go asserts against the same literal, and the unit test
+	// in this package pins it against real grpc-go output rather than a
+	// hand-written string.
+	goawayNoErrorDetail = "received prior goaway: code: NO_ERROR"
 )
 
 // Config holds configuration for connecting to the Registrar service.
@@ -486,8 +502,12 @@ func (r *RegistrarRegistry) watchLoop(ctx context.Context) {
 		r.log.DebugContext(ctx, "watch stream connected", "filtered", services != nil, "filterServices", len(services))
 		r.signalReconnect()
 
-		lastVersion = r.processStream(ctx, stream, lastVersion)
+		var failure error
+		lastVersion, failure = r.processStream(ctx, stream, lastVersion)
 		streamCancel()
+		if failure != nil && !r.failStream(ctx, "watch stream disconnected, retrying", failure, &backoff) {
+			return
+		}
 	}
 }
 
@@ -519,10 +539,18 @@ func (r *RegistrarRegistry) recoverStreamOpen(ctx context.Context, err error, ca
 		return true
 	}
 
+	return r.failStream(ctx, "failed to start watch stream, retrying", err, backoff)
+}
+
+// failStream applies the failure path shared by both stream-loss shapes: count
+// the failure, log it at ERROR, then sleep the current backoff with jitter and
+// double it for the next attempt. It reports whether the loop should keep
+// watching (false = the context ended while waiting, i.e. shutdown).
+func (r *RegistrarRegistry) failStream(ctx context.Context, msg string, err error, backoff *time.Duration) bool {
 	r.metrics.streamFailed(ctx)
 	jitter := time.Duration(float64(*backoff) * jitterFraction * rand.Float64())
 	wait := *backoff + jitter
-	r.log.ErrorContext(ctx, "failed to start watch stream, retrying", "error", err, "backoff", wait)
+	r.log.ErrorContext(ctx, msg, "error", err, "backoff", wait)
 	select {
 	case <-ctx.Done():
 		return false
@@ -532,9 +560,24 @@ func (r *RegistrarRegistry) recoverStreamOpen(ctx context.Context, err error, ca
 	return true
 }
 
+// isServerDrainGoaway reports whether err is an established stream ending
+// because the server drained itself: a graceful, server-initiated GOAWAY with
+// NO_ERROR, which is exactly what a registrar Deployment roll produces
+// (GracefulStop on SIGTERM). The agent reconnects to a surviving replica
+// immediately, so this is a handoff, not a failure (issue #718).
+func isServerDrainGoaway(err error) bool {
+	if status.Code(err) != codes.Unavailable {
+		return false
+	}
+	return strings.Contains(status.Convert(err).Message(), goawayNoErrorDetail)
+}
+
 // processStream reads events from the stream and updates the local cache.
-// It returns the last version seen, for use as a resume token.
-func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv1.RegistrarService_WatchEndpointsClient, lastVersion string) string {
+// It returns the last version seen, for use as a resume token, and the error
+// the stream ended with when that end was a genuine failure (nil when it was
+// an expected end: EOF, our own shutdown or filter re-assert, a forced resync,
+// or a server drain — see handleStreamError).
+func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv1.RegistrarService_WatchEndpointsClient, lastVersion string) (string, error) {
 	snapshotCleared := false
 	// Catalog replay: SERVICE_ADDED events before SNAPSHOT_COMPLETE rebuild
 	// the service set, swapped in at the marker — but only when the server
@@ -567,27 +610,42 @@ func (r *RegistrarRegistry) processStream(ctx context.Context, stream registrarv
 	}
 }
 
-// handleStreamError classifies a stream.Recv error and returns the appropriate resume token.
-func (r *RegistrarRegistry) handleStreamError(ctx context.Context, err error, lastVersion string) string {
-	// DataLoss means the registrar force-resynced this watcher (its
-	// event buffer overflowed). Resuming from lastVersion could skip
-	// the missed events — batches share a version, so lastVersion may
-	// match the current version while events were still dropped. Clear
-	// the resume token so the reconnect receives a full snapshot.
-	if status.Code(err) == codes.DataLoss {
+// handleStreamError classifies a stream.Recv error and returns the appropriate
+// resume token plus the error to fail on — nil for every end that is not a
+// failure, so the caller neither logs at ERROR, nor counts watch_errors, nor
+// pays the reconnect backoff.
+func (r *RegistrarRegistry) handleStreamError(ctx context.Context, err error, lastVersion string) (string, error) {
+	switch {
+	case status.Code(err) == codes.DataLoss:
+		// DataLoss means the registrar force-resynced this watcher (its
+		// event buffer overflowed). Resuming from lastVersion could skip
+		// the missed events — batches share a version, so lastVersion may
+		// match the current version while events were still dropped. Clear
+		// the resume token so the reconnect receives a full snapshot.
 		r.log.InfoContext(ctx, "registrar forced a resync; requesting full snapshot on reconnect")
-		return ""
-	}
-	if status.Code(err) == codes.Canceled && ctx.Err() == nil {
+		return "", nil
+
+	case status.Code(err) == codes.Canceled && ctx.Err() == nil:
 		// The stream was cancelled locally (SetServiceFilter
 		// re-asserting a changed filter), not a registrar failure.
 		r.log.DebugContext(ctx, "watch stream ended for filter re-assertion")
-		return lastVersion
+		return lastVersion, nil
+
+	case err == io.EOF || ctx.Err() != nil:
+		// A clean end of stream, or our own shutdown: the cancellation IS
+		// the shutdown (kept quiet by #712).
+		return lastVersion, nil
+
+	case isServerDrainGoaway(err):
+		// The registrar is draining for a roll and sent a graceful GOAWAY;
+		// the surviving replica is already there. Announce the handoff, but
+		// reconnect straight away: no ERROR, no watch_errors, no backoff
+		// (issue #718).
+		r.log.InfoContext(ctx, "watch stream closed by server drain; reconnecting", "server_drain", true, "error", err)
+		return lastVersion, nil
 	}
-	if err != io.EOF && ctx.Err() == nil {
-		r.log.ErrorContext(ctx, "watch stream disconnected", "error", err)
-	}
-	return lastVersion
+
+	return lastVersion, err
 }
 
 // handleCatalogEvent processes SERVICE_ADDED, SERVICE_REMOVED, and SNAPSHOT_COMPLETE

--- a/registry/internal/registrar/registrar_test.go
+++ b/registry/internal/registrar/registrar_test.go
@@ -482,7 +482,7 @@ func TestProcessStream_TracksLastVersion(t *testing.T) {
 		err: io.EOF,
 	}
 
-	got := r.processStream(context.Background(), stream, "5")
+	got, _ := r.processStream(context.Background(), stream, "5")
 	assert.Equal(t, "7", got, "lastVersion must advance to the newest event version")
 }
 
@@ -506,7 +506,7 @@ func TestProcessStream_DataLossClearsResumeToken(t *testing.T) {
 		err: status.Error(codes.DataLoss, "watch stream overflowed; reconnect for a full snapshot"),
 	}
 
-	got := r.processStream(context.Background(), stream, "5")
+	got, _ := r.processStream(context.Background(), stream, "5")
 	assert.Equal(t, "", got, "DataLoss must clear the resume token to force a full snapshot")
 }
 
@@ -516,7 +516,7 @@ func TestProcessStream_OtherErrorsKeepResumeToken(t *testing.T) {
 		err: status.Error(codes.Unavailable, "connection reset"),
 	}
 
-	got := r.processStream(context.Background(), stream, "5")
+	got, _ := r.processStream(context.Background(), stream, "5")
 	assert.Equal(t, "5", got, "transient errors must keep the resume token")
 }
 
@@ -554,7 +554,7 @@ func TestSnapshotCompleteClosesReady(t *testing.T) {
 		err: io.EOF,
 	}
 
-	got := r.processStream(context.Background(), stream, "")
+	got, _ := r.processStream(context.Background(), stream, "")
 	assert.Equal(t, "8", got, "marker version must advance the resume token")
 	require.NoError(t, r.WaitReady(context.Background()), "ready must be closed after the marker")
 
@@ -635,7 +635,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-c", "6"),
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_REMOVED, "default/svc-b", "7"),
 	}, err: io.EOF}
-	last := r.processStream(context.Background(), stream, "")
+	last, _ := r.processStream(context.Background(), stream, "")
 	assert.Equal(t, "7", last)
 	assert.True(t, r.HasService("default/svc-a"))
 	assert.False(t, r.HasService("default/svc-b"), "incremental removal applies")
@@ -648,7 +648,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED, "svc-z", "9"),
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "9"),
 	}, err: io.EOF}
-	_ = r.processStream(context.Background(), stream, "7")
+	_, _ = r.processStream(context.Background(), stream, "7")
 	assert.True(t, r.HasService("svc-z"))
 	assert.False(t, r.HasService("default/svc-a"), "swap drops stale catalog entries")
 	assert.False(t, r.HasService("svc-c"))
@@ -658,7 +658,7 @@ func TestServiceCatalog_ReplayAndIncrementals(t *testing.T) {
 	stream = &fakeWatchStream{events: []*registrarv1.WatchEndpointsResponse{
 		ev(registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE, "", "9"),
 	}, err: io.EOF}
-	_ = r.processStream(context.Background(), stream, "9")
+	_, _ = r.processStream(context.Background(), stream, "9")
 	assert.True(t, r.HasService("svc-z"), "current client keeps its catalog")
 }
 

--- a/registry/internal/registrar/watch_drain_test.go
+++ b/registry/internal/registrar/watch_drain_test.go
@@ -1,0 +1,251 @@
+package registrar
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	registrarv1 "aethermesh.dev/api/aether/registrar/v1"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// catalogWatchServer answers WatchEndpoints with a one-service catalog and its
+// SNAPSHOT_COMPLETE marker, then holds the stream open — the shape of a live
+// registrar watch. Two of these stand in for the two registrar replicas a roll
+// hands the agent between.
+type catalogWatchServer struct {
+	registrarv1.UnimplementedRegistrarServiceServer
+
+	service string
+	version string
+
+	mu       sync.Mutex
+	requests int
+}
+
+func (s *catalogWatchServer) WatchEndpoints(_ *registrarv1.WatchEndpointsRequest, stream grpc.ServerStreamingServer[registrarv1.WatchEndpointsResponse]) error {
+	s.mu.Lock()
+	s.requests++
+	s.mu.Unlock()
+
+	if err := stream.Send(&registrarv1.WatchEndpointsResponse{
+		Type:        registrarv1.WatchEndpointsResponse_EVENT_TYPE_SERVICE_ADDED,
+		ServiceName: s.service,
+		Version:     s.version,
+	}); err != nil {
+		return err
+	}
+	if err := stream.Send(&registrarv1.WatchEndpointsResponse{
+		Type:    registrarv1.WatchEndpointsResponse_EVENT_TYPE_SNAPSHOT_COMPLETE,
+		Version: s.version,
+	}); err != nil {
+		return err
+	}
+
+	<-stream.Context().Done()
+	return stream.Context().Err()
+}
+
+func (s *catalogWatchServer) requestCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.requests
+}
+
+// swappableListener is the dial target the client keeps re-dialing: a test
+// swaps in the surviving replica's listener before draining the current one,
+// exactly as a Deployment roll leaves a second registrar Pod behind the
+// Service VIP.
+type swappableListener struct {
+	mu  sync.Mutex
+	lis *bufconn.Listener
+}
+
+func (s *swappableListener) set(lis *bufconn.Listener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lis = lis
+}
+
+func (s *swappableListener) dial(ctx context.Context, _ string) (net.Conn, error) {
+	s.mu.Lock()
+	lis := s.lis
+	s.mu.Unlock()
+	if lis == nil {
+		return nil, errors.New("no registrar listening")
+	}
+	return lis.DialContext(ctx)
+}
+
+// serveCatalog stands a catalogWatchServer up on a fresh bufconn listener and
+// returns both, plus the gRPC server so the test can drain or kill it.
+func serveCatalog(t *testing.T, service, version string) (*grpc.Server, *bufconn.Listener, *catalogWatchServer) {
+	t.Helper()
+
+	lis := bufconn.Listen(1024 * 1024)
+	srv := grpc.NewServer()
+	fake := &catalogWatchServer{service: service, version: version}
+	registrarv1.RegisterRegistrarServiceServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return srv, lis, fake
+}
+
+// newSwappableRegistry wires a logging registry (and a ManualReader-backed
+// metric set) onto the swappable dial target.
+func newSwappableRegistry(t *testing.T, target *swappableListener) (*RegistrarRegistry, *lockedBuffer, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	r, logs := newLoggingRegistry(t, []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(target.dial),
+	})
+	metrics, reader := newTestClientMetrics(t)
+	r.metrics = metrics
+	return r, logs, reader
+}
+
+// logRecords parses the JSON slog output into records.
+func logRecords(t *testing.T, logs *lockedBuffer) []map[string]any {
+	t.Helper()
+
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(logs.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &rec), "log line is not JSON: %s", line)
+		out = append(out, rec)
+	}
+	return out
+}
+
+// findRecord returns the first record whose msg matches.
+func findRecord(records []map[string]any, msg string) map[string]any {
+	for _, rec := range records {
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	return nil
+}
+
+// TestWatchLoop_ServerDrainGoawayIsNotAnError reproduces a registrar Deployment
+// roll: the replica the agent is streaming from drains (GracefulStop sends a
+// graceful GOAWAY, then the Pod goes away with the stream still open) while a
+// second replica is already serving. The client must treat that as a handoff —
+// INFO with server_drain=true, no ERROR, no watch_errors, no backoff — and pick
+// the next snapshot up from the survivor (issue #718).
+func TestWatchLoop_ServerDrainGoawayIsNotAnError(t *testing.T) {
+	target := &swappableListener{}
+	srv1, lis1, fake1 := serveCatalog(t, "default/svc-before-roll", "1")
+	target.set(lis1)
+
+	r, logs, reader := newSwappableRegistry(t, target)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, r.Initialize(ctx))
+	defer func() { _ = r.Close() }()
+
+	readyCtx, readyCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer readyCancel()
+	require.NoError(t, r.WaitReady(readyCtx))
+	require.True(t, r.HasService("default/svc-before-roll"))
+
+	// The surviving replica is up behind the Service VIP before the drained one
+	// finishes going away.
+	_, lis2, fake2 := serveCatalog(t, "default/svc-after-roll", "2")
+	target.set(lis2)
+
+	// Drain replica 1: GracefulStop writes the GOAWAY (NO_ERROR) immediately and
+	// then blocks on the still-open watch handler; Stop tears the transport down
+	// with the stream open, which is what turns the GOAWAY into the client-side
+	// Unavailable status the classifier reads.
+	graceDone := make(chan struct{})
+	go func() {
+		defer close(graceDone)
+		srv1.GracefulStop()
+	}()
+	time.Sleep(100 * time.Millisecond)
+	srv1.Stop()
+	<-graceDone
+
+	// The client reconnects to the survivor and applies its snapshot.
+	require.Eventually(t, func() bool {
+		return fake2.requestCount() > 0 && r.HasService("default/svc-after-roll")
+	}, 30*time.Second, 10*time.Millisecond, "client must resume against the surviving replica; logs:\n%s", logs.String())
+	require.Equal(t, 1, fake1.requestCount())
+
+	records := logRecords(t, logs)
+	for _, rec := range records {
+		require.NotEqual(t, "ERROR", rec["level"], "a registrar drain must not log at ERROR; got:\n%s", logs.String())
+	}
+
+	drain := findRecord(records, "watch stream closed by server drain; reconnecting")
+	require.NotNil(t, drain, "the drain handoff must be announced at INFO; got:\n%s", logs.String())
+	require.Equal(t, "INFO", drain["level"])
+	require.Equal(t, true, drain["server_drain"])
+
+	// Pin the classifier against real grpc-go output rather than a hand-written
+	// string: this is the status message the agent saw on talos-main (#718).
+	gotErr, ok := drain["error"].(string)
+	require.True(t, ok, "the INFO line must carry the same error attr the ERROR line did; got %v", drain)
+	require.Contains(t, gotErr, "rpc error: code = Unavailable")
+	require.Contains(t, gotErr, "received prior goaway: code: NO_ERROR")
+
+	// No failure was counted: watch_errors must not exist at all.
+	_, found := metricValue(t, reader, "aether.agent.registry.watch_errors")
+	require.False(t, found, "a server drain must not count as a watch error")
+}
+
+// TestWatchLoop_NonGoawayDisconnectStillErrors is the negative half: a replica
+// that dies without a graceful GOAWAY is still a failure — ERROR, watch_errors,
+// and the reconnect backoff.
+func TestWatchLoop_NonGoawayDisconnectStillErrors(t *testing.T) {
+	target := &swappableListener{}
+	srv1, lis1, _ := serveCatalog(t, "default/svc-before-kill", "1")
+	target.set(lis1)
+
+	r, logs, reader := newSwappableRegistry(t, target)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, r.Initialize(ctx))
+	defer func() { _ = r.Close() }()
+
+	readyCtx, readyCancel := context.WithTimeout(ctx, 30*time.Second)
+	defer readyCancel()
+	require.NoError(t, r.WaitReady(readyCtx))
+
+	// Killed, not drained: Stop closes the transport without a GOAWAY.
+	srv1.Stop()
+
+	require.Eventually(t, func() bool {
+		return findRecord(logRecords(t, logs), "watch stream disconnected, retrying") != nil
+	}, 30*time.Second, 10*time.Millisecond, "an ungraceful disconnect must still log at ERROR; logs:\n%s", logs.String())
+
+	disconnect := findRecord(logRecords(t, logs), "watch stream disconnected, retrying")
+	require.Equal(t, "ERROR", disconnect["level"])
+	require.NotContains(t, disconnect["error"], "received prior goaway: code: NO_ERROR",
+		"this case must not carry a graceful GOAWAY, or the test proves nothing")
+	require.Contains(t, disconnect, "backoff", "the failure path must back off before reconnecting")
+
+	require.Eventually(t, func() bool {
+		got, found := metricValue(t, reader, "aether.agent.registry.watch_errors")
+		return found && got >= 1
+	}, 10*time.Second, 10*time.Millisecond, "an ungraceful disconnect must count a watch error")
+}


### PR DESCRIPTION
Fixes #718.

## The line that had to be explained away

On every registrar Deployment roll (helm rev199/200/201 on 2026-09-05) one or two agents logged, at ERROR:

```
registrar/registrar.go:588 watch stream disconnected
  rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR ...
```

The draining registrar sent a graceful GOAWAY, the agent reconnected to the surviving replica immediately, nothing was lost. But after #712 quieted the startup case this was the *only* ERROR an agent emits in a healthy deploy, so it tripped every "zero ERROR lines" gate (deploy validation, the pressure harness's informational list, soak grading).

## Classification rule

`isServerDrainGoaway(err)` is true when **both**:

1. `status.Code(err) == codes.Unavailable`, and
2. the status message contains `received prior goaway: code: NO_ERROR`.

grpc-go exposes the GOAWAY code nowhere structurally — the status carries no `Details`, and `google.golang.org/grpc/internal/transport` is not importable — so the substring match on the rendered message is the discriminator. It comes from `internal/transport/http2_client.go`:

```go
st = status.Newf(codes.Unavailable, "closing transport due to: %v, received prior goaway: %v", err, goAwayDebugMessage)
goAwayDebugMessage = fmt.Sprintf("code: %s", f.ErrCode)               // no debug data
goAwayDebugMessage = fmt.Sprintf("code: %s, debug data: %q", …)       // with debug data
```

grpc-go's own `test/goaway_test.go` asserts against the same literal, and the unit test here pins it against real grpc-go output rather than a hand-written string. The exact status the test observed from a real `GracefulStop()` on grpc-go v1.83.0:

```
rpc error: code = Unavailable desc = closing transport due to: connection error: desc = "error reading from server: EOF", received prior goaway: code: NO_ERROR, debug data: "graceful_stop"
```

## What changes

For a server drain the agent now logs, at INFO:

```json
{"level":"INFO","logger":"registrar-registry","msg":"watch stream closed by server drain; reconnecting","server_drain":true,"error":"rpc error: code = Unavailable desc = closing transport due to: connection error: desc = \"error reading from server: EOF\", received prior goaway: code: NO_ERROR, debug data: \"graceful_stop\""}
```

— no `watch_errors`, no backoff; it re-dials the survivor straight away.

## What still logs ERROR

Everything that is a real failure. `handleStreamError` now returns the error to fail on (nil for every expected end), and the loop runs the failure path on it:

- an ungraceful disconnect (replica SIGKILLed, TCP reset, `Stop()` without GOAWAY) — ERROR `watch stream disconnected, retrying` + `watch_errors` + jittered backoff;
- a registrar that will not serve the stream at all — unchanged ERROR `failed to start watch stream, retrying` (#700/#712);
- a GOAWAY with any code other than `NO_ERROR`, or any non-`Unavailable` status.

Still quiet, as before: `io.EOF`, the parent-context-cancelled shutdown, a local filter re-assert (`Canceled`), and a `DataLoss` forced resync.

Two behaviour notes:

- The established-stream loss path previously had **no** metric and **no** backoff — it re-dialled instantly and only the stream-open path backed off. It now shares `failStream` with the open path, so a genuinely failing established stream is counted and paced (~1s + jitter) instead of spinning.
- The ERROR message gained `, retrying` (`watch stream disconnected` → `watch stream disconnected, retrying`), matching the open-path wording. Nothing in the repo, charts or dashboards greps the old string.

## Validation

- New `registry/internal/registrar/watch_drain_test.go`, reusing #712's bufconn + locked-JSON-slog harness. Two in-process registrars behind a swappable dial target (the Service VIP): the client streams from replica 1, replica 2 comes up, then replica 1 is drained (`GracefulStop()` in a goroutine writes the GOAWAY; `Stop()` then tears the transport down with the stream open — that is what turns the GOAWAY into the client-side `Unavailable` status). Asserts zero `"level":"ERROR"` records, one INFO carrying `server_drain=true` and the real grpc-go error string, `aether.agent.registry.watch_errors` never recorded, and that the client reconnects and applies the survivor's snapshot.
- `TestWatchLoop_NonGoawayDisconnectStillErrors` is the negative half: `Stop()` with no GOAWAY still yields the ERROR line (with a `backoff` attr, and no GOAWAY detail in the error) and increments `watch_errors`.
- **The drain test fails without the production change**: neutering `isServerDrainGoaway` to return false reproduces `Should not be: "ERROR" … a registrar drain must not log at ERROR`.
- `bazel test --test_arg=-test.short //registry/... //agent/...` — 39/39 pass; `make gazelle`, `make format-check`, and the gocognit lint aspect with `--@aspect_rules_lint//lint:fail_on_violation` clean.

No chart change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr