### PR TITLE
fix(ci): hand off the proxy chart pin on a pushed branch, and gate the pin in CI (#703)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,6 +116,149 @@ jobs:
       - name: Require the xDS bindings to match the proxy's Envoy
         run: scripts/check-envoy-api-parity.sh
 
+  # The chart's aether-proxy pin has three parts that must agree: `tag:`,
+  # `digest:`, and what the registry actually serves under that tag. Two shipped
+  # bugs were exactly this class and both were invisible until a deploy: #648 (a
+  # hand-pin whose digest came from a different build) and #705 (proxy-release
+  # moved only `tag:`, and `aether.image` prefers `digest:`, so every proxy
+  # release silently kept deploying the Envoy v1.39.0 index). Deliberately
+  # unconditional — no `if`, no path filter: the pin can rot without
+  # values.yaml changing (tags are mutable), //bazel/proxy_pin reads these same
+  # lines to pick the binary //test/envoy_validate runs, and a required check
+  # that skips is a required check that never reports.
+  proxy-pin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # ghcr.io/bpalermo/aether/aether-proxy is a PUBLIC package — anonymous pull
+      # works and nothing below logs in. Declared for the day it is made private
+      # (then a docker/login-action step is needed too, as //bazel/proxy_pin says).
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup helm
+        uses: azure/setup-helm@v4
+      - name: Assert the aether-proxy pin agrees with the registry and the chart
+        run: |
+          values=charts/aether/values.yaml
+
+          # Parse exactly the way bazel/proxy_pin/extensions.bzl does, so the two
+          # can never disagree about what the pin is: the first `repository:`
+          # whose last path segment is `aether-proxy`, then `tag:` / `digest:`
+          # inside that same mapping — indentation >= the repository key's, with
+          # blank and comment-only lines not ending the block.
+          scalar() {
+            raw="${1%%#*}"
+            raw="$(printf '%s' "$raw" | sed -e 's|^[[:space:]]*||' -e 's|[[:space:]]*$||')"
+            case "$raw" in
+              \"*\") raw="${raw#\"}" ; raw="${raw%\"}" ;;
+              \'*\') raw="${raw#\'}" ; raw="${raw%\'}" ;;
+            esac
+            printf '%s' "$raw"
+          }
+
+          repository=""
+          tag=""
+          digest=""
+          in_block=0
+          key_indent=0
+          while IFS= read -r line; do
+            stripped="${line#"${line%%[![:space:]]*}"}"
+            indent=$((${#line} - ${#stripped}))
+            if [ "$in_block" -eq 0 ]; then
+              case "$stripped" in
+                repository:*)
+                  candidate="$(scalar "${stripped#repository:}")"
+                  if [ "${candidate##*/}" = "aether-proxy" ]; then
+                    repository="$candidate"
+                    key_indent="$indent"
+                    in_block=1
+                  fi
+                  ;;
+              esac
+              continue
+            fi
+            if [ -z "$stripped" ]; then
+              continue
+            fi
+            case "$stripped" in
+              \#*) continue ;;
+            esac
+            if [ "$indent" -lt "$key_indent" ]; then
+              break
+            fi
+            case "$stripped" in
+              tag:*) tag="$(scalar "${stripped#tag:}")" ;;
+              digest:*)
+                digest="$(scalar "${stripped#digest:}")"
+                break
+                ;;
+            esac
+          done < "$values"
+
+          fail=0
+          if [ -z "$repository" ]; then
+            echo "::error file=${values}::no aether-proxy image pin found. Expected a line \`repository: <registry>/<path>/aether-proxy\` — the same contract bazel/proxy_pin/extensions.bzl parses."
+            fail=1
+          fi
+          if [ -z "$tag" ]; then
+            echo "::error file=${values}::the aether-proxy image mapping has no \`tag:\`. proxy-release pins tag AND digest together (#703)."
+            fail=1
+          fi
+          if [ -z "$digest" ]; then
+            echo "::error file=${values}::the aether-proxy image mapping has no \`digest:\`. aether.image prefers digest over tag, so a tag-only pin deploys whatever the OLD digest was (#705)."
+            fail=1
+          elif ! printf '%s' "$digest" | grep -Eq '^sha256:[0-9a-f]{64}$'; then
+            echo "::error file=${values}::the aether-proxy \`digest:\` is \"${digest}\", which is not a sha256:<64 hex chars> reference."
+            fail=1
+          fi
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+
+          echo "chart pin: ${repository}"
+          echo "  tag:    ${tag}"
+          echo "  digest: ${digest}"
+
+          # (1) registry: the tag must resolve to exactly the pinned digest.
+          registry_digest=""
+          if ! registry_digest="$(docker buildx imagetools inspect "${repository}:${tag}" \
+            --format '{{.Manifest.Digest}}' 2> "$RUNNER_TEMP/imagetools.err")"; then
+            echo "::error file=${values}::could not resolve ${repository}:${tag} in the registry. aether-proxy is a public package, so this is not an auth problem — the tag does not exist (a hand-typed sha, or a proxy-release that never published):"
+            sed 's|^|  |' "$RUNNER_TEMP/imagetools.err"
+            fail=1
+          fi
+          if [ -z "$registry_digest" ]; then
+            :
+          elif [ "$registry_digest" = "$digest" ]; then
+            echo "registry: ${repository}:${tag} -> ${registry_digest} (agrees with digest:)"
+          else
+            echo "::error file=${values}::\`tag:\` and \`digest:\` disagree with the registry — ${repository}:${tag} resolves to ${registry_digest}, but \`digest:\` pins ${digest}. Both lines must come from the same build; move them together (#648, #703)."
+            fail=1
+          fi
+
+          # (2) + (3) the chart must actually deploy repository@digest. This is
+          # the assertion that catches a stale or missing digest, because
+          # aether.image falls back to the tag and nothing else would notice.
+          helm template aether charts/aether > "$RUNNER_TEMP/rendered.yaml"
+          if grep -qF "\"${repository}@${digest}\"" "$RUNNER_TEMP/rendered.yaml"; then
+            echo "helm: proxy container renders ${repository}@${digest}"
+          else
+            echo "::error file=${values}::helm template does not render the proxy container as ${repository}@${digest}. Rendered aether-proxy references:"
+            grep -n "$repository" "$RUNNER_TEMP/rendered.yaml" || echo "  (none at all)"
+            fail=1
+          fi
+          if grep -qF "\"${repository}:${tag}\"" "$RUNNER_TEMP/rendered.yaml"; then
+            echo "::error file=${values}::helm template renders the proxy container by TAG (${repository}:${tag}). aether.image must resolve to ${repository}@${digest} — a tag reference is mutable and is exactly the #705 bug."
+            fail=1
+          fi
+
+          if [ "$fail" -ne 0 ]; then
+            exit 1
+          fi
+          echo "aether-proxy pin is consistent: values.yaml tag + digest, the registry, and the rendered chart all agree."
+
   # Build every impacted target (compile + lint on BuildBuddy RBE; warms the
   # remote cache the integration/e2e legs reuse) and run the impacted unit tests.
   test:
@@ -242,7 +385,7 @@ jobs:
   # the main branch ruleset.
   ci:
     if: always()
-    needs: [changes, diff, chart-version-bump, envoy-api-parity, test, integration, e2e]
+    needs: [changes, diff, chart-version-bump, envoy-api-parity, proxy-pin, test, integration, e2e]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any control-plane job failed or was cancelled

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -16,14 +16,15 @@ on:
 permissions:
   contents: read
 
-# Serialise proxy releases for the same reason as `publish` (#692): the
-# `bump-chart` job rewrites `charts/aether/values.yaml` on top of whatever `main`
-# is at checkout time and force-pushes the single rolling `chore/proxy-image-bump`
-# branch, so two overlapping runs race on that shared branch and the loser's image
-# pin is silently dropped. `cancel-in-progress: false` because each run publishes
-# a distinct, commit-SHA-tagged multi-arch image that nothing else will republish;
-# cancelling one would leave per-arch blobs pushed with no manifest referencing
-# them.
+# Serialise proxy releases for the same reason as `publish` (#692): `bump-chart`
+# rewrites `charts/aether/values.yaml` and bumps `Chart.yaml` on top of whatever
+# `main` is at checkout time, so two overlapping runs would compute the *same*
+# next chart version off the same base and the second PR to merge would land a
+# duplicate version (and, before #703's per-release branches, would also have
+# clobbered the first run's pin on the shared branch).
+# `cancel-in-progress: false` because each run publishes a distinct,
+# commit-SHA-tagged multi-arch image that nothing else will republish; cancelling
+# one would leave per-arch blobs pushed with no manifest referencing them.
 concurrency:
   group: proxy-release-main
   cancel-in-progress: false
@@ -180,16 +181,44 @@ jobs:
           echo "index_digest=$index" >> "$GITHUB_OUTPUT"
           echo "index: $index"
 
-  # Pin the aether chart to the just-published image (commit-SHA tag) by opening a
-  # PR against the protected main branch. peter-evans reuses a single rolling
-  # branch, so repeat releases update the same PR; if the chart is already pinned
-  # to this SHA there's no diff and no PR.
+  # Pin the aether chart to the just-published image (commit-SHA tag).
+  #
+  # This job deliberately does NOT open the PR (#703). Two independent walls make
+  # an automated PR impossible here:
+  #   * "Allow GitHub Actions to create and approve pull requests" is off, so
+  #     `GITHUB_TOKEN` cannot create a PR at all — every proxy release used to end
+  #     red here with `GitHub Actions is not permitted to create or approve pull
+  #     requests`;
+  #   * turning that setting on would not help. GitHub's recursion guard means a
+  #     PR opened by `GITHUB_TOKEN` fires no `pull_request` events, so the `ci` +
+  #     `proxy` checks the `main` ruleset requires would never report — and the
+  #     ruleset has no bypass actors, so the PR would be permanently unmergeable.
+  #     Pushing straight to `main` is blocked by the same ruleset. There is no PAT
+  #     and there will not be one.
+  # A PR *opened by a human* on a branch a bot pushed does fire `pull_request`
+  # normally, because the event is attributed to whoever opens the PR and not to
+  # whoever pushed the branch. So this job pushes the branch and hands off: a step
+  # summary plus a comment on the rolling "proxy releases pending chart pin"
+  # issue, both carrying the exact `gh pr create` one-liner. That is one command
+  # per proxy release, alongside the talos deploy which is manual anyway — and it
+  # costs no credential, no ruleset bypass and no repository setting change.
+  #
+  # The branch is per-release (`chore/proxy-image-bump-<short sha>`) rather than a
+  # single rolling one: a later `GITHUB_TOKEN` push onto a branch that already has
+  # an open PR fires no `pull_request: synchronize` either, so the new head would
+  # carry no checks and the PR would be stuck (recoverable only by close/reopen).
+  # A fresh branch per release makes every PR a fresh `opened` event. Superseded
+  # `chore/proxy-image-bump-*` PRs are closed by hand.
   bump-chart:
     needs: manifest
     runs-on: ubuntu-latest
     permissions:
+      # contents: write to push the branch; issues: write for the hand-off
+      # comment. No pull-requests: write — this job cannot and must not open PRs.
       contents: write
-      pull-requests: write
+      issues: write
+    env:
+      TRACKING_ISSUE_TITLE: proxy releases pending chart pin
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -197,8 +226,10 @@ jobs:
           ref: main
 
       - name: Pin aether chart to aether-proxy:${{ github.sha }}
+        id: pin
         env:
           INDEX_DIGEST: ${{ needs.manifest.outputs.index_digest }}
+          SHA: ${{ github.sha }}
         run: |
           test -n "$INDEX_DIGEST"
           # charts/aether/values.yaml carries `repository:` + `tag:` + `digest:`
@@ -215,9 +246,20 @@ jobs:
           sed -i -E '\|repository: ghcr\.io/bpalermo/aether/aether-proxy|,+4{s|helper prefers digest over tag\..*|helper prefers digest over tag. Multi-arch index for '"${{ github.sha }}"'.|}' \
             charts/aether/values.yaml
           grep -A5 'repository: ghcr.io/bpalermo/aether/aether-proxy' charts/aether/values.yaml
+          # A re-run of an already-pinned sha (or a release whose proxy bits did
+          # not change the published index) leaves no diff: skip the branch, the
+          # chart bump and the hand-off rather than pushing an empty commit.
+          if git diff --quiet -- charts/aether/values.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "chart is already pinned to $SHA / $INDEX_DIGEST — nothing to do"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       # Any charts/ change must bump the chart version (CI-enforced).
       - name: Bump chart patch version
+        id: chart
+        if: steps.pin.outputs.changed == 'true'
         run: |
           # The version is quoted in Chart.yaml (`version: "0.92.1"`).
           cur="$(sed -nE 's|^version: "?([0-9]+\.[0-9]+\.[0-9]+)"?$|\1|p' charts/aether/Chart.yaml)"
@@ -226,24 +268,162 @@ jobs:
           sed -i -E "s|^version: \"?${cur}\"?$|version: \"${next}\"|" charts/aether/Chart.yaml
           echo "chart $cur -> $next"
           grep -n '^version:' charts/aether/Chart.yaml
+          {
+            echo "from=$cur"
+            echo "to=$next"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Open chart-bump PR
-        uses: peter-evans/create-pull-request@v7
-        with:
-          # Default GITHUB_TOKEN works, but PRs it opens don't trigger CI (GitHub
-          # recursion guard). If main requires status checks to merge, set a PAT
-          # secret CHART_BUMP_PAT so the PR runs CI.
-          token: ${{ secrets.CHART_BUMP_PAT || secrets.GITHUB_TOKEN }}
-          base: main
-          branch: chore/proxy-image-bump
-          delete-branch: true
-          commit-message: "chore(proxy): pin aether chart to aether-proxy:${{ github.sha }}"
-          title: "chore(proxy): pin aether chart to aether-proxy:${{ github.sha }}"
-          body: |
-            Auto-generated by `proxy-release`. Pins the aether chart's proxy image
-            to the multi-arch image published for `${{ github.sha }}`
-            (`${{ needs.manifest.outputs.index_digest }}`) and bumps the chart
-            patch version.
+      - name: Commit and push the chart-pin branch
+        id: push
+        if: steps.pin.outputs.changed == 'true'
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          short="${SHA:0:7}"
+          branch="chore/proxy-image-bump-${short}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add charts/aether/values.yaml charts/aether/Chart.yaml
+          git commit \
+            -m "chore(proxy): pin aether chart to aether-proxy:${SHA}" \
+            -m "Pushed by the proxy-release run for ${SHA}. Moves both tag: and digest: (aether.image prefers digest over tag) and bumps the chart patch version. A human opens the PR so ci + proxy actually run (#703)."
+          # `--force-with-lease` with no value resolves the expected head through
+          # the remote's *configured* fetch refspec. actions/checkout clones
+          # single-branch (main only), so no other branch has a mapping and the
+          # push is rejected as `stale info` even immediately after fetching it.
+          # Pass the lease explicitly instead: the fetched head when the branch
+          # already exists, the empty string ("must not exist") when it does not.
+          lease=""
+          if git fetch -q origin "+refs/heads/${branch}:refs/remotes/origin/${branch}" 2>/dev/null; then
+            lease="$(git rev-parse "refs/remotes/origin/${branch}")"
+          fi
+          git push --force-with-lease="${branch}:${lease}" origin "HEAD:refs/heads/${branch}"
+          {
+            echo "branch=$branch"
+            echo "short=$short"
+          } >> "$GITHUB_OUTPUT"
 
-            `aether.image` prefers `digest:` over `tag:`, so both lines move —
-            a tag-only bump would leave the previously pinned image deployed.
+      # The hand-off: everything a human needs to turn the pushed branch into a
+      # PR, written twice — to the run summary (for whoever is looking at the run)
+      # and to the rolling tracking issue (the notification channel: a bot comment
+      # on an issue the owner subscribes to does notify).
+      - name: Hand off the chart-pin branch
+        if: steps.pin.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          INDEX_DIGEST: ${{ needs.manifest.outputs.index_digest }}
+          BRANCH: ${{ steps.push.outputs.branch }}
+          CHART_FROM: ${{ steps.chart.outputs.from }}
+          CHART_TO: ${{ steps.chart.outputs.to }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="chore(proxy): pin aether chart to aether-proxy:${SHA}"
+          body="$RUNNER_TEMP/pr-body.md"
+          handoff="$RUNNER_TEMP/handoff.md"
+          # Quoted heredoc + __PLACEHOLDERS__: the body is markdown full of
+          # backticks, which an expanding heredoc would run as command
+          # substitutions.
+          cat > "$body" <<'PRBODY'
+          Auto-generated by the `proxy-release` run for `__SHA__` (__RUN_URL__).
+
+          Pins the aether chart's proxy image to the multi-arch index published for
+          that commit, and bumps the chart patch version.
+
+          | | |
+          |---|---|
+          | image | `ghcr.io/bpalermo/aether/aether-proxy:__SHA__` |
+          | index digest | `__DIGEST__` |
+          | chart version | `__CHART_FROM__` -> `__CHART_TO__` |
+
+          `aether.image` (`charts/aether/templates/_helpers.tpl`) prefers `digest:`
+          over `tag:`, so both lines move — a tag-only bump would leave the
+          previously pinned image deployed (#703, #705). The `proxy-pin` CI job
+          re-checks that `tag:`, `digest:` and the registry agree.
+
+          The branch was pushed by the workflow and this PR opened by hand on
+          purpose: a PR opened by `GITHUB_TOKEN` fires no `pull_request` events, so
+          the required `ci` + `proxy` checks would never report and the `main`
+          ruleset (no bypass actors) could never be satisfied (#703).
+
+          If an older `chore/proxy-image-bump-*` PR is still open, this one
+          supersedes it — close the older one.
+
+          🤖 Generated with [Claude Code](https://claude.com/claude-code)
+          PRBODY
+          sed -i \
+            -e "s|__SHA__|${SHA}|g" \
+            -e "s|__DIGEST__|${INDEX_DIGEST}|g" \
+            -e "s|__CHART_FROM__|${CHART_FROM}|g" \
+            -e "s|__CHART_TO__|${CHART_TO}|g" \
+            -e "s|__BRANCH__|${BRANCH}|g" \
+            -e "s|__RUN_URL__|${RUN_URL}|g" \
+            "$body"
+
+          {
+            echo "## Chart pin ready for \`aether-proxy:${SHA}\`"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| image | \`ghcr.io/bpalermo/aether/aether-proxy:${SHA}\` |"
+            echo "| index digest | \`${INDEX_DIGEST}\` |"
+            echo "| chart version | \`${CHART_FROM}\` -> \`${CHART_TO}\` |"
+            echo "| branch | \`${BRANCH}\` |"
+            echo "| release run | ${RUN_URL} |"
+            echo
+            echo "\`proxy-release\` pushed the branch but cannot open the PR (#703)."
+            echo "Run this from a checkout (bash — it uses process substitution):"
+            echo
+            echo '```sh'
+            echo "gh pr create --base main --head ${BRANCH} --title \"${title}\" --body-file <(cat <<'PRBODY'"
+            cat "$body"
+            echo "PRBODY"
+            echo ")"
+            echo '```'
+          } > "$handoff"
+
+          cat "$handoff" >> "$GITHUB_STEP_SUMMARY"
+
+          # One rolling tracking issue, exact-title matched (the search is fuzzy,
+          # the select is not). Created on first use.
+          num="$(gh issue list --state open --limit 100 \
+            --search "\"${TRACKING_ISSUE_TITLE}\" in:title" \
+            --json number,title \
+            --jq "[.[] | select(.title == \"${TRACKING_ISSUE_TITLE}\")] | .[0].number // empty")"
+          if [ -z "$num" ]; then
+            issue_body="$RUNNER_TEMP/issue-body.md"
+            cat > "$issue_body" <<'ISSUEBODY'
+          Rolling tracker for the `proxy-release` -> chart-pin hand-off (#703).
+
+          Every `proxy-release` run publishes a commit-SHA-tagged multi-arch
+          `aether-proxy` image, pins `charts/aether/values.yaml` to it and pushes
+          the result to `chore/proxy-image-bump-<short sha>`. It cannot open the PR
+          itself: `GITHUB_TOKEN` may not create PRs here, and a PR it created would
+          get no `pull_request` runs, hence none of the `ci` + `proxy` checks the
+          `main` ruleset requires.
+
+          So each run comments here with the exact `gh pr create` one-liner. Run it,
+          let `ci` + `proxy` go green, squash-merge, then deploy and assert
+          `appVersion` (docs/runbook.md §7). Close any superseded
+          `chore/proxy-image-bump-*` PR.
+          ISSUEBODY
+            url="$(gh issue create --title "${TRACKING_ISSUE_TITLE}" --body-file "$issue_body")"
+            num="${url##*/}"
+            echo "created tracking issue #${num}: ${url}"
+          fi
+          gh issue comment "$num" --body-file "$handoff"
+          echo "commented on tracking issue #${num}"
+
+      - name: Chart already pinned to this sha
+        if: steps.pin.outputs.changed != 'true'
+        env:
+          SHA: ${{ github.sha }}
+          INDEX_DIGEST: ${{ needs.manifest.outputs.index_digest }}
+        run: |
+          {
+            echo "## Chart already pinned to \`aether-proxy:${SHA}\`"
+            echo
+            echo "\`charts/aether/values.yaml\` needed no change (index \`${INDEX_DIGEST}\`)."
+            echo "No branch pushed, no chart bump, no hand-off comment."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -237,6 +237,17 @@ esac
 string equality. If it fails, the chart tag you pulled was built from a different
 commit: re-run that commit's `publish` workflow and upgrade again.
 
+**After a proxy release, open the PR the workflow pushed.** `proxy-release`
+publishes the image, pins `charts/aether/values.yaml` (`tag:` *and* `digest:`)
+and pushes `chore/proxy-image-bump-<short sha>`, but it cannot open the PR:
+`GITHUB_TOKEN` may not create PRs here, and one it created would get no
+`pull_request` runs, so the required `ci` + `proxy` checks would never report
+(#703). Copy the `gh pr create` one-liner from the run summary — the same block
+is posted to the rolling **proxy releases pending chart pin** issue — open the
+PR, let `ci` + `proxy` go green, squash-merge, and close any superseded
+`chore/proxy-image-bump-*` PR. Only then is there a `publish` run whose
+commit-suffixed chart tag (`<X.Y.Z>-<full sha>`, above) carries the new proxy.
+
 From a checkout, the Bazel install targets do the same in order:
 
 ```bash


### PR DESCRIPTION
Closes #703.

## The mechanism (and why the repo setting would not help)

Every `proxy-release` run has ended red at `bump-chart` since
"Allow GitHub Actions to create and approve pull requests" was turned off:
`peter-evans/create-pull-request` with `GITHUB_TOKEN` dies at
`GitHub Actions is not permitted to create or approve pull requests`. The image
is published, the chart stays unpinned, the deploy has to be hand-pinned.

**Turning that setting back on would not fix it.** A PR opened by `GITHUB_TOKEN`
fires no `pull_request` events (GitHub's recursion guard), so the `ci` + `proxy`
checks the `main` ruleset requires would never report — and the ruleset has no
bypass actors, so the PR would be permanently unmergeable. Pushing straight to
`main` is blocked by the same ruleset. There is no PAT and there will not be one;
a ruleset bypass for a bot would break the no-bypass invariant.

A PR **opened by a human on a branch a bot pushed** does fire `pull_request`
normally — the event is attributed to whoever opens the PR, not to whoever pushed
the branch. So:

* `bump-chart` keeps the existing seds (`values.yaml` `tag:` + `digest:` +
  the provenance comment) and the `Chart.yaml` patch bump, then commits as
  `github-actions[bot]` onto a **per-release** branch
  `chore/proxy-image-bump-<short sha>` and
  `git push --force-with-lease` es it with `GITHUB_TOKEN`
  (`contents: write`, already granted). `pull-requests: write` is dropped;
  `issues: write` is added.
* Per-release, not the old rolling `chore/proxy-image-bump`, because a later
  `GITHUB_TOKEN` push onto a branch that already has an open PR fires no
  `pull_request: synchronize` either — the new head would carry no checks and the
  PR would be stuck. A fresh branch makes every PR a fresh `opened` event.
* If the chart is already pinned to this sha there is no diff: no chart bump, no
  branch, no hand-off — the summary says so.
* The lease is passed explicitly (`--force-with-lease=<branch>:<sha-or-empty>`).
  A bare `--force-with-lease` resolves the expected head through the remote's
  *configured* fetch refspec, and `actions/checkout` clones single-branch, so any
  other branch is rejected as `stale info` even right after fetching it. Verified
  locally against a scratch remote for all three cases (new branch, existing
  branch, genuinely stale lease → rejected).

### Hand-off

The job writes the same block to `$GITHUB_STEP_SUMMARY` **and** as a comment on a
single rolling tracking issue titled **`proxy releases pending chart pin`**
(searched by exact title, created on first use) — that issue comment is the
notification channel. The block is:

```
## Chart pin ready for `aether-proxy:<full sha>`

| | |
|---|---|
| image | `ghcr.io/bpalermo/aether/aether-proxy:<full sha>` |
| index digest | `sha256:…` |
| chart version | `0.92.3` -> `0.92.4` |
| branch | `chore/proxy-image-bump-<short sha>` |
| release run | <run url> |

`proxy-release` pushed the branch but cannot open the PR (#703).
Run this from a checkout (bash — it uses process substitution):

```sh
gh pr create --base main --head chore/proxy-image-bump-<short sha> --title "chore(proxy): pin aether chart to aether-proxy:<full sha>" --body-file <(cat <<'PRBODY'
…body, ending with the generated-with trailer…
PRBODY
)
```
```

## The new `proxy-pin` CI job

Unconditional (no `if`, no path filter) and folded into the `ci` fan-in `needs`,
so it is a required check on every PR. It catches the #648 / #705 class — a pin
whose parts came from different builds — on a PR instead of on a deploy. Three
assertions:

1. **values.yaml is well-formed.** `repository:` / `tag:` / `digest:` for
   `aether-proxy` are parsed with *exactly* the contract
   `bazel/proxy_pin/extensions.bzl` uses (first `repository:` whose last path
   segment is `aether-proxy`; then `tag:` / `digest:` inside that mapping,
   indentation >= the key's, blank and comment-only lines not ending the block;
   `digest:` must be `sha256:<64 hex>`), so the CI gate and the
   `//test/envoy_validate` binary selection can never disagree about what the pin
   is.
2. **The registry agrees.**
   `docker buildx imagetools inspect <repo>:<tag> --format '{{.Manifest.Digest}}'`
   must equal `digest:`. `aether-proxy` is a public GHCR package so this needs no
   login (`packages: read` is declared for the day it is not).
3. **The chart deploys the digest.** `helm template charts/aether` must render the
   proxy container as `<repo>@<digest>`, and must *not* render it as
   `<repo>:<tag>` — `aether.image` prefers `digest:`, which is precisely why the
   tag-only bump in #705 was invisible.

Every failure emits an `::error file=charts/aether/values.yaml::` naming which of
the three disagrees and what each side says.

## How this was validated

Both workflow files parse (`python3 -c 'import yaml…'`) and `actionlint 1.7.7`
reports nothing new (the one `github.head_ref` warning it prints on `ci.yaml` is
present on `main` too). `make format-check` is clean.

The `bump-chart` steps were extracted from the YAML and dry-run locally with a
stubbed `gh`: the pin step reports `changed=true` on a fresh file and
`changed=false` on an already-pinned one, and the hand-off step produces the
summary and one-liner shown above (the `<(cat <<'PRBODY' … )` construct was
checked to actually run in bash).

The `proxy-pin` step was extracted and run under `bash -e` against the real
`charts/aether/values.yaml`:

* **PASSES** on the current pin — tag `51ba12979d545bcde021d81ef9151355db7c6a07`,
  digest `sha256:9e401334408d8f87d59d0c409d957553d56938fb373b258eab002d3e655bd8a3`;
  the registry returns that same digest and `helm template` renders
  `…/aether-proxy@sha256:9e4013…`. Exit 0.
* **FAILS** when the digest is corrupted to `sha256:0e401334…`:
  `::error … tag: and digest: disagree with the registry — …:51ba129… resolves to
  sha256:9e4013…, but digest: pins sha256:0e4013…`. Exit 1.
* Also fails, with its own message, when `digest:` is deleted (tag-only pin, the
  #705 shape) and when the tag does not exist in the registry.

`charts/` is untouched, so no chart version bump is needed here.

## Note on merging this PR

`.github/workflows/proxy-release.yml` is itself a `proxy-release` trigger path, so
**merging this PR runs the new path end to end**: it publishes an `aether-proxy`
image for the merge commit, pushes `chore/proxy-image-bump-<short sha>`, writes
the summary and creates + comments on the tracking issue. The first real hand-off
therefore happens on merge — open that PR by hand, watch `ci` + `proxy` run on it,
merge, then deploy and assert `appVersion` as usual (`docs/runbook.md` §7, which
this PR updates).

The stale rolling branch `chore/proxy-image-bump` (c4e878d, pinning dff1677) is
now dead and can be deleted; left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
