### PR TITLE
fix(prober): stop the mesh_dns SLI measuring the prober's own CPU quota (#735)

### DIFF
--- a/charts/prober/Chart.yaml
+++ b/charts/prober/Chart.yaml
@@ -8,7 +8,7 @@ description: |
   is structurally blind to during hot restarts.
 type: application
 # Stamped at package time when built with `--stamp` (see registrar Chart.yaml).
-version: "0.2.0-{GIT_COMMIT}"
+version: "0.3.0-{GIT_COMMIT}"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/prober/values.yaml
+++ b/charts/prober/values.yaml
@@ -55,10 +55,29 @@ probe:
 telemetry:
   otlpEndpoint: ""
 
+# The prober MEASURES mesh latency, so it must never be the thing adding it, and a CPU
+# limit is exactly that thing: the limit is a CFS quota, and once a 100 ms period's
+# quota is gone the runnable goroutine sleeps to the next period boundary — probe
+# latency comes out quantised in ~100 ms steps no matter how fast the mesh answered.
+#
+# At the previous 50m limit that was not a theoretical risk, it was the dominant term in
+# the SLI (issue #735). Measured on talos-main: the container was throttled in 81–90% of
+# ALL CFS periods on every one of the five nodes, and the mesh_dns tier's p50 read 179 ms
+# against a source-proxy `duration` of 29 ms for the very same requests — roughly 150 ms
+# of the published SLI was the prober's own quota. Even the liveness tier, a local
+# direct_response an unthrottled client measures at ~1 ms, read 9 ms p50 / 317 ms p99.
+#
+# The tier that costs the CPU is mesh_dns: it resolves and dials on EVERY probe by
+# design (that is the SLI), and ~39% of the process's CPU goes to
+# net.(*Resolver).tryOneName plus http.(*Transport).dialConn.
+#
+# Hence: a request that reflects real demand, and NO CPU limit. The workload is
+# open-loop and rate-bounded (probe.rate × number of targets) so it cannot run away.
+# The memory limit stays — it also feeds GOMEMLIMIT. Re-add limits.cpu here only with a
+# quota that cannot bind (>= 1), never a fraction of a core.
 resources:
   requests:
-    cpu: 10m
+    cpu: 100m
     memory: 32Mi
   limits:
-    cpu: 50m
     memory: 64Mi

--- a/prober/internal/prober/prober.go
+++ b/prober/internal/prober/prober.go
@@ -13,6 +13,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -40,6 +41,12 @@ const (
 	// defaultMeshDNSPort is appended to a mesh_dns target that omits a port so the
 	// probe still dials the local mesh egress listener after resolving the name.
 	defaultMeshDNSPort = "18081"
+
+	// maxDrainBytes caps the response body drain (see drainBody). Every probe target
+	// answers with a local reply or a small echo document, so the cap is only there so
+	// a misrouted probe onto a streaming endpoint can't make the prober the thing that
+	// hangs — the probe's own deadline still governs.
+	maxDrainBytes = 64 << 10
 
 	resultSuccess         = "success"
 	resultHTTPError       = "http_error"
@@ -86,6 +93,10 @@ type target struct {
 	name      string // metric "target" label
 	url       string
 	authority string
+	// client is the HTTP client this tier probes with. The liveness and reachability
+	// tiers share the keep-alive client; the mesh_dns tier gets the no-keep-alive one
+	// so it resolves and dials on every probe (see Prober.dnsClient).
+	client *http.Client
 }
 
 // probeDurationBuckets are the explicit histogram boundaries, in SECONDS, for
@@ -113,13 +124,35 @@ func newDurationHistogram(meter metric.Meter) (metric.Float64Histogram, error) {
 
 // Prober samples the mesh data plane and records results to OTel.
 type Prober struct {
-	cfg      Config
-	log      logr.Logger
-	client   *http.Client
-	provider *sdkmetric.MeterProvider // nil when telemetry is disabled
-	counter  metric.Int64Counter
-	duration metric.Float64Histogram
-	targets  []target
+	cfg       Config
+	log       logr.Logger
+	client    *http.Client
+	dnsClient *http.Client
+	provider  *sdkmetric.MeterProvider // nil when telemetry is disabled
+	counter   metric.Int64Counter
+	duration  metric.Float64Histogram
+	targets   []target
+}
+
+// newClient builds a probe client. Redirects are never followed: a probe measures the
+// hop it dialled, not wherever that hop points.
+//
+// keepAlive=false disables connection reuse outright, which is how the mesh_dns tier
+// guarantees the property it exists to measure: Go resolves a name only when it dials,
+// so a reused connection would silently stop exercising mesh DNS. That guarantee used
+// to be accidental — the tier's upstream answers with a body, and probe() closed the
+// body without draining it, which is itself enough to make Go destroy the connection.
+// It is now stated, so it survives an upstream that answers with no body (as the
+// liveness route's direct_response does) and it no longer depends on the drain.
+func newClient(keepAlive bool) *http.Client {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.DisableKeepAlives = !keepAlive
+	return &http.Client{
+		// No client.Timeout: the per-probe deadline is a context so we can tell
+		// timeout from connection error.
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+		Transport:     tr,
+	}
 }
 
 // New builds a Prober.
@@ -140,11 +173,8 @@ func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Pro
 
 	p := &Prober{
 		cfg: cfg, log: log, counter: counter, duration: duration, provider: provider,
-		client: &http.Client{
-			// No client.Timeout: the per-probe deadline is a context so we can tell
-			// timeout from connection error. Don't follow redirects.
-			CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
-		},
+		client:    newClient(true),
+		dnsClient: newClient(false),
 	}
 
 	// Liveness tier (always): hit the proxy's egress local-reply route. No upstream
@@ -154,6 +184,7 @@ func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Pro
 		name:      "egress",
 		url:       "http://" + cfg.Egress + cfg.LivenessPath,
 		authority: cfg.LivenessAuthority,
+		client:    p.client,
 	})
 	// Reachability tier (optional): full round-trip to an echo upstream.
 	for _, svc := range cfg.ReachabilityTargets {
@@ -162,6 +193,7 @@ func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Pro
 			name:      svc,
 			url:       "http://" + cfg.Egress + "/",
 			authority: svc + "." + cfg.MeshDomain,
+			client:    p.client,
 		})
 	}
 	// Mesh-DNS tier (optional): unlike the tiers above, the URL is the REAL
@@ -177,6 +209,12 @@ func New(ctx context.Context, cfg Config, log logr.Logger, version string) (*Pro
 			url:  "http://" + withDefaultPort(fqdn, defaultMeshDNSPort) + "/",
 			// authority intentionally left empty: do NOT override the Host, so the
 			// transport actually resolves and connects to the real name.
+			//
+			// dnsClient, not client: keep-alives are off so every probe dials, and
+			// therefore every probe resolves. That IS the SLI (issue #574) — a tier
+			// that reused a connection would keep reporting success straight through
+			// a mesh-DNS outage.
+			client: p.dnsClient,
 		})
 	}
 	return p, nil
@@ -297,18 +335,34 @@ func (p *Prober) probe(ctx context.Context, t target) {
 	// tracing equivalent for the direct_response liveness route).
 	req.Header.Set("traceparent", notSampledTraceparent())
 	start := time.Now()
-	resp, err := p.client.Do(req)
+	resp, err := t.client.Do(req)
 	elapsed := time.Since(start).Seconds()
 	if err != nil {
 		p.record(t, classifyErr(rctx, err), elapsed)
 		return
 	}
-	_ = resp.Body.Close()
+	drainBody(resp.Body)
 	if resp.StatusCode == http.StatusOK {
 		p.record(t, resultSuccess, elapsed)
 		return
 	}
 	p.record(t, resultHTTPError, elapsed)
+}
+
+// drainBody reads the rest of the response body before closing it. Closing a body that
+// has not reached EOF makes Go's transport DESTROY the connection instead of returning
+// it to the idle pool, so a bare Close() silently converts every keep-alive tier into a
+// connect-per-probe tier: the reachability tier is documented as reusing the fixed
+// egress, and on this mesh a new connection costs a full upstream mTLS handshake
+// (the node proxy's clusters set connection_pool_per_downstream_connection, by design).
+// The liveness tier only escaped because its direct_response carries no body at all.
+//
+// The drain deliberately happens AFTER the caller has stopped the clock: the probe
+// measures time-to-response-headers, which is what Client.Do returns on, and reading a
+// small already-buffered body must not be folded into the SLI.
+func drainBody(body io.ReadCloser) {
+	_, _ = io.Copy(io.Discard, io.LimitReader(body, maxDrainBytes))
+	_ = body.Close()
 }
 
 // notSampledTraceparent builds a W3C traceparent with the sampled flag clear

--- a/prober/internal/prober/prober_test.go
+++ b/prober/internal/prober/prober_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"regexp"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -238,4 +242,124 @@ func cumulativeAt(t *testing.T, dp metricdata.HistogramDataPoint[float64], bound
 		total += c
 	}
 	return total
+}
+
+// TestTierClients pins which transport each tier probes with (#735). The mesh_dns tier
+// MUST NOT reuse connections: Go resolves a name only when it dials, so a pooled
+// connection would keep the tier reporting success straight through a mesh-DNS outage —
+// the exact blind spot the tier exists to close (#574). The other tiers dial a fixed
+// address and have nothing to re-resolve, so they keep the pool.
+func TestTierClients(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.ReachabilityTargets = []string{"svc-1"}
+	cfg.MeshDNSTargets = []string{"echo.aether-test.aether.internal:18081"}
+	p, err := New(context.Background(), cfg, logr.Discard(), "test")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if transportOf(t, p.client).DisableKeepAlives {
+		t.Fatalf("shared client DisableKeepAlives = true, want false")
+	}
+	if !transportOf(t, p.dnsClient).DisableKeepAlives {
+		t.Fatalf("mesh_dns client DisableKeepAlives = false, want true")
+	}
+	for _, tgt := range p.targets {
+		if tgt.client == nil {
+			t.Fatalf("target %s/%s has no client", tgt.tier, tgt.name)
+		}
+		want := tgt.tier == tierMeshDNS
+		if got := transportOf(t, tgt.client).DisableKeepAlives; got != want {
+			t.Fatalf("target %s/%s DisableKeepAlives = %v, want %v", tgt.tier, tgt.name, got, want)
+		}
+	}
+}
+
+func transportOf(t *testing.T, c *http.Client) *http.Transport {
+	t.Helper()
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("client transport = %T, want *http.Transport", c.Transport)
+	}
+	return tr
+}
+
+// TestProbeConnectionReuse is the behavioural half of TestTierClients: what the wire
+// actually does over repeated probes against a server that answers WITH A BODY.
+//
+// The body matters. Before #735 probe() closed resp.Body without draining it, and Go's
+// transport destroys rather than pools a connection whose body never reached EOF, so
+// every tier was connect-per-probe — invisibly, because the liveness tier's
+// direct_response carries no body and pooled anyway. On this mesh a new connection is
+// not free: the node proxy's clusters set connection_pool_per_downstream_connection, so
+// each one costs a fresh upstream mTLS handshake.
+func TestProbeConnectionReuse(t *testing.T) {
+	const probes = 4
+	for _, tc := range []struct {
+		name     string
+		tier     string
+		wantConn int
+	}{
+		{"keep-alive tier reuses one connection", tierLiveness, 1},
+		{"mesh_dns tier dials every probe", tierMeshDNS, probes},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			conns := make(map[net.Conn]struct{})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				// A non-empty body is the whole point: an empty one pools regardless.
+				_, _ = io.WriteString(w, `{"echo":"body that must be drained"}`)
+			}))
+			srv.Config.ConnState = func(c net.Conn, state http.ConnState) {
+				if state != http.StateNew {
+					return
+				}
+				mu.Lock()
+				conns[c] = struct{}{}
+				mu.Unlock()
+			}
+			t.Cleanup(srv.Close)
+
+			cfg := DefaultConfig()
+			cfg.Egress = strings.TrimPrefix(srv.URL, "http://")
+			cfg.LivenessPath = "/"
+			cfg.MeshDNSTargets = []string{cfg.Egress}
+			p, err := New(context.Background(), cfg, logr.Discard(), "test")
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			tgt := findTarget(t, p, tc.tier)
+			for range probes {
+				p.probe(context.Background(), tgt)
+			}
+
+			mu.Lock()
+			got := len(conns)
+			mu.Unlock()
+			if got != tc.wantConn {
+				t.Fatalf("server saw %d connections over %d probes, want %d", got, probes, tc.wantConn)
+			}
+		})
+	}
+}
+
+// TestDrainBody pins drainBody itself: it must leave the body at EOF, which is the
+// precondition Go's transport checks before pooling a connection.
+func TestDrainBody(t *testing.T) {
+	body := io.NopCloser(strings.NewReader("a body the probe never reads"))
+	drainBody(body)
+	n, err := body.Read(make([]byte, 1))
+	if n != 0 || !errors.Is(err, io.EOF) {
+		t.Fatalf("after drainBody: read %d bytes, err %v; want 0, io.EOF", n, err)
+	}
+}
+
+func findTarget(t *testing.T, p *Prober, tier string) target {
+	t.Helper()
+	for _, tgt := range p.targets {
+		if tgt.tier == tier {
+			return tgt
+		}
+	}
+	t.Fatalf("no %s target among %d targets", tier, len(p.targets))
+	return target{}
 }


### PR DESCRIPTION
Fixes #735.

## The attribution

`tier="mesh_dns"` reported p50 **179 ms** (`aether.internal` target) / **196 ms** (`svc.cluster.local` target) with **0% under 10 ms**, against a mesh-DNS resolver whose server-side p50 is **1 ms** and a `tier="liveness"` p50 of **9 ms**. Both DNS targets cost the same although one is answered authoritatively by the node-local resolver and the other is forwarded to kube-dns — so DNS was never the variable.

Measured on talos-main (rev206, 2026-09-06 15:45–16:00Z) from four independent vantage points — the prober's histogram, the source/destination Envoy access logs, a one-shot meshed `netshoot` Job on `main-worker-01` (since deleted), and the kubelet's cAdvisor endpoint. Medians:

| layer | measured | how |
|---|---|---|
| mesh-dns resolver, `A` and `AAAA`, mesh name | **0 ms** (`aa`, `ANSWER: 0` for AAAA — already a correct authoritative NODATA) | `dig +stats` ×20 |
| kube-dns forward path, `A` and `AAAA` | **0–3 ms** | `dig +stats` ×20 |
| full client-side resolution | **0 ms** | `getent ahosts` ×10 |
| fresh TCP connect + HTTP to the **local egress** `direct_response` | **1.8 ms** (p90 2.8) | curl ×20 |
| warm-connection version of the same | **0.9 ms** | curl |
| **the mesh hop, as the source proxy itself times it** | **29 ms** (p90 42, p99 62), `upstream_service_time` 27 ms | access log, `reporter:"source"`, **n=24,129** |
| ... of which the destination proxy + echo app | **3 ms** (`upstream_service_time` 1 ms) | `reporter:"destination"`, n=24,121 |
| **the prober's own number** | **179 / 196 ms** | `aether_probe_request_duration_seconds` |

Source-proxy `duration` is **29 ms for both DNS targets** and 28–30 ms on all five nodes.

**179 − 29 = ~150 ms is outside the proxy and outside DNS.** It is the prober being CFS-throttled by its own chart. `limits.cpu: 50m` is a 5 ms budget per 100 ms period, and off the kubelet's cAdvisor endpoint (cAdvisor is *not* scraped into Prometheus here, which is why this stayed invisible until #733 fixed the buckets):

| node | pod | periods | throttled | **% throttled** | throttled seconds (pod life ≈ 4,000 s) |
|---|---|---|---|---|---|
| main-worker-01 | prober-2w6fx | 40,070 | 34,621 | **86.4%** | 3,916 s |
| main-worker-02 | prober-hvxnx | 39,581 | 35,685 | **90.2%** | 2,285 s |
| main-worker-03 | prober-ffc5r | 39,813 | 32,240 | **81.0%** | 2,882 s |
| main-worker-04 | prober-pc8gf | 40,223 | 32,971 | **82.0%** | 1,055 s |
| main-worker-05 | prober-2c48t | 40,477 | 33,438 | **82.6%** | 1,922 s |

`kubectl top`: 44–48 m on every pod — pinned at the quota. Once the quota is gone the runnable goroutine sleeps to the next period boundary, so probe latency comes out quantised in ~100 ms steps: exactly the 0% ≤ 10 ms / 21% ≤ 100 ms / 73% ≤ 250 ms distribution in the issue, exactly a median of ~1.75 periods.

The same throttle inflates the control: the liveness tier's 9 ms p50 / **317 ms p99** is a local `direct_response` that an unthrottled client in the same pod network measures at **0.9 ms warm / 1.8 ms fresh**. A local reply cannot take 317 ms on any network.

The CPU goes where the tier's design puts it. `aether_mesh_dns_queries_total` confirms the tier really does resolve every probe (`qtype=a,result=answered` 25.09/s and `qtype=aaaa,result=nodata` 25.10/s = 5/s × 5 nodes, one A and one AAAA each), and Pyroscope `{k8s_container_name="prober"}` puts **21.5% of the whole process in `net.(*Resolver).tryOneName`** and **17.7% in `http.(*Transport).dialConn`** (→ `internetSocket` 13.9%, `netFD.dial` 9.7%).

All three candidates on the issue are answered: (1) AAAA is fine — answered locally, authoritatively, NODATA, in 0 ms; (2) the fresh connection per probe is real but costs 29 ms, not 170; (3) no search-list expansion — `ndots:2`, both names carry 3 and 4 dots, one A + one AAAA per probe.

## The change

**`charts/prober/values.yaml`** (chart 0.2.0 → 0.3.0) — `requests.cpu: 100m` and **no CPU limit**. A limit is a quota, and the one workload that must never measure its own scheduling is the one that publishes the latency SLI. The prober is open-loop and rate-bounded (`probe.rate` × targets) so it cannot run away; the memory limit stays (it also feeds `GOMEMLIMIT`). The values comment says to re-add `limits.cpu` only with a quota that cannot bind (≥ 1), never a fraction of a core.

**`prober/internal/prober/prober.go`**

- The mesh_dns tier gets its own `DisableKeepAlives` transport. It must resolve on every probe — that IS the SLI (#574) — and Go resolves only when it dials. That held before only by accident: `probe()` closed `resp.Body` without draining it, which is itself enough to make Go destroy the connection. Stating it means the tier survives an upstream that answers with no body (as the liveness `direct_response` does) and it no longer leaks onto tiers that want reuse.
- Drain the body before closing it, so the keep-alive tiers actually keep alive. The liveness tier only escaped the old behaviour because a `direct_response` carries no body; the (currently unconfigured) reachability tier, documented as reusing the fixed egress, would have silently connected per probe. The drain happens **after** the clock stops, so the metric still means time-to-response-headers.

**Tests** — `TestTierClients` pins which transport each tier uses; `TestProbeConnectionReuse` asserts on the wire that a keep-alive tier opens **1** connection over 4 probes and the mesh_dns tier opens **4**, against a server that answers with a body (verified to fail with the old bare `Close()`); `TestDrainBody` pins the EOF postcondition Go's pooling depends on.

## Not changed: the other 29 ms

`connection_pool_per_downstream_connection: true` on every node-proxy service cluster (`agent/internal/xds/proxy/egress.go:213`), deliberately, so one source pod's upstream connection and its client certificate are never reused for another source. Measured on w01 over 5 minutes: **2,028 requests, 1,981 downstream connections, 1,869 upstream connections** — no pooling across downstream connections. So each new client connection pays a fresh cross-node TCP + mTLS handshake: source `upstream_service_time` 28 ms against a destination-side total of 3 ms, i.e. **~25 ms of handshake per new connection**, uniform across clusters (`echo` 29 ms, `uds-echo` 22 ms, `uds-cr-echo` 22 ms) and across nodes including those hosting a local replica.

That is the price of the per-source-identity model, not a defect, and the proxy is untouched here. Two follow-ups worth their own issues: 25 ms is high for a LAN handshake and the destination inbound's accept path deserves a look; and any future latency objective on this SLI must be stated per-connection, not per-request, because the happy path is a connection-establishment benchmark by design.

## Expected after deploy

| series | now | expected |
|---|---|---|
| `mesh_dns` p50, both targets | 179 / 196 ms | **~30–35 ms** (the 29 ms proxy-observed hop + ~1–3 ms DNS + ~1 ms dial; the unthrottled curl control measured 31.4 ms with DNS bypassed and 28.5 ms via the egress) |
| `liveness` p50 | 9.05 ms | **~1–2 ms** |
| `liveness` p99 | 317 ms | low tens of ms |
| CFS periods throttled | 81–90% | **0%** |

```promql
# the SLI itself
histogram_quantile(0.5, sum by (tier, target, le) (rate(aether_probe_request_duration_seconds_bucket[10m])))
histogram_quantile(0.99, sum by (tier, target, le) (rate(aether_probe_request_duration_seconds_bucket[10m])))

# the fraction of probes that now land under 10 ms (was 0 for mesh_dns)
  sum(rate(aether_probe_request_duration_seconds_bucket{tier="mesh_dns", le="0.01"}[10m]))
/ sum(rate(aether_probe_request_duration_seconds_count{tier="mesh_dns"}[10m]))

# the prober must stay unthrottled; cAdvisor is NOT scraped into Prometheus on
# talos-main, so read it off the kubelet:
#   kubectl get --raw "/api/v1/nodes/<node>/proxy/metrics/cadvisor" \
#     | grep -E 'container_cpu_cfs_(periods|throttled_periods)_total\{container="prober"'
# throttled/periods must be ~0.

# the mesh hop should be unchanged at ~29 ms — this change must not move it
# (VictoriaLogs LogsQL, source reporter):
#   authority:"echo.aether-test.aether.internal:18081" reporter:"source"
#     | stats quantile(0.5, duration_ms) dur_p50, quantile(0.5, upstream_service_time) ust_p50
```

Refs #733 (buckets), #728 (resolver options), #574 (the blind spot the tier closes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
