### PR TITLE
chore(agent): bump go-control-plane/envoy to v1.39.0 + CI parity check with the proxy's Envoy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,6 +104,18 @@ jobs:
       - name: Require a Chart.yaml version bump for chart changes
         run: scripts/check-chart-version-bump.sh "${{ github.event.pull_request.base.sha }}"
 
+  envoy-api-parity:
+    needs: changes
+    # The agent's xDS bindings (go.mod: go-control-plane/envoy) must track the
+    # Envoy the proxy is built from (proxy/MODULE.bazel: envoy_api). Cheap, and
+    # deliberately unconditional: either side can move on its own.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Require the xDS bindings to match the proxy's Envoy
+        run: scripts/check-envoy-api-parity.sh
+
   # Build every impacted target (compile + lint on BuildBuddy RBE; warms the
   # remote cache the integration/e2e legs reuse) and run the impacted unit tests.
   test:
@@ -230,7 +242,7 @@ jobs:
   # the main branch ruleset.
   ci:
     if: always()
-    needs: [changes, diff, chart-version-bump, test, integration, e2e]
+    needs: [changes, diff, chart-version-bump, envoy-api-parity, test, integration, e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any control-plane job failed or was cancelled

--- a/go.mod
+++ b/go.mod
@@ -159,7 +159,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containernetworking/cni v1.3.0
 	github.com/envoyproxy/go-control-plane v0.14.0
-	github.com/envoyproxy/go-control-plane/envoy v1.37.0
+	github.com/envoyproxy/go-control-plane/envoy v1.39.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.4

--- a/go.sum
+++ b/go.sum
@@ -293,6 +293,8 @@ github.com/envoyproxy/go-control-plane/envoy v1.36.0 h1:yg/JjO5E7ubRyKX3m07GF3re
 github.com/envoyproxy/go-control-plane/envoy v1.36.0/go.mod h1:ty89S1YCCVruQAm9OtKeEkQLTb+Lkz0k8v9W0Oxsv98=
 github.com/envoyproxy/go-control-plane/envoy v1.37.0 h1:u3riX6BoYRfF4Dr7dwSOroNfdSbEPe9Yyl09/B6wBrQ=
 github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQOAOHNYMALuowAnbjjEMkkWOi6A=
+github.com/envoyproxy/go-control-plane/envoy v1.39.0 h1:1uwRDYPYG8BIBU9Mj1sUAebNmlM6beu/ZKKweSLDxk8=
+github.com/envoyproxy/go-control-plane/envoy v1.39.0/go.mod h1:5e4ylfTZO723MEEFsCpSW4ZEBWR8mwkEyXfwJBTCZ9c=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an9lx6VBE2cnb8wp1vEGNYGI=
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=

--- a/scripts/check-envoy-api-parity.sh
+++ b/scripts/check-envoy-api-parity.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Keep the agent's xDS API bindings aligned with the Envoy the proxy is built from.
+#
+# The agent generates Envoy config with github.com/envoyproxy/go-control-plane/envoy
+# (go.mod), which go-control-plane publishes per Envoy release (envoy/v1.NN.0). The
+# proxy is built from the envoy_api module pinned in proxy/MODULE.bazel, which is
+# either a release (1.NN.0.envoy) or a main snapshot (1.NN.0-dev.<date>.<sha>.envoy).
+# Fields added between the two are invisible to the agent, and deprecated ones can
+# vanish from the proxy first, so the bindings must be the release matching the
+# proxy, or — while the proxy tracks a -dev snapshot of the NEXT release, which has
+# no bindings yet — the latest release before it (exactly one minor behind).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+bindings=$(sed -nE 's|^\s*github.com/envoyproxy/go-control-plane/envoy v([0-9]+\.[0-9]+)\.[0-9]+.*$|\1|p' go.mod | head -1)
+proxy_line=$(sed -nE 's|^bazel_dep\(name = "envoy_api", version = "([^"]+)"\)|\1|p' proxy/MODULE.bazel | head -1)
+[ -n "$bindings" ] || {
+	echo "::error::go.mod: no github.com/envoyproxy/go-control-plane/envoy requirement found"
+	exit 1
+}
+[ -n "$proxy_line" ] || {
+	echo "::error::proxy/MODULE.bazel: no bazel_dep(name = \"envoy_api\", version = ...) found"
+	exit 1
+}
+
+proxy_mm=$(sed -nE 's|^([0-9]+\.[0-9]+)\.[0-9]+.*$|\1|p' <<<"$proxy_line")
+case "$proxy_line" in *-dev.*) dev=1 ;; *) dev=0 ;; esac
+
+b_major=${bindings%%.*}
+b_minor=${bindings#*.}
+p_major=${proxy_mm%%.*}
+p_minor=${proxy_mm#*.}
+
+echo "bindings: go-control-plane/envoy v${bindings}  proxy: envoy_api ${proxy_line} (dev=${dev})"
+if [ "$b_major" != "$p_major" ]; then
+	echo "::error::Envoy major version mismatch: bindings ${bindings} vs proxy ${proxy_mm}"
+	exit 1
+fi
+if [ "$dev" = 1 ]; then
+	# A -dev snapshot of 1.NN has no bindings yet; 1.(NN-1) is the newest possible.
+	if [ "$b_minor" -ne "$((p_minor - 1))" ] && [ "$b_minor" -ne "$p_minor" ]; then
+		echo "::error::bindings v${bindings} are not the latest release before the proxy's ${proxy_line} snapshot (want ${p_major}.$((p_minor - 1)) or ${proxy_mm}): run 'bazel run @rules_go//go -- get github.com/envoyproxy/go-control-plane/envoy@v${p_major}.$((p_minor - 1)).0 && make tidy'"
+		exit 1
+	fi
+elif [ "$b_minor" -ne "$p_minor" ]; then
+	echo "::error::bindings v${bindings} do not match the proxy's release ${proxy_line}: run 'bazel run @rules_go//go -- get github.com/envoyproxy/go-control-plane/envoy@v${proxy_mm}.0 && make tidy'"
+	exit 1
+fi
+echo "OK: xDS bindings are aligned with the proxy's Envoy"


### PR DESCRIPTION
The agent's xDS bindings (`github.com/envoyproxy/go-control-plane/envoy`) were pinned at **v1.37.0** while the proxy is built from **Envoy 1.40.0-dev** (#705): three minors of API the agent could not express. go-control-plane publishes bindings per Envoy release (none for `-dev`), and `envoy/v1.39.0` is the newest, so this bumps to it.

`scripts/check-envoy-api-parity.sh`, wired as the unconditional `envoy-api-parity` job in the `ci` fan-in, keeps them aligned from now on: bindings must be the release matching `proxy/MODULE.bazel`'s `envoy_api` version, or — while the proxy tracks a `-dev` snapshot of the next release — the latest release before it. Verified: passes after the bump, fails on the pre-bump go.mod with the exact `go get` remedy in the message. The #695 re-pin to `1.40.0.envoy` will therefore have to bump the bindings to v1.40.0 in the same PR.

Validation: `bazel test --test_arg=-test.short //agent/... //common/... //test/... //registrar/... //controller/... //registry/...` 71/71 pass on the new bindings (incl. `//test/envoy_validate` against the pinned proxy binary, #716). Deploying to talos-main tonight ahead of the soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr