### PR TITLE
feat(mesh-dns): keep answering after SIGTERM until the successor is proven serving (#729)

### DIFF
--- a/agent/cmd/mesh-dns/main.go
+++ b/agent/cmd/mesh-dns/main.go
@@ -65,6 +65,7 @@ var (
 	readyMarker     string
 	readinessCheck  bool
 	forwardPoolSize int
+	lameDuckMax     time.Duration
 )
 
 func main() {
@@ -115,15 +116,31 @@ func rootCmd() *cobra.Command {
 	f.StringVar(&readyMarker, "ready-marker", "/run/aether/mesh-dns.ready", "Pod-local path for the readiness marker written once the resolver's listeners are bound")
 	f.BoolVar(&readinessCheck, "readiness-check", false, "DEPRECATED (#683): exit 0 iff the --ready-marker file exists (exec readiness probe mode). Re-execing this 16.9MB daemon every 15s per pod cost ~3-4% of its CPU in container exec and Go package init alone; the chart execs the stdlib-only /mesh-dns-ready prober from this same image instead. Retained so a chart predating #683 keeps a working probe against a newer image")
 	f.IntVar(&forwardPoolSize, "forward-pool-size", meshdns.DefaultForwardPoolSize, "Connected UDP sockets kept open per forward upstream (issue #674); 0 dials a fresh socket per forwarded query")
+	f.DurationVar(&lameDuckMax, "lame-duck-max", meshdns.DefaultLameDuckMax, "Longest this resolver keeps SERVING after SIGTERM before closing its SO_REUSEPORT listeners (issue #729). It stops reporting ready immediately and closes as soon as a successor is observed answering on the same address, so this ceiling only applies when no successor appears (a scale-down, or a failed surge). Must stay below the pod's terminationGracePeriodSeconds — the chart derives that as this + 5s. 0 disables the window and closes on SIGTERM, which is what dropped one queued datagram on every roll before #729")
 
 	return cmd
 }
 
 // run builds the resolver, wires OTel (best-effort), starts serving, and reloads the
 // record table on snapshot-file changes until the process is signalled to stop.
+//
+// "Signalled to stop" is not "stop": since #729 the first SIGTERM starts a LAME-DUCK
+// window (see meshdns.WithLameDuck) in which the resolver stops reporting ready but
+// keeps answering, so the datagrams the kernel already queued to its SO_REUSEPORT
+// socket are drained by this process instead of discarded by its close(). A second
+// signal cuts that short.
 func run(ctx context.Context) error {
 	ctx, stop := signal.NotifyContext(ctx, syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
+
+	// A SECOND termination signal cuts the lame-duck window (#729) short. The first one
+	// only cancels ctx, which STARTS the window — the resolver deliberately keeps
+	// serving after it — so without this an operator has no way to say "stop waiting"
+	// short of SIGKILL.
+	abort := make(chan struct{})
+	stopped := make(chan struct{})
+	defer close(stopped)
+	go awaitSecondSignal(ctx, abort, stopped)
 
 	// Metrics + log push, best-effort (push-only OTel like the proxy-supervisor): the
 	// daemon runs in the host netns with no controller-runtime manager and no scrape
@@ -153,12 +170,39 @@ func run(ctx context.Context) error {
 		meshdns.WithReusePort(true),
 		meshdns.WithReadyMarker(readyMarker),
 		meshdns.WithForwardPoolSize(forwardPoolSize),
+		meshdns.WithLameDuck(lameDuckMax),
+		meshdns.WithLameDuckAbort(abort),
 	)
 	server.SetUpstreams(resolveUpstreams(l, resolvConfPath))
 
 	go watchSnapshot(ctx, server, snapshotPath, l)
 
 	return server.Start(ctx)
+}
+
+// awaitSecondSignal closes abort when a termination signal arrives AFTER the shutdown
+// has already begun, so the lame-duck window can be cut short.
+//
+// The handler is registered only once ctx is done, which is what makes "second" work
+// without bookkeeping: the first signal was consumed by signal.NotifyContext, whose
+// channel is already full and therefore swallows anything further, so nothing here can
+// ever see it. (NotifyContext leaves the handler installed after cancelling, so an
+// extra signal in the sliver before we register is dropped rather than killing the
+// process; the lame-duck deadline remains the backstop.)
+func awaitSecondSignal(ctx context.Context, abort chan<- struct{}, stopped <-chan struct{}) {
+	select {
+	case <-ctx.Done():
+	case <-stopped:
+		return
+	}
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigs)
+	select {
+	case <-sigs:
+		close(abort)
+	case <-stopped:
+	}
 }
 
 // resolveUpstreams returns the forward upstreams: the explicit --mesh-dns-upstream

--- a/agent/internal/meshdns/BUILD.bazel
+++ b/agent/internal/meshdns/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "meshdns",
     srcs = [
         "forwardpool.go",
+        "lameduck.go",
         "metrics.go",
         "resolvconf.go",
         "selfcheck.go",
@@ -36,6 +37,7 @@ go_test(
     name = "meshdns_test",
     srcs = [
         "forwardpool_test.go",
+        "lameduck_test.go",
         "metrics_test.go",
         "resolvconf_test.go",
         "selfcheck_test.go",

--- a/agent/internal/meshdns/lameduck.go
+++ b/agent/internal/meshdns/lameduck.go
@@ -1,0 +1,332 @@
+package meshdns
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"log/slog"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// DefaultLameDuckMax is the default ceiling on the post-SIGTERM lame-duck window
+// (issue #729). It must stay comfortably below the DaemonSet's
+// terminationGracePeriodSeconds — the chart derives that as this value + 5s — because
+// the kubelet SIGKILLs at the grace deadline and a SIGKILL is exactly the abrupt
+// socket close the lame duck exists to avoid.
+const DefaultLameDuckMax = 10 * time.Second
+
+// lameDuckProbeInterval is how often the lame duck asks the SO_REUSEPORT group who is
+// answering. Each probe is a fresh 4-tuple, so with two sockets in the group the kernel
+// steers roughly half of them at the successor: a handful of probes is enough, and at
+// 200ms the whole detection costs a few datagrams to ourselves.
+const lameDuckProbeInterval = 200 * time.Millisecond
+
+// lameDuckProbeTimeout bounds ONE successor probe. It is deliberately shorter than the
+// probe interval: the loopback exchange is a sub-millisecond in-process handler run, so
+// anything slower is a lost datagram, and waiting on it would only delay the next roll
+// of the reuseport dice.
+const lameDuckProbeTimeout = 150 * time.Millisecond
+
+// instanceLabels is the reserved two-label prefix of the instance-identity name; the
+// mesh domain is appended to it. See instanceQName.
+const instanceLabels = "_instance._aether"
+
+// Lame-duck exit reasons — the `reason` attribute on aether.mesh_dns.lame_duck.exits.
+const (
+	// lameDuckSuccessor: a DIFFERENT instance answered on our own listen address, so
+	// the successor is in the reuseport group and serving. This is the reason a
+	// healthy surge rollout must show on every node.
+	lameDuckSuccessor = "successor"
+	// lameDuckDeadline: --lame-duck-max elapsed with no successor observed. Normal for
+	// a genuine scale-down or node drain (nothing is replacing us); on a rollout it
+	// means the successor never came up, and the exposure is the same drop this
+	// feature exists to remove.
+	lameDuckDeadline = "deadline"
+	// lameDuckSignal: a SECOND termination signal arrived. An operator (or a kubelet
+	// racing its own grace period) asked us to stop waiting, so we close at once.
+	lameDuckSignal = "signal"
+)
+
+// WithLameDuck sets the ceiling on the post-SIGTERM lame-duck window (issue #729).
+//
+// On SIGTERM the resolver stops reporting ready but KEEPS SERVING until either a
+// successor is observed answering on the same SO_REUSEPORT address or max elapses,
+// and only then closes its sockets. Without it the predecessor's socket closes the
+// instant the successor passes its first readiness probe, and every datagram the
+// kernel had already queued to that socket is discarded — one lost query per roll,
+// which #726 traced to a multi-second stall in every client that singleflights by
+// name.
+//
+// Zero (or negative) disables the window and restores the pre-#729 close-on-SIGTERM
+// behaviour.
+func WithLameDuck(max time.Duration) Option {
+	return func(s *Server) { s.lameDuckMax = max }
+}
+
+// WithLameDuckAbort wires a channel that cuts the lame-duck window short when it is
+// closed (or receives). The standalone daemon closes it on a SECOND termination signal.
+// A nil channel (the default) simply never fires.
+func WithLameDuckAbort(ch <-chan struct{}) Option {
+	return func(s *Server) { s.lameDuckAbort = ch }
+}
+
+// WithInstanceID overrides the random per-process identity stamp this resolver serves
+// at instanceQName and compares successor probes against. Production never sets it —
+// the point of the stamp is that no two processes can collude on it — but a test needs
+// deterministic identities for the two co-bound servers it drives.
+func WithInstanceID(id string) Option {
+	return func(s *Server) { s.instanceID = id }
+}
+
+// newInstanceID mints this process's identity stamp: 64 random bits, hex.
+//
+// It CANNOT be derived from the pid. The predecessor and successor run in separate
+// containers with their own PID namespaces, so both are pid 1 — a pid-based stamp would
+// make the successor look like us and the lame duck would always run to its deadline.
+func newInstanceID() string {
+	var b [8]byte
+	// crypto/rand.Read never returns an error (it panics if the system source is
+	// unusable), so there is no degraded path to handle here.
+	_, _ = rand.Read(b[:])
+	return hex.EncodeToString(b[:])
+}
+
+// instanceQName is the name this resolver answers its identity stamp at —
+// "_instance._aether.<meshDomain>." — as a TXT record with TTL 0.
+//
+// It is shaped exactly like the self-check probe name (see selfCheckQName) and for the
+// same reasons: it sits under the mesh domain so it is answered AUTHORITATIVELY and
+// never forwarded to kube-dns, and both labels begin with "_", which is not a legal
+// DNS-1123 namespace or Service name, so the record table can never hold a colliding
+// key. The difference is the direction: the self-check must never leave the process,
+// while this one must — it is asked OVER the wire precisely so the kernel's reuseport
+// hash decides which of the co-bound processes answers it.
+//
+// Any pod on the node can ask for it (the CNI DNATs :53 here) and learn 16 hex
+// characters that mean nothing outside this handoff. That is the whole exposure.
+func (s *Server) instanceQName() string {
+	return instanceLabels + "." + dns.Fqdn(s.meshDomain)
+}
+
+// isInstanceName reports whether qname is the identity name. Checked BEFORE isMeshName
+// in serve: the identity name is under the mesh domain and would otherwise be answered
+// as an ordinary (always missing) mesh record.
+func (s *Server) isInstanceName(qname string) bool {
+	return strings.EqualFold(dns.Fqdn(qname), s.instanceQName())
+}
+
+// serveInstance answers the identity name authoritatively: TXT returns this process's
+// stamp, every other type returns NODATA — the same "the name consistently EXISTS"
+// contract serveMesh keeps, so a client that also asks A/AAAA is not told the zone is
+// broken.
+//
+// TTL is 0: this is an identity, not a record, and a cached answer would let the
+// predecessor's stamp outlive the predecessor.
+func (s *Server) serveInstance(w dns.ResponseWriter, r *dns.Msg, q dns.Question) string {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Authoritative = true
+	if opt := r.IsEdns0(); opt != nil {
+		m.SetEdns0(opt.UDPSize(), opt.Do())
+	}
+	if q.Qtype == dns.TypeTXT {
+		m.Answer = []dns.RR{&dns.TXT{
+			Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 0},
+			Txt: []string{s.instanceID},
+		}}
+	}
+	_ = w.WriteMsg(m)
+	return resultInstance
+}
+
+// probeSuccessor asks the reuseport group for its identity stamp ONCE and reports the
+// peer's stamp when a DIFFERENT process answered.
+//
+// This is the entire successor-detection mechanism, and it works because the query goes
+// over the WIRE to our own listen address. Both processes hold a socket in the same
+// SO_REUSEPORT group, so the kernel hashes the probe's 4-tuple to one of them; a fresh
+// ephemeral source port per probe re-rolls that hash. Our own stamp coming back proves
+// nothing (we already know we are alive) and is retried; the peer's stamp proves two
+// things at once, and both are required before we may close: the successor is IN the
+// group (so the kernel will steer to it) and it is ANSWERING (so what it is steered
+// actually gets a reply).
+//
+// No reply at all is also "not yet": the probe itself can lose the reuseport coin flip
+// against a socket that is bound but whose handler has not started, which is exactly the
+// state we must not close into.
+func (s *Server) probeSuccessor(ctx context.Context) (string, bool) {
+	addr := probeDialAddr(s.addr)
+	if addr == "" {
+		return "", false
+	}
+	req := new(dns.Msg)
+	req.SetQuestion(s.instanceQName(), dns.TypeTXT)
+	c := &dns.Client{
+		Net:          protoUDP,
+		DialTimeout:  lameDuckProbeTimeout,
+		ReadTimeout:  lameDuckProbeTimeout,
+		WriteTimeout: lameDuckProbeTimeout,
+	}
+	resp, _, err := c.ExchangeContext(ctx, req, addr)
+	if err != nil || resp == nil {
+		return "", false
+	}
+	id := instanceIDFrom(resp)
+	if id == "" || id == s.instanceID {
+		return "", false
+	}
+	return id, true
+}
+
+// probeDialAddr turns the listen address into one the probe can dial. In production the
+// resolver binds a concrete HOST_IP, which is dialable as-is; a wildcard bind
+// (0.0.0.0 / :: / a bare ":port") is not, so it is dialled through loopback — which
+// still lands in the same reuseport group, since the group is keyed by the bound port.
+// An unparseable address disables probing (the lame duck then runs to its deadline).
+func probeDialAddr(listen string) string {
+	host, port, err := net.SplitHostPort(listen)
+	if err != nil {
+		return ""
+	}
+	if host == "" {
+		return net.JoinHostPort("127.0.0.1", port)
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		if ip.To4() != nil {
+			return net.JoinHostPort("127.0.0.1", port)
+		}
+		return net.JoinHostPort("::1", port)
+	}
+	return net.JoinHostPort(host, port)
+}
+
+// instanceIDFrom extracts the stamp from an identity reply, or "" when the reply
+// carries none (a NODATA, or an answer section from something that is not us).
+func instanceIDFrom(m *dns.Msg) string {
+	for _, rr := range m.Answer {
+		if txt, ok := rr.(*dns.TXT); ok && len(txt.Txt) > 0 {
+			return strings.Join(txt.Txt, "")
+		}
+	}
+	return ""
+}
+
+// lameDuckClock is the lame duck's time source, injected so the state machine can be
+// tested without sleeping. Tick returns the channel and its stop function rather than a
+// *time.Ticker so a fake can hand back a plain channel.
+type lameDuckClock interface {
+	Now() time.Time
+	After(d time.Duration) <-chan time.Time
+	Tick(d time.Duration) (c <-chan time.Time, stop func())
+}
+
+// realClock is the production lameDuckClock.
+type realClock struct{}
+
+func (realClock) Now() time.Time                         { return time.Now() }
+func (realClock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (realClock) Tick(d time.Duration) (<-chan time.Time, func()) {
+	t := time.NewTicker(d)
+	return t.C, t.Stop
+}
+
+// lameDuckOutcome is why the window ended and how long it lasted.
+type lameDuckOutcome struct {
+	reason   string
+	peer     string
+	duration time.Duration
+}
+
+// lameDuck is the post-SIGTERM state machine: keep serving, watch for the successor,
+// and give up at the deadline. It owns no sockets — closing them is the caller's job,
+// and happens only once run returns.
+type lameDuck struct {
+	max      time.Duration
+	interval time.Duration
+	selfID   string
+	// detect runs one successor probe, returning the peer's identity stamp when a
+	// DIFFERENT process answered on our listen address.
+	detect func(context.Context) (string, bool)
+	abort  <-chan struct{}
+	clock  lameDuckClock
+	log    *slog.Logger
+}
+
+// run holds the listeners open until the successor is demonstrably serving, the
+// deadline elapses, or a second signal cuts it short.
+//
+// ctx here is deliberately NOT the shutdown context (which is already cancelled by the
+// time we are called) — it is a detached one, so the probes can still run.
+func (d *lameDuck) run(ctx context.Context) lameDuckOutcome {
+	start := d.clock.Now()
+	d.log.InfoContext(ctx, "lame duck started",
+		"instance", d.selfID, "max", d.max, "probeInterval", d.interval)
+	deadline := d.clock.After(d.max)
+	tick, stopTick := d.clock.Tick(d.interval)
+	defer stopTick()
+	for {
+		select {
+		case <-d.abort:
+			d.log.InfoContext(ctx, "lame duck aborted by a second termination signal",
+				"instance", d.selfID)
+			return d.outcome(lameDuckSignal, "", start)
+		case <-deadline:
+			d.log.InfoContext(ctx, "lame duck deadline reached",
+				"instance", d.selfID, "max", d.max)
+			return d.outcome(lameDuckDeadline, "", start)
+		case <-tick:
+			peer, ok := d.detect(ctx)
+			if !ok {
+				continue
+			}
+			d.log.InfoContext(ctx, "successor observed",
+				"instance", d.selfID, "successor", peer)
+			return d.outcome(lameDuckSuccessor, peer, start)
+		}
+	}
+}
+
+// outcome stamps the elapsed window onto a reason.
+func (d *lameDuck) outcome(reason, peer string, start time.Time) lameDuckOutcome {
+	return lameDuckOutcome{reason: reason, peer: peer, duration: d.clock.Now().Sub(start)}
+}
+
+// runLameDuck is Start's post-SIGTERM step: stop reporting ready, keep serving until the
+// successor is demonstrably answering (or the deadline), and record the outcome. The
+// CALLER closes the listeners afterwards.
+//
+// Readiness goes first and it is honest, not cosmetic: from this moment on the pod is
+// leaving, and the DaemonSet controller's view should say so. It does NOT steer
+// datagrams — for a hostNetwork SO_REUSEPORT listener the kernel decides which co-bound
+// socket receives each datagram, and it neither knows nor cares what the kubelet thinks
+// of the pod. That is precisely why the socket has to stay open.
+//
+// RESIDUAL (kernel race, not closable from userspace): even after the successor is
+// observed, the instant of close() can still discard a datagram the kernel queued to our
+// socket between our last recvfrom and the close. Fully removing that needs eBPF
+// sk_reuseport steering to drain the departing socket out of the group first. The window
+// this narrows the exposure from is "every roll" to that sub-millisecond race.
+func (s *Server) runLameDuck(ctx context.Context) {
+	if s.lameDuckMax <= 0 {
+		return
+	}
+	s.removeReadyMarker()
+	d := &lameDuck{
+		max:      s.lameDuckMax,
+		interval: lameDuckProbeInterval,
+		selfID:   s.instanceID,
+		detect:   s.probeSuccessor,
+		abort:    s.lameDuckAbort,
+		clock:    realClock{},
+		log:      s.log,
+	}
+	// Detached from the shutdown context: it is already cancelled, and every probe
+	// issued under it would fail instantly.
+	out := d.run(context.WithoutCancel(ctx))
+	s.metrics.recordLameDuck(out.reason, out.duration)
+}

--- a/agent/internal/meshdns/lameduck_test.go
+++ b/agent/internal/meshdns/lameduck_test.go
@@ -1,0 +1,470 @@
+package meshdns
+
+import (
+	"context"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// fakeClock drives the lame-duck state machine without sleeping. Every channel is
+// buffered and PRE-FILLED by the test, so which select arm fires is decided by the test
+// and not by a race: an arm the test does not want to take is simply left empty.
+type fakeClock struct {
+	// times is handed out by successive Now calls (the last one repeats), so a test
+	// pins the reported window duration exactly.
+	times  []time.Time
+	i      int
+	afterC chan time.Time
+	tickC  chan time.Time
+	// afterD / tickD record the durations the state machine asked for, and stops
+	// counts the ticker teardowns, so the test can assert the machine is not leaking
+	// a ticker per window.
+	afterD time.Duration
+	tickD  time.Duration
+	stops  int
+}
+
+func newFakeClock(times ...time.Time) *fakeClock {
+	return &fakeClock{
+		times:  times,
+		afterC: make(chan time.Time, 1),
+		tickC:  make(chan time.Time, 4),
+	}
+}
+
+func (c *fakeClock) Now() time.Time {
+	t := c.times[min(c.i, len(c.times)-1)]
+	c.i++
+	return t
+}
+
+func (c *fakeClock) After(d time.Duration) <-chan time.Time {
+	c.afterD = d
+	return c.afterC
+}
+
+func (c *fakeClock) Tick(d time.Duration) (<-chan time.Time, func()) {
+	c.tickD = d
+	return c.tickC, func() { c.stops++ }
+}
+
+// tick queues n probe opportunities.
+func (c *fakeClock) tick(n int) {
+	for range n {
+		c.tickC <- time.Time{}
+	}
+}
+
+// fire queues the deadline.
+func (c *fakeClock) fire() { c.afterC <- time.Time{} }
+
+// newTestLameDuck wires a state machine over a fake clock and a scripted detector.
+// detect returns the nth element of results on the nth probe (the last one repeats).
+func newTestLameDuck(clock *fakeClock, abort <-chan struct{}, results ...string) (*lameDuck, *int) {
+	probes := 0
+	d := &lameDuck{
+		max:      10 * time.Second,
+		interval: 200 * time.Millisecond,
+		selfID:   "self",
+		abort:    abort,
+		clock:    clock,
+		log:      slog.New(slog.DiscardHandler),
+	}
+	d.detect = func(context.Context) (string, bool) {
+		peer := ""
+		if len(results) > 0 {
+			peer = results[min(probes, len(results)-1)]
+		}
+		probes++
+		return peer, peer != ""
+	}
+	return d, &probes
+}
+
+// TestLameDuckExitsOnSuccessor is the reason the feature exists: the window ends the
+// moment a DIFFERENT instance is seen answering, not when a timer says so.
+func TestLameDuckExitsOnSuccessor(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	clock := newFakeClock(t0, t0.Add(420*time.Millisecond))
+	clock.tick(1)
+	d, probes := newTestLameDuck(clock, nil, "peer-b")
+
+	out := d.run(context.Background())
+
+	assert.Equal(t, lameDuckSuccessor, out.reason)
+	assert.Equal(t, "peer-b", out.peer, "the successor's stamp must be reported, for the log line and a post-mortem")
+	assert.Equal(t, 420*time.Millisecond, out.duration)
+	assert.Equal(t, 1, *probes)
+	assert.Equal(t, 1, clock.stops, "the probe ticker must be stopped on every exit path")
+}
+
+// TestLameDuckKeepsProbingUntilSuccessorAnswers: a probe that loses the SO_REUSEPORT
+// coin flip lands back on ourselves (or on nothing at all). That is "not yet", never
+// "no successor" — closing on the first unhelpful probe would reintroduce the drop.
+func TestLameDuckKeepsProbingUntilSuccessorAnswers(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	clock := newFakeClock(t0, t0.Add(600*time.Millisecond))
+	clock.tick(3)
+	d, probes := newTestLameDuck(clock, nil, "", "", "peer-b")
+
+	out := d.run(context.Background())
+
+	assert.Equal(t, lameDuckSuccessor, out.reason)
+	assert.Equal(t, 3, *probes, "the two inconclusive probes must not end the window")
+}
+
+// TestLameDuckExitsOnDeadline: with no successor (a scale-down, or a surge that never
+// came up) the window is bounded, so the pod can never outlive its grace period and be
+// SIGKILLed mid-drain.
+func TestLameDuckExitsOnDeadline(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	clock := newFakeClock(t0, t0.Add(10*time.Second))
+	clock.fire()
+	d, probes := newTestLameDuck(clock, nil)
+	d.max = 10 * time.Second
+
+	out := d.run(context.Background())
+
+	assert.Equal(t, lameDuckDeadline, out.reason)
+	assert.Empty(t, out.peer)
+	assert.Equal(t, 10*time.Second, out.duration)
+	assert.Zero(t, *probes)
+	assert.Equal(t, 10*time.Second, clock.afterD, "the deadline must be armed at --lame-duck-max")
+	assert.Equal(t, 200*time.Millisecond, clock.tickD)
+	assert.Equal(t, 1, clock.stops)
+}
+
+// TestLameDuckAbortsOnSecondSignal: a second SIGTERM means "stop waiting". It must win
+// even when a successor probe would have succeeded, so the deadline is not the only way
+// out of a window an operator wants ended.
+func TestLameDuckAbortsOnSecondSignal(t *testing.T) {
+	t0 := time.Unix(1_700_000_000, 0)
+	clock := newFakeClock(t0, t0.Add(50*time.Millisecond))
+	abort := make(chan struct{})
+	close(abort)
+	d, _ := newTestLameDuck(clock, abort, "peer-b")
+
+	out := d.run(context.Background())
+
+	assert.Equal(t, lameDuckSignal, out.reason)
+	assert.Equal(t, 50*time.Millisecond, out.duration)
+	assert.Equal(t, 1, clock.stops)
+}
+
+// TestInstanceIDIsUniquePerProcess pins the property the whole detection rests on. It
+// cannot be derived from the pid: predecessor and successor each run as pid 1 in their
+// own container, so a pid stamp would make the successor indistinguishable from us and
+// every window would run to its deadline.
+func TestInstanceIDIsUniquePerProcess(t *testing.T) {
+	seen := map[string]bool{}
+	for range 100 {
+		id := newInstanceID()
+		assert.Len(t, id, 16, "64 random bits, hex")
+		assert.False(t, seen[id], "instance ids must not repeat")
+		seen[id] = true
+	}
+}
+
+// TestServeInstanceAnswersTheStamp: the identity name is answered authoritatively (so
+// it is never forwarded to kube-dns, which has no mesh zone), TXT carries the stamp,
+// and every other type is NODATA so the name consistently exists.
+func TestServeInstanceAnswersTheStamp(t *testing.T) {
+	s := NewServerWithOptions("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler),
+		WithInstanceID("stamp-a"))
+
+	txt := serve(s, query("_instance._aether.aether.internal", dns.TypeTXT))
+	require.NotNil(t, txt)
+	assert.True(t, txt.Authoritative)
+	assert.Equal(t, dns.RcodeSuccess, txt.Rcode)
+	assert.Equal(t, "stamp-a", instanceIDFrom(txt))
+	require.Len(t, txt.Answer, 1)
+	assert.Zero(t, txt.Answer[0].Header().Ttl, "an identity must never be cached")
+
+	a := serve(s, query("_instance._aether.aether.internal", dns.TypeA))
+	require.NotNil(t, a)
+	assert.True(t, a.Authoritative)
+	assert.Equal(t, dns.RcodeSuccess, a.Rcode)
+	assert.Empty(t, a.Answer)
+}
+
+// TestInstanceNameIsNotAMeshRecord: the identity name sits under the mesh domain, so it
+// must be matched BEFORE the record path — otherwise it is just a permanently missing
+// service and the probe never sees a stamp. A record table that somehow held the same
+// key must not shadow it either.
+func TestInstanceNameIsNotAMeshRecord(t *testing.T) {
+	s := NewServerWithOptions("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler),
+		WithInstanceID("stamp-a"))
+	s.SetRecords(map[string]string{"_aether/_instance": "10.0.0.1"})
+
+	resp := serve(s, query("_instance._aether.aether.internal", dns.TypeTXT))
+	require.NotNil(t, resp)
+	assert.Equal(t, "stamp-a", instanceIDFrom(resp))
+
+	// Case-insensitivity: DNS names are, and a client may 0x20-randomise.
+	upper := serve(s, query("_INSTANCE._Aether.Aether.Internal", dns.TypeTXT))
+	require.NotNil(t, upper)
+	assert.Equal(t, "stamp-a", instanceIDFrom(upper))
+
+	// A neighbouring reserved name is NOT the identity name.
+	other := serve(s, query("_selfcheck._aether.aether.internal", dns.TypeTXT))
+	require.NotNil(t, other)
+	assert.Equal(t, dns.RcodeNameError, other.Rcode)
+}
+
+// TestProbeDialAddr: a wildcard bind is not dialable, so it is probed through loopback
+// — which still lands in the same reuseport group, because the group is keyed by port.
+func TestProbeDialAddr(t *testing.T) {
+	tests := []struct {
+		name, listen, want string
+	}{
+		{name: "concrete host is dialled as-is", listen: "192.168.0.61:18054", want: "192.168.0.61:18054"},
+		{name: "ipv4 wildcard goes to loopback", listen: "0.0.0.0:18054", want: "127.0.0.1:18054"},
+		{name: "ipv6 wildcard goes to ipv6 loopback", listen: "[::]:18054", want: "[::1]:18054"},
+		{name: "bare port goes to loopback", listen: ":18054", want: "127.0.0.1:18054"},
+		{name: "unparseable disables probing", listen: "not-an-address", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, probeDialAddr(tc.listen))
+		})
+	}
+}
+
+// TestInstanceIDFromIgnoresNonTXT guards the parser against a reply that is not ours.
+func TestInstanceIDFromIgnoresNonTXT(t *testing.T) {
+	empty := new(dns.Msg)
+	assert.Empty(t, instanceIDFrom(empty))
+
+	withA := new(dns.Msg)
+	withA.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeA, Class: dns.ClassINET},
+		A:   net.IPv4(10, 0, 0, 1),
+	}}
+	assert.Empty(t, instanceIDFrom(withA))
+}
+
+// TestLameDuckDisabledClosesImmediately: --lame-duck-max=0 is the documented kill switch
+// and must restore the pre-#729 behaviour exactly — close on SIGTERM, no window.
+func TestLameDuckDisabledClosesImmediately(t *testing.T) {
+	dir := t.TempDir()
+	marker := filepath.Join(dir, "ready")
+	s := NewServerWithOptions("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler),
+		WithLameDuck(0), WithReadyMarker(marker))
+
+	start := time.Now()
+	s.runLameDuck(context.Background())
+
+	assert.Less(t, time.Since(start), time.Second, "a disabled window must not wait")
+}
+
+// --- integration-style: two co-bound resolvers, one real handoff ----------------
+
+// TestLameDuckHandsOffToACoBoundSuccessor is the end-to-end proof, hermetically: two
+// real resolvers co-bind ONE SO_REUSEPORT UDP/TCP port on loopback, a client queries
+// continuously throughout, and the predecessor is terminated mid-stream.
+//
+// The assertions are the two halves of #729: the predecessor exits for reason
+// `successor` (it PROVED the peer was answering before closing, rather than trusting a
+// readiness probe it cannot see), and not one query in the stream went unanswered while
+// it did so.
+func TestLameDuckHandsOffToACoBoundSuccessor(t *testing.T) {
+	if testing.Short() {
+		// It binds a real port and drives real datagrams; no container, but not free.
+		t.Skip("skipping the co-bound handoff test in short mode")
+	}
+	reader := installManualReader(t)
+	addr := reusablePort(t)
+	domain := "aether.internal"
+	records := map[string]string{"default/echo": "10.111.0.6"}
+
+	predecessor, stopPredecessor, predDone := startCoBound(t, domain, addr, "pred", records, 5*time.Second)
+	// The successor gets NO window of its own: it is not the subject here, and a
+	// window would make the test's own teardown wait out its deadline.
+	successor, _, _ := startCoBound(t, domain, addr, "succ", records, 0)
+
+	// Both must be genuinely serving before the handoff is meaningful. The successor's
+	// ready marker proves it BOUND; a probe that comes back with its stamp proves it
+	// ANSWERS — which is exactly what the lame duck is about to look for.
+	requireMarker(t, successor)
+	requireStampSeen(t, predecessor, "succ")
+
+	// A steady query stream over the shared port. Whichever socket the kernel picks,
+	// the answer must be identical, so any failure here is a dropped datagram.
+	stream := newQueryStream(t, addr, "echo.default."+domain)
+
+	stopPredecessor() // the SIGTERM equivalent: it is what cancels Start's context
+	select {
+	case err := <-predDone:
+		require.NoError(t, err)
+	case <-time.After(20 * time.Second):
+		t.Fatal("the predecessor never returned from its lame-duck window")
+	}
+
+	failures, total := stream.stop()
+	assert.Positive(t, total, "the query stream must actually have run")
+	// At most the documented RESIDUAL: close() on a reuseport socket can still discard
+	// a datagram the kernel queued between the last recvfrom and the close, which no
+	// userspace window can prevent (eBPF sk_reuseport steering would). Anything beyond
+	// that single instant is the pre-#729 behaviour coming back — before the window,
+	// EVERY in-flight datagram for the whole handoff was lost, not one.
+	assert.LessOrEqual(t, failures, int64(1),
+		"queries must keep being answered throughout the handoff (%d sent, %d unanswered)", total, failures)
+
+	assert.Equal(t, map[string]int64{lameDuckSuccessor: 1}, lameDuckExitCounts(t, reader),
+		"the predecessor must close because it OBSERVED the successor, not because a timer expired")
+	assert.NoFileExists(t, predecessor.readyMarker,
+		"the lame duck must stop reporting ready the moment it starts")
+}
+
+// installManualReader points the global MeterProvider at a manual reader for the test.
+func installManualReader(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+	return reader
+}
+
+// lameDuckExitCounts collects aether.mesh_dns.lame_duck.exits as reason -> count.
+func lameDuckExitCounts(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	counts := map[string]int64{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "aether.mesh_dns.lame_duck.exits" {
+				continue
+			}
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.True(t, ok, "lame_duck.exits should be an int64 sum")
+			for _, dp := range sum.DataPoints {
+				v, ok := dp.Attributes.Value("reason")
+				require.True(t, ok, "every exit must carry a reason")
+				counts[v.Emit()] += dp.Value
+			}
+		}
+	}
+	return counts
+}
+
+// reusablePort picks a loopback port both servers can co-bind. It is chosen by binding
+// and releasing an ephemeral one — the classic small race, and acceptable here because
+// the alternative (a hard-coded port) collides with whatever else runs on the machine.
+func reusablePort(t *testing.T) string {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := pc.LocalAddr().String()
+	require.NoError(t, pc.Close())
+	return addr
+}
+
+// startCoBound launches one resolver on the shared SO_REUSEPORT address and returns it
+// with its cancel func and a channel carrying Start's error.
+func startCoBound(t *testing.T, domain, addr, id string, records map[string]string, lameDuck time.Duration) (*Server, context.CancelFunc, <-chan error) {
+	t.Helper()
+	marker := filepath.Join(t.TempDir(), "ready")
+	s := NewServerWithOptions(
+		domain, addr, "", slog.New(slog.DiscardHandler),
+		WithReusePort(true),
+		WithReadyMarker(marker),
+		WithInstanceID(id),
+		WithLameDuck(lameDuck),
+		WithForwardPoolSize(0),
+	)
+	s.SetRecords(records)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Buffered AND closed after the send, so the cleanup below can wait for the exit
+	// even when the test body has already consumed the error.
+	done := make(chan error, 1)
+	go func() {
+		done <- s.Start(ctx)
+		close(done)
+	}()
+	// Cleanups run LIFO, so each server is stopped and REAPED before the one launched
+	// before it — no test may leave a socket in the shared reuseport group.
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+	return s, cancel, done
+}
+
+// requireMarker waits until the server has written its pod-local ready marker, i.e. its
+// listeners are bound.
+func requireMarker(t *testing.T, s *Server) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(s.readyMarker)
+		return err == nil
+	}, 10*time.Second, 10*time.Millisecond, "the resolver never reported ready")
+}
+
+// requireStampSeen waits until a probe from s comes back carrying want's stamp, proving
+// the kernel will steer to that peer AND that the peer answers.
+func requireStampSeen(t *testing.T, s *Server, want string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		peer, ok := s.probeSuccessor(context.Background())
+		return ok && peer == want
+	}, 10*time.Second, 20*time.Millisecond, "never saw %q answer on the shared reuseport address", want)
+}
+
+// queryStream fires mesh A queries at the shared address until stopped, counting the
+// ones that did not come back with the expected answer.
+type queryStream struct {
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	failures atomic.Int64
+	total    atomic.Int64
+}
+
+func newQueryStream(t *testing.T, addr, qname string) *queryStream {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	q := &queryStream{cancel: cancel}
+	q.wg.Add(1)
+	go func() {
+		defer q.wg.Done()
+		// A generous per-query timeout: the point is to catch a DROPPED datagram, not
+		// to measure latency, and a loopback answer that takes 2s never happens.
+		c := &dns.Client{Net: protoUDP, DialTimeout: 2 * time.Second, ReadTimeout: 2 * time.Second, WriteTimeout: 2 * time.Second}
+		req := new(dns.Msg)
+		req.SetQuestion(dns.Fqdn(qname), dns.TypeA)
+		for ctx.Err() == nil {
+			resp, _, err := c.ExchangeContext(ctx, req.Copy(), addr)
+			if ctx.Err() != nil {
+				return
+			}
+			q.total.Add(1)
+			if err != nil || resp == nil || len(resp.Answer) != 1 {
+				q.failures.Add(1)
+			}
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+	t.Cleanup(cancel)
+	return q
+}
+
+func (q *queryStream) stop() (failures, total int64) {
+	q.cancel()
+	q.wg.Wait()
+	return q.failures.Load(), q.total.Load()
+}

--- a/agent/internal/meshdns/metrics.go
+++ b/agent/internal/meshdns/metrics.go
@@ -23,6 +23,19 @@ var queryDurationBuckets = []float64{
 	0.0001, 0.00025, 0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5,
 }
 
+// lameDuckDurationBuckets are the explicit histogram boundaries (SECONDS) for
+// aether.mesh_dns.lame_duck.duration.
+//
+// They are seconds-oriented on purpose. #732 (fixed in #733) was the prober's duration
+// histogram recording seconds against OTel's DEFAULT boundaries (5, 10, 25, ... — tuned
+// for milliseconds): every value below 5s landed in the first bucket, so the #726
+// validation could not tell a 2s stall from a 2ms success. The interesting range here is
+// "the successor answered within a few hundred ms" up to the 10s default
+// --lame-duck-max, so the boundaries have to resolve exactly that.
+var lameDuckDurationBuckets = []float64{
+	0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 5, 7.5, 10, 15, 30,
+}
+
 // resolverState is the point-in-time Server state the observable gauges export. It is
 // a plain value copied out from under the Server's RWMutex (see Server.observedState)
 // so the OTel collect callback never holds a resolver lock while exporting.
@@ -55,6 +68,10 @@ type metrics struct {
 	// from 1.0 to near zero.
 	forwardDials    metric.Int64Counter
 	forwardRecycles metric.Int64Counter
+	// lameDuckExits / lameDuckDuration record the post-SIGTERM handoff window
+	// (issue #729): why it ended and how long the predecessor kept serving.
+	lameDuckExits    metric.Int64Counter
+	lameDuckDuration metric.Float64Histogram
 }
 
 // newMetrics builds the resolver metrics on the global MeterProvider (a no-op meter
@@ -77,7 +94,11 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 	reloads := b.counter("aether.mesh_dns.snapshot_reloads_total",
 		"Attempts to read the record snapshot the agent writes, by result (success, missing=file absent, parse_error=corrupt, read_error=I/O failure)")
 	duration := b.histogram("aether.mesh_dns.query.duration",
-		"End-to-end time to handle a DNS query, by result")
+		"End-to-end time to handle a DNS query, by result", queryDurationBuckets)
+	lameDuckExits := b.counter("aether.mesh_dns.lame_duck.exits",
+		"Post-SIGTERM lame-duck windows that ended, by reason (successor=a DIFFERENT instance answered on this listener's SO_REUSEPORT address, so the handoff drained instead of dropping the queued datagrams; deadline=--lame-duck-max elapsed with no successor, which is normal for a scale-down and a failed surge otherwise; signal=a second termination signal cut the window short). On a healthy DaemonSet roll every node must show successor")
+	lameDuckDuration := b.histogram("aether.mesh_dns.lame_duck.duration",
+		"Seconds the resolver kept serving after SIGTERM before closing its listeners, by exit reason", lameDuckDurationBuckets)
 
 	age := b.floatGauge("aether.mesh_dns.snapshot_age_seconds",
 		"Seconds since the agent stamped the record snapshot. Grows without bound when the writing agent crashes, loses RBAC, or its capture reconciler wedges — the resolver then serves a frozen table and NXDOMAINs new services authoritatively")
@@ -134,6 +155,9 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 
 		forwardDials:    forwardDials,
 		forwardRecycles: forwardRecycles,
+
+		lameDuckExits:    lameDuckExits,
+		lameDuckDuration: lameDuckDuration,
 	}
 }
 
@@ -150,11 +174,15 @@ func (b *meterBuilder) counter(name, desc string) metric.Int64Counter {
 	return i
 }
 
-func (b *meterBuilder) histogram(name, desc string) metric.Float64Histogram {
+// histogram builds a seconds-unit histogram with EXPLICIT boundaries. The boundaries
+// are a required parameter rather than a package default: OTel's implicit set is
+// milliseconds-oriented, and silently recording seconds against it is exactly the
+// resolution loss #732/#733 swept out of the rest of the repo.
+func (b *meterBuilder) histogram(name, desc string, buckets []float64) metric.Float64Histogram {
 	i, err := b.meter.Float64Histogram(name,
 		metric.WithDescription(desc),
 		metric.WithUnit("s"),
-		metric.WithExplicitBucketBoundaries(queryDurationBuckets...))
+		metric.WithExplicitBucketBoundaries(buckets...))
 	b.latch(err)
 	return i
 }
@@ -245,6 +273,19 @@ func (m *metrics) recordForwardRecycle(reason string) {
 	m.forwardRecycles.Add(context.Background(), 1, metric.WithAttributes(attribute.String("reason", reason)))
 }
 
+// recordLameDuck records one completed lame-duck window: the exit reason on the counter
+// and, with the same reason attribute, how long the predecessor kept serving. Both carry
+// reason so "we always run to the deadline" (a successor that never answers) is
+// distinguishable from "we hand off in 400ms" without joining two metrics.
+func (m *metrics) recordLameDuck(reason string, d time.Duration) {
+	if m == nil {
+		return
+	}
+	attrs := metric.WithAttributes(attribute.String("reason", reason))
+	m.lameDuckExits.Add(context.Background(), 1, attrs)
+	m.lameDuckDuration.Record(context.Background(), d.Seconds(), attrs)
+}
+
 // recordReload counts a snapshot read attempt by outcome.
 func (m *metrics) recordReload(result string) {
 	if m == nil {
@@ -273,6 +314,12 @@ const (
 	// populated (warm-start snapshot empty + no reconcile yet); answered SERVFAIL
 	// so the client retries instead of caching a negative answer.
 	resultCold = "cold"
+	// resultInstance is a query for the reserved instance-identity name
+	// (_instance._aether.<meshDomain>, issue #729): the TXT stamp that lets a
+	// departing predecessor recognise its successor in the SO_REUSEPORT group. A
+	// handful per roll; a steady stream of them means something other than the lame
+	// duck is polling it.
+	resultInstance = "instance_id"
 )
 
 const (

--- a/agent/internal/meshdns/server.go
+++ b/agent/internal/meshdns/server.go
@@ -131,6 +131,16 @@ type Server struct {
 	// exported as aether.mesh_dns.last_answered_timestamp_seconds.
 	lastAnswered atomic.Int64
 
+	// Lame-duck handoff (issue #729, see lameduck.go). instanceID is this process's
+	// random identity stamp, served at instanceQName and compared against what the
+	// SO_REUSEPORT group answers so the predecessor can tell the successor apart from
+	// itself. lameDuckMax bounds the post-SIGTERM window (0 disables it) and
+	// lameDuckAbort cuts it short on a second termination signal. All three are set
+	// once at construction and only read afterwards, so they need no lock.
+	instanceID    string
+	lameDuckMax   time.Duration
+	lameDuckAbort <-chan struct{}
+
 	mu          sync.RWMutex
 	records     map[string]string // "<ns>/<svc>" -> A-record IP
 	ready       bool              // records have been populated at least once
@@ -193,6 +203,7 @@ func NewServerWithOptions(meshDomain, addr, snapshotPath string, log *slog.Logge
 		records:      map[string]string{},
 		poolSize:     DefaultForwardPoolSize,
 		pools:        map[string]*forwardPool{},
+		instanceID:   newInstanceID(),
 	}
 	for _, o := range opts {
 		o(s)
@@ -487,15 +498,32 @@ func (s *Server) Start(ctx context.Context) error {
 		go func() { errc <- udp.ListenAndServe() }()
 		go func() { errc <- tcp.ListenAndServe() }()
 	}
-	s.log.InfoContext(ctx, "mesh DNS resolver listening", "addr", s.addr, "reusePort", s.reusePort)
+	s.log.InfoContext(ctx, "mesh DNS resolver listening",
+		"addr", s.addr, "reusePort", s.reusePort, "instance", s.instanceID)
 	select {
 	case <-ctx.Done():
-		_ = udp.Shutdown()
-		_ = tcp.Shutdown()
-		return nil
+		return s.shutdown(ctx, stopWatchdog, udp, tcp)
 	case err := <-errc:
 		return err
 	}
+}
+
+// shutdown is Start's termination path: run the lame-duck window (issue #729) and only
+// then close the listeners.
+//
+// The ORDER is the whole fix. Closing first is what #726 diagnosed: the kernel had
+// already queued datagrams to this SO_REUSEPORT socket, and close() discards them
+// silently, costing every client that singleflights by name a full retransmit timeout.
+func (s *Server) shutdown(ctx context.Context, stopWatchdog func(), udp, tcp *dns.Server) error {
+	// The wedge watchdog's only lever is the ready marker, which the lame duck is
+	// about to remove deliberately. Left running, a passing self-check would restore
+	// it and re-advertise a pod that is on its way out.
+	stopWatchdog()
+	s.runLameDuck(ctx)
+	_ = udp.Shutdown()
+	_ = tcp.Shutdown()
+	s.log.Info("listener closed", "addr", s.addr, "instance", s.instanceID)
+	return nil
 }
 
 // writeReadyMarker creates (truncating) the pod-local ready-marker file. A
@@ -598,7 +626,8 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 // reporting that it CANNOT answer, and a resolver stuck emitting them is not healthy.
 func answeredResult(result string) bool {
 	return result == resultAnswered || result == resultNoData ||
-		result == resultNXDomain || result == resultForwarded
+		result == resultNXDomain || result == resultForwarded ||
+		result == resultInstance
 }
 
 // queryProto reports the transport a query ARRIVED on, read from the writer's remote
@@ -617,6 +646,12 @@ func queryProto(w dns.ResponseWriter) string {
 func (s *Server) serve(w dns.ResponseWriter, r *dns.Msg) string {
 	if len(r.Question) == 1 {
 		q := r.Question[0]
+		// The identity name sits UNDER the mesh domain, so it must be matched before
+		// isMeshName or it would be answered as an ordinary (permanently missing)
+		// mesh record and the handoff probe would never see a stamp.
+		if s.isInstanceName(q.Name) {
+			return s.serveInstance(w, r, q)
+		}
 		if s.isMeshName(q.Name) {
 			return s.serveMesh(w, r, q)
 		}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.7"
+version: "0.92.8"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/_helpers.tpl
+++ b/charts/aether/templates/_helpers.tpl
@@ -90,6 +90,37 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/version: {{ . | quote }}
 {{- end }}
 {{- end -}}
+{{/*
+aether.meshDns.lameDuckSeconds converts agent.meshDnsDaemon.lameDuckMax (a Go duration
+string, e.g. "10s") to whole seconds, so terminationGracePeriodSeconds can be DERIVED
+from it rather than hand-maintained alongside it (issue #729). A grace period shorter
+than the lame-duck ceiling means the kubelet SIGKILLs mid-window — which is precisely
+the abrupt socket close the window exists to avoid — so the two must never drift.
+Accepts h/m/s/ms suffixes and a bare number (read as seconds); "ms" is rounded UP so a
+sub-second window still gets a non-zero budget.
+
+An UNSET (null) value renders no flag, so the binary falls back to its own
+DefaultLameDuckMax — and the grace period must follow it there, not to zero, or the
+kubelet would SIGKILL 5s into a 10s window. Keep this literal in step with
+meshdns.DefaultLameDuckMax.
+*/}}
+{{- define "aether.meshDns.lameDuckSeconds" -}}
+{{- $v := . | toString | trim | lower -}}
+{{- if or (kindIs "invalid" .) (eq $v "") -}}
+{{- 10 -}}
+{{- else -}}
+{{- $n := regexFind "^[0-9]+" $v | default "0" | atoi -}}
+{{- if hasSuffix "ms" $v -}}
+{{- div (add $n 999) 1000 -}}
+{{- else if hasSuffix "h" $v -}}
+{{- mul $n 3600 -}}
+{{- else if hasSuffix "m" $v -}}
+{{- mul $n 60 -}}
+{{- else -}}
+{{- $n -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 
 {{/* ------------------------------------------------------------------ proxy */}}
 {{- define "aether.proxy.fullname" -}}{{- "aether-proxy" -}}{{- end -}}

--- a/charts/aether/templates/mesh-dns-daemonset.yaml
+++ b/charts/aether/templates/mesh-dns-daemonset.yaml
@@ -29,6 +29,18 @@ spec:
         {{- include "aether.meshDns.labels" . | nindent 8 }}
     spec:
       hostNetwork: true
+      # Derived from --lame-duck-max, never set independently (issue #729). On SIGTERM
+      # the resolver stops reporting ready but KEEPS SERVING its SO_REUSEPORT socket
+      # until it observes the successor answering on the same address, so the datagrams
+      # the kernel already queued to it are drained instead of discarded by close().
+      # If the grace period expired first the kubelet would SIGKILL mid-window, which is
+      # exactly the abrupt close the window exists to avoid — so it is lame-duck-max
+      # plus a 5s margin for the close, the final metric flush and process exit.
+      #
+      # There is deliberately NO preStop hook: the process handles SIGTERM itself, and a
+      # preStop sleep would only add a fixed delay in FRONT of a window that already
+      # ends as soon as the successor is proven to be serving.
+      terminationGracePeriodSeconds: {{ add (include "aether.meshDns.lameDuckSeconds" .Values.agent.meshDnsDaemon.lameDuckMax | int) 5 }}
       # Resolve the default upstream from the node's resolv.conf (kube-dns);
       # ClusterFirst is ignored for hostNetwork pods.
       dnsPolicy: ClusterFirstWithHostNet
@@ -69,6 +81,13 @@ spec:
                    the pool ON, which is the one failure an operator reaching for the
                    switch must never hit. Unset renders no arg. */}}
             - "--forward-pool-size={{ .Values.agent.meshDnsDaemon.forwardPoolSize }}"
+            {{- end }}
+            {{- if not (kindIs "invalid" .Values.agent.meshDnsDaemon.lameDuckMax) }}
+            {{- /* Same explicit nil-check as forwardPoolSize, and for the same reason:
+                   "0s" is the kill switch that restores the pre-#729 close-on-SIGTERM
+                   behaviour, and a `with` would render nothing and leave the window ON.
+                   terminationGracePeriodSeconds above is derived from this same key. */}}
+            - "--lame-duck-max={{ .Values.agent.meshDnsDaemon.lameDuckMax }}"
             {{- end }}
             {{- with .Values.otel.endpoint }}
             - "--otlp-endpoint={{ . }}"
@@ -123,6 +142,14 @@ spec:
             # ships in THIS image (same layer set as the daemon), so there is no
             # chart/image skew to sequence: /mesh-dns --readiness-check is retained but
             # deprecated for a chart older than this one.
+            #
+            # Since #729 the marker is also removed the moment SIGTERM starts the
+            # lame-duck window, so this probe reports the pod NotReady while it is
+            # still answering. That is honest — the pod IS leaving — and it costs
+            # nothing: readiness does not steer datagrams here. For a hostNetwork
+            # SO_REUSEPORT listener the KERNEL picks which co-bound socket receives
+            # each datagram, and it neither knows nor cares what the kubelet thinks of
+            # the pod. That is the whole reason the socket must stay open.
             #
             # Timings are deliberately UNCHANGED. periodSeconds x failureThreshold is
             # the marker-flap absorption window (the self-check clears the marker when

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -198,6 +198,30 @@ agent:
     # any datagram not from the upstream's exact address and an off-path attacker cannot
     # land a spoofed answer at all.
     forwardPoolSize: null
+    # Issue #729: how long the resolver keeps SERVING after SIGTERM before it closes
+    # its SO_REUSEPORT listeners.
+    #
+    # The problem it fixes (#726 Phase 1): on a roll (maxSurge:1/maxUnavailable:0) the
+    # DaemonSet controller deletes the predecessor the instant the successor passes its
+    # first readiness probe, and the predecessor used to close its socket immediately.
+    # Every datagram the kernel had already steered into that socket's queue was
+    # discarded — one lost DNS query per roll, and because Go's resolver singleflights
+    # by name, one lost query stalls every concurrent lookup of that name for a full
+    # retransmit timeout (5s before #728, ~1s after).
+    #
+    # With a window, the predecessor instead: stops reporting ready, keeps answering,
+    # and closes as soon as it observes a DIFFERENT instance answering on the same
+    # address (it asks the reuseport group for a TXT identity stamp — a reply carrying
+    # someone else's stamp proves the successor is both in the group and serving).
+    # This ceiling therefore only bites when NO successor appears: a scale-down, a node
+    # drain, or a surge that failed. Watch aether_mesh_dns_lame_duck_exits_total{reason}
+    # — a healthy roll is `successor` on every node.
+    #
+    # terminationGracePeriodSeconds on the DaemonSet is DERIVED from this value (+5s),
+    # so raising it cannot silently leave the kubelet SIGKILLing mid-window. Set "0s"
+    # to disable the window entirely and restore the pre-#729 close-on-SIGTERM
+    # behaviour. Not a tuning knob: the window ends on evidence, not on the clock.
+    lameDuckMax: "10s"
     # Verbose (TRACE) logging for THIS daemon only. Issue #684: the top-level
     # `debug` is true by default and used to reach mesh-dns, so every node ran the
     # resolver at TRACE — on the one component that sits on every managed pod's


### PR DESCRIPTION
Closes #729.

## The mechanism (from #726 Phase 1)

`aether-mesh-dns` rolls with `maxSurge: 1 / maxUnavailable: 0`, `SO_REUSEPORT`, readiness `initialDelaySeconds: 1`, **no preStop and no drain**. The DaemonSet controller deletes the predecessor the instant the successor passes its first readiness probe, the kubelet SIGTERMs it, and `Server.Start` closed the UDP + TCP sockets immediately on `<-ctx.Done()`.

While both sockets are in the reuseport group the kernel hashes each arriving datagram at one of them. Anything already steered into the departing socket's queue is **silently discarded** by `close()`. #726 measured exactly that: a 5.106 s hole (12:30:40.841Z → 12:30:45.947Z) in one prober's mesh-domain access log, 16 timeouts, and **zero** non-200 responses anywhere in Envoy — the requests never reached the data plane. One lost datagram, amplified because Go's resolver singleflights by name, so every concurrent lookup of that name waited out the same retransmit.

#728 shrank the client-side cost (`options timeout:1 attempts:3`, `dns_timeout` now reachable). The datagram loss itself was untouched, and that is this PR.

## Design as implemented

**1. Lame duck on SIGTERM** (`agent/internal/meshdns/lameduck.go`). On SIGTERM the resolver:
- removes its pod-local ready marker (so `mesh-dns-ready` reports NotReady) and stops the wedge watchdog, so nothing can restore the marker,
- **keeps the UDP + TCP listeners serving**,
- closes them only when a successor is observed serving, `--lame-duck-max` elapses, or a second signal arrives,
- then closes and exits 0.

**2. Successor detection is evidence, not a timer.** The resolver answers a reserved identity name — `_instance._aether.<mesh-domain>` **TXT**, TTL 0 — with 64 random bits minted at process start. The stamp is random rather than pid-derived on purpose: predecessor and successor each run as **pid 1** in their own container, so a pid stamp would make them indistinguishable and every window would run to its deadline.

The lame duck queries that name **over the wire** at its own listen address every 200 ms (150 ms timeout). Both processes hold a socket in the reuseport group, so the kernel hashes each probe's 4-tuple at one of them, and a fresh ephemeral source port per probe re-rolls that hash. A reply carrying **someone else's** stamp proves both halves of what must be true before closing: the successor is **in** the group (the kernel will steer to it) and it **answers** (what it is steered gets a reply). Our own stamp, or no reply at all, is "not yet" — never "no successor".

The name is shaped like the existing self-check probe (`_selfcheck._aether.…`) and for the same reasons: under the mesh domain so it is answered authoritatively and never forwarded to kube-dns, and both labels start with `_`, which is not a legal DNS-1123 namespace or Service name, so the record table can never hold a colliding key. It is matched **before** `isMeshName` in `serve`, or it would just be a permanently missing service. Exposure: any pod on the node can ask for it and learn 16 hex characters that mean nothing outside this handoff.

**3. Second SIGTERM aborts.** `signal.NotifyContext` consumes the first signal; the abort handler is registered only *after* the shutdown begins, so the first signal can never be mistaken for the second.

**4. Readiness during lame duck.** The marker goes first, via the same pod-local marker mechanism the proxy supervisor uses, so the DaemonSet controller's view is honest. **This does not affect datagram steering** — for a hostNetwork `SO_REUSEPORT` listener the *kernel* picks which co-bound socket receives each datagram and neither knows nor cares what the kubelet thinks of the pod. That is exactly why the socket has to stay open; readiness alone would change nothing.

**5. Residual — documented in `runLameDuck`, in the chart, and here.** The instant of `close()` on a reuseport socket can still drop a datagram the kernel queued between the last `recvfrom` and the close. That is a kernel race and is not closable from userspace; eBPF `sk_reuseport` steering (drain the departing socket out of the group first) would be the complete fix. **The lame duck reduces the exposure from "every roll" to that sub-millisecond race.**

## New flag and values keys

| | |
|---|---|
| flag | `--lame-duck-max` (duration, default `10s`; `0` disables and restores the pre-#729 close-on-SIGTERM) |
| values | `agent.meshDnsDaemon.lameDuckMax: "10s"` |
| chart | `0.92.7` → **`0.92.8`** |

`terminationGracePeriodSeconds` is **derived** from `lameDuckMax` (+5 s) by a new `aether.meshDns.lameDuckSeconds` helper rather than hand-maintained beside it: a grace period shorter than the window means the kubelet SIGKILLs mid-drain, which is precisely the abrupt close this removes. Rendered: `"10s"` → 15, `"0s"` → 5, `"2m"` → 125, `"500ms"` → 6, unset → 15 (it follows the binary's own default, not zero). The flag uses the existing `{{- if not (kindIs "invalid" …) }}` guard so `"0s"` renders as a real kill switch. **No `preStop`** — the process handles SIGTERM itself, and a preStop sleep would only add a fixed delay in front of a window that already ends on evidence. `maxSurge: 1 / maxUnavailable: 0` unchanged.

## Metrics and log lines, as exported by Prometheus

| OTel instrument | Prometheus |
|---|---|
| `aether.mesh_dns.lame_duck.exits` (counter, attr `reason`) | `aether_mesh_dns_lame_duck_exits_total{reason="successor\|deadline\|signal"}` |
| `aether.mesh_dns.lame_duck.duration` (histogram, unit `s`, attr `reason`) | `aether_mesh_dns_lame_duck_duration_seconds_{bucket,sum,count}` |

Buckets are **seconds-oriented**: `0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 3, 5, 7.5, 10, 15, 30`. That is deliberate — #732/#733 was seconds recorded against OTel's millisecond-tuned defaults, which flattened every value below 5 s into one bucket and is exactly why the #726 validation could not measure this window. The shared `meterBuilder.histogram` now **requires** boundaries instead of defaulting to one instrument's set, so the next histogram cannot repeat it.

`aether.mesh_dns.queries` gains one bounded result value, `result="instance_id"` (a handful per roll).

INFO lines, from the `mesh-dns` logger:

```
lame duck started              instance=<self> max=10s probeInterval=200ms
successor observed             instance=<self> successor=<peer>
lame duck deadline reached     instance=<self> max=10s
lame duck aborted by a second termination signal   instance=<self>
listener closed                addr=<host:18054> instance=<self>
```

## Validated locally

- `bazel test --test_arg=-test.short //agent/internal/meshdns/... //agent/cmd/mesh-dns/... //agent/cmd/mesh-dns-ready/... //common/...` — 21/21 pass; full (non-short) meshdns run passes too.
- Unit tests over the state machine with a **fake clock** and a scripted detector: successor observed → `reason=successor` with the peer's stamp and the exact window duration; inconclusive probes keep the window open; deadline → `reason=deadline` with the ticker armed at `--lame-duck-max`; second signal → `reason=signal`, immediate, winning over a detector that *would* have succeeded. Plus: stamp uniqueness (100 draws), the identity name answered authoritatively as TXT/NODATA with TTL 0 and not shadowed by a colliding record-table key or by case, `probeDialAddr` wildcard→loopback, `--lame-duck-max=0` closing immediately.
- **Integration-style, hermetic (no Docker):** two real resolvers co-bind one `SO_REUSEPORT` UDP/TCP port on 127.0.0.1 (ephemeral), a client streams mesh A queries throughout, the predecessor's context is cancelled (the SIGTERM equivalent). Asserts the predecessor exits with `lame_duck.exits{reason="successor"} == 1` read off an OTel `ManualReader`, its ready marker is gone, and the query stream stays answered (tolerating at most the one documented close-instant residual). Observed handoff: 0.3–0.8 s.
- `make gazelle`, `make format-check`, `bazel build --config=lint --@aspect_rules_lint//lint:fail_on_violation` (gocognit 15) — all clean.
- `helm lint charts/aether` clean; `helm template` verified for the default and for `0s / 2m / 500ms / null`.

## On-cluster validation recipe

Not run here — this is deploy-and-measure work for the main session.

1. Deploy chart `0.92.8` with the new image, confirm `appVersion` after upgrade (#692 publish race) and that every `aether-mesh-dns` pod carries `--lame-duck-max=10s` and `terminationGracePeriodSeconds: 15`.
2. Under steady prober load (5 rq/s per path per prober, 5 probers), do **≥10** `kubectl rollout restart daemonset/aether-mesh-dns` cycles, waiting for full convergence + a 120 s settle between them.
3. **Per roll, per path, per prober: raw per-series counter deltas** (not `rate()`, not `increase()`) of `timeout` + `dns_timeout` + `connection_error`. **Pass = 0 on every roll on both paths** (`echo.aether-test.aether.internal:18081` and `echo.aether-test.svc.cluster.local:18081`).
4. **Per roll: `aether_mesh_dns_lame_duck_exits_total{reason}` per node.** Expect `reason="successor"` on **every** node, every roll. A `deadline` means the successor never answered — the exposure is unchanged for that node and the roll should be treated as a finding.
5. **Lame-duck duration per node:** `aether_mesh_dns_lame_duck_duration_seconds_bucket` — expect the mass at `le=0.25`/`le=0.5`. Anything near `le=10` is a `deadline` in disguise.
6. **Access-log gap method (#726 Phase 1), the only direct measurement of the residual.** For each roll, LogsQL `log_name:"aether_access_logs" reporter:"source" pod_name:"<prober>" authority:"echo.aether-test.aether.internal:18081"` across the roll window; compute consecutive-record gaps. **Pass = no gap ≥ 1 s on the mesh-domain path**, with the `svc.cluster.local` path as the in-window control. Control-test every negative (`response_flags:"URX"` field syntax) — LogsQL false zeros have burned three investigations.
7. Also assert: mesh-dns restarts 0, `aether_mesh_dns_ready`/`watch_active` = 1 and `records` steady on all nodes, no alerts in `#alerts` during the window.

Worth a follow-up either way: an alert on `increase(aether_mesh_dns_lame_duck_exits_total{reason="deadline"}[1h]) > 0` outside a genuine scale-down, in the GitOps repo where the deployed rules live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
