### PR TITLE
chore(proxy): pin aether chart to aether-proxy:d16de766658d572f37dbfb7abd6241d1b9feb300

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.6"
+version: "0.92.7"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -281,10 +281,10 @@ proxy:
   # commit SHA. Mirror by overriding `repository`.
   image:
     repository: ghcr.io/bpalermo/aether/aether-proxy
-    tag: ffe3c5b7d9c3ff75661519e5043dc414a833142b
+    tag: d16de766658d572f37dbfb7abd6241d1b9feb300
     # Digest-pinned (option A): content-addressed, tamper-proof. The aether.image
-    # helper prefers digest over tag. Multi-arch index for ffe3c5b7d9c3ff75661519e5043dc414a833142b.
-    digest: "sha256:32ac264f82f501f320f40f260c77a951c52a8da6e504608341d54dd7b37fff20"
+    # helper prefers digest over tag. Multi-arch index for d16de766658d572f37dbfb7abd6241d1b9feb300.
+    digest: "sha256:c8d7232b29426d742a4ade7b4c0146dcca33deb354fc1060a4c4e59f47245189"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application logs as one JSON object per line (bootstrap


### PR DESCRIPTION
Auto-generated by the `proxy-release` run for `d16de766658d572f37dbfb7abd6241d1b9feb300` (https://github.com/bpalermo/aether/actions/runs/34035841252).

Pins the aether chart's proxy image to the multi-arch index published for
that commit, and bumps the chart patch version.

| | |
|---|---|
| image | `ghcr.io/bpalermo/aether/aether-proxy:d16de766658d572f37dbfb7abd6241d1b9feb300` |
| index digest | `sha256:c8d7232b29426d742a4ade7b4c0146dcca33deb354fc1060a4c4e59f47245189` |
| chart version | `0.92.6` -> `0.92.7` |

`aether.image` (`charts/aether/templates/_helpers.tpl`) prefers `digest:`
over `tag:`, so both lines move — a tag-only bump would leave the
previously pinned image deployed (#703, #705). The `proxy-pin` CI job
re-checks that `tag:`, `digest:` and the registry agree.

Opened by the `proxy-release` workflow with the `RELEASE_PAT` fine-grained
token (#727). A PR opened by a *user* token fires `pull_request` normally,
so `ci` + `proxy` run and report — unlike one opened by `GITHUB_TOKEN`,
which GitHub's recursion guard leaves without checks and therefore
permanently unmergeable under the `main` ruleset (#703). Auto-merge
(squash) is armed: GitHub merges this the moment the required checks pass,
and the ruleset — which has no bypass actors — is still the only gate.

Any older `chore/proxy-image-bump-*` PR is superseded and was closed by
the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
