### PR TITLE
fix(prober): give the seconds-valued duration histograms explicit seconds buckets (#732)

### DIFF
--- a/agent/internal/cni/server/metrics.go
+++ b/agent/internal/cni/server/metrics.go
@@ -105,6 +105,15 @@ func (m *cniMetrics) registerSweepInstruments(meter metric.Meter) error {
 	return nil
 }
 
+// promotionDelayBuckets are the explicit boundaries, in SECONDS, for
+// aether.agent.liveness.promotion_delay_seconds. The OTel defaults are
+// millisecond-oriented (0, 5, 10, ... 10000), which would put every promotion into the
+// "<= 5 s" first bucket (#732). The liveness loop ticks every livenessInterval (5 s), so
+// the interesting range is one tick to a couple of minutes.
+var promotionDelayBuckets = []float64{
+	0.5, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 45, 60, 90, 120, 300,
+}
+
 // registerLifecycleInstruments registers the unmeshed/storage gauges, the liveness
 // instruments and the identity-override counter.
 func (m *cniMetrics) registerLifecycleInstruments(meter metric.Meter) error {
@@ -128,7 +137,8 @@ func (m *cniMetrics) registerLifecycleInstruments(meter metric.Meter) error {
 	}
 	if m.promotionDelay, err = meter.Float64Histogram("aether.agent.liveness.promotion_delay_seconds",
 		metric.WithDescription("Seconds from the liveness loop first observing a pod's programmed health gateway to promoting it HEALTHY in the registry"),
-		metric.WithUnit("s")); err != nil {
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(promotionDelayBuckets...)); err != nil {
 		return fmt.Errorf("promotion delay: %w", err)
 	}
 	if m.spiffeIDOverrides, err = meter.Int64Counter("aether.agent.identity.spiffe_id_override_rejected",

--- a/agent/internal/xds/cache/cachemetrics/cachemetrics.go
+++ b/agent/internal/xds/cache/cachemetrics/cachemetrics.go
@@ -67,6 +67,15 @@ type Metrics struct {
 	inboundBindingMismatch metric.Int64Counter
 }
 
+// snapshotDurationBuckets are the explicit boundaries, in SECONDS, for
+// aether.agent.snapshot.duration. The OTel default boundaries are millisecond-oriented
+// (0, 5, 10, ... 10000), so a seconds-valued duration would collapse into the "<= 5 s"
+// first bucket and the quantiles would read flat (#732). A snapshot build is
+// sub-millisecond on a small node and tens of milliseconds on a dense one.
+var snapshotDurationBuckets = []float64{
+	0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
+}
+
 // New registers the snapshot instruments on the given meter.
 func New(meter metric.Meter) (*Metrics, error) {
 	m := &Metrics{}
@@ -82,7 +91,8 @@ func New(meter metric.Meter) (*Metrics, error) {
 	}
 	if m.duration, err = meter.Float64Histogram("aether.agent.snapshot.duration",
 		metric.WithDescription("Duration of an xDS snapshot generation"),
-		metric.WithUnit("s")); err != nil {
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(snapshotDurationBuckets...)); err != nil {
 		return nil, fmt.Errorf("duration: %w", err)
 	}
 	if m.version, err = meter.Int64Gauge("aether.agent.snapshot.version",

--- a/docs/proposals/013_mesh-availability-prober.md
+++ b/docs/proposals/013_mesh-availability-prober.md
@@ -148,6 +148,10 @@ Emitted through the existing OTel → `otel-collector` → Prometheus pipeline:
 - `aether_probe_requests_total{tier, target, result}` — counter
   (`tier` = `liveness` | `reachability`).
 - `aether_probe_request_duration_seconds{tier, target}` — histogram (optional).
+  Its boundaries are set EXPLICITLY, in seconds (0.001 … 1, 1.5, 2, 2.5, 5): the OTel
+  SDK's defaults are millisecond-oriented, so a seconds-valued duration would put every
+  observation — a 2 ms probe and a timed-out 2 s one alike — in the same `le="5"`
+  bucket and flatten every derived quantile (#732).
 
 Per-node de-collapse via `OTEL_RESOURCE_ATTRIBUTES=k8s.node.name=$(NODE_NAME)`
 (downward API) + the collector `transform/promote` already in place (à la PR #210).

--- a/prober/internal/prober/BUILD.bazel
+++ b/prober/internal/prober/BUILD.bazel
@@ -21,5 +21,9 @@ go_test(
     name = "prober_test",
     srcs = ["prober_test.go"],
     embed = [":prober"],
-    deps = ["@com_github_go_logr_logr//:logr"],
+    deps = [
+        "@com_github_go_logr_logr//:logr",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk_metric//metricdata",
+    ],
 )

--- a/prober/internal/prober/prober.go
+++ b/prober/internal/prober/prober.go
@@ -88,6 +88,29 @@ type target struct {
 	authority string
 }
 
+// probeDurationBuckets are the explicit histogram boundaries, in SECONDS, for
+// aether_probe_request_duration_seconds. They must be set explicitly: the OTel SDK's
+// default boundaries (0, 5, 10, 25, ... 10000) are tuned for values expressed in
+// MILLISECONDS, so against a seconds-valued duration the first bucket is "<= 5 s" and a
+// healthy 2 ms probe is indistinguishable from a timed-out 2 s one — every observation
+// lands in the first bucket and the derived quantiles are flat (#732).
+//
+// The ladder separates the four regimes that actually matter: healthy sub-10 ms probes,
+// the 1 s resolver retransmit (#728), the 2 s probe budget (Config.Timeout) and the 5 s
+// legacy resolver retransmit.
+var probeDurationBuckets = []float64{
+	0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 5,
+}
+
+// newDurationHistogram builds the probe duration histogram. It is a named function so a
+// test can assert the boundaries that actually reach the SDK.
+func newDurationHistogram(meter metric.Meter) (metric.Float64Histogram, error) {
+	return meter.Float64Histogram("aether_probe_request_duration_seconds",
+		metric.WithDescription("Synthetic mesh probe duration."),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(probeDurationBuckets...))
+}
+
 // Prober samples the mesh data plane and records results to OTel.
 type Prober struct {
 	cfg      Config
@@ -110,8 +133,7 @@ func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Pro
 	if err != nil {
 		return nil, fmt.Errorf("probe counter: %w", err)
 	}
-	duration, err := meter.Float64Histogram("aether_probe_request_duration_seconds",
-		metric.WithDescription("Synthetic mesh probe duration."), metric.WithUnit("s"))
+	duration, err := newDurationHistogram(meter)
 	if err != nil {
 		return nil, fmt.Errorf("probe histogram: %w", err)
 	}

--- a/prober/internal/prober/prober_test.go
+++ b/prober/internal/prober/prober_test.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 var traceparentRe = regexp.MustCompile(`^00-[0-9a-f]{32}-[0-9a-f]{16}-00$`)
@@ -155,4 +158,84 @@ func TestNewTargets(t *testing.T) {
 	if want := "svc-1.aether.internal"; p.targets[1].authority != want {
 		t.Fatalf("reachability authority = %q, want %q", p.targets[1].authority, want)
 	}
+}
+
+// TestDurationHistogramBuckets pins the seconds-oriented boundaries of
+// aether_probe_request_duration_seconds (#732). Without them the SDK falls back to its
+// millisecond-oriented defaults (0, 5, 10, ... 10000), whose first bucket is "<= 5 s":
+// a 2 ms probe and a timed-out 2 s probe then land in the same bucket and every derived
+// quantile reads flat. The assertion is made against the EXPORTED data point, so it
+// covers the option actually reaching the SDK, not just the package variable.
+func TestDurationHistogramBuckets(t *testing.T) {
+	ctx := context.Background()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { _ = mp.Shutdown(ctx) })
+
+	h, err := newDurationHistogram(mp.Meter(telemetryServiceName))
+	if err != nil {
+		t.Fatalf("newDurationHistogram: %v", err)
+	}
+	h.Record(ctx, 0.002) // a healthy sub-10 ms probe
+	h.Record(ctx, 2.0)   // a probe that burned the full 2 s budget
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(ctx, &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+	m := findMetric(t, &rm, "aether_probe_request_duration_seconds")
+	if m.Unit != "s" {
+		t.Fatalf("unit = %q, want %q", m.Unit, "s")
+	}
+	hist, ok := m.Data.(metricdata.Histogram[float64])
+	if !ok {
+		t.Fatalf("aggregation = %T, want metricdata.Histogram[float64]", m.Data)
+	}
+	if len(hist.DataPoints) != 1 {
+		t.Fatalf("data points = %d, want 1", len(hist.DataPoints))
+	}
+	dp := hist.DataPoints[0]
+
+	want := []float64{0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 5}
+	if !slices.Equal(dp.Bounds, want) {
+		t.Fatalf("exported bounds = %v, want %v", dp.Bounds, want)
+	}
+	// The whole point of the fix: the 2 s observation must NOT be in le=1.5 and must be
+	// in le=2. Under the OTel defaults both cumulative counts would have been 2.
+	if got := cumulativeAt(t, dp, 1.5); got != 1 {
+		t.Fatalf("le=1.5 cumulative count = %d, want 1 (only the 2 ms probe)", got)
+	}
+	if got := cumulativeAt(t, dp, 2); got != 2 {
+		t.Fatalf("le=2 cumulative count = %d, want 2 (the 2 s probe lands here)", got)
+	}
+}
+
+// findMetric returns the named metric from a collected ResourceMetrics.
+func findMetric(t *testing.T, rm *metricdata.ResourceMetrics, name string) metricdata.Metrics {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m
+			}
+		}
+	}
+	t.Fatalf("metric %q not exported", name)
+	return metricdata.Metrics{}
+}
+
+// cumulativeAt returns the Prometheus-style cumulative count for the le=bound bucket,
+// i.e. the number of observations <= bound. OTel exports per-bucket counts, so this
+// sums every bucket up to and including the one that bound closes.
+func cumulativeAt(t *testing.T, dp metricdata.HistogramDataPoint[float64], bound float64) uint64 {
+	t.Helper()
+	idx := slices.Index(dp.Bounds, bound)
+	if idx < 0 {
+		t.Fatalf("bound %v is not one of the exported boundaries %v", bound, dp.Bounds)
+	}
+	var total uint64
+	for _, c := range dp.BucketCounts[:idx+1] {
+		total += c
+	}
+	return total
 }

--- a/registrar/internal/replicator/metrics.go
+++ b/registrar/internal/replicator/metrics.go
@@ -21,6 +21,14 @@ type metrics struct {
 	syncSecs  metric.Float64Histogram
 }
 
+// syncDurationBuckets are the explicit boundaries, in SECONDS, for
+// aether.replicator.sync.duration. The OTel defaults are millisecond-oriented
+// (0, 5, 10, ... 10000): against a seconds-valued duration every range-sync would land
+// in the "<= 5 s" first bucket and the quantiles would read flat (#732).
+var syncDurationBuckets = []float64{
+	0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
+}
+
 // newMetrics builds the instruments on the global MeterProvider (a no-op
 // meter until a provider is installed). Returns nil on registration error
 // (methods are nil-safe).
@@ -46,7 +54,8 @@ func newMetrics() *metrics {
 	}
 	if m.syncSecs, err = meter.Float64Histogram("aether.replicator.sync.duration",
 		metric.WithUnit("s"),
-		metric.WithDescription("Full range-sync duration")); err != nil {
+		metric.WithDescription("Full range-sync duration"),
+		metric.WithExplicitBucketBoundaries(syncDurationBuckets...)); err != nil {
 		return nil
 	}
 	return m

--- a/registrar/internal/server/metrics.go
+++ b/registrar/internal/server/metrics.go
@@ -68,6 +68,15 @@ type Metrics struct {
 	wbShields       metric.Int64Counter
 }
 
+// syncDurationBuckets are the explicit boundaries, in SECONDS, for
+// aether.registrar.sync.duration. The OTel defaults are millisecond-oriented
+// (0, 5, 10, ... 10000), so a seconds-valued sync duration would collapse into the
+// "<= 5 s" first bucket and the quantiles would read flat (#732). A sync cycle runs
+// every 5 s and is normally a few milliseconds of registry list plus diff.
+var syncDurationBuckets = []float64{
+	0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60,
+}
+
 // NewMetrics registers the registrar server instruments on the given meter.
 func NewMetrics(meter metric.Meter) (*Metrics, error) {
 	m := &Metrics{}
@@ -87,7 +96,8 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 	}
 	if m.syncDuration, err = meter.Float64Histogram("aether.registrar.sync.duration",
 		metric.WithDescription("Duration of a registry sync cycle"),
-		metric.WithUnit("s")); err != nil {
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(syncDurationBuckets...)); err != nil {
 		return nil, fmt.Errorf("sync duration: %w", err)
 	}
 	if m.syncErrors, err = meter.Int64Counter("aether.registrar.sync.errors",


### PR DESCRIPTION
Fixes #732.

## The bug

`prober/internal/prober` records `time.Since(start).Seconds()` into
`aether_probe_request_duration_seconds` but created the instrument with no boundaries, so
it inherited the OTel SDK's defaults — `0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000,
2500, 5000, 7500, 10000` — which are tuned for values expressed in **milliseconds**.
Against a seconds-valued duration the first bucket is `le="5"` **seconds**: a healthy 2 ms
probe and a timed-out 2 s probe are indistinguishable. Control-tested on talos during the
#728 validation: all 18,394 pre-fix ~2 s `timeout` observations on one prober sit in
`le=5`, identical to `+Inf`.

## Mechanism used: the instrument option, not a View

`metric.WithExplicitBucketBoundaries` has been an instrument option since otel metric
v1.20 and the repo pins `go.opentelemetry.io/otel/metric v1.44.0` /
`go.opentelemetry.io/otel/sdk/metric v1.44.0`, so the option is honoured directly by the
SDK — no `sdkmetric.NewView` is needed (and none exists anywhere in the repo today; the
mesh-DNS resolver already uses the instrument option the same way). The new test asserts
against the **exported** data point through an `sdkmetric.ManualReader`, so it proves the
option actually reaches the SDK rather than just checking a package variable.

Boundaries chosen so the four regimes that matter are each separated:

```
0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 5
```

healthy sub-10 ms probes · the 1 s resolver retransmit (#728) · the 2 s probe budget
(`Config.Timeout`) · the 5 s legacy resolver retransmit. Metric name and unit (`"s"`)
are unchanged.

## Sweep: every histogram instrument in the repo

`grep -rn 'Float64Histogram\|Int64Histogram' --include='*.go' agent/ common/ registrar/ controller/ prober/ registry/ cni/`

| Instrument | File | Recorded value | Boundaries before | Status |
|---|---|---|---|---|
| `aether_probe_request_duration_seconds` | `prober/internal/prober/prober.go` | seconds (`time.Since().Seconds()`) | SDK default (ms-oriented) | **FIXED** — 0.001 … 1, 1.5, 2, 2.5, 5 |
| `aether.agent.snapshot.duration` (unit `s`) | `agent/internal/xds/cache/cachemetrics/cachemetrics.go` | seconds | SDK default (ms-oriented) | **FIXED** — 0.0001 … 1, 2.5, 5 (a build is sub-ms to tens of ms) |
| `aether.agent.liveness.promotion_delay_seconds` | `agent/internal/cni/server/metrics.go` | seconds | SDK default (ms-oriented) | **FIXED** — 0.5 … 60, 90, 120, 300 (loop ticks every 5 s) |
| `aether.registrar.sync.duration` (unit `s`) | `registrar/internal/server/metrics.go` | seconds | SDK default (ms-oriented) | **FIXED** — 0.001 … 5, 10, 30, 60 (5 s sync cycle) |
| `aether.replicator.sync.duration` (unit `s`) | `registrar/internal/replicator/metrics.go` | seconds | SDK default (ms-oriented) | **FIXED** — 0.001 … 5, 10, 30, 60 |
| `aether.mesh_dns.query.duration` (unit `s`) | `agent/internal/meshdns/metrics.go` | seconds | explicit `queryDurationBuckets` 0.0001 … 5 | already correct (verified, not assumed — this is why its p99 read a plausible 87.5 ms on 09-05) |
| `aether.supervisor.handoff.duration` (unit `s`) | `agent/internal/proxy/hotrestart/metrics.go` | seconds | explicit `1, 5, 10, 30, 60, 120, 300` | already correct |
| `aether.supervisor.drain.duration` (unit `s`) | `agent/internal/proxy/hotrestart/metrics.go` | seconds | explicit `1, 5, 10, 30, 60, 120` | already correct |
| `aether.cni.operation.duration` (unit `s`) | `cni/internal/telemetry/operations.go` | seconds | explicit `0.05 … 10` | already correct |

No `Int64Histogram` exists anywhere in the repo; `controller/` and `registry/` register no
histograms at all.

Note the OTLP→Prometheus exporter appends the unit suffix, so the dot-named instruments
above all land in Prometheus as `*_duration_seconds` — the same trap, same fix.

## Dashboards / hard-coded bucket labels

- **In this repo:** nothing hard-codes an `le` value for any of these metrics. The only
  prober references are counter queries (`aether_probe_requests_total`) in
  `e2e/soak/README.md`, `e2e/pressure/run.sh` and `docs/observability/mesh-dns-alerts.yml`
  — unaffected. `docs/proposals/013_mesh-availability-prober.md` is updated to record the
  explicit boundaries as part of the metric's contract.
- **GitOps (`k8s-talos-main`, read-only from here):** `grep -rn aether_probe_request_duration`
  returns **nothing** — no Grafana panel or alert rule consumes the prober histogram today,
  so no `le` label changes are required there. The only `le`-bearing aether rule is
  `MeshDNSAuthoritativeSlow` in `clusters/talos-main/prometheus/values.yaml:481`
  (`histogram_quantile(0.99, sum by (le, node)(rate(aether_mesh_dns_query_duration_seconds_bucket{result="answered"}[10m]))) > 0.15`)
  — it reads the mesh-DNS histogram, whose buckets are unchanged by this PR, so the 150 ms
  threshold keeps its meaning. Whoever adds prober latency panels should now be able to,
  which was the point.

## Validation

- `bazel test --test_arg=-test.short //prober/... //common/... //agent/internal/meshdns/...` — pass
- `bazel test --test_arg=-test.short //agent/internal/xds/cache/... //agent/internal/cni/... //registrar/... //cni/...` — pass (every touched package)
- `make gazelle`, `make format-check` — clean. No dependency changes.
- No `charts/` change: the prober chart is version-stamped per commit.

After deploying the prober chart, this should read in **milliseconds**, not `0` or `5`:

```promql
histogram_quantile(0.99, sum by (le) (rate(aether_probe_request_duration_seconds_bucket{tier="mesh_dns"}[5m])))
```

and the timeout tail should now be visible as its own bucket rather than folded into `le=5`:

```promql
sum by (le) (rate(aether_probe_request_duration_seconds_bucket{tier="mesh_dns"}[5m]))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
