### PR TITLE
fix(soak): k6 runs 8h30m so the runners cannot self-restart inside the graded window

### DIFF
--- a/e2e/soak/README.md
+++ b/e2e/soak/README.md
@@ -75,7 +75,7 @@ forgot the TRIPLE's proxy. The set of rolls has not changed, only the tally.
 | 360 | svc-1 — the last roll of any kind | | | |
 | **360 → 450** | **NO-ROLL WINDOW** — nothing is rolled for 90 minutes | | | |
 | 450 | **SHRINK** — `svc-5` scaled to 0 for 90s, then restored | | | |
-| ~452 | `churn driver complete` (k6 runs 7h40m, so both land under load) | | | |
+| ~452 | `churn driver complete` (k6 runs 8h30m: both land under load AND the runners cannot self-restart inside the graded T0+8h window) | | | |
 
 \* = 30 minutes after that proxy roll an age-matched RSS sample is taken in the
 background (`sample-proxy-rss.sh --at-age 1800`), for #628. Six samples per run.

--- a/e2e/soak/churn.sh
+++ b/e2e/soak/churn.sh
@@ -35,7 +35,7 @@
 #   360   NO-ROLL WINDOW BEGIN       nothing is rolled for 90 minutes
 #   450   NO-ROLL WINDOW END
 #   450   SHRINK                     svc-5 -> 0 replicas for 90s, then restored
-#   ~452  churn driver complete      (k6 runs 7h40m, so both land under load)
+#   ~452  churn driver complete      (k6 runs 8h30m: both land under load AND the runners cannot self-restart inside the graded T0+8h window)
 #
 #   * = 30 minutes later an age-matched proxy RSS sample is taken in the
 #       background (sample-proxy-rss.sh --at-age 1800), for #628.

--- a/e2e/soak/k6-mesh-soak.js
+++ b/e2e/soak/k6-mesh-soak.js
@@ -6,7 +6,7 @@ export const options = {
     mesh_soak: {
       executor: 'constant-arrival-rate',
       rate: 60, timeUnit: '1s',
-      duration: '7h40m',
+      duration: '8h30m',
       preAllocatedVUs: 60, maxVUs: 180,
     },
   },

--- a/e2e/soak/k6-runner.yaml
+++ b/e2e/soak/k6-runner.yaml
@@ -48,7 +48,7 @@ spec:
               mountPath: /soak
           resources:
             # k6 accumulates metric samples in memory for the end-of-run summary, so
-            # a 7h40m run outgrows a small limit: at 256Mi every runner OOM-restarted
+            # an 8h30m run outgrows a small limit: at 256Mi every runner OOM-restarted
             # ~3-5h in (07-23 and 07-24 soaks), fragmenting the run and losing the
             # http_req_failed summary. 1Gi comfortably covers the full 8h.
             requests:


### PR DESCRIPTION
Found by the 2026-09-06 grade: the k6 DaemonSet runners (`restartPolicy: Always`) ran a 7h40m script, so at T0+7h39m all five restarted their k6 container together — a 26-timeout fleet-wide burst and a 2-minute load dip (728.5 → 692 rq/s) landed inside the `[T0, T0+8h]` grade window. 26 of the run's 81 timeouts were the harness, not the mesh.

8h30m outlasts the window; the grade's teardown (~T0+8h18m) deletes the runners before the script ends. Comments in `churn.sh`, the README table and the runner manifest updated to match. Harness only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr