### PR TITLE
fix(agent): bound the DNS retransmit budget and stop hiding resolution stalls as timeouts (#726)

### DIFF
--- a/controller/internal/podmutate/mutator.go
+++ b/controller/internal/podmutate/mutator.go
@@ -12,6 +12,17 @@
 //     resolver apply the search domains first; glibc tolerates the fall-through to
 //     the bare name, but musl (Alpine) trips on the churn and fails to resolve mesh
 //     names. ndots is opt-in (default off) alongside mesh DNS.
+//   - dnsConfig timeout/attempts: bounds what a single LOST DNS datagram costs.
+//     The resolver a managed pod talks to is node-local (the CNI DNATs :53 to the
+//     node's mesh-DNS), so a query that gets no answer is not a slow answer, it is
+//     a dropped one — and the stock resolv.conf default makes the client wait a
+//     full 5s before retransmitting. Because Go's resolver singleflights by name,
+//     that one drop stalls EVERY concurrent lookup of that name for the whole 5s,
+//     turning a lost packet into a seconds-long per-name outage (issue #726: a
+//     mesh-DNS surge handoff closes the predecessor's SO_REUSEPORT socket, the
+//     datagram in flight to it is discarded, and the client eats 5s). A 1s
+//     retransmit against a node-local resolver is generous, and 3 attempts leave a
+//     3s worst case against the 10s the defaults allow.
 //
 // The webhook is wired with two rules: an objectSelector (aether.io/managed=true
 // pods, in any namespace) and a namespaceSelector (pods in aether.io/managed=true
@@ -30,10 +41,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-const ndotsOption = "ndots"
+const (
+	ndotsOption    = "ndots"
+	timeoutOption  = "timeout"
+	attemptsOption = "attempts"
 
-// Mutator injects dnsConfig ndots=NDots into a pod on CREATE. NDots is the dot count
-// of <svc>.<meshDomain> (= the label count of meshDomain; 2 for aether.internal), so
+	// resolverTimeout and resolverAttempts are the resolv.conf retransmit budget
+	// injected into managed pods. They are derived constants rather than flags for
+	// the same reason ndots is (see podNDots): the value follows from the topology —
+	// the resolver is node-local — not from an operator preference.
+	resolverTimeout  = "1"
+	resolverAttempts = "3"
+)
+
+// Mutator injects the mesh resolv.conf options into a pod on CREATE: ndots=NDots
+// plus the retransmit budget (timeout/attempts). NDots is the dot count of
+// <svc>.<meshDomain> (= the label count of meshDomain; 2 for aether.internal), so
 // mesh FQDNs are resolved absolute-first while shorter k8s names keep their search
 // behavior.
 type Mutator struct {
@@ -49,9 +72,10 @@ func NewMutator(ndots string, log *slog.Logger) *Mutator {
 // Handle reaches here for a pod matched either by the managed-pod objectSelector
 // or the managed-namespace namespaceSelector. It (1) ensures the aether.io/managed
 // label so the CNI meshes the pod — unless the pod explicitly opts out with
-// aether.io/managed=false — and (2) injects ndots into managed pods. A pod that
-// opts out is left entirely untouched. Idempotent: re-admission (or a pod that
-// already carries the label / ndots) produces no spurious patch.
+// aether.io/managed=false — and (2) injects the mesh resolv.conf options into
+// managed pods. A pod that opts out is left entirely untouched. Idempotent:
+// re-admission (or a pod that already carries the label / the options) produces no
+// spurious patch.
 func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 	if err := json.Unmarshal(req.Object.Raw, pod); err != nil {
@@ -72,33 +96,63 @@ func (m *Mutator) Handle(ctx context.Context, req admission.Request) admission.R
 		changed = true
 	}
 
-	if m.NDots != "" && !hasNdots(pod) {
-		if pod.Spec.DNSConfig == nil {
-			pod.Spec.DNSConfig = &corev1.PodDNSConfig{}
+	for _, opt := range m.dnsOptions() {
+		if setDNSOption(pod, opt.name, opt.value) {
+			changed = true
 		}
-		v := m.NDots
-		pod.Spec.DNSConfig.Options = append(pod.Spec.DNSConfig.Options, corev1.PodDNSConfigOption{Name: ndotsOption, Value: &v})
-		changed = true
 	}
 
 	if !changed {
-		return admission.Allowed("pod already managed with ndots")
+		return admission.Allowed("pod already managed with mesh DNS options")
 	}
 
 	marshaled, err := json.Marshal(pod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	m.Log.DebugContext(ctx, "mesh-injected pod (managed label + ndots)", "namespace", req.Namespace, "ndots", m.NDots)
+	m.Log.DebugContext(ctx, "mesh-injected pod (managed label + DNS options)", "namespace", req.Namespace,
+		"ndots", m.NDots, "timeout", resolverTimeout, "attempts", resolverAttempts)
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaled)
 }
 
-func hasNdots(pod *corev1.Pod) bool {
+// dnsOption is one resolv.conf option the webhook injects.
+type dnsOption struct{ name, value string }
+
+// dnsOptions is the ordered set of resolv.conf options injected into a managed pod.
+// An empty value disables that option (NDots is empty when mesh DNS is off); the
+// retransmit budget is unconditional because it is a pure robustness bound that
+// costs nothing when resolution is healthy.
+func (m *Mutator) dnsOptions() []dnsOption {
+	return []dnsOption{
+		{ndotsOption, m.NDots},
+		{timeoutOption, resolverTimeout},
+		{attemptsOption, resolverAttempts},
+	}
+}
+
+// setDNSOption appends name=value to the pod's dnsConfig and reports whether it
+// changed the pod. It NEVER overrides an option the pod already carries: an explicit
+// value is the workload author's decision, and silently rewriting it would be a
+// surprising failure mode to debug. An empty value is a no-op (option disabled).
+func setDNSOption(pod *corev1.Pod, name, value string) bool {
+	if value == "" || hasDNSOption(pod, name) {
+		return false
+	}
+	if pod.Spec.DNSConfig == nil {
+		pod.Spec.DNSConfig = &corev1.PodDNSConfig{}
+	}
+	v := value
+	pod.Spec.DNSConfig.Options = append(pod.Spec.DNSConfig.Options, corev1.PodDNSConfigOption{Name: name, Value: &v})
+	return true
+}
+
+// hasDNSOption reports whether the pod already declares the named resolv.conf option.
+func hasDNSOption(pod *corev1.Pod, name string) bool {
 	if pod.Spec.DNSConfig == nil {
 		return false
 	}
 	for _, o := range pod.Spec.DNSConfig.Options {
-		if o.Name == ndotsOption {
+		if o.Name == name {
 			return true
 		}
 	}

--- a/controller/internal/podmutate/mutator_test.go
+++ b/controller/internal/podmutate/mutator_test.go
@@ -51,40 +51,111 @@ func TestMutator_RespectsOptOut(t *testing.T) {
 	assert.Empty(t, resp.Patches, "opt-out pod gets no patch")
 }
 
-// TestMutator_NoOpWhenAlreadyManagedWithNdots: an already-labeled pod that already
-// sets ndots needs no patch (idempotent / the explicit-label ndots path steady state).
-func TestMutator_NoOpWhenAlreadyManagedWithNdots(t *testing.T) {
-	m := NewMutator("2", slog.New(slog.DiscardHandler))
-	v := "2"
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "p", Labels: map[string]string{aetherlabels.LabelAetherManaged: "true"}},
-		Spec:       corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &v}}}},
+// dnsOpts builds a pod dnsConfig option list from name/value pairs.
+func dnsOpts(kv ...string) []corev1.PodDNSConfigOption {
+	opts := make([]corev1.PodDNSConfigOption, 0, len(kv)/2)
+	for i := 0; i < len(kv); i += 2 {
+		v := kv[i+1]
+		opts = append(opts, corev1.PodDNSConfigOption{Name: kv[i], Value: &v})
 	}
-	resp := m.Handle(context.Background(), request(pod))
-	require.True(t, resp.Allowed)
-	assert.Empty(t, resp.Patches, "no patch when already managed and ndots set")
+	return opts
 }
 
-// TestMutator_LabelOnlyWhenNdotsDisabled: with ndots disabled (NDots=""), a managed
-// namespace still gets the label, just no dnsConfig.
-func TestMutator_LabelOnlyWhenNdotsDisabled(t *testing.T) {
+// managedPod is an already-labeled pod carrying the given dnsConfig options.
+func managedPod(opts ...corev1.PodDNSConfigOption) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "p", Labels: map[string]string{aetherlabels.LabelAetherManaged: "true"}},
+		Spec:       corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{Options: opts}},
+	}
+}
+
+// TestMutator_NoOpWhenAlreadyManagedWithMeshDNSOptions: an already-labeled pod that
+// already carries the full mesh resolv.conf option set needs no patch (idempotent /
+// the explicit-label steady state).
+func TestMutator_NoOpWhenAlreadyManagedWithMeshDNSOptions(t *testing.T) {
+	m := NewMutator("2", slog.New(slog.DiscardHandler))
+	pod := managedPod(dnsOpts("ndots", "2", "timeout", resolverTimeout, "attempts", resolverAttempts)...)
+	resp := m.Handle(context.Background(), request(pod))
+	require.True(t, resp.Allowed)
+	assert.Empty(t, resp.Patches, "no patch when already managed with every mesh DNS option set")
+}
+
+// TestMutator_LabelAndBudgetWhenNdotsDisabled: with ndots disabled (NDots=""), a
+// managed namespace still gets the label and still gets the retransmit budget — the
+// budget is unconditional because a lost datagram costs 5s whichever resolver
+// answers, mesh-DNS or kube-dns.
+func TestMutator_LabelAndBudgetWhenNdotsDisabled(t *testing.T) {
 	m := NewMutator("", slog.New(slog.DiscardHandler))
 	resp := m.Handle(context.Background(), request(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}))
 	require.True(t, resp.Allowed)
 	require.NotEmpty(t, resp.Patches)
 	assert.True(t, patchesLabel(resp), "label added even with ndots disabled")
+
+	opts := m.dnsOptions()
+	require.Len(t, opts, 3)
+	assert.Equal(t, dnsOption{ndotsOption, ""}, opts[0], "ndots carries no value, so it is skipped")
+	assert.Equal(t, dnsOption{timeoutOption, resolverTimeout}, opts[1])
+	assert.Equal(t, dnsOption{attemptsOption, resolverAttempts}, opts[2])
 }
 
 // TestMutator_RespectsExistingNdots: an already-managed pod that sets its own ndots
-// keeps it (no ndots churn), and needs no other change.
+// keeps it (no ndots churn). It still gains the retransmit budget it lacks.
 func TestMutator_RespectsExistingNdots(t *testing.T) {
 	m := NewMutator("2", slog.New(slog.DiscardHandler))
-	v := "1"
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{aetherlabels.LabelAetherManaged: "true"}},
-		Spec:       corev1.PodSpec{DNSConfig: &corev1.PodDNSConfig{Options: []corev1.PodDNSConfigOption{{Name: "ndots", Value: &v}}}},
-	}
+	pod := managedPod(dnsOpts("ndots", "1")...)
 	resp := m.Handle(context.Background(), request(pod))
 	require.True(t, resp.Allowed)
-	assert.Empty(t, resp.Patches, "no patch when already managed and ndots set")
+	require.NotEmpty(t, resp.Patches, "the missing timeout/attempts options are still added")
+	// The pod's own ndots survives untouched.
+	assert.False(t, setDNSOption(managedPod(dnsOpts("ndots", "1")...), ndotsOption, "2"),
+		"an ndots the pod already declares is never overridden")
+}
+
+// TestMutator_InjectsRetransmitBudget pins the #726 fix: a fresh managed pod is given
+// options timeout:1 attempts:3, so a single lost DNS datagram costs ~1s instead of the
+// stock 5s resolv.conf retransmit — which Go's per-name singleflight otherwise turns
+// into a 5s outage of that name for the whole pod.
+func TestMutator_InjectsRetransmitBudget(t *testing.T) {
+	m := NewMutator("2", slog.New(slog.DiscardHandler))
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}
+	require.True(t, setDNSOption(pod, timeoutOption, resolverTimeout))
+	require.True(t, setDNSOption(pod, attemptsOption, resolverAttempts))
+
+	got := map[string]string{}
+	for _, o := range pod.Spec.DNSConfig.Options {
+		got[o.Name] = *o.Value
+	}
+	assert.Equal(t, map[string]string{timeoutOption: "1", attemptsOption: "3"}, got)
+
+	// And the webhook actually emits them for a pod that has neither.
+	resp := m.Handle(context.Background(), request(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p"}}))
+	require.True(t, resp.Allowed)
+	b, err := json.Marshal(resp.Patches)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), timeoutOption)
+	assert.Contains(t, string(b), attemptsOption)
+}
+
+// TestSetDNSOption covers the injection primitive directly: it adds a missing option,
+// never overrides one the workload author already declared, treats an empty value as
+// "option disabled", and materializes a nil dnsConfig.
+func TestSetDNSOption(t *testing.T) {
+	t.Run("adds when absent", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		assert.True(t, setDNSOption(pod, timeoutOption, "1"))
+		require.NotNil(t, pod.Spec.DNSConfig, "a nil dnsConfig is materialized")
+		require.Len(t, pod.Spec.DNSConfig.Options, 1)
+		assert.Equal(t, "1", *pod.Spec.DNSConfig.Options[0].Value)
+	})
+	t.Run("never overrides an explicit value", func(t *testing.T) {
+		pod := managedPod(dnsOpts(timeoutOption, "7")...)
+		assert.False(t, setDNSOption(pod, timeoutOption, "1"))
+		require.Len(t, pod.Spec.DNSConfig.Options, 1)
+		assert.Equal(t, "7", *pod.Spec.DNSConfig.Options[0].Value, "the workload's own value wins")
+	})
+	t.Run("empty value is a no-op", func(t *testing.T) {
+		pod := &corev1.Pod{}
+		assert.False(t, setDNSOption(pod, ndotsOption, ""))
+		assert.Nil(t, pod.Spec.DNSConfig, "a disabled option must not materialize a dnsConfig")
+	})
 }

--- a/docs/observability/mesh-dns-alerts.yml
+++ b/docs/observability/mesh-dns-alerts.yml
@@ -115,8 +115,12 @@ groups:
 
       # External SLI. Deliberately EXCLUDES http_error: that is the cross-node drain
       # path (a different failure domain), and including it would fire on every proxy
-      # roll. Generic `timeout` IS included -- a hung resolver surfaces as a context
-      # deadline, not as dns_timeout.
+      # roll. Generic `timeout` IS still included as a belt-and-braces catch: a
+      # resolution stall that outlives the probe's own deadline now classifies as
+      # dns_timeout (issue #726 -- the prober used to test ctx.Err() ahead of the
+      # *net.DNSError branch, which made dns_timeout structurally unreachable and made
+      # "dns_* is zero" read as "DNS is healthy" when it only meant "DNS never failed
+      # FAST"), but a connect-side hang still lands in `timeout`.
       - alert: MeshDNSResolutionFailing
         expr: |
           sum by (node, target) (

--- a/prober/internal/prober/prober.go
+++ b/prober/internal/prober/prober.go
@@ -310,13 +310,22 @@ func notSampledTraceparent() string {
 // regression is an unambiguous, independently alertable signal — never folded into
 // connection_error. A connect failure AFTER successful resolution stays
 // connection_error.
+//
+// Resolution is classified FIRST, ahead of the probe's own deadline. This ordering
+// is load-bearing, not stylistic (issue #726). The per-probe budget (Config.Timeout,
+// 2s) is SHORTER than the stock resolv.conf retransmit timeout (5s), so a lookup that
+// loses a datagram always blows the probe deadline before the resolver retries. With
+// the deadline tested first, ctx.Err() was ALWAYS context.DeadlineExceeded by the time
+// the error came back and dns_timeout was structurally unreachable for exactly the
+// failure it exists to name: three separate investigations read "dns_* is zero" as
+// "DNS is healthy" when it only ever meant "DNS never failed FAST".
+//
+// The reorder is safe because *net.DNSError is produced only by resolution — Go
+// returns one (with IsTimeout set) when the context deadline cancels a lookup in
+// flight, and a plain OpError with no DNSError inside when the deadline lands on a
+// post-resolution connect. So the DNS branch catches resolution stalls and nothing
+// else; connect stalls still fall through to resultTimeout below.
 func classifyErr(ctx context.Context, err error) string {
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
-		return resultTimeout
-	}
-	// A DNS failure is checked before the generic net.Error timeout branch: a
-	// *net.DNSError also satisfies net.Error, and a resolution timeout must surface
-	// as dns_timeout (not the transport timeout) so the mesh-DNS signal is distinct.
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
 		switch {
@@ -327,6 +336,9 @@ func classifyErr(ctx context.Context, err error) string {
 		default:
 			return resultDNSError
 		}
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+		return resultTimeout
 	}
 	var ne net.Error
 	if errors.As(err, &ne) && ne.Timeout() {

--- a/prober/internal/prober/prober_test.go
+++ b/prober/internal/prober/prober_test.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 )
@@ -67,6 +68,41 @@ func TestClassifyErr(t *testing.T) {
 		err := fmt.Errorf("dial tcp 10.0.0.1:18081: %w", &net.OpError{Op: "dial", Err: errors.New("connection refused")})
 		if got := classifyErr(context.Background(), err); got != resultConnectionError {
 			t.Fatalf("got %q, want %q", got, resultConnectionError)
+		}
+	})
+
+	// The subtests above all pass a live context, which is precisely why the
+	// misordering in #726 survived: in production the probe's own 2s deadline has
+	// ALWAYS expired by the time a 5s resolver retransmit surfaces, so ctx.Err() is
+	// DeadlineExceeded on every real dns_timeout. These pin the expired-context case.
+	t.Run("DNS timeout with an ALREADY-EXPIRED probe context -> dns_timeout", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			t.Fatalf("test setup: want an expired context, got %v", ctx.Err())
+		}
+		// What Go hands back when the probe deadline cancels a lookup in flight.
+		err := fmt.Errorf("dial: %w", &net.DNSError{Err: "i/o timeout", Name: "echo.aether-test.aether.internal", IsTimeout: true})
+		if got := classifyErr(ctx, err); got != resultDNSTimeout {
+			t.Fatalf("a resolution stall must be attributed to DNS even once the probe deadline has expired: got %q, want %q", got, resultDNSTimeout)
+		}
+	})
+	t.Run("DNS nxdomain with an ALREADY-EXPIRED probe context -> dns_nxdomain", func(t *testing.T) {
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		err := fmt.Errorf("dial: %w", &net.DNSError{Err: "no such host", Name: "bogus.aether.internal", IsNotFound: true})
+		if got := classifyErr(ctx, err); got != resultDNSNXDomain {
+			t.Fatalf("got %q, want %q", got, resultDNSNXDomain)
+		}
+	})
+	t.Run("connect stall with an expired probe context stays timeout", func(t *testing.T) {
+		// The other side of the reorder: a deadline that lands AFTER resolution carries
+		// no *net.DNSError, so it must still be a transport timeout, never a dns_* class.
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+		defer cancel()
+		err := fmt.Errorf("dial tcp 10.107.111.199:18081: %w", &net.OpError{Op: "dial", Err: context.DeadlineExceeded})
+		if got := classifyErr(ctx, err); got != resultTimeout {
+			t.Fatalf("got %q, want %q", got, resultTimeout)
 		}
 	})
 }


### PR DESCRIPTION
Closes #726 (mechanism confirmed in https://github.com/bpalermo/aether/issues/726#issuecomment-5559352992).

## The hypothesis in the issue is refuted

#726 proposed that the mesh-domain path is served by an `:authority`-named on-demand cluster whose endpoints miss the DRAINING-aware health the service cluster gets. It isn't, on either the data or the code:

- **The failing requests never reach Envoy.** Across 12:29:30–12:32:00Z on 2026-09-06 there is not one non-`200` source-reporter access log anywhere in the mesh — no `UT`, no `UF`, no `URX`, no `DC`, no 503. Control-tested both ways so this is not a false zero: `response_flags:"UT"` returns the k6 504s at 05:54:56Z and `NOT response_code:"200"` returns a `DC` on w04 at 12:44:47Z.
- **Both paths are one data path.** For both authorities in the same seconds, `downstream_local_address` is `10.107.111.199:18081` (echo's ClusterIP), `upstream_cluster` is `aether-test/echo`, and `upstream_host` rotates over all three replicas. mesh-DNS returns the mesh Service's ClusterIP, never pod IPs, so there is no pod pinning.
- **The alias cluster shares the EDS resource.** `echo.aether-test.aether.internal:18081` sets `EdsClusterConfig.ServiceName` to the bare `aether-test/echo` (`agent/internal/xds/cache/cluster.go:401-421`), and `buildHTTPEndpointBuckets` appends the *same* `*LbEndpoint` pointer into every bucket, so `HealthStatus_DRAINING` reaches every cluster shape by construction. #152 cannot diverge between them — and it never engages here anyway, since rolling `aether-proxy` deletes no `echo` pods.

## The confirmed mechanism

The rev204 deploy rolled `aether-mesh-dns` too, which the issue's timeline missed. On main-worker-02:

```
12:30:39.383Z  warm-started mesh-DNS records from snapshot   generation=6 records=14
12:30:39.632Z  mesh DNS resolver listening  addr=192.168.0.61:18054  reusePort=true
```

The DaemonSet is `maxSurge:1 / maxUnavailable:0`, readiness is an exec probe with `initialDelaySeconds:1, periodSeconds:15`, and there is **no `preStop` and no drain**. Successor binds at `:39.63`, its first readiness probe passes at ≈`:40.6`, the DS controller deletes the predecessor, and `Server.Start` closes the SO_REUSEPORT UDP socket immediately (`agent/internal/meshdns/server.go:493-497`). While both sockets are in the reuseport group the kernel hashes each datagram to one of them; a datagram steered at the departing socket in the closing window is silently discarded.

The client then waits the stock resolv.conf `timeout:5`, and Go's resolver singleflights by name, so that one lost packet stalls **every** concurrent lookup of that name:

| | |
|---|---|
| last mesh-domain access log before the hole | `12:30:40.841Z` |
| first after | `12:30:45.947Z` |
| gap | **5.106 s** = the default resolv.conf retransmit |
| same prober, `svc.cluster.local`, same window | 81 records, continuous at 5.06/s, **no gap** |
| prober counter `…aether.internal` | 17725 → **17741 (+16)** |
| prober counter `…svc.cluster.local` | 18016 → 18016 (+0) |

The arithmetic closes: probes issued in the first ~3.1 s of the 5.1 s stall blow their own 2 s deadline (`3.1 × 4.99 ≈ 16`); the rest were still queued when resolution completed and were released in a visible pile-up — three requests inside 1 ms at `12:30:45.947/.948/.948`, twelve inside 0.6 s, far above the 5/s tick.

**The mesh-domain path is not disadvantaged.** Largest single burst per prober over 24h:

| prober (node) | `svc.cluster.local` | `aether.internal` |
|---|---|---|
| prober-5p56l (w01) | **81** | 78 |
| prober-qqwvb (w03) | **35** | 26 |
| prober-gz7gf (w05) | 7 | **19** |
| prober-sw777 (w02) | 7 | **16** |
| prober-5bt7w (w04) | **9** | 1 |

The biggest burst in the fleet is on cluster.local, three of five probers have their worst there, and every prober has more cluster.local timeouts lifetime than mesh-domain ones. Both names lose the same coin flip; the three samples in the issue caught the mesh side three times.

## The change

**1. Bound the retransmit cost** — `controller/internal/podmutate`

The pod-mutating webhook now injects `options timeout:1 attempts:3` alongside the existing `ndots`. The resolver a managed pod talks to is node-local (the CNI DNATs `:53` to the node's mesh-DNS), so a query that gets no answer is a dropped one, not a slow one — 1 s is generous, and 3 attempts leave a 3 s worst case against the 10 s the defaults allow. A lost datagram costs ~1 s instead of 5 s: under the prober's 2 s budget and under essentially any client's.

- Fail-open (a resolv.conf option), and it covers **every** managed pod, not the prober — so it also fixes the symmetric cluster.local bursts including the 81 on w01.
- An option the workload author already declares is **never** overridden.
- Derived constants rather than flags, for the same reason `ndots` is derived from `--mesh-domain` (the retired `--pod-ndots`): the value follows from the topology, not from an operator preference. **No chart change, so no `Chart.yaml` bump.**

**2. Make the class observable** — `prober/internal/prober`

`classifyErr` tested `ctx.Err()` before the `*net.DNSError` branch. The probe budget (2 s) is shorter than the resolver retransmit (5 s), so `ctx.Err()` was *always* `DeadlineExceeded` by the time the error surfaced, and `dns_timeout` was structurally unreachable for exactly the failure it exists to name. Three separate investigations read "`dns_*` is zero" as "DNS is healthy" when it only ever meant "DNS never failed **fast**". The function's own comment already prescribed DNS-first; the code contradicted it.

The reorder is safe because `*net.DNSError` is produced only by resolution: Go returns one (with `IsTimeout` set) when the deadline cancels a lookup in flight, and a plain `OpError` with no `DNSError` inside when the deadline lands on a post-resolution connect. Connect stalls still classify as `timeout`.

Every pre-existing `classifyErr` subtest passed `context.Background()`, which is precisely why this survived. The new subtests pin the already-expired-context case in both directions.

`MeshDNSResolutionFailing` already matched `dns_timeout|timeout`, so alerting behaviour is unchanged; its comment (which documented the misconception) is corrected.

## Not in this PR

Eliminating the datagram loss itself. A post-SIGTERM lame-duck window in `Server.Start` (drop the ready marker first, keep serving briefly, then close) would narrow it, but the drop is a kernel reuseport-group race at socket close and cannot be fully closed from userspace without eBPF socket steering. Bounding the client's retransmit is what removes the user-visible outage; narrowing the window is second-order. Worth its own issue.

## Generated xDS

Unchanged. Nothing in this PR touches the xDS cache or proxy packages, and `//test/envoy_validate` is unaffected.

## Validation on talos-main

The webhook mutates on **CREATE only**, so existing pods keep the old resolv.conf until recreated. Sequence:

1. Deploy the controller and prober images, then **recreate the prober DaemonSet pods** (`kubectl -n aether-test rollout restart ds/prober`) so they pick up the new `dnsConfig`. Confirm on one:
   `kubectl -n aether-test get pod <prober> -o jsonpath='{.spec.dnsConfig}'` → must show `ndots:2`, `timeout:1`, `attempts:3`.
2. Baseline the counters, then run **≥10 `aether-mesh-dns` DaemonSet rolls** under steady prober load (this is the trigger — not the proxy roll). Ten rolls is the floor: the historical hit rate is ~1 in 3, so 10 gives ~97% power to see at least one pre-fix-sized burst if the fix did nothing.
3. Per roll, per path, count the delta:
   ```promql
   aether_probe_requests_total{tier="mesh_dns",result="timeout",target="echo.aether-test.aether.internal:18081"}
   aether_probe_requests_total{tier="mesh_dns",result="timeout",target="echo.aether-test.svc.cluster.local:18081"}
   ```
   Use raw per-series deltas, not `rate()`/`increase()` — the counters are OTLP-pushed and `rate()` lies across scrape gaps.
4. **Pass:** no burst above ~2 on either path in any roll (a 1 s stall is well inside the 2 s probe budget, so a lost datagram should now be invisible). Any burst ≥5 means the retransmit budget did not reach that pod — check its `dnsConfig` first.
5. **New signal to watch:** should a resolution stall still occur, it now lands in `result="dns_timeout"` rather than `result="timeout"`. A non-zero `dns_timeout` after this deploy is the fix working as an observability change, not a regression — grade `dns_timeout + timeout` together against the old `timeout` baseline.
6. Also confirm no collateral: `aether_probe_requests_total{result="dns_nxdomain"}` stays at its baseline (a too-aggressive retransmit would surface as spurious NXDOMAIN from truncated search-list walks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
