### PR TITLE
fix(mesh-dns): stamp the lame-duck exit metrics with the per-generation instance (#736)

### DIFF
--- a/agent/internal/meshdns/lameduck.go
+++ b/agent/internal/meshdns/lameduck.go
@@ -328,5 +328,8 @@ func (s *Server) runLameDuck(ctx context.Context) {
 	// Detached from the shutdown context: it is already cancelled, and every probe
 	// issued under it would fail instantly.
 	out := d.run(context.WithoutCancel(ctx))
-	s.metrics.recordLameDuck(out.reason, out.duration)
+	// The instance stamp goes on the metric too (issue #736): the exit is a
+	// once-per-process event, so without a per-generation attribute every successor
+	// restarts the same {node,reason} series at 1 and increase() across a roll reads ~0.
+	s.metrics.recordLameDuck(s.instanceID, out.reason, out.duration)
 }

--- a/agent/internal/meshdns/lameduck_test.go
+++ b/agent/internal/meshdns/lameduck_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -329,6 +330,59 @@ func TestLameDuckHandsOffToACoBoundSuccessor(t *testing.T) {
 		"the lame duck must stop reporting ready the moment it starts")
 }
 
+// TestLameDuckExitsCarryThePerGenerationInstance is issue #736: the exit is a
+// once-per-process event, so with only {node,reason} every generation increments a
+// fresh process-local counter to 1 and Prometheus sees the same series go 1 -> 1 -> 1 —
+// which is not a reset, so increase() over a multi-roll window reports ~0. The instance
+// stamp makes each generation its own series, and each one a genuine 0 -> 1 rise.
+//
+// Both instruments are asserted: the histogram's _count is a counter too, with exactly
+// the same defect when it is not per-generation.
+func TestLameDuckExitsCarryThePerGenerationInstance(t *testing.T) {
+	reader := installManualReader(t)
+
+	// Two generations of the same resolver on one node: a predecessor and the successor
+	// that later exits for the SAME reason. The abort channel is pre-closed so each
+	// window ends at once through the real runLameDuck path — what is under test is the
+	// wiring from the server's stamp onto the instruments, not the state machine.
+	for _, id := range []string{"gen-a", "gen-b"} {
+		abort := make(chan struct{})
+		close(abort)
+		s := NewServerWithOptions("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler),
+			WithInstanceID(id), WithLameDuck(5*time.Second), WithLameDuckAbort(abort))
+		s.runLameDuck(context.Background())
+	}
+
+	want := map[lameDuckSeries]int64{
+		{reason: lameDuckSignal, instance: "gen-a"}: 1,
+		{reason: lameDuckSignal, instance: "gen-b"}: 1,
+	}
+	assert.Equal(t, want, lameDuckExitSeries(t, reader, "aether.mesh_dns.lame_duck.exits"),
+		"two generations exiting for the same reason must be two SERIES, not one series stuck at 1")
+	assert.Equal(t, want, lameDuckExitSeries(t, reader, "aether.mesh_dns.lame_duck.duration"),
+		"the duration histogram's _count resets per generation too, so it carries the same stamp")
+}
+
+// TestLameDuckExitInstanceIsTheServersStamp: the attribute must be THIS process's
+// identity stamp — the same 16 hex characters the `lame duck started` / `successor
+// observed` log lines carry as instance=, which is what makes the metric joinable to
+// the logs of the generation that emitted it.
+func TestLameDuckExitInstanceIsTheServersStamp(t *testing.T) {
+	reader := installManualReader(t)
+	abort := make(chan struct{})
+	close(abort)
+	// No WithInstanceID: the production path, a randomly minted stamp.
+	s := NewServerWithOptions("aether.internal", "127.0.0.1:0", "", slog.New(slog.DiscardHandler),
+		WithLameDuck(5*time.Second), WithLameDuckAbort(abort))
+	require.Len(t, s.instanceID, 16)
+
+	s.runLameDuck(context.Background())
+
+	assert.Equal(t, map[lameDuckSeries]int64{
+		{reason: lameDuckSignal, instance: s.instanceID}: 1,
+	}, lameDuckExitSeries(t, reader, "aether.mesh_dns.lame_duck.exits"))
+}
+
 // installManualReader points the global MeterProvider at a manual reader for the test.
 func installManualReader(t *testing.T) *sdkmetric.ManualReader {
 	t.Helper()
@@ -339,27 +393,73 @@ func installManualReader(t *testing.T) *sdkmetric.ManualReader {
 	return reader
 }
 
-// lameDuckExitCounts collects aether.mesh_dns.lame_duck.exits as reason -> count.
+// lameDuckSeries identifies one exported time series of the lame-duck instruments: the
+// closed reason plus the per-generation instance stamp (#736).
+type lameDuckSeries struct {
+	reason   string
+	instance string
+}
+
+// lameDuckExitCounts collects aether.mesh_dns.lame_duck.exits as reason -> count,
+// summed across generations.
 func lameDuckExitCounts(t *testing.T, reader *sdkmetric.ManualReader) map[string]int64 {
+	t.Helper()
+	counts := map[string]int64{}
+	for series, v := range lameDuckExitSeries(t, reader, "aether.mesh_dns.lame_duck.exits") {
+		counts[series.reason] += v
+	}
+	return counts
+}
+
+// lameDuckExitSeries collects one lame-duck instrument as {reason,instance} -> count.
+// For the counter that is the summed value; for the duration histogram it is the bucket
+// count — the number that carries the same per-generation reset problem.
+func lameDuckExitSeries(t *testing.T, reader *sdkmetric.ManualReader, name string) map[lameDuckSeries]int64 {
 	t.Helper()
 	var rm metricdata.ResourceMetrics
 	require.NoError(t, reader.Collect(context.Background(), &rm))
-	counts := map[string]int64{}
+	out := map[lameDuckSeries]int64{}
 	for _, sm := range rm.ScopeMetrics {
 		for _, m := range sm.Metrics {
-			if m.Name != "aether.mesh_dns.lame_duck.exits" {
+			if m.Name != name {
 				continue
 			}
-			sum, ok := m.Data.(metricdata.Sum[int64])
-			require.True(t, ok, "lame_duck.exits should be an int64 sum")
-			for _, dp := range sum.DataPoints {
-				v, ok := dp.Attributes.Value("reason")
-				require.True(t, ok, "every exit must carry a reason")
-				counts[v.Emit()] += dp.Value
-			}
+			collectLameDuckSeries(t, name, m.Data, out)
 		}
 	}
-	return counts
+	return out
+}
+
+// collectLameDuckSeries folds one instrument's data points into out.
+func collectLameDuckSeries(t *testing.T, name string, data metricdata.Aggregation, out map[lameDuckSeries]int64) {
+	t.Helper()
+	switch d := data.(type) {
+	case metricdata.Sum[int64]:
+		for _, dp := range d.DataPoints {
+			out[lameDuckSeriesOf(t, dp.Attributes)] += dp.Value
+		}
+	case metricdata.Histogram[float64]:
+		for _, dp := range d.DataPoints {
+			out[lameDuckSeriesOf(t, dp.Attributes)] += int64(dp.Count)
+		}
+	default:
+		t.Fatalf("%s has unexpected aggregation %T", name, data)
+	}
+}
+
+// lameDuckSeriesOf reads the identifying attributes off one exported data point. It
+// also pins the reason set CLOSED: anything outside successor|deadline|signal is a new
+// unbounded dimension, and it fails here rather than in Prometheus.
+func lameDuckSeriesOf(t *testing.T, attrs attribute.Set) lameDuckSeries {
+	t.Helper()
+	reason, ok := attrs.Value("reason")
+	require.True(t, ok, "every exit must carry a reason")
+	require.Contains(t, []string{lameDuckSuccessor, lameDuckDeadline, lameDuckSignal}, reason.Emit(),
+		"the reason attribute set must stay closed")
+	instance, ok := attrs.Value("instance")
+	require.True(t, ok, "every exit must carry its per-generation instance stamp (#736)")
+	require.NotEmpty(t, instance.Emit())
+	return lameDuckSeries{reason: reason.Emit(), instance: instance.Emit()}
 }
 
 // reusablePort picks a loopback port both servers can co-bind. It is chosen by binding

--- a/agent/internal/meshdns/metrics.go
+++ b/agent/internal/meshdns/metrics.go
@@ -96,9 +96,9 @@ func newMetrics(state func() resolverState, log *slog.Logger) *metrics {
 	duration := b.histogram("aether.mesh_dns.query.duration",
 		"End-to-end time to handle a DNS query, by result", queryDurationBuckets)
 	lameDuckExits := b.counter("aether.mesh_dns.lame_duck.exits",
-		"Post-SIGTERM lame-duck windows that ended, by reason (successor=a DIFFERENT instance answered on this listener's SO_REUSEPORT address, so the handoff drained instead of dropping the queued datagrams; deadline=--lame-duck-max elapsed with no successor, which is normal for a scale-down and a failed surge otherwise; signal=a second termination signal cut the window short). On a healthy DaemonSet roll every node must show successor")
+		"Post-SIGTERM lame-duck windows that ended, by reason (successor=a DIFFERENT instance answered on this listener's SO_REUSEPORT address, so the handoff drained instead of dropping the queued datagrams; deadline=--lame-duck-max elapsed with no successor, which is normal for a scale-down and a failed surge otherwise; signal=a second termination signal cut the window short) and by instance (this process's lame-duck identity stamp, exactly one value per mesh-DNS generation, issue #736 — it makes each generation its own series so sum by (node)(increase(aether_mesh_dns_lame_duck_exits_total[30m])) counts every roll in the window instead of reading ~0, and it joins to the `instance=` field on this process's `lame duck started` / `successor observed` log lines). On a healthy DaemonSet roll every node must show successor")
 	lameDuckDuration := b.histogram("aether.mesh_dns.lame_duck.duration",
-		"Seconds the resolver kept serving after SIGTERM before closing its listeners, by exit reason", lameDuckDurationBuckets)
+		"Seconds the resolver kept serving after SIGTERM before closing its listeners, by exit reason and by the same per-generation instance stamp as aether.mesh_dns.lame_duck.exits (its _count is a counter and would otherwise reset with every generation, issue #736)", lameDuckDurationBuckets)
 
 	age := b.floatGauge("aether.mesh_dns.snapshot_age_seconds",
 		"Seconds since the agent stamped the record snapshot. Grows without bound when the writing agent crashes, loses RBAC, or its capture reconciler wedges — the resolver then serves a frozen table and NXDOMAINs new services authoritatively")
@@ -274,14 +274,30 @@ func (m *metrics) recordForwardRecycle(reason string) {
 }
 
 // recordLameDuck records one completed lame-duck window: the exit reason on the counter
-// and, with the same reason attribute, how long the predecessor kept serving. Both carry
+// and, with the same attributes, how long the predecessor kept serving. Both carry
 // reason so "we always run to the deadline" (a successor that never answers) is
 // distinguishable from "we hand off in 400ms" without joining two metrics.
-func (m *metrics) recordLameDuck(reason string, d time.Duration) {
+//
+// Both also carry `instance`, this process's lame-duck identity stamp (lameduck.go), and
+// that attribute is what makes the counter READABLE across a rollout (issue #736). A
+// lame-duck exit happens once per process, at the end of its life: with only {node,
+// reason} every generation increments a fresh process-local counter to 1, Prometheus
+// sees the same series go 1 -> 1 -> 1, which is not a counter reset, and increase() over
+// a window spanning several rolls reports ~0. The stamp is minted once per process and
+// never reused, so each generation is its own series, every one of them a genuine 0 -> 1
+// rise that increase() sums. Cardinality is one series per generation per node — bounded
+// by how often the DaemonSet rolls, and the series age out with the generation.
+//
+// The reason attribute stays a CLOSED set (successor|deadline|signal); instance is the
+// only unbounded-in-time dimension, and deliberately so.
+func (m *metrics) recordLameDuck(instance, reason string, d time.Duration) {
 	if m == nil {
 		return
 	}
-	attrs := metric.WithAttributes(attribute.String("reason", reason))
+	attrs := metric.WithAttributes(
+		attribute.String("reason", reason),
+		attribute.String("instance", instance),
+	)
 	m.lameDuckExits.Add(context.Background(), 1, attrs)
 	m.lameDuckDuration.Record(context.Background(), d.Seconds(), attrs)
 }

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -333,6 +333,68 @@ pre-#674 dial-per-query behaviour:
 helm upgrade ... --set agent.meshDnsDaemon.forwardPoolSize=0
 ```
 
+### Grading the mesh-DNS lame-duck handoff across a roll
+
+On SIGTERM the resolver keeps serving until it has PROVEN a successor is answering on
+the shared SO_REUSEPORT address, and only then closes its sockets (issue #729). Every
+window ends with exactly one exit, counted by `reason`:
+
+| `reason` | meaning |
+| --- | --- |
+| `successor` | a DIFFERENT instance answered on our listen address — the handoff drained. **This is what a healthy DaemonSet roll must show on every node.** |
+| `deadline` | `--lame-duck-max` elapsed with no successor. Expected on a scale-down or node drain; on a roll it means the successor never came up, and the queued datagrams were dropped as they were before #729. |
+| `signal` | a second termination signal cut the window short. |
+
+The exit is a **once-per-process event**, so the counter carries an `instance` attribute
+— this process's 64-bit lame-duck identity stamp, exactly one value per mesh-DNS
+generation (issue #736). Without it every successor restarts the same `{node,reason}`
+series at 1, Prometheus never sees a reset, and `increase()` over a window spanning
+several rolls reads ~0 (the #729 validation had to count 50 exits from raw per-roll
+snapshots). With it each generation is its own series and a genuine 0 → 1 rise:
+
+```promql
+# Exits per node over the last 30m. After two rolls this is 2 per node -- it counts
+# every generation, which the pre-#736 series could not.
+sum by (node) (increase(aether_mesh_dns_lame_duck_exits_total[30m]))
+
+# The only breakdown that matters: everything must be reason="successor".
+sum by (node, reason) (increase(aether_mesh_dns_lame_duck_exits_total[30m]))
+
+# How long each generation held its sockets open, p95 (10s is --lame-duck-max,
+# i.e. a window that ran to its deadline).
+histogram_quantile(0.95,
+  sum by (le) (rate(aether_mesh_dns_lame_duck_duration_seconds_bucket[30m])))
+```
+
+> **Sample count.** A generation records its exit and then dies, so its series is
+> exported by the shutdown flush and usually carries a **single** sample. `rate()` and
+> `increase()` need two samples in the range to produce anything for a series, so if a
+> window you know had rolls still comes back empty, count the series instead — each one
+> tops out at exactly 1, so this is exact regardless of how many samples landed:
+>
+> ```promql
+> # Rolls per node, sample-count independent.
+> sum by (node) (max_over_time(aether_mesh_dns_lame_duck_exits_total[30m]))
+> sum by (node, reason) (max_over_time(aether_mesh_dns_lame_duck_exits_total[30m]))
+> ```
+>
+> `max_over_time` is also what survives the series ageing out with its generation — the
+> same trap that produced two premature "zero" readings on #638.
+
+`instance` is also the join key back to the logs: the same stamp appears as `instance=`
+on that generation's `lame duck started` and `successor observed` lines (and as
+`successor=` on the *predecessor's* line, naming the generation that replaced it), so a
+suspicious series resolves to one pod's window.
+
+```
+_stream:{service.name="aether-mesh-dns"} AND instance:"<stamp>"
+```
+
+Cardinality is one series per generation per node — bounded by how often the DaemonSet
+rolls, and the series age out with the generation. That ageing-out is why an **instant**
+query is never the right read here: minutes after a roll the generation's series is
+gone, and the instant read returns nothing at all rather than the exit it recorded.
+
 ### The agent reports an unrepairable conflist
 
 Symptom: `AetherCNIConflistUnchained` fires for a node, the agent there is NotReady and


### PR DESCRIPTION
Fixes #736. Option 1 from the issue, with the process's own lame-duck stamp instead of the pod name — no collector/GitOps change is needed for it to appear.

## Mechanism

A lame-duck exit is a **once-per-process event, emitted at the end of the process's life**. With the exported label set `{node, job, reason}`, each mesh-DNS generation increments its own fresh process-local counter to 1 and exits; the successor starts at 0 and, when it later exits, also reaches 1. Prometheus therefore sees one series go `1 → 1 → 1`, which is not a counter reset, so `increase()`/`rate()` over a window spanning several rolls report ~0. The #729 validation (10 rolls) had to count its 50/50 `successor` exits from raw per-roll snapshots.

## The attribute

Both instruments now carry `instance` — the 64-bit random identity stamp the process already mints for successor detection (`newInstanceID`, `lameduck.go`):

- `aether.mesh_dns.lame_duck.exits` (the counter)
- `aether.mesh_dns.lame_duck.duration` (its `_count` is a counter with exactly the same defect)

The stamp is exactly one value per generation and is never reused, so each generation is its own series and each exit a genuine `0 → 1` rise. It is also the value already logged as `instance=` on the `lame duck started` / `successor observed` lines, so the metric joins straight to the logs of the generation that emitted it.

Exported label set as Prometheus will see it:

```
aether_mesh_dns_lame_duck_exits_total{node, job, reason, instance}
aether_mesh_dns_lame_duck_duration_seconds_{bucket,sum,count}{node, job, reason, instance}
```

`reason` stays a **closed** set (`successor|deadline|signal`) — the tests fail on anything else. `instance` is the only unbounded-in-time dimension, deliberately.

## Cardinality

One series per generation per node: bounded by DaemonSet roll frequency (≈31 rolls per 8h soak across 5 nodes), and the series age out with the generation rather than accumulating.

## The corrected PromQL

```promql
# Exits per node. Two rolls => 2 per node, which the pre-#736 series could not show.
sum by (node) (increase(aether_mesh_dns_lame_duck_exits_total[30m]))

# Everything must be reason="successor" on a healthy roll.
sum by (node, reason) (increase(aether_mesh_dns_lame_duck_exits_total[30m]))
```

One caveat documented in the runbook: a generation records its exit and then dies, so its series is exported by the shutdown flush and usually carries a **single** sample, and `rate()`/`increase()` need two samples in a range to yield anything for a series. Since each series tops out at exactly 1, the sample-count-independent form is exact:

```promql
sum by (node) (max_over_time(aether_mesh_dns_lame_duck_exits_total[30m]))
```

An instant query is never right here — the series ages out with the generation (the same trap behind two premature "zero" readings on #638).

## Docs

- Both instrument descriptions state the mechanism and the corrected query.
- `docs/runbook.md` gains **"Grading the mesh-DNS lame-duck handoff across a roll"** under Troubleshooting: the `reason` table, the PromQL above, the sample-count caveat, and the `instance` → log join (`_stream:{service.name="aether-mesh-dns"} AND instance:"<stamp>"`).

No chart change.

## Tests

The ManualReader helpers now collect `{reason,instance}` series for both instruments (and assert the closed `reason` set):

- `TestLameDuckExitsCarryThePerGenerationInstance` — two generations exiting for the **same** reason produce **two** series, on the counter and on the histogram.
- `TestLameDuckExitInstanceIsTheServersStamp` — the attribute equals the server's own randomly minted stamp, through the real `runLameDuck` path.
- The existing co-bound handoff test is unchanged and still green.

```
bazel test --test_arg=-test.short //agent/internal/meshdns/... //agent/cmd/mesh-dns/...   # pass
bazel test //agent/internal/meshdns/...                                                   # pass (co-bound handoff included)
make gazelle && make format-check                                                         # clean
bazel build --config=lint --@aspect_rules_lint//lint:fail_on_violation //agent/internal/meshdns/...  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
