### PR TITLE
chore(proxy): pin aether chart to aether-proxy:ffe3c5b7d9c3ff75661519e5043dc414a833142b

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.5"
+version: "0.92.6"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -281,10 +281,10 @@ proxy:
   # commit SHA. Mirror by overriding `repository`.
   image:
     repository: ghcr.io/bpalermo/aether/aether-proxy
-    tag: 51ba12979d545bcde021d81ef9151355db7c6a07
+    tag: ffe3c5b7d9c3ff75661519e5043dc414a833142b
     # Digest-pinned (option A): content-addressed, tamper-proof. The aether.image
-    # helper prefers digest over tag. Multi-arch index for 51ba12979d545bcde021d81ef9151355db7c6a07.
-    digest: "sha256:9e401334408d8f87d59d0c409d957553d56938fb373b258eab002d3e655bd8a3"
+    # helper prefers digest over tag. Multi-arch index for ffe3c5b7d9c3ff75661519e5043dc414a833142b.
+    digest: "sha256:32ac264f82f501f320f40f260c77a951c52a8da6e504608341d54dd7b37fff20"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application logs as one JSON object per line (bootstrap


### PR DESCRIPTION
Auto-generated by the `proxy-release` run for `ffe3c5b7d9c3ff75661519e5043dc414a833142b` (https://github.com/bpalermo/aether/actions/runs/34032571930).

Pins the aether chart's proxy image to the multi-arch index published for
that commit, and bumps the chart patch version.

| | |
|---|---|
| image | `ghcr.io/bpalermo/aether/aether-proxy:ffe3c5b7d9c3ff75661519e5043dc414a833142b` |
| index digest | `sha256:32ac264f82f501f320f40f260c77a951c52a8da6e504608341d54dd7b37fff20` |
| chart version | `0.92.5` -> `0.92.6` |

`aether.image` (`charts/aether/templates/_helpers.tpl`) prefers `digest:`
over `tag:`, so both lines move — a tag-only bump would leave the
previously pinned image deployed (#703, #705). The `proxy-pin` CI job
re-checks that `tag:`, `digest:` and the registry agree.

The branch was pushed by the workflow and this PR opened by hand on
purpose: a PR opened by `GITHUB_TOKEN` fires no `pull_request` events, so
the required `ci` + `proxy` checks would never report and the `main`
ruleset (no bypass actors) could never be satisfied (#703).

If an older `chore/proxy-image-bump-*` PR is still open, this one
supersedes it — close the older one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
