### PR TITLE
fix(agent): wait for the SPIRE Workload API instead of dying on it (#740)

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//agent/internal/edge/secret",
         "//agent/internal/endpointpolicy",
         "//agent/internal/gamma",
+        "//agent/internal/identity",
         "//agent/internal/l4route",
         "//agent/internal/meshdns",
         "//agent/internal/node",
@@ -50,6 +51,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/cache",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/manager",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@org_golang_google_grpc//:grpc",
@@ -62,6 +64,7 @@ go_test(
     srcs = [
         "config_test.go",
         "root_test.go",
+        "spire_identity_test.go",
         "supervisor_test.go",
     ],
     embed = [":cmd"],
@@ -71,5 +74,6 @@ go_test(
         "//agent/internal/node",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_controller_runtime//pkg/manager",
     ],
 )

--- a/agent/internal/cmd/config.go
+++ b/agent/internal/cmd/config.go
@@ -9,6 +9,7 @@ import (
 	"aethermesh.dev/agent/internal/xds/proxy"
 	meshconst "aethermesh.dev/common/constants/mesh"
 	"aethermesh.dev/common/manager"
+	commonspire "aethermesh.dev/common/spire"
 	"aethermesh.dev/common/udspath"
 )
 
@@ -91,6 +92,10 @@ type AgentConfig struct {
 	SpireAdminSocketPath string
 	// SpireWorkloadSocketPath is the path to the SPIRE Workload API UDS socket
 	SpireWorkloadSocketPath string
+	// SpireWaitWarnAfter is how long the wait for this workload's first SVID
+	// stays at INFO before escalating to WARN, and the dwell the spire-svid
+	// readiness gate allows before reporting NotReady (issue #740).
+	SpireWaitWarnAfter time.Duration
 
 	// CNIServerConfig holds CNI server configuration
 	CNIServerConfig *cniServer.CNIServerConfig
@@ -205,5 +210,6 @@ func NewAgentConfig() *AgentConfig {
 		SpireEnabled:            true,
 		SpireAdminSocketPath:    constants.DefaultSpireAdminSocketPath,
 		SpireWorkloadSocketPath: constants.DefaultSpireWorkloadSocketPath,
+		SpireWaitWarnAfter:      commonspire.DefaultWaitWarnAfter,
 	}
 }

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	"aethermesh.dev/agent/internal/configimport"
 	"aethermesh.dev/agent/internal/endpointpolicy"
 	"aethermesh.dev/agent/internal/gamma"
+	"aethermesh.dev/agent/internal/identity"
 	"aethermesh.dev/agent/internal/l4route"
 	"aethermesh.dev/agent/internal/meshdns"
 	"aethermesh.dev/agent/internal/node"
@@ -63,6 +64,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -167,6 +169,7 @@ func registerSharedFlags(cmd *cobra.Command, requirePodIdentity bool) {
 
 	// SPIRE workload socket (per-instance; the SPIRE on/off policy is system-wide).
 	cmd.Flags().StringVar(&cfg.SpireWorkloadSocketPath, "spire-workload-socket", constants.DefaultSpireWorkloadSocketPath, "Path to the SPIRE Workload API UDS socket used for registrar mTLS")
+	cmd.Flags().DurationVar(&cfg.SpireWaitWarnAfter, "spire-wait-warn-after", cfg.SpireWaitWarnAfter, "How long to wait for this workload's first SVID before escalating the waiting log line to WARN; also the dwell before the spire-svid readiness check reports NotReady")
 
 	// These calls only fail if the flag name is not registered, which would be a programming error.
 	must.NoError(cmd.MarkFlagRequired("cluster-name"))
@@ -240,7 +243,7 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	spireSource, identityTrustDomain, err := setupSpireSource(ctx)
+	spireSource, identityTrustDomain, err := startSpireIdentity(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -262,6 +265,11 @@ func runAgent(ctx context.Context) (retErr error) {
 	// next agent on this node restores what this one was serving (#701).
 	defer snapshotCache.FlushObservedUpstreams()
 
+	// Fold the real trust domain in whenever SPIRE gets around to issuing the
+	// first SVID. Everything below is wired from the seeded value (the mesh
+	// domain), which is what SPIRE issues into in every supported topology.
+	reconcileSpireIdentity(ctx, spireSource, identityTrustDomain, snapshotCache, localStorage)
+
 	ackTracker := ack.NewTracker(l)
 
 	spireBridge, err := wireSpireBridge(ctx, m, snapshotCache, spireSource)
@@ -269,7 +277,7 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache, ackTracker, identityTrustDomain); err != nil {
+	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache, ackTracker, identityTrustDomain.Get()); err != nil {
 		return err
 	}
 
@@ -279,11 +287,11 @@ func runAgent(ctx context.Context) (retErr error) {
 	// self-heal evictions. It is registered with the manager further down.
 	reasserter := newCNIConflistReasserter()
 
-	if err = setupCNIServer(m, localStorage, reg, snapshotCache, ackTracker, spireBridge, identityTrustDomain, chainStateOf(reasserter)); err != nil {
+	if err = setupCNIServer(m, localStorage, reg, snapshotCache, ackTracker, spireBridge, identityTrustDomain.Get(), chainStateOf(reasserter)); err != nil {
 		return err
 	}
 
-	if err = setupNodeGating(m, reasserter); err != nil {
+	if err = setupNodeGating(m, reasserter, spireSource); err != nil {
 		return err
 	}
 
@@ -314,37 +322,102 @@ func runAgent(ctx context.Context) (retErr error) {
 	return m.Start(ctx)
 }
 
-// setupSpireSource opens the SPIRE Workload API source and resolves the trust domain.
-// When SPIRE is disabled, it returns nil source and the mesh domain as trust domain.
-// The caller is responsible for closing the returned source via defer.
-func setupSpireSource(ctx context.Context) (*commonspire.Source, string, error) {
+// runnableAdder is the one thing startSpireIdentity needs from the manager. A
+// narrow interface rather than ctrl.Manager so the "returns immediately" test
+// does not need a live manager (and an apiserver) to prove the point.
+type runnableAdder interface {
+	Add(ctrlmanager.Runnable) error
+}
+
+// startSpireIdentity registers the agent's SPIRE identity source with the manager
+// and RETURNS IMMEDIATELY, along with the trust-domain holder every downstream
+// consumer is wired from. When SPIRE is disabled it registers nothing, logs
+// nothing, and hands back the mesh domain (issue #421's cleartext path, byte for
+// byte what it was).
+//
+// This slot used to be a blocking, FATAL wait for the first SVID
+// (commonspire.NewSource, 25s bound). It ran before m.Start, so /healthz and
+// /readyz were still silent, and a SPIRE server that was itself still starting —
+// the normal state of a cold boot — exited the process with "failed to create
+// SPIRE Workload API source: context deadline exceeded". On the 2026-09-07 power
+// failure that cost 2-4 restarts on every node and ~60s of mesh readiness, for a
+// dependency that recovered on its own in 13 seconds (issue #740).
+//
+// Nothing here needs the SVID to exist yet:
+//   - the registrar client dials lazily and defers its watch stream while the
+//     identity is pending (registry/internal/registrar: IdentityReady),
+//   - the SPIRE bridge retries its delegated-identity streams forever and serves
+//     the node SVID the moment WaitingSource announces it,
+//   - the xDS cache omits upstream mTLS until SetNodeIdentity lands, and Envoy
+//     tolerates the absent secret (#715),
+//   - the trust domain is seeded with the mesh domain, which is what SPIRE issues
+//     into in every supported topology (peer authorization is scoped to it
+//     unconditionally in setupRegistrarClient), and reconciled against the real
+//     SVID by reconcileSpireIdentity.
+//
+// What is NOT tolerated indefinitely is a node that never gets an identity: the
+// spire-svid readiness gate reports NotReady once the wait passes its dwell
+// (setupNodeGating).
+func startSpireIdentity(ctx context.Context, m runnableAdder) (*commonspire.WaitingSource, *identity.TrustDomain, error) {
+	trustDomain := identity.NewTrustDomain(cfg.MeshDomain)
 	if !cfg.SpireEnabled {
-		return nil, cfg.MeshDomain, nil
+		return nil, trustDomain, nil
 	}
-	// When SPIRE is enabled, open the Workload API source and resolve the real
-	// trust domain SPIRE issues into (e.g. "aether.internal"). That trust domain
-	// names the SDS resources / SPIFFE IDs the agent programs into Envoy so they
-	// match the secrets the SPIRE bridge delivers. Peer authorization uses the
-	// mesh domain — addressing (<svc>.<mesh-domain>) and identity
-	// (spiffe://<mesh-domain>/...) are one domain by design, never split.
-	//
-	// This wait is on the startup path, before the manager serves /healthz, so it
-	// is bounded (commonspire.SourceTimeout) and announced: an unattested agent
-	// used to stall here with no log line at all until the liveness probe killed
-	// it (issue #662).
-	l.InfoContext(ctx, "waiting for the SPIRE Workload API to issue this agent's SVID",
-		"socket", cfg.SpireWorkloadSocketPath, "timeout", commonspire.SourceTimeout)
-	spireSource, err := commonspire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
-	if err != nil {
-		return nil, "", err
+
+	src := commonspire.NewWaitingSource(cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l)
+	if err := m.Add(src); err != nil {
+		return nil, nil, fmt.Errorf("failed to add the SPIRE identity source: %w", err)
 	}
-	identityTrustDomain, err := commonspire.TrustDomainFromSource(spireSource)
-	if err != nil {
-		_ = spireSource.Close()
-		return nil, "", fmt.Errorf("failed to resolve SPIRE trust domain: %w", err)
+	l.InfoContext(ctx, "acquiring this agent's SVID in the background; startup does not wait for SPIRE",
+		"socket", cfg.SpireWorkloadSocketPath, "warnAfter", cfg.SpireWaitWarnAfter)
+	return src, trustDomain, nil
+}
+
+// reconcileSpireIdentity folds the trust domain SPIRE actually issued into the
+// agent's configuration once the first SVID lands. It is a no-op when SPIRE is
+// disabled, and returns immediately otherwise: the work happens in a goroutine
+// that ends with ctx.
+//
+// The overwhelmingly common outcome is that SPIRE confirms the seed and this
+// logs one line. When it does NOT — SPIRE issuing into a trust domain other than
+// the mesh domain — every SDS name derived from the seed is wrong, so the
+// listeners are rebuilt from storage with the real one. That reload is
+// merge-safe: LoadListenersFromStorage merges into the live listener set rather
+// than replacing it (agent/internal/xds/cache), so a pod meshed in the meantime
+// is not lost.
+func reconcileSpireIdentity(
+	ctx context.Context,
+	src *commonspire.WaitingSource,
+	trustDomain *identity.TrustDomain,
+	snapshotCache *cache.SnapshotCache,
+	localStorage storage.Storage[*cniv1.CNIPod],
+) {
+	if src == nil {
+		return
 	}
-	l.InfoContext(ctx, "resolved workload trust domain from SPIRE", "trustDomain", identityTrustDomain)
-	return spireSource, identityTrustDomain, nil
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-src.Ready():
+		}
+
+		resolved, err := commonspire.TrustDomainFromSource(src)
+		if err != nil {
+			l.WarnContext(ctx, "failed to read the workload trust domain from the SPIRE SVID", "error", err)
+			return
+		}
+		l.InfoContext(ctx, "resolved workload trust domain from SPIRE", "trustDomain", resolved)
+
+		if !trustDomain.Set(resolved) {
+			return // SPIRE confirmed the seed: nothing to rebuild
+		}
+		l.WarnContext(ctx, "SPIRE issues into a different trust domain than the mesh domain; rebuilding listeners from storage",
+			"meshDomain", cfg.MeshDomain, "trustDomain", resolved)
+		if err := snapshotCache.LoadListenersFromStorage(ctx, localStorage, resolved); err != nil {
+			l.ErrorContext(ctx, "failed to rebuild listeners for the resolved trust domain", "error", err, "trustDomain", resolved)
+		}
+	}()
 }
 
 // configureSnapshotCache creates and configures the xDS snapshot cache, including
@@ -465,11 +538,24 @@ func newCNIConflistReasserter() *cniconflist.Reasserter {
 // The two compose: the guard arms the taint, and the remover then refuses to drop
 // it while the node is still unchained. A nil re-asserter
 // (--cni-conflist-reassert=false) reduces both to their pre-#667 behaviour.
-func setupNodeGating(m ctrl.Manager, reasserter *cniconflist.Reasserter) error {
+func setupNodeGating(m ctrl.Manager, reasserter *cniconflist.Reasserter, spireSource *commonspire.WaitingSource) error {
 	chain := chainStateOf(reasserter)
 
 	if err := m.AddReadyzCheck("cni-chained", cniconflist.ReadyChecker(chain)); err != nil {
 		return fmt.Errorf("failed to set up the CNI chaining ready check: %w", err)
+	}
+
+	// The identity half of the same question, on the same terms (#740). A node
+	// with no SVID cannot give a new pod a working mesh identity, so past the
+	// dwell it should stop attracting pods — but only past the dwell: the taint
+	// guard re-arms on 30s of NotReady and spire-server does not tolerate that
+	// taint, so a hard-from-t=0 gate would let a brief SPIRE outage fence the
+	// cluster against spire-server's own rescheduling. See
+	// commonspire.NotReadyDwell. Nil (SPIRE disabled) registers no check at all.
+	if spireSource != nil {
+		if err := m.AddReadyzCheck("spire-svid", commonspire.ReadyChecker(spireSource)); err != nil {
+			return fmt.Errorf("failed to set up the SPIRE identity ready check: %w", err)
+		}
 	}
 
 	tr := &node.TaintRemover{
@@ -516,7 +602,7 @@ func wireCNIConflistReasserter(m ctrl.Manager, reasserter *cniconflist.Reasserte
 
 // wireSpireBridge optionally creates and registers the SPIRE bridge for SDS when
 // SPIRE is enabled. Returns the bridge (nil when SPIRE is disabled).
-func wireSpireBridge(ctx context.Context, m ctrl.Manager, snapshotCache *cache.SnapshotCache, spireSource *commonspire.Source) (*spire.Bridge, error) {
+func wireSpireBridge(ctx context.Context, m ctrl.Manager, snapshotCache *cache.SnapshotCache, spireSource *commonspire.WaitingSource) (*spire.Bridge, error) {
 	if !cfg.SpireEnabled {
 		l.InfoContext(ctx, "SPIRE integration disabled")
 		return nil, nil
@@ -753,7 +839,7 @@ func setupStorage(ctx context.Context, path string) (storage.Storage[*cniv1.CNIP
 // registration and discovery operations. When SPIRE is enabled, the connection
 // uses mTLS with an X.509 SVID fetched over the SPIRE Workload API socket;
 // otherwise, insecure transport is used.
-func setupRegistrarClient(ctx context.Context, src *commonspire.Source) (registry.Registry, error) {
+func setupRegistrarClient(ctx context.Context, src commonspire.SVIDSource) (registry.Registry, error) {
 	regCfg := registrarclient.Config{
 		Address:     cfg.RegistrarAddress,
 		ClusterName: cfg.ClusterName,
@@ -768,6 +854,13 @@ func setupRegistrarClient(ctx context.Context, src *commonspire.Source) (registr
 			return nil, err
 		}
 		regCfg.DialOptions = []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))}
+		// The SVID may not exist yet (#740): the watch loop defers instead of
+		// reporting stream failures it cannot do anything about. Sources that
+		// always hold one (the edge's, which is still created synchronously
+		// until PR 2) advertise no readiness and keep today's behaviour.
+		if waiting, ok := src.(interface{ HasSVID() bool }); ok {
+			regCfg.IdentityReady = waiting.HasSVID
+		}
 		l.InfoContext(ctx, "registrar client using SPIRE mTLS", "socket", cfg.SpireWorkloadSocketPath, "trustDomain", cfg.MeshDomain)
 	} else {
 		l.InfoContext(ctx, "registrar client using insecure transport")

--- a/agent/internal/cmd/spire_identity_test.go
+++ b/agent/internal/cmd/spire_identity_test.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// startingAdder stands in for the controller-runtime manager: it records what
+// was registered and starts it, exactly as the real manager does at m.Start.
+// Starting it is what makes the timing assertion meaningful — the retry loop is
+// genuinely running while startSpireIdentity's caller carries on.
+type startingAdder struct {
+	ctx context.Context
+
+	mu    sync.Mutex
+	added []ctrlmanager.Runnable
+	done  chan error
+}
+
+func (a *startingAdder) Add(r ctrlmanager.Runnable) error {
+	a.mu.Lock()
+	a.added = append(a.added, r)
+	a.mu.Unlock()
+
+	a.done = make(chan error, 1)
+	go func() { a.done <- r.Start(a.ctx) }()
+	return nil
+}
+
+func (a *startingAdder) count() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return len(a.added)
+}
+
+// withSpireConfig sets the SPIRE-related globals for one test and restores them.
+func withSpireConfig(t *testing.T, enabled bool, socket string, logger *slog.Logger) {
+	t.Helper()
+
+	prevEnabled, prevSocket, prevMesh, prevWarn, prevLog := cfg.SpireEnabled, cfg.SpireWorkloadSocketPath, cfg.MeshDomain, cfg.SpireWaitWarnAfter, l
+	t.Cleanup(func() {
+		cfg.SpireEnabled, cfg.SpireWorkloadSocketPath, cfg.MeshDomain, cfg.SpireWaitWarnAfter, l = prevEnabled, prevSocket, prevMesh, prevWarn, prevLog
+	})
+
+	cfg.SpireEnabled = enabled
+	cfg.SpireWorkloadSocketPath = socket
+	cfg.MeshDomain = "aether.internal"
+	cfg.SpireWaitWarnAfter = time.Minute
+	l = logger
+}
+
+// TestStartSpireIdentityReturnsImmediately is the regression test for #740 at
+// the call site. This slot used to block for up to 25s against an unreachable
+// Workload API and then EXIT THE PROCESS — before the manager was started, so
+// /healthz and /readyz were still silent and the kubelet was already counting.
+// It must now come back at once, with the retry loop running behind it.
+func TestStartSpireIdentityReturnsImmediately(t *testing.T) {
+	dir, err := os.MkdirTemp("", "spire-identity")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	withSpireConfig(t, true, filepath.Join(dir, "absent.sock"), slog.New(slog.DiscardHandler))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	adder := &startingAdder{ctx: ctx}
+
+	start := time.Now()
+	src, trustDomain, err := startSpireIdentity(ctx, adder)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "an unreachable Workload API must not fail startup")
+	require.NotNil(t, src)
+	assert.Less(t, elapsed, 100*time.Millisecond, "startup must not wait for SPIRE")
+	assert.Equal(t, 1, adder.count(), "the identity source must be registered as a runnable")
+	assert.Equal(t, "aether.internal", trustDomain.Get(), "the trust domain is seeded with the mesh domain")
+	assert.False(t, src.HasSVID(), "no SVID can exist against a socket nobody serves")
+
+	// And the runnable it registered keeps waiting rather than failing.
+	cancel()
+	select {
+	case runErr := <-adder.done:
+		require.NoError(t, runErr, "the identity runnable must never fail the manager")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the identity runnable did not return after cancellation")
+	}
+}
+
+// TestStartSpireIdentityDisabledIsUnchanged pins the #421 cleartext path: with
+// --spire-enabled=false nothing is registered, nothing is logged, and the trust
+// domain is the mesh domain — byte for byte the old behaviour.
+func TestStartSpireIdentityDisabledIsUnchanged(t *testing.T) {
+	logs := &bytes.Buffer{}
+	withSpireConfig(t, false, "/nonexistent/workload.sock",
+		slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	adder := &startingAdder{ctx: t.Context()}
+	src, trustDomain, err := startSpireIdentity(t.Context(), adder)
+
+	require.NoError(t, err)
+	assert.Nil(t, src, "SPIRE off must create no source at all")
+	assert.Equal(t, "aether.internal", trustDomain.Get())
+	assert.Equal(t, 0, adder.count(), "SPIRE off must register no runnable")
+	assert.Empty(t, logs.String(), "SPIRE off must log nothing")
+}
+
+// TestReconcileSpireIdentityDisabledIsANoOp keeps the same promise for the
+// post-arrival half: with no source there is nothing to wait on, and no
+// goroutine is left behind holding a nil cache.
+func TestReconcileSpireIdentityDisabledIsANoOp(t *testing.T) {
+	withSpireConfig(t, false, "/nonexistent/workload.sock", slog.New(slog.DiscardHandler))
+
+	// nil cache and nil storage on purpose: reaching either would panic, which
+	// is the assertion.
+	reconcileSpireIdentity(t.Context(), nil, nil, nil, nil)
+}

--- a/agent/internal/identity/BUILD.bazel
+++ b/agent/internal/identity/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "identity",
+    srcs = ["trustdomain.go"],
+    importpath = "aethermesh.dev/agent/internal/identity",
+    visibility = ["//agent:__subpackages__"],
+)
+
+go_test(
+    name = "identity_test",
+    srcs = ["trustdomain_test.go"],
+    embed = [":identity"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)

--- a/agent/internal/identity/trustdomain.go
+++ b/agent/internal/identity/trustdomain.go
@@ -1,0 +1,50 @@
+// Package identity holds the node agent's late-bound workload identity facts —
+// the ones that used to be resolved synchronously on the startup path and are
+// now folded in whenever SPIRE gets around to issuing an SVID (issue #740).
+package identity
+
+import "sync/atomic"
+
+// TrustDomain is a concurrency-safe holder for the SPIFFE trust domain the
+// agent programs into Envoy (SDS resource names, SPIFFE IDs, peer validation).
+//
+// It exists because the trust domain is no longer knowable at wiring time. It
+// used to come from the first SVID, which the process blocked on before starting
+// anything; now the process wires everything up first and the SVID arrives
+// later. The holder is seeded with the mesh domain — the only value that can be
+// right, since peer authorization is scoped to it unconditionally and aether
+// treats addressing (<svc>.<mesh-domain>) and identity (spiffe://<mesh-domain>/…)
+// as one domain by design — and is reconciled against the real SVID the moment
+// one lands.
+//
+// The zero value is usable and reads as "".
+type TrustDomain struct {
+	v atomic.Pointer[string]
+}
+
+// NewTrustDomain returns a holder seeded with the given trust domain.
+func NewTrustDomain(seed string) *TrustDomain {
+	t := &TrustDomain{}
+	t.v.Store(&seed)
+	return t
+}
+
+// Get returns the current trust domain.
+func (t *TrustDomain) Get() string {
+	if v := t.v.Load(); v != nil {
+		return *v
+	}
+	return ""
+}
+
+// Set stores td and reports whether it DIFFERS from what was held before.
+//
+// The boolean is the point: a changed trust domain means every resource named
+// from the seeded value is wrong and has to be rebuilt, which is a WARN-worthy
+// misconfiguration (SPIRE issuing into a trust domain other than the mesh
+// domain), while the overwhelmingly common "SPIRE confirmed the seed" case must
+// stay silent and do no work.
+func (t *TrustDomain) Set(td string) bool {
+	prev := t.v.Swap(&td)
+	return prev == nil || *prev != td
+}

--- a/agent/internal/identity/trustdomain_test.go
+++ b/agent/internal/identity/trustdomain_test.go
@@ -1,0 +1,61 @@
+package identity
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTrustDomainSeedAndSet pins the two things callers rely on: the seed is
+// readable before SPIRE has said anything, and Set reports whether the value
+// actually changed — the boolean that decides between one INFO line and a WARN
+// plus a listener rebuild.
+func TestTrustDomainSeedAndSet(t *testing.T) {
+	td := NewTrustDomain("aether.internal")
+	assert.Equal(t, "aether.internal", td.Get(), "the seed must be readable immediately")
+
+	assert.False(t, td.Set("aether.internal"), "SPIRE confirming the seed is not a change")
+	assert.Equal(t, "aether.internal", td.Get())
+
+	assert.True(t, td.Set("example.org"), "a different trust domain must be reported as a change")
+	assert.Equal(t, "example.org", td.Get())
+}
+
+// TestTrustDomainZeroValue keeps the holder usable before it is seeded.
+func TestTrustDomainZeroValue(t *testing.T) {
+	var td TrustDomain
+	assert.Equal(t, "", td.Get())
+	assert.True(t, td.Set("example.org"), "the first value is always a change")
+	assert.Equal(t, "example.org", td.Get())
+}
+
+// TestTrustDomainConcurrentAccess is the -race test. The whole reason this
+// holder exists is that the value is now written by a goroutine waiting on SPIRE
+// while the wiring path reads it; a plain string field would be a data race.
+func TestTrustDomainConcurrentAccess(t *testing.T) {
+	td := NewTrustDomain("aether.internal")
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				assert.NotEmpty(t, td.Get())
+			}
+		}()
+	}
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 500 {
+				td.Set("example.org")
+			}
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, "example.org", td.Get())
+}

--- a/agent/internal/spire/BUILD.bazel
+++ b/agent/internal/spire/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
 go_test(
     name = "spire_test",
     srcs = [
+        "bridge_late_identity_test.go",
         "bridge_reconnect_test.go",
         "bridge_test.go",
         "converter_test.go",

--- a/agent/internal/spire/bridge.go
+++ b/agent/internal/spire/bridge.go
@@ -59,9 +59,21 @@ type NodeIdentitySink interface {
 }
 
 // X509SVIDSource provides the agent's own node SVID. It is satisfied by the
-// go-spiffe Workload API X509Source the agent already uses for registrar mTLS.
+// go-spiffe Workload API X509Source the agent already uses for registrar mTLS,
+// and by the WaitingSource that wraps it (issue #740), whose GetX509SVID errors
+// until SPIRE has issued one.
 type X509SVIDSource interface {
 	GetX509SVID() (*x509svid.SVID, error)
+}
+
+// UpdatedSource is the optional extension of X509SVIDSource that announces when
+// the SVID changed. When the node source implements it, the bridge serves the
+// node identity the instant it arrives instead of on the next 30s tick — which
+// is what keeps a late SVID (SPIRE still coming up at boot) from costing the
+// node up to half a minute of upstream mTLS after identity is finally available.
+// Both workloadapi.X509Source and spire.WaitingSource satisfy it.
+type UpdatedSource interface {
+	Updated() <-chan struct{}
 }
 
 // Bridge connects the SPIRE Delegated Identity API to the xDS snapshot cache.
@@ -168,7 +180,10 @@ func (b *Bridge) Start(ctx context.Context) error {
 	// node-health listener) and keep it refreshed on rotation.
 	if b.nodeSource != nil {
 		if err := b.refreshNodeSVID(ctx); err != nil {
-			b.log.ErrorContext(ctx, "serving initial node SVID", "error", err)
+			// Not an error at boot: while SPIRE is still coming up the source
+			// holds no SVID yet (issue #740). runNodeSVIDRefresh serves it the
+			// moment it lands, so this is an announcement, not a failure.
+			b.log.InfoContext(ctx, "node SVID not available yet; serving it as soon as SPIRE issues one", "error", err)
 		}
 		go b.runNodeSVIDRefresh(ctx)
 	}
@@ -511,19 +526,33 @@ func (b *Bridge) handleSVIDUpdate(ctx context.Context, resp *delegatedidentityv1
 	return b.pushSecrets(ctx)
 }
 
-// runNodeSVIDRefresh periodically re-reads and re-serves the node SVID so
-// rotations are pushed to Envoy. It returns when the context is cancelled.
+// runNodeSVIDRefresh re-reads and re-serves the node SVID whenever the source
+// says it changed, and on a periodic tick as a backstop. It returns when the
+// context is cancelled.
+//
+// The update channel is what makes a LATE first identity cheap: with SPIRE still
+// coming up the initial refreshNodeSVID in Start finds nothing, and before
+// issue #740 the node identity then waited for the next 30s tick even though the
+// SVID may have landed a second later. Sources that do not announce updates fall
+// back to the tick alone, exactly as before.
 func (b *Bridge) runNodeSVIDRefresh(ctx context.Context) {
 	ticker := time.NewTicker(nodeSVIDRefreshInterval)
 	defer ticker.Stop()
+
+	var updated <-chan struct{}
+	if src, ok := b.nodeSource.(UpdatedSource); ok {
+		updated = src.Updated()
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := b.refreshNodeSVID(ctx); err != nil {
-				b.log.DebugContext(ctx, "refreshing node SVID", "error", err)
-			}
+		case <-updated:
+		}
+		if err := b.refreshNodeSVID(ctx); err != nil {
+			b.log.DebugContext(ctx, "refreshing node SVID", "error", err)
 		}
 	}
 }

--- a/agent/internal/spire/bridge_late_identity_test.go
+++ b/agent/internal/spire/bridge_late_identity_test.go
@@ -1,0 +1,124 @@
+package spire
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/require"
+)
+
+// lateNodeSource is a node SVID source that has NO identity yet and announces
+// one later — the shape a WaitingSource has while SPIRE is still coming up
+// (issue #740).
+type lateNodeSource struct {
+	updated chan struct{}
+
+	mu   sync.Mutex
+	svid *x509svid.SVID
+}
+
+func newLateNodeSource() *lateNodeSource {
+	return &lateNodeSource{updated: make(chan struct{}, 1)}
+}
+
+func (s *lateNodeSource) GetX509SVID() (*x509svid.SVID, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.svid == nil {
+		return nil, errors.New("no SVID yet")
+	}
+	return s.svid, nil
+}
+
+func (s *lateNodeSource) Updated() <-chan struct{} { return s.updated }
+
+// arrive publishes the SVID and wakes whoever is watching, as go-spiffe does on
+// the first Workload API update.
+func (s *lateNodeSource) arrive(svid *x509svid.SVID) {
+	s.mu.Lock()
+	s.svid = svid
+	s.mu.Unlock()
+	select {
+	case s.updated <- struct{}{}:
+	default:
+	}
+}
+
+// identityStore records what the bridge pushed into the xDS cache.
+type identityStore struct {
+	mu     sync.Mutex
+	nodeID string
+	pushes int
+}
+
+func (s *identityStore) SetSecrets(context.Context, []*tlsv3.Secret) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pushes++
+	return nil
+}
+
+func (s *identityStore) SetNodeIdentity(_ context.Context, nodeSpiffeID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodeID = nodeSpiffeID
+	return nil
+}
+
+func (s *identityStore) identity() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nodeID
+}
+
+// TestNodeSVIDServedWhenIdentityArrivesLate is the bridge half of #740. The
+// agent no longer blocks on SPIRE, so the bridge routinely starts with a node
+// source that has nothing to give. It must (a) not treat that as a failure, and
+// (b) serve the node identity the moment the source announces one — not up to
+// 30s later on the refresh tick, which is the only thing that used to wake it.
+func TestNodeSVIDServedWhenIdentityArrivesLate(t *testing.T) {
+	_, sock := startFakeSpire(t)
+
+	store := &identityStore{}
+	source := newLateNodeSource()
+
+	b := NewBridge(sock, store, source, slog.New(slog.DiscardHandler))
+	b.backoffInitial = 10 * time.Millisecond
+	b.backoffMax = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- b.Start(ctx) }()
+
+	select {
+	case <-b.Started():
+	case <-time.After(10 * time.Second):
+		t.Fatal("bridge did not start")
+	}
+
+	// No identity yet: nothing is claimed, and the bridge is still running.
+	time.Sleep(200 * time.Millisecond)
+	require.Empty(t, store.identity(), "the bridge must not invent a node identity before SPIRE issues one")
+	select {
+	case err := <-done:
+		t.Fatalf("a node source without an SVID must not fail the bridge: %v", err)
+	default:
+	}
+
+	const nodeID = "spiffe://example.org/ns/aether-system/sa/aether-agent"
+	source.arrive(newTestX509SVID(t, nodeID))
+
+	// One second, deliberately: the refresh ticker is 30s, so anything that
+	// passes here passed because of the update wake.
+	require.Eventually(t, func() bool {
+		return store.identity() == nodeID
+	}, time.Second, 10*time.Millisecond,
+		"the node identity must be served as soon as the SVID arrives, not on the next 30s tick")
+}

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.8"
+version: "0.92.9"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/templates/agent-daemonset.yaml
+++ b/charts/aether/templates/agent-daemonset.yaml
@@ -138,6 +138,7 @@ spec:
             {{- if .Values.spire.enabled }}
             - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
             - "--spire-admin-socket={{ .Values.spire.adminSocket.mountPath }}/{{ .Values.spire.adminSocket.socketName }}"
+            - "--spire-wait-warn-after={{ .Values.spire.waitWarnAfter }}"
             {{- end }}
           ports:
             - name: metrics

--- a/charts/aether/templates/controller-deployment.yaml
+++ b/charts/aether/templates/controller-deployment.yaml
@@ -78,6 +78,7 @@ spec:
             {{- if .Values.controller.webhook.spire }}
             - "--spire-enabled=true"
             - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
+            - "--spire-wait-warn-after={{ .Values.spire.waitWarnAfter }}"
             - "--webhook-config-name={{ include "aether.controller.clusterScopedName" . }}"
             {{- if .Values.controller.injectPodNdots }}
             - "--mutating-webhook-config-name={{ include "aether.controller.clusterScopedName" . }}-pod-ndots"

--- a/charts/aether/templates/edge-deployment.yaml
+++ b/charts/aether/templates/edge-deployment.yaml
@@ -142,6 +142,9 @@ spec:
             {{- if and .Values.spire.enabled (ne .Values.spire.workloadSocketPath "/run/secrets/workload-spiffe-uds/socket") }}
             - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
             {{- end }}
+            {{- if .Values.spire.enabled }}
+            - "--spire-wait-warn-after={{ .Values.spire.waitWarnAfter }}"
+            {{- end }}
           env:
             - name: POD_NAME
               valueFrom:

--- a/charts/aether/templates/registrar-deployment.yaml
+++ b/charts/aether/templates/registrar-deployment.yaml
@@ -79,6 +79,7 @@ spec:
             - "--spire-enabled={{ .Values.spire.enabled }}"
             {{- if .Values.spire.enabled }}
             - "--spire-workload-socket={{ .Values.spire.workloadSocketPath }}"
+            - "--spire-wait-warn-after={{ .Values.spire.waitWarnAfter }}"
             {{- end }}
           ports:
             - name: grpc

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -92,6 +92,18 @@ spire:
     hostPath: /run/spire/agent/sockets/csi.spiffe.io/admin
     mountPath: /run/spire/admin-sockets
     socketName: admin.sock
+  # How long a component may wait for SPIRE to issue its first SVID before the
+  # waiting log line escalates from INFO to WARN. On the agent this is ALSO the
+  # dwell before the spire-svid readiness check reports NotReady (issue #740):
+  # startup no longer dies when the Workload API is not serving yet, it waits and
+  # keeps /healthz and /readyz answering.
+  #
+  # NOTE: spire-server AND spire-agent must tolerate aether.io/agent-not-ready
+  # (:NoSchedule). Past this dwell an identity-less node reports NotReady, and the
+  # controller's node-taint guard re-arms that taint 30s later — a SPIRE that
+  # cannot be rescheduled onto the very nodes it has to attest cannot recover the
+  # cluster on its own.
+  waitWarnAfter: 2m
 
 # Proxy MeshConfig — the controller seeds and projects the singleton MeshConfig CR
 # into a ConfigMap the agent mounts. The CR ONLY overrides the proxy data plane's

--- a/common/spire/BUILD.bazel
+++ b/common/spire/BUILD.bazel
@@ -2,18 +2,43 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "spire",
-    srcs = ["tls.go"],
+    srcs = [
+        "metrics.go",
+        "tls.go",
+        "waiting.go",
+    ],
     importpath = "aethermesh.dev/common/spire",
     visibility = ["//visibility:public"],
     deps = [
+        "//common/log",
+        "@com_github_spiffe_go_spiffe_v2//bundle/x509bundle",
         "@com_github_spiffe_go_spiffe_v2//spiffeid",
         "@com_github_spiffe_go_spiffe_v2//spiffetls/tlsconfig",
+        "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
         "@com_github_spiffe_go_spiffe_v2//workloadapi",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel_metric//:metric",
     ],
 )
 
 go_test(
     name = "spire_test",
-    srcs = ["tls_test.go"],
+    srcs = [
+        "tls_test.go",
+        "waiting_test.go",
+    ],
     embed = [":spire"],
+    deps = [
+        "@com_github_spiffe_go_spiffe_v2//proto/spiffe/workload",
+        "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_otel//:otel",
+        "@io_opentelemetry_go_otel_sdk_metric//:metric",
+        "@io_opentelemetry_go_otel_sdk_metric//metricdata",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+    ],
 )

--- a/common/spire/metrics.go
+++ b/common/spire/metrics.go
@@ -1,0 +1,84 @@
+package spire
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opentelemetry.io/otel/metric"
+)
+
+// waitMeterName identifies this instrumentation scope in metric backends.
+const waitMeterName = "aether/spire-identity"
+
+// waitSecondsBuckets are the explicit boundaries, in SECONDS, for
+// aether.agent.spire.wait_seconds. The OTel defaults are millisecond-oriented
+// (0, 5, 10, … 10000), which would put every wait short of 5s — the healthy
+// case — into one bucket and every outage into the next (#732). The interesting
+// range is one retry (1s) to well past the warn threshold (2m).
+var waitSecondsBuckets = []float64{0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600}
+
+// waitMetrics instruments the wait for the first SVID. All methods are
+// nil-receiver-safe so the wait runs unchanged when instrument registration
+// failed or telemetry is disabled.
+type waitMetrics struct {
+	wait     metric.Float64Histogram
+	restarts metric.Int64Counter
+	ready    metric.Int64ObservableGauge
+	meter    metric.Meter
+}
+
+// newWaitMetrics registers the identity-wait instruments on the given meter.
+func newWaitMetrics(meter metric.Meter) (*waitMetrics, error) {
+	m := &waitMetrics{meter: meter}
+	var err error
+
+	if m.wait, err = meter.Float64Histogram("aether.agent.spire.wait_seconds",
+		metric.WithDescription("Seconds from process start to the SPIRE Workload API issuing this workload's first SVID (recorded once, when it arrives)"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(waitSecondsBuckets...)); err != nil {
+		return nil, fmt.Errorf("spire wait seconds: %w", err)
+	}
+	if m.restarts, err = meter.Int64Counter("aether.agent.spire.source_restarts",
+		metric.WithDescription("Workload API sources that connected but could not serve an SVID and were re-created; expected to stay 0")); err != nil {
+		return nil, fmt.Errorf("spire source restarts: %w", err)
+	}
+	if m.ready, err = meter.Int64ObservableGauge("aether.agent.spire.svid_ready",
+		metric.WithDescription("1 when this workload holds a SPIRE SVID, 0 while it is still waiting for its first one")); err != nil {
+		return nil, fmt.Errorf("spire svid ready: %w", err)
+	}
+
+	return m, nil
+}
+
+// observeReadiness wires the svid_ready gauge to ready, which is polled on every
+// collection. A registration failure only drops the gauge.
+func (m *waitMetrics) observeReadiness(ready func() bool) {
+	if m == nil {
+		return
+	}
+	_, _ = m.meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		var v int64
+		if ready() {
+			v = 1
+		}
+		o.ObserveInt64(m.ready, v)
+		return nil
+	}, m.ready)
+}
+
+// waited records the one-shot wait duration once the first SVID has arrived.
+func (m *waitMetrics) waited(ctx context.Context, d time.Duration) {
+	if m == nil {
+		return
+	}
+	m.wait.Record(ctx, d.Seconds())
+}
+
+// sourceRestarted records one Workload API source discarded and re-created.
+func (m *waitMetrics) sourceRestarted(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.restarts.Add(ctx, 1)
+}

--- a/common/spire/tls.go
+++ b/common/spire/tls.go
@@ -11,14 +11,35 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
 // Source is an auto-rotating X.509 SVID source backed by the Workload API.
 // Callers own the returned source and must Close it on shutdown.
 type Source = workloadapi.X509Source
+
+// SVIDSource is the narrow view of a Workload API source that every helper in
+// this package needs: the workload's own SVID, the bundles peers are verified
+// against, and a signal that either changed.
+//
+// It exists so that a source no longer has to be a *Source that ALREADY holds an
+// SVID. WaitingSource implements it while the first SVID is still being waited
+// for (returning ErrNoSVIDYet meanwhile), which is what lets a binary finish
+// starting up — and answer /readyz — before SPIRE is serving (issue #740).
+// *Source satisfies it too, so existing callers are unaffected.
+type SVIDSource interface {
+	x509svid.Source
+	x509bundle.Source
+
+	// Updated returns a channel that is sent on whenever the SVID or the bundles
+	// change, including the first time one arrives. Same contract as
+	// workloadapi.X509Source.Updated.
+	Updated() <-chan struct{}
+}
 
 // SourceTimeout bounds how long NewSource waits for the Workload API to issue
 // this workload's first SVID.
@@ -76,7 +97,7 @@ const RootCATrustDomain = "ROOTCA"
 // resource names from the real trust domain SPIRE issues into, rather than from a
 // configured value (which may be the RootCATrustDomain authorization sentinel).
 // The source has already fetched its first SVID by the time NewSource returns.
-func TrustDomainFromSource(src *Source) (string, error) {
+func TrustDomainFromSource(src SVIDSource) (string, error) {
 	svid, err := src.GetX509SVID()
 	if err != nil {
 		return "", fmt.Errorf("fetching workload SVID for trust domain: %w", err)
@@ -87,7 +108,7 @@ func TrustDomainFromSource(src *Source) (string, error) {
 // ServerTLSConfig returns a mutual-TLS server config that presents the workload
 // SVID from src and authorizes peers belonging to trustDomain (or any valid peer
 // when trustDomain is empty / RootCATrustDomain).
-func ServerTLSConfig(src *Source, trustDomain string) (*tls.Config, error) {
+func ServerTLSConfig(src SVIDSource, trustDomain string) (*tls.Config, error) {
 	auth, err := authorizer(trustDomain)
 	if err != nil {
 		return nil, err
@@ -104,7 +125,7 @@ func ServerTLSConfig(src *Source, trustDomain string) (*tls.Config, error) {
 // the SVID must carry as a DNS SAN (set dnsNames on the SPIRE registration
 // entry). Setting GetCertificate here makes controller-runtime skip its CertDir
 // file watcher entirely.
-func WebhookServerCert(src *Source) func(*tls.Config) {
+func WebhookServerCert(src SVIDSource) func(*tls.Config) {
 	return func(cfg *tls.Config) {
 		cfg.GetCertificate = tlsconfig.GetCertificate(src)
 		cfg.ClientAuth = tls.NoClientCert
@@ -117,7 +138,7 @@ func WebhookServerCert(src *Source) func(*tls.Config) {
 // TrustBundlePEM returns the PEM-encoded X.509 trust bundle for the SVID's own
 // trust domain, suitable for use as a webhook/CRD caBundle. It reflects the
 // current bundle in src and should be re-read after each rotation (src.Updated()).
-func TrustBundlePEM(src *Source) ([]byte, error) {
+func TrustBundlePEM(src SVIDSource) ([]byte, error) {
 	svid, err := src.GetX509SVID()
 	if err != nil {
 		return nil, fmt.Errorf("fetching workload SVID for trust bundle: %w", err)
@@ -136,7 +157,7 @@ func TrustBundlePEM(src *Source) ([]byte, error) {
 // ClientTLSConfig returns a mutual-TLS client config that presents the workload
 // SVID from src and authorizes peers belonging to trustDomain (or any valid peer
 // when trustDomain is empty / RootCATrustDomain).
-func ClientTLSConfig(src *Source, trustDomain string) (*tls.Config, error) {
+func ClientTLSConfig(src SVIDSource, trustDomain string) (*tls.Config, error) {
 	auth, err := authorizer(trustDomain)
 	if err != nil {
 		return nil, err

--- a/common/spire/waiting.go
+++ b/common/spire/waiting.go
@@ -1,0 +1,354 @@
+package spire
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/rand/v2"
+	"net/http"
+	"sync"
+	"time"
+
+	commonlog "aethermesh.dev/common/log"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"go.opentelemetry.io/otel"
+)
+
+// ErrNoSVIDYet is what every SVIDSource method of a WaitingSource returns until
+// the Workload API has issued the first SVID. It is a WAITING state, not a
+// failure: callers that can degrade (the registrar watch stream, Envoy's SDS,
+// the readiness gate inside its dwell) treat it as "not yet" rather than as an
+// error to report or to die on.
+var ErrNoSVIDYet = errors.New("no SPIRE SVID yet: still waiting for the Workload API to issue this workload's first SVID")
+
+const (
+	// DefaultWaitWarnAfter is how long the wait for the first SVID stays at INFO
+	// before escalating to WARN. Two minutes comfortably covers a cold boot
+	// (SPIRE server + agent attesting a whole fleet at once) while still making a
+	// real outage loud. Also the readiness dwell — see NotReadyDwell.
+	DefaultWaitWarnAfter = 2 * time.Minute
+
+	// attemptTimeout bounds ONE attempt at creating the Workload API source, so a
+	// SPIRE agent that accepts the connection and then never answers cannot park
+	// the loop forever without logging.
+	attemptTimeout = 10 * time.Second
+
+	// Backoff between attempts. Same policy as the SPIRE bridge's stream
+	// re-subscribe and the registrar watch loop: 1s doubling to 30s, jittered so
+	// a whole fleet restarting together does not retry in lockstep.
+	waitBackoffInitial = 1 * time.Second
+	waitBackoffMax     = 30 * time.Second
+	waitJitterFraction = 0.2
+)
+
+// WaitingSource is an SVIDSource that acquires the underlying Workload API
+// source in the background, retrying forever, and NEVER fails its caller.
+//
+// It replaces the one-shot, fatal creation that made every binary's startup a
+// hard dependency on SPIRE being up (issue #740): a 25s bounded wait that
+// expired exited the process, so a SPIRE server that was still coming up during
+// a cold boot crash-looped the whole fleet — 2-4 restarts per node — for a
+// condition that resolves itself in under a minute.
+//
+// Nothing downstream needs the process to die: the SPIRE->SDS bridge dials
+// lazily and retries forever, the xDS cache skips upstream-mTLS injection until
+// SetNodeIdentity lands, and Envoy tolerates the absent secret (#715). So the
+// process starts, answers /healthz and /readyz, programs everything that does
+// not need identity, and folds identity in the moment it arrives.
+//
+// Start is a controller-runtime Runnable. Until the first SVID lands, every
+// source method returns ErrNoSVIDYet; afterwards they delegate to the real
+// source, which go-spiffe keeps rotating for the process's lifetime.
+type WaitingSource struct {
+	socketPath string
+	log        *slog.Logger
+	warnAfter  time.Duration
+	metrics    *waitMetrics
+
+	// Retry policy; the package constants in NewWaitingSource, shortened in tests.
+	attemptTimeout time.Duration
+	backoffInitial time.Duration
+	backoffMax     time.Duration
+
+	// startedAt is when the wait began (construction, i.e. process start), which
+	// is what the WARN escalation and the readiness dwell are measured from.
+	startedAt time.Time
+
+	// updated carries the SVIDSource update signal. Buffered with capacity 1 and
+	// written non-blocking, matching workloadapi.X509Source.Updated: a consumer
+	// that is not selecting on it right now still sees exactly one pending wake.
+	// Exactly one consumer gets each wake, so it is the SDS bridge's channel.
+	updated chan struct{}
+
+	// ready is CLOSED when the first SVID lands. A closed channel broadcasts, so
+	// unlike updated it can have any number of waiters — which is what the
+	// trust-domain reconcile uses, without racing the bridge for a wake.
+	ready     chan struct{}
+	readyOnce sync.Once
+
+	mu  sync.RWMutex
+	src *Source
+}
+
+// NewWaitingSource returns a WaitingSource for the Workload API at socketPath.
+// warnAfter is how long the wait stays at INFO before escalating to WARN (and
+// the readiness dwell); a non-positive value means DefaultWaitWarnAfter.
+// Nothing is dialled until Start runs.
+func NewWaitingSource(socketPath string, warnAfter time.Duration, log *slog.Logger) *WaitingSource {
+	if warnAfter <= 0 {
+		warnAfter = DefaultWaitWarnAfter
+	}
+	// Instruments ride the global MeterProvider (no-op unless --otel-enabled); a
+	// registration failure only disables instrumentation, never the wait.
+	metrics, err := newWaitMetrics(otel.Meter(waitMeterName))
+	if err != nil {
+		log.Error("failed to create SPIRE wait metrics; continuing without instrumentation", "error", err)
+	}
+
+	w := &WaitingSource{
+		socketPath:     socketPath,
+		log:            commonlog.Named(log, "spire-identity"),
+		warnAfter:      warnAfter,
+		metrics:        metrics,
+		attemptTimeout: attemptTimeout,
+		backoffInitial: waitBackoffInitial,
+		backoffMax:     waitBackoffMax,
+		startedAt:      time.Now(),
+		updated:        make(chan struct{}, 1),
+		ready:          make(chan struct{}),
+	}
+	metrics.observeReadiness(w.HasSVID)
+	return w
+}
+
+// Start acquires the Workload API source, retrying with bounded backoff until it
+// succeeds or ctx ends, then relays the source's rotation signal for the rest of
+// the process's life. It implements controller-runtime's Runnable and returns
+// nil on shutdown: a SPIRE outage must never take the manager down with it.
+func (w *WaitingSource) Start(ctx context.Context) error {
+	if !w.acquire(ctx) {
+		return nil // shutting down before the first SVID arrived
+	}
+	w.relayUpdates(ctx)
+	return nil
+}
+
+// NeedLeaderElection reports false: every replica needs its own identity.
+func (w *WaitingSource) NeedLeaderElection() bool { return false }
+
+// acquire loops until the source is created and serving an SVID. It reports
+// whether it succeeded (false = ctx ended first).
+func (w *WaitingSource) acquire(ctx context.Context) bool {
+	backoff := w.backoffInitial
+	for attempt := 1; ; attempt++ {
+		if w.attempt(ctx, attempt) {
+			return true
+		}
+		wait := jitter(backoff)
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(wait):
+		}
+		backoff = nextBackoff(backoff, w.backoffMax)
+	}
+}
+
+// nextBackoff doubles d, capped at maxBackoff.
+func nextBackoff(d, maxBackoff time.Duration) time.Duration {
+	return min(d*2, maxBackoff)
+}
+
+// attempt makes one bounded attempt at creating the source and reading its first
+// SVID, reporting whether the source is now serving. It never returns an error:
+// a failure is logged (INFO, escalating to WARN past warnAfter) and retried.
+func (w *WaitingSource) attempt(ctx context.Context, attempt int) bool {
+	attemptCtx, cancel := context.WithTimeout(ctx, w.attemptTimeout)
+	defer cancel()
+
+	// The source's own first-SVID bound is disabled (0): attemptCtx is the bound.
+	src, err := NewSourceWithTimeout(attemptCtx, w.socketPath, 0)
+	if err != nil {
+		w.logWaiting(ctx, attempt, err)
+		return false
+	}
+
+	td, err := TrustDomainFromSource(src)
+	if err != nil {
+		// A source that was created but cannot serve an SVID is worse than none:
+		// drop it and build a fresh one. This is the only path that re-creates a
+		// source, which is why aether.agent.spire.source_restarts staying 0 is a
+		// meaningful signal.
+		_ = src.Close()
+		w.metrics.sourceRestarted(ctx)
+		w.logWaiting(ctx, attempt, err)
+		return false
+	}
+
+	w.mu.Lock()
+	w.src = src
+	w.mu.Unlock()
+
+	waited := time.Since(w.startedAt)
+	w.metrics.waited(ctx, waited)
+	w.readyOnce.Do(func() { close(w.ready) })
+	w.signalUpdated()
+	w.log.InfoContext(ctx, "obtained this workload's SVID from the SPIRE Workload API",
+		"socket", w.socketPath, "attempts", attempt, "elapsed", waited.Round(time.Millisecond), "trustDomain", td)
+	return true
+}
+
+// logWaiting emits the one line per attempt that makes the wait visible, at INFO
+// until warnAfter has elapsed and at WARN after it. The elapsed counter is what
+// distinguishes "SPIRE is still coming up" from "SPIRE is not coming".
+func (w *WaitingSource) logWaiting(ctx context.Context, attempt int, err error) {
+	elapsed := time.Since(w.startedAt)
+	level := slog.LevelInfo
+	if elapsed >= w.warnAfter {
+		level = slog.LevelWarn
+	}
+	w.log.Log(ctx, level, "waiting for the SPIRE Workload API to issue this workload's SVID",
+		"socket", w.socketPath, "attempt", attempt, "elapsed", elapsed.Round(time.Millisecond),
+		"warnAfter", w.warnAfter, "error", err)
+}
+
+// relayUpdates forwards the acquired source's rotation signal onto this source's
+// own Updated channel until ctx ends, so consumers can hold one channel across
+// the acquisition.
+func (w *WaitingSource) relayUpdates(ctx context.Context) {
+	w.mu.RLock()
+	src := w.src
+	w.mu.RUnlock()
+	if src == nil {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-src.Updated():
+			w.signalUpdated()
+		}
+	}
+}
+
+// signalUpdated wakes one waiter without ever blocking the caller.
+func (w *WaitingSource) signalUpdated() {
+	select {
+	case w.updated <- struct{}{}:
+	default:
+	}
+}
+
+// Updated implements SVIDSource. The channel is sent on when the first SVID
+// arrives and on every rotation after it. Each send wakes exactly ONE receiver;
+// waiters that just want the first SVID should use Ready.
+func (w *WaitingSource) Updated() <-chan struct{} { return w.updated }
+
+// Ready returns a channel closed once the first SVID has been obtained. Any
+// number of goroutines may wait on it.
+func (w *WaitingSource) Ready() <-chan struct{} { return w.ready }
+
+// HasSVID reports whether the first SVID has arrived. It is what the readiness
+// gate and the registrar client's identity check read.
+func (w *WaitingSource) HasSVID() bool {
+	if w == nil {
+		return false
+	}
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	return w.src != nil
+}
+
+// GetX509SVID implements x509svid.Source, returning ErrNoSVIDYet until the first
+// SVID has been issued.
+func (w *WaitingSource) GetX509SVID() (*x509svid.SVID, error) {
+	src, err := w.source()
+	if err != nil {
+		return nil, err
+	}
+	return src.GetX509SVID()
+}
+
+// GetX509BundleForTrustDomain implements x509bundle.Source, returning
+// ErrNoSVIDYet until the first SVID has been issued.
+func (w *WaitingSource) GetX509BundleForTrustDomain(td spiffeid.TrustDomain) (*x509bundle.Bundle, error) {
+	src, err := w.source()
+	if err != nil {
+		return nil, err
+	}
+	return src.GetX509BundleForTrustDomain(td)
+}
+
+// Close releases the underlying source. It is safe to call before the source has
+// been acquired (and safe on a nil receiver, i.e. with SPIRE disabled).
+func (w *WaitingSource) Close() error {
+	if w == nil {
+		return nil
+	}
+	w.mu.Lock()
+	src := w.src
+	w.src = nil
+	w.mu.Unlock()
+	if src == nil {
+		return nil
+	}
+	return src.Close()
+}
+
+// source returns the acquired source or ErrNoSVIDYet.
+func (w *WaitingSource) source() (*Source, error) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	if w.src == nil {
+		return nil, fmt.Errorf("%w (socket %s)", ErrNoSVIDYet, w.socketPath)
+	}
+	return w.src, nil
+}
+
+// NotReadyDwell is how long a workload may be waiting for its first SVID before
+// the spire-svid readiness check starts failing.
+//
+// It is deliberately EQUAL to the warn threshold, and the value is the
+// non-obvious decision in issue #740. The controller's node-taint guard
+// (proposal 033) re-arms aether.io/agent-not-ready:NoSchedule on any agent that
+// has been NotReady for longer than its 30s grace (controller/internal/nodetaint/
+// guard.go), and spire-server does NOT tolerate that taint. A gate that failed
+// from t=0 would therefore turn a 40s SPIRE hiccup into a fleet-wide taint that
+// prevents spire-server itself from being rescheduled — the outage would fence
+// out its own cure. The dwell keeps a routine cold boot invisible (every agent
+// on the 2026-09-07 boot had its SVID inside 2m15s of SPIRE recovering) while a
+// genuine outage still escalates to NotReady, which is what an operator wants:
+// no new pods scheduled onto a node that cannot give them an identity.
+const NotReadyDwell = DefaultWaitWarnAfter
+
+// ReadyChecker returns a readiness check (assignable to controller-runtime's
+// healthz.Checker) that fails once this workload has been waiting for its first
+// SVID for longer than the wait's warn threshold.
+//
+// A nil source (SPIRE disabled) always passes: with --spire-enabled=false there
+// is no identity to wait for and the check must disappear entirely, exactly as
+// the CNI chaining check disappears with its kill switch.
+func ReadyChecker(w *WaitingSource) func(*http.Request) error {
+	return func(*http.Request) error {
+		if w == nil || w.HasSVID() {
+			return nil
+		}
+		if waiting := time.Since(w.startedAt); waiting < w.warnAfter {
+			return nil // inside the dwell: still a normal startup
+		}
+		return fmt.Errorf(
+			"no SPIRE SVID after %s (socket %s); this workload cannot serve or verify mesh identity",
+			time.Since(w.startedAt).Round(time.Second), w.socketPath,
+		)
+	}
+}
+
+// jitter returns d plus up to waitJitterFraction of random jitter, so a fleet
+// restarting together does not retry in lockstep.
+func jitter(d time.Duration) time.Duration {
+	return d + time.Duration(float64(d)*waitJitterFraction*rand.Float64())
+}

--- a/common/spire/waiting_test.go
+++ b/common/spire/waiting_test.go
@@ -1,0 +1,545 @@
+package spire
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const testTrustDomain = "example.org"
+
+// fakeWorkloadAPI is a SPIRE Workload API server whose FetchX509SVID refuses to
+// serve — exactly as a SPIRE agent that is up but cannot attest the workload yet
+// — until startServing is called. That switch is the whole point: it reproduces
+// the boot-time window in issue #740 without a container.
+type fakeWorkloadAPI struct {
+	workload.UnimplementedSpiffeWorkloadAPIServer
+
+	svid *workload.X509SVID
+
+	serving   atomic.Bool
+	fetches   atomic.Int64
+	badHeader atomic.Int64
+}
+
+func (f *fakeWorkloadAPI) startServing() { f.serving.Store(true) }
+
+func (f *fakeWorkloadAPI) FetchX509SVID(_ *workload.X509SVIDRequest, stream grpc.ServerStreamingServer[workload.X509SVIDResponse]) error {
+	f.fetches.Add(1)
+
+	// The Workload API's security header. go-spiffe sets it on every call; a
+	// real SPIRE agent rejects calls without it, so the fake asserts it too.
+	md, _ := metadata.FromIncomingContext(stream.Context())
+	if values := md.Get("workload.spiffe.io"); len(values) != 1 || values[0] != "true" {
+		f.badHeader.Add(1)
+		return status.Error(codes.InvalidArgument, "missing workload.spiffe.io header")
+	}
+
+	if !f.serving.Load() {
+		return status.Error(codes.Unavailable, "no identity issued for this workload yet")
+	}
+	if err := stream.Send(&workload.X509SVIDResponse{Svids: []*workload.X509SVID{f.svid}}); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	return nil
+}
+
+// startFakeWorkloadAPI serves a fakeWorkloadAPI on a temporary UDS and returns
+// it with the socket path. os.MkdirTemp("") keeps the path inside the ~108-byte
+// AF_UNIX budget, which a Bazel sandbox path would blow (same reason as
+// agent/internal/spire's fake SPIRE agent).
+func startFakeWorkloadAPI(t *testing.T) (*fakeWorkloadAPI, string) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "wlapi")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "workload.sock")
+
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	fake := &fakeWorkloadAPI{svid: newWorkloadSVID(t, "spiffe://"+testTrustDomain+"/ns/aether-system/sa/aether-agent")}
+	srv := grpc.NewServer()
+	workload.RegisterSpiffeWorkloadAPIServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return fake, sock
+}
+
+// newWorkloadSVID mints a CA plus a leaf carrying the SPIFFE ID as its URI SAN
+// and marshals them the way the Workload API returns them (DER chain, PKCS#8
+// key, DER bundle), so go-spiffe's own parser accepts them.
+func newWorkloadSVID(t *testing.T, id string) *workload.X509SVID {
+	t.Helper()
+
+	sid := spiffeid.RequireFromString(id)
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"SPIRE test CA"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{Organization: []string{"SPIRE test leaf"}},
+		URIs:                  []*url.URL{sid.URL()},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	require.NoError(t, err)
+
+	return &workload.X509SVID{
+		SpiffeId:    id,
+		X509Svid:    leafDER,
+		X509SvidKey: keyDER,
+		Bundle:      caDER,
+	}
+}
+
+// newTestWaitingSource builds a WaitingSource with the retry policy compressed
+// so a test can watch several attempts go by, plus a recorder for its logs.
+func newTestWaitingSource(t *testing.T, socket string, warnAfter time.Duration) (*WaitingSource, *lockedBuffer) {
+	t.Helper()
+
+	logs := &lockedBuffer{}
+	w := NewWaitingSource(socket, warnAfter, slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	w.attemptTimeout = 500 * time.Millisecond
+	w.backoffInitial = 10 * time.Millisecond
+	w.backoffMax = 50 * time.Millisecond
+	return w, logs
+}
+
+// lockedBuffer is a concurrency-safe log sink.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// records parses the JSON log lines emitted so far.
+func (b *lockedBuffer) records(t *testing.T) []map[string]any {
+	t.Helper()
+
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(b.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &rec), "log line is not JSON: %s", line)
+		out = append(out, rec)
+	}
+	return out
+}
+
+// waitingLines returns the per-attempt waiting records.
+func (b *lockedBuffer) waitingLines(t *testing.T) []map[string]any {
+	t.Helper()
+
+	var out []map[string]any
+	for _, rec := range b.records(t) {
+		if rec["msg"] == "waiting for the SPIRE Workload API to issue this workload's SVID" {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+// TestWaitingSourceIsNeverFatal is the regression test for #740: an unreachable
+// Workload API must produce a source that keeps waiting — with an attempt/elapsed
+// breadcrumb every time — and a Runnable that neither returns an error nor stops
+// trying. Before the fix this whole path was one bounded call whose expiry exited
+// the process.
+func TestWaitingSourceIsNeverFatal(t *testing.T) {
+	// A path nobody is serving: attempts fail, forever.
+	dir, err := os.MkdirTemp("", "wlapi")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	w, logs := newTestWaitingSource(t, filepath.Join(dir, "absent.sock"), time.Hour)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- w.Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return len(logs.waitingLines(t)) >= 3
+	}, 30*time.Second, 10*time.Millisecond, "the wait must be announced once per attempt; logs:\n%s", logs.String())
+
+	// The attempt counter increases and the elapsed counter never goes backwards:
+	// that pair is what tells an operator "still coming up" from "not coming".
+	lines := logs.waitingLines(t)
+	var lastElapsed float64
+	for i, rec := range lines {
+		assert.Equal(t, float64(i+1), rec["attempt"], "attempts must be numbered consecutively")
+		assert.Equal(t, "INFO", rec["level"], "a wait inside the warn threshold stays at INFO")
+		elapsed, ok := rec["elapsed"].(float64) // slog renders a Duration as nanoseconds
+		require.True(t, ok, "the wait line must carry an elapsed counter; got %v", rec)
+		assert.GreaterOrEqual(t, elapsed, lastElapsed, "elapsed must not go backwards")
+		lastElapsed = elapsed
+	}
+	assert.Positive(t, lastElapsed, "the elapsed counter must actually advance")
+
+	assert.False(t, w.HasSVID(), "no SVID can have arrived")
+	select {
+	case err := <-done:
+		t.Fatalf("Start returned instead of waiting: %v", err)
+	default:
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a SPIRE outage must never fail the runnable")
+	case <-time.After(30 * time.Second):
+		t.Fatal("Start did not return after cancellation")
+	}
+}
+
+// TestWaitingSourceEscalatesToWarn pins the escalation: past
+// --spire-wait-warn-after the same line is logged at WARN, so a wait that has
+// stopped being a normal boot is loud without ever being fatal.
+func TestWaitingSourceEscalatesToWarn(t *testing.T) {
+	dir, err := os.MkdirTemp("", "wlapi")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	// Warn immediately: every line must be WARN.
+	w, logs := newTestWaitingSource(t, filepath.Join(dir, "absent.sock"), time.Nanosecond)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	require.Eventually(t, func() bool {
+		return len(logs.waitingLines(t)) >= 2
+	}, 30*time.Second, 10*time.Millisecond, "logs:\n%s", logs.String())
+
+	for _, rec := range logs.waitingLines(t) {
+		assert.Equal(t, "WARN", rec["level"], "past the warn threshold the wait must escalate")
+		assert.Contains(t, rec, "error", "the line must carry why the attempt failed")
+	}
+}
+
+// TestWaitingSourceBecomesReadyWhenSPIREArrives is the other half of the
+// mechanism: the process that started without an identity picks one up the
+// moment SPIRE starts serving, wakes its consumers, and records the wait once.
+func TestWaitingSourceBecomesReadyWhenSPIREArrives(t *testing.T) {
+	reader := installTestMeterProvider(t)
+
+	fake, sock := startFakeWorkloadAPI(t)
+	w, logs := newTestWaitingSource(t, sock, time.Hour)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	// Still refusing to attest: the source waits and serves ErrNoSVIDYet.
+	require.Eventually(t, func() bool {
+		return fake.fetches.Load() >= 1
+	}, 30*time.Second, 10*time.Millisecond, "the source must be attempting; logs:\n%s", logs.String())
+	require.False(t, w.HasSVID())
+	_, err := w.GetX509SVID()
+	require.ErrorIs(t, err, ErrNoSVIDYet)
+	require.Equal(t, int64(0), fake.badHeader.Load(), "every call must carry the workload.spiffe.io header")
+	require.Equal(t, int64(0), metricSum(t, reader, "aether.agent.spire.source_restarts"))
+	require.Equal(t, int64(0), gaugeValue(t, reader, "aether.agent.spire.svid_ready"))
+
+	fake.startServing()
+
+	select {
+	case <-w.Ready():
+	case <-time.After(30 * time.Second):
+		t.Fatalf("the source never became ready after SPIRE started serving; logs:\n%s", logs.String())
+	}
+
+	require.True(t, w.HasSVID())
+	svid, err := w.GetX509SVID()
+	require.NoError(t, err)
+	assert.Equal(t, testTrustDomain, svid.ID.TrustDomain().Name())
+
+	td, err := TrustDomainFromSource(w)
+	require.NoError(t, err)
+	assert.Equal(t, testTrustDomain, td)
+
+	bundle, err := w.GetX509BundleForTrustDomain(spiffeid.RequireTrustDomainFromString(testTrustDomain))
+	require.NoError(t, err)
+	assert.NotEmpty(t, bundle.X509Authorities(), "the bundle must be served once the SVID lands")
+
+	// The SDS bridge's wake: Updated fires on the first SVID, which is what
+	// lets the node identity be served immediately rather than on the 30s tick.
+	select {
+	case <-w.Updated():
+	case <-time.After(10 * time.Second):
+		t.Fatal("Updated() did not fire when the first SVID arrived")
+	}
+
+	// The wait is recorded exactly once, and the readiness gauge flips.
+	require.Equal(t, uint64(1), histogramCount(t, reader, "aether.agent.spire.wait_seconds"))
+	require.Equal(t, int64(1), gaugeValue(t, reader, "aether.agent.spire.svid_ready"))
+	require.Equal(t, int64(0), metricSum(t, reader, "aether.agent.spire.source_restarts"),
+		"a source that comes up cleanly must never be re-created")
+
+	ready := findRecord(logs.records(t), "obtained this workload's SVID from the SPIRE Workload API")
+	require.NotNil(t, ready, "the arrival must be announced; logs:\n%s", logs.String())
+	assert.Equal(t, testTrustDomain, ready["trustDomain"])
+}
+
+// TestWaitingSourceErrNoSVIDYet pins the pre-identity contract every consumer
+// relies on: a typed, recognisable "not yet", not a generic failure.
+func TestWaitingSourceErrNoSVIDYet(t *testing.T) {
+	w := NewWaitingSource("/nonexistent/workload.sock", 0, slog.New(slog.DiscardHandler))
+
+	_, err := w.GetX509SVID()
+	require.ErrorIs(t, err, ErrNoSVIDYet)
+	assert.Contains(t, err.Error(), "/nonexistent/workload.sock", "the error must name the socket")
+
+	_, err = w.GetX509BundleForTrustDomain(spiffeid.RequireTrustDomainFromString(testTrustDomain))
+	require.ErrorIs(t, err, ErrNoSVIDYet)
+
+	assert.False(t, w.HasSVID())
+	assert.NoError(t, w.Close(), "closing before acquisition is a no-op")
+	assert.Equal(t, DefaultWaitWarnAfter, w.warnAfter, "a non-positive warn threshold means the default")
+	assert.False(t, w.NeedLeaderElection(), "identity is per-replica, never leader-elected")
+}
+
+// TestWaitingSourceBackoffIsBounded pins the retry policy: doubling, capped, and
+// jittered. Unbounded growth would leave a node minutes behind SPIRE's recovery;
+// no growth would hammer a SPIRE agent that is already struggling.
+func TestWaitingSourceBackoffIsBounded(t *testing.T) {
+	got := waitBackoffInitial
+	seen := []time.Duration{got}
+	for range 10 {
+		got = nextBackoff(got, waitBackoffMax)
+		seen = append(seen, got)
+	}
+	assert.Equal(t, waitBackoffMax, got, "the backoff must saturate at the maximum")
+	for i := 1; i < len(seen); i++ {
+		assert.GreaterOrEqual(t, seen[i], seen[i-1], "the backoff must never shrink")
+		assert.LessOrEqual(t, seen[i], waitBackoffMax, "the backoff must never exceed the maximum")
+	}
+
+	for range 100 {
+		j := jitter(time.Second)
+		assert.GreaterOrEqual(t, j, time.Second)
+		assert.Less(t, j, time.Duration(float64(time.Second)*(1+waitJitterFraction)))
+	}
+}
+
+// TestReadyChecker is the readiness table, dwell included.
+func TestReadyChecker(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "/readyz", nil)
+	require.NoError(t, err)
+
+	ready := NewWaitingSource("/nonexistent/workload.sock", time.Minute, slog.New(slog.DiscardHandler))
+	ready.src = &Source{} // stand-in: only its presence is read
+
+	waitingInsideDwell := NewWaitingSource("/nonexistent/workload.sock", time.Minute, slog.New(slog.DiscardHandler))
+
+	waitingPastDwell := NewWaitingSource("/nonexistent/workload.sock", time.Minute, slog.New(slog.DiscardHandler))
+	waitingPastDwell.startedAt = time.Now().Add(-2 * time.Minute)
+
+	tests := []struct {
+		name    string
+		src     *WaitingSource
+		wantErr bool
+	}{
+		{
+			// The kill switch. --spire-enabled=false means there is no identity
+			// to wait for, so the check must disappear exactly as the CNI
+			// chaining check does with its own kill switch.
+			name: "nil source (SPIRE disabled) always passes",
+			src:  nil,
+		},
+		{
+			name: "holding an SVID passes",
+			src:  ready,
+		},
+		{
+			// The decision this dwell exists for: a node must not go NotReady
+			// during the boot window, because the controller's taint guard
+			// re-arms on 30s of NotReady and spire-server does not tolerate
+			// that taint.
+			name: "waiting inside the dwell passes",
+			src:  waitingInsideDwell,
+		},
+		{
+			name:    "waiting past the dwell fails",
+			src:     waitingPastDwell,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ReadyChecker(tc.src)(req)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "no SPIRE SVID after")
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// TestNotReadyDwellOutlastsTaintGuardGrace pins the cross-component relationship
+// the dwell exists for. The controller's node-taint guard re-arms
+// aether.io/agent-not-ready:NoSchedule after this many seconds of an agent being
+// NotReady (grace, controller/internal/nodetaint/guard.go), and spire-server does
+// not tolerate that taint — so if this dwell were ever shortened below it, a
+// SPIRE outage would taint every node and block spire-server's own rescheduling.
+func TestNotReadyDwellOutlastsTaintGuardGrace(t *testing.T) {
+	const taintGuardGrace = 30 * time.Second
+	assert.Greater(t, NotReadyDwell, taintGuardGrace,
+		"the spire-svid dwell must outlast the node-taint guard's grace")
+	assert.Equal(t, DefaultWaitWarnAfter, NotReadyDwell,
+		"the dwell and the WARN threshold are deliberately the same instant")
+}
+
+// TestSourcesImplementSVIDSource keeps both sources interchangeable: the
+// widened helpers must keep accepting the plain Workload API source that the
+// controller, registrar and edge still create synchronously.
+func TestSourcesImplementSVIDSource(t *testing.T) {
+	var _ SVIDSource = (*WaitingSource)(nil)
+	var _ SVIDSource = (*Source)(nil)
+}
+
+// installTestMeterProvider points the global meter provider at a manual reader
+// for the duration of the test, so instruments registered by NewWaitingSource
+// are collectable.
+func installTestMeterProvider(t *testing.T) *sdkmetric.ManualReader {
+	t.Helper()
+
+	reader := sdkmetric.NewManualReader()
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader)))
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+	return reader
+}
+
+// collect gathers the metric with the given name, or nil.
+func collect(t *testing.T, reader *sdkmetric.ManualReader, name string) metricdata.Aggregation {
+	t.Helper()
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name == name {
+				return m.Data
+			}
+		}
+	}
+	return nil
+}
+
+// metricSum returns a counter's total, 0 when it was never recorded.
+func metricSum(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+
+	sum, ok := collect(t, reader, name).(metricdata.Sum[int64])
+	if !ok {
+		return 0
+	}
+	var total int64
+	for _, dp := range sum.DataPoints {
+		total += dp.Value
+	}
+	return total
+}
+
+// gaugeValue returns an observable gauge's latest value.
+func gaugeValue(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+
+	gauge, ok := collect(t, reader, name).(metricdata.Gauge[int64])
+	require.True(t, ok, "metric %s is not an int64 gauge", name)
+	require.NotEmpty(t, gauge.DataPoints)
+	return gauge.DataPoints[len(gauge.DataPoints)-1].Value
+}
+
+// histogramCount returns how many observations a histogram holds.
+func histogramCount(t *testing.T, reader *sdkmetric.ManualReader, name string) uint64 {
+	t.Helper()
+
+	hist, ok := collect(t, reader, name).(metricdata.Histogram[float64])
+	require.True(t, ok, "metric %s is not a float64 histogram", name)
+	var count uint64
+	for _, dp := range hist.DataPoints {
+		count += dp.Count
+	}
+	return count
+}
+
+// findRecord returns the first record whose msg matches.
+func findRecord(records []map[string]any, msg string) map[string]any {
+	for _, rec := range records {
+		if rec["msg"] == msg {
+			return rec
+		}
+	}
+	return nil
+}

--- a/controller/internal/cmd/config.go
+++ b/controller/internal/cmd/config.go
@@ -2,8 +2,11 @@
 package cmd
 
 import (
+	"time"
+
 	meshconst "aethermesh.dev/common/constants/mesh"
 	"aethermesh.dev/common/manager"
+	"aethermesh.dev/common/spire"
 	"aethermesh.dev/controller/internal/meshconfig"
 )
 
@@ -28,6 +31,11 @@ type ControllerConfig struct {
 	SpireEnabled bool
 	// SpireWorkloadSocketPath is the SPIRE Workload API UDS socket path.
 	SpireWorkloadSocketPath string
+	// SpireWaitWarnAfter is how long the wait for this workload's first SVID may
+	// run before it is reported at WARN. Accepted here so the chart can set the
+	// same value on every component; the controller's own non-fatal wait lands in
+	// PR 2 of issue #740.
+	SpireWaitWarnAfter time.Duration
 
 	// WebhookConfigName is the ValidatingWebhookConfiguration whose caBundle the
 	// controller patches with the SPIRE trust bundle (SPIRE mode only).
@@ -61,6 +69,7 @@ func NewControllerConfig() *ControllerConfig {
 		},
 		MeshConfigMapName:       meshconfig.DefaultMeshConfigMapName,
 		SpireWorkloadSocketPath: DefaultSpireWorkloadSocketPath,
+		SpireWaitWarnAfter:      spire.DefaultWaitWarnAfter,
 		MeshDomain:              meshconst.DefaultMeshDomain,
 	}
 }

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -79,6 +79,7 @@ func init() {
 	rootCmd.Flags().StringVar(&cfg.MeshConfigMapName, "mesh-config-configmap", cfg.MeshConfigMapName, "Name of the ConfigMap the MeshConfig reconciler projects into (in each MeshConfig's own namespace)")
 	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", cfg.SpireEnabled, "Serve the validating webhook with a SPIRE X.509 SVID and inject the SPIRE trust bundle into the webhook caBundle (instead of a static cert)")
 	rootCmd.Flags().StringVar(&cfg.SpireWorkloadSocketPath, "spire-workload-socket", cfg.SpireWorkloadSocketPath, "Path to the SPIRE Workload API UDS socket")
+	rootCmd.Flags().DurationVar(&cfg.SpireWaitWarnAfter, "spire-wait-warn-after", cfg.SpireWaitWarnAfter, "How long to wait for this workload's first SVID before escalating the waiting log line to WARN (issue #740)")
 	rootCmd.Flags().StringVar(&cfg.WebhookConfigName, "webhook-config-name", cfg.WebhookConfigName, "ValidatingWebhookConfiguration to patch with the SPIRE caBundle (SPIRE mode)")
 	rootCmd.Flags().StringVar(&cfg.MutatingWebhookConfigName, "mutating-webhook-config-name", cfg.MutatingWebhookConfigName, "MutatingWebhookConfiguration (pod ndots) to patch with the SPIRE caBundle (SPIRE mode); empty disables")
 	rootCmd.Flags().StringVar(&cfg.MeshDomain, "mesh-domain", cfg.MeshDomain, "DNS-style domain mesh authorities live under; the pod-mutating webhook derives the injected dnsConfig ndots from its label count (2 for aether.internal)")

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -434,6 +434,69 @@ grep -c aether-cni /etc/cni/net.d/*.conflist
 
 Never hand-write either file: `cni-install` is the durable entry's only writer, and the
 conflist belongs to the primary CNI plus the re-assert loop.
+### The agent is stuck waiting for SPIRE
+
+Symptom: the agent logs, once per retry,
+
+```
+waiting for the SPIRE Workload API to issue this workload's SVID socket=/run/secrets/workload-spiffe-uds/socket attempt=7 elapsed=41.2s warnAfter=2m0s error=...
+```
+
+**That line is the fix working, not the failure** (issue #740). Startup no longer dies
+when the Workload API is not serving yet: the agent programs everything that does not
+need identity, keeps `/healthz` and `/readyz` answering, and folds the SVID in when it
+arrives. The signature of a healthy wait is the waiting lines plus **0 restarts** and
+**no** `failed to create SPIRE Workload API source` anywhere. Before #740 that error was
+followed by `exit 1`, which is how a cold boot produced 2-4 restarts per node.
+
+What to check, in order:
+
+```bash
+# 1. Is it still waiting, or did it resolve? (arrival is one INFO line)
+kubectl -n aether logs ds/aether-agent | grep -E "waiting for the SPIRE Workload API|obtained this workload's SVID|resolved workload trust domain"
+
+# 2. Restarts must be zero — a restarting agent is a DIFFERENT problem
+kubectl -n aether get pods -l app.kubernetes.io/name=aether-agent
+
+# 3. The readiness gate and its dwell
+kubectl -n aether exec ds/aether-agent -c agent -- wget -qO- localhost:8082/readyz?verbose
+```
+
+`readyz?verbose` reads `spire-svid ok` for the first **2 minutes** of the wait
+(`--spire-wait-warn-after`, `spire.waitWarnAfter`) and then fails with
+`no SPIRE SVID after 2m10s (socket …)`. The dwell is deliberate: the controller's
+node-taint guard re-arms `aether.io/agent-not-ready:NoSchedule` after 30s of NotReady,
+and spire-server does not tolerate that taint — a gate that failed immediately would let
+a brief SPIRE outage fence the cluster against spire-server's own rescheduling. Past the
+dwell the NotReady is the point: stop scheduling pods onto a node that cannot give them
+an identity.
+
+The upstream cause is almost always spire-server or the node's spire-agent, not aether:
+
+```bash
+kubectl -n spire-server get pods                  # spire-server-0 Running and 1/1?
+kubectl -n spire-system get pods -o wide          # this node's spire-agent Running?
+kubectl -n spire-server logs spire-server-0 | tail -50
+```
+
+Metrics for the same question, fleet-wide:
+
+```promql
+# nodes without an SVID right now (0 = waiting)
+min by (k8s_node_name) (aether_agent_spire_svid_ready)
+# how long the wait took on the last boot
+histogram_quantile(0.99, sum by (le) (rate(aether_agent_spire_wait_seconds_bucket[15m])))
+# must stay flat at 0: a source that connected but could not serve an SVID
+sum(increase(aether_agent_spire_source_restarts_total[1h]))
+```
+
+While the wait is on, the registrar watch stream logs
+`watch stream deferred until this agent has an SVID` at INFO and counts no
+`watch_errors` — the agent cannot handshake without a certificate, and that is not a
+registrar fault. Envoy keeps serving on the certificates it already holds; a **new** pod
+on that node gets its listener but no upstream mTLS until the SVID lands, which is the
+same absent-secret transient #715 covers.
+
 ### Grepping the outbound identity bindings during a soak (issue #638)
 
 `ssl_fail_verify_san` bursts a few tens of seconds into a fresh proxy generation point at

--- a/registrar/internal/cmd/config.go
+++ b/registrar/internal/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"aethermesh.dev/common/manager"
+	"aethermesh.dev/common/spire"
 )
 
 const (
@@ -74,6 +75,11 @@ type RegistrarConfig struct {
 	SpireEnabled bool
 	// SpireWorkloadSocketPath is the path to the SPIRE Workload API UDS socket
 	SpireWorkloadSocketPath string
+	// SpireWaitWarnAfter is how long the wait for this workload's first SVID may
+	// run before it is reported at WARN. Accepted here so the chart can set the
+	// same value on every component; the registrar's own non-fatal wait lands in
+	// PR 2 of issue #740.
+	SpireWaitWarnAfter time.Duration
 }
 
 // DefaultSpireWorkloadSocketPath is the default SPIRE CSI-mounted socket path.
@@ -108,5 +114,6 @@ func NewRegistrarConfig() *RegistrarConfig {
 		GRPCAddress:             defaultGRPCAddress,
 		SpireEnabled:            true,
 		SpireWorkloadSocketPath: DefaultSpireWorkloadSocketPath,
+		SpireWaitWarnAfter:      spire.DefaultWaitWarnAfter,
 	}
 }

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -83,6 +83,7 @@ func init() {
 	// it can never disagree with what SPIRE actually issues.
 	rootCmd.Flags().BoolVar(&cfg.SpireEnabled, "spire-enabled", cfg.SpireEnabled, "Enable SPIRE mTLS for the gRPC server")
 	rootCmd.Flags().StringVar(&cfg.SpireWorkloadSocketPath, "spire-workload-socket", cfg.SpireWorkloadSocketPath, "Path to the SPIRE Workload API UDS socket")
+	rootCmd.Flags().DurationVar(&cfg.SpireWaitWarnAfter, "spire-wait-warn-after", cfg.SpireWaitWarnAfter, "How long to wait for this workload's first SVID before escalating the waiting log line to WARN (issue #740)")
 
 	must.NoError(rootCmd.MarkFlagRequired("cluster-name"))
 }

--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "metrics_test.go",
         "registrar_test.go",
         "watch_drain_test.go",
+        "watch_identity_test.go",
         "watch_startup_test.go",
     ],
     embed = [":registrar"],

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -63,6 +63,17 @@ type Config struct {
 	// DialOptions are additional gRPC dial options (e.g., TLS credentials).
 	// When empty, insecure credentials are used.
 	DialOptions []grpc.DialOption
+	// IdentityReady reports whether this client can complete an mTLS handshake
+	// yet — i.e. whether SPIRE has issued this workload's SVID. Optional; nil
+	// means "always ready" (SPIRE disabled, or a caller with no such notion).
+	//
+	// Since #740 the process no longer blocks on the first SVID, so the watch
+	// stream can legitimately start before identity exists. Every such attempt
+	// fails the handshake, and reporting those as stream FAILURES would bury the
+	// one signal this loop's ERRORs exist for (a registrar that will not serve
+	// the stream, #700) under a boot's worth of noise, and count watch_errors
+	// for a condition that is not an error.
+	IdentityReady func() bool
 }
 
 // RegistrarRegistry implements the Registry interface by communicating with a
@@ -547,6 +558,9 @@ func (r *RegistrarRegistry) recoverStreamOpen(ctx context.Context, err error, ca
 // double it for the next attempt. It reports whether the loop should keep
 // watching (false = the context ended while waiting, i.e. shutdown).
 func (r *RegistrarRegistry) failStream(ctx context.Context, msg string, err error, backoff *time.Duration) bool {
+	if r.identityPending() {
+		return r.deferStream(ctx, err, *backoff)
+	}
 	r.metrics.streamFailed(ctx)
 	jitter := time.Duration(float64(*backoff) * jitterFraction * rand.Float64())
 	wait := *backoff + jitter
@@ -557,6 +571,31 @@ func (r *RegistrarRegistry) failStream(ctx context.Context, msg string, err erro
 	case <-time.After(wait):
 	}
 	*backoff = min(*backoff*2, maxBackoff)
+	return true
+}
+
+// identityPending reports whether this client is configured for mTLS but does
+// not have its SVID yet, which makes a failed stream a deferral rather than a
+// failure.
+func (r *RegistrarRegistry) identityPending() bool {
+	return r.config.IdentityReady != nil && !r.config.IdentityReady()
+}
+
+// deferStream is the failure path's counterpart for a stream that could not be
+// established because this workload has no identity yet (issue #740): announce
+// it at INFO, wait out the CURRENT backoff with the usual jitter, and leave the
+// backoff where it is. No ERROR, no watch_errors, and no escalation — the wait
+// is on SPIRE, not on the registrar, and the moment the SVID lands the very next
+// attempt handshakes. It reports whether the loop should keep watching.
+func (r *RegistrarRegistry) deferStream(ctx context.Context, err error, backoff time.Duration) bool {
+	jitter := time.Duration(float64(backoff) * jitterFraction * rand.Float64())
+	wait := backoff + jitter
+	r.log.InfoContext(ctx, "watch stream deferred until this agent has an SVID", "error", err, "backoff", wait)
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(wait):
+	}
 	return true
 }
 

--- a/registry/internal/registrar/watch_identity_test.go
+++ b/registry/internal/registrar/watch_identity_test.go
@@ -1,0 +1,86 @@
+package registrar
+
+import (
+	"context"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// newIdentityGatedRegistry wires a registry whose watch stream cannot connect
+// (nothing is listening) and whose identity readiness the test controls.
+func newIdentityGatedRegistry(t *testing.T, ready func() bool) (*RegistrarRegistry, *lockedBuffer, *sdkmetric.ManualReader) {
+	t.Helper()
+
+	logs := &lockedBuffer{}
+	log := slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	r := NewRegistrarRegistry(log, Config{
+		Address:     "passthrough:///registrar-test",
+		ClusterName: "test-cluster",
+		NodeName:    "test-node",
+		DialOptions: []grpc.DialOption{
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithContextDialer((&swappableListener{}).dial), // nobody is listening
+		},
+		IdentityReady: ready,
+	})
+	metrics, reader := newTestClientMetrics(t)
+	r.metrics = metrics
+	return r, logs, reader
+}
+
+// TestWatchLoop_DefersWhileIdentityNotReady covers the agent's new startup
+// shape (#740): the process comes up before SPIRE has issued its SVID, so the
+// watch stream cannot handshake yet. That is a deferral, not a failure — INFO,
+// no watch_errors, and no escalating backoff — because the ERROR path here
+// exists to report a registrar that will not serve the stream (#700, #712), and
+// burying that under a boot's worth of identity noise is exactly what #712
+// removed.
+func TestWatchLoop_DefersWhileIdentityNotReady(t *testing.T) {
+	var ready atomic.Bool // starts false: no SVID yet
+	r, logs, reader := newIdentityGatedRegistry(t, ready.Load)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	require.NoError(t, r.Initialize(ctx))
+	defer func() { _ = r.Close() }()
+
+	require.Eventually(t, func() bool {
+		return findRecord(logRecords(t, logs), "watch stream deferred until this agent has an SVID") != nil
+	}, 30*time.Second, 10*time.Millisecond, "the pre-identity wait must be announced; logs:\n%s", logs.String())
+
+	deferred := findRecord(logRecords(t, logs), "watch stream deferred until this agent has an SVID")
+	require.Equal(t, "INFO", deferred["level"])
+	require.Contains(t, deferred, "backoff", "the deferral still waits before retrying")
+
+	for _, rec := range logRecords(t, logs) {
+		require.NotEqual(t, "ERROR", rec["level"],
+			"waiting for our own identity must not be reported as a registrar failure; logs:\n%s", logs.String())
+	}
+	_, found := metricValue(t, reader, "aether.agent.registry.watch_errors")
+	require.False(t, found, "a deferral must not count as a watch error")
+
+	// The negative control: once the SVID exists, a stream that still will not
+	// open is a real failure again, with the ERROR and the counter back.
+	ready.Store(true)
+
+	require.Eventually(t, func() bool {
+		return findRecord(logRecords(t, logs), "failed to start watch stream, retrying") != nil
+	}, 30*time.Second, 10*time.Millisecond, "with an identity in hand the failure path must be restored; logs:\n%s", logs.String())
+
+	failed := findRecord(logRecords(t, logs), "failed to start watch stream, retrying")
+	require.Equal(t, "ERROR", failed["level"])
+
+	require.Eventually(t, func() bool {
+		got, ok := metricValue(t, reader, "aether.agent.registry.watch_errors")
+		return ok && got >= 1
+	}, 10*time.Second, 10*time.Millisecond, "a real stream failure must still count")
+}


### PR DESCRIPTION
Part 1 of #740 (the agent). PR 2 = controller/registrar/edge.

## The mechanism

`workloadapi.NewX509Source` was called in exactly one place — `common/spire/tls.go`'s
`NewSourceWithTimeout`, with the 25s `SourceTimeout` #668 introduced to turn the SDK's
unbounded first-SVID wait into a bounded one. Bounded, but still **fatal**: the agent
called it at `root.go:243`, *before* `m.Start`, so `/healthz` and `/readyz` were still
silent, and a SPIRE server that was itself still coming up — the normal state of a cold
boot — exited the process with `failed to create SPIRE Workload API source: context
deadline exceeded`. On the 2026-09-07 power failure that cost 2–4 restarts on every
node and ~60s of mesh readiness, for a dependency that recovered on its own in 13s.

Nothing downstream ever needed the process to die:

- the SPIRE→SDS bridge dials lazily and retries its streams forever,
- `nodeSource` is already an interface whose `GetX509SVID` errors are retried,
- the xDS cache skips upstream-mTLS injection until `SetNodeIdentity` lands, and Envoy
  tolerates the absent secret (#715),
- go-spiffe reconnects mid-life on a `context.Background()` watcher, so only the one-shot
  *creation* was ever fatal.

## What changed

**`common/spire`** — a narrow `SVIDSource` interface (`x509svid.Source` +
`x509bundle.Source` + `Updated()`); every TLS helper widened to it; the `Source` alias
kept, so the three call sites PR 2 will move still compile untouched. New
`WaitingSource` (`waiting.go`): a controller-runtime Runnable that creates the source in
a retry loop — 10s per attempt, jittered backoff 1s→30s, **never fatal** — serving
`ErrNoSVIDYet` until the first SVID and then delegating to the real source. A source
that connects but cannot serve an SVID is discarded and re-created (the only path that
increments `source_restarts`).

**Agent** — `setupSpireSource` → `startSpireIdentity`, in the same slot, returning
immediately. The trust domain is late-bound through a tiny atomic holder
(`agent/internal/identity`) seeded with the mesh domain — the only value that can work,
since peer authorization is scoped to it unconditionally — and `reconcileSpireIdentity`
folds in what SPIRE actually issued when the SVID lands (WARN + a merge-safe
`LoadListenersFromStorage` re-run if it ever differs). The bridge's node-SVID refresh
now also wakes on `Updated()`, so a late identity is served immediately instead of on
the next 30s tick. `defer spireSource.Close()` unchanged in shape.

**Registrar client** — `Config.IdentityReady func() bool`. A stream that cannot
handshake before the SVID exists logs INFO `watch stream deferred until this agent has
an SVID`, counts no `watch_errors`, and does not escalate the backoff (only the usual
jitter). Waiting on our own certificate is not a registrar failure, and burying #700's
ERROR under a boot's worth of it is exactly what #712 removed.

Nothing in `runAgent` or `PreListen` is reordered (#700/#712), and
`--spire-enabled=false` (#421) is byte-identical: no source, no runnable, no log line.

## The dwell decision

`readyz` gains `spire-svid` beside `cni-chained`, **with a 2m dwell equal to the warn
threshold** — the non-obvious part. The controller's node-taint guard (proposal 033)
re-arms `aether.io/agent-not-ready:NoSchedule` on any agent NotReady past its 30s grace
(`controller/internal/nodetaint/guard.go:31`), and **spire-server does not tolerate that
taint**. A gate that failed from t=0 would let a 40s SPIRE hiccup taint every node and
block spire-server's own rescheduling — the outage would fence out its own cure. With
the dwell, the 2026-09-07 boot (SPIRE healthy 16:00:35Z, agents up by 16:02:45Z)
produces zero NotReady and zero taints; a real outage (>2m) still escalates to NotReady,
which is what an operator wants: stop scheduling pods onto a node that cannot give them
an identity. `TestNotReadyDwellOutlastsTaintGuardGrace` pins the relationship.

SPIRE is deliberately **not** added to the #667 taint gate: that gate is for the
CNI-never-issues-ADD failure, a different class. SPIRE is fleet-correlated, exactly like
#668's collector argument.

## What an operator sees

```
INFO  waiting for the SPIRE Workload API to issue this workload's SVID  socket=… attempt=7 elapsed=41.2s warnAfter=2m0s error=…
WARN  waiting for the SPIRE Workload API to issue this workload's SVID  … elapsed=2m3.4s …
INFO  obtained this workload's SVID from the SPIRE Workload API  socket=… attempts=9 elapsed=52.8s trustDomain=aether.internal
INFO  resolved workload trust domain from SPIRE  trustDomain=aether.internal
```

`readyz?verbose` reads `spire-svid ok` for the first 2 minutes and then
`no SPIRE SVID after 2m10s (socket …); this workload cannot serve or verify mesh
identity`. Metrics (as Prometheus sees them):
`aether_agent_spire_wait_seconds_{bucket,sum,count}` (seconds-oriented buckets, #732),
`aether_agent_spire_source_restarts_total` (must stay 0),
`aether_agent_spire_svid_ready` (1/0 gauge).

## Test evidence

All hermetic — a fake `workload.SpiffeWorkloadAPIServer` on a temp UDS with a
`startServing()` switch (asserting the `workload.spiffe.io: true` header), plus the
existing fake SPIRE agent. Negative controls run by reverting each fix in place, per the
#668 precedent:

| Test | Asserts | Without the fix |
|---|---|---|
| `TestWaitingSourceIsNeverFatal` | unreachable socket → one INFO line per attempt, attempt/elapsed increasing, `Start` never returns an error | — (the pre-fix path is `NewSource`, whose bound is already pinned by #668's `TestNewSourceWithTimeout_BoundsFirstSVIDWait`) |
| `TestWaitingSourceEscalatesToWarn` | past `warnAfter` the same line is WARN and carries the error | — |
| `TestWaitingSourceBecomesReadyWhenSPIREArrives` | becomes ready when SPIRE starts serving; `Updated()` fires; `wait_seconds` recorded **once**; `svid_ready` 0→1; `source_restarts` 0; header asserted | — |
| `TestWaitingSourceErrNoSVIDYet` | typed `ErrNoSVIDYet` naming the socket, on both source methods | — |
| `TestWaitingSourceBackoffIsBounded` | doubling, capped at 30s, jitter within 20% | — |
| `TestReadyChecker` (table) | nil source passes; holding an SVID passes; **waiting inside the dwell passes**; waiting past it fails | **FAILED** (dwell removed → "inside the dwell" case fails) |
| `TestNotReadyDwellOutlastsTaintGuardGrace` | dwell > the taint guard's 30s grace, and == the WARN threshold | — |
| `TestStartSpireIdentityReturnsImmediately` | returns in <100ms against an unreachable socket, registers the runnable, seeds the trust domain, runnable exits clean | **FAILED in 25.2s** (old synchronous `NewSource` restored — the exact `SourceTimeout` hang) |
| `TestStartSpireIdentityDisabledIsUnchanged` | SPIRE off: nil source, mesh domain, no runnable, **no log output** | — |
| `TestTrustDomain*` (incl. concurrent) | seed readable, `Set` reports change; race-clean under `--features=race` | — |
| `TestNodeSVIDServedWhenIdentityArrivesLate` | no identity → no `SetNodeIdentity`, bridge still running; identity arrives → served **within 1s** (ticker is 30s) | **FAILED** (update wake removed) |
| `TestWatchLoop_DefersWhileIdentityNotReady` | INFO deferral, zero ERROR lines, no `watch_errors`; then with identity ready the ERROR + counter come back | **FAILED in 30.1s** (deferral removed) |

```
bazel test --test_arg=-test.short //agent/... //common/... //registry/... //registrar/... //controller/...  → 71 tests pass
bazel build --config=lint //agent/... //common/... //registry/...  → OK (gocognit 15 gate; runAgent gained no branch)
make format-check → clean
helm lint charts/aether → 0 failed; helm template … | grep spire-wait-warn-after → 4 (agent, edge, registrar, controller)
```

## Chart

`spire.waitWarnAfter: 2m`, threaded to all four binaries under the existing SPIRE guard
idiom. The registrar and controller parse the flag but do not act on it yet (PR 2) —
they must accept it now, or the chart would hand them an unknown flag. `values.yaml`
carries the toleration note: **spire-server and spire-agent must tolerate
`aether.io/agent-not-ready:NoSchedule`**. `charts/aether` 0.92.8 → **0.92.9**.

## On-cluster validation (talos-main)

Scaling spire-server to 0 alone does **not** reproduce it — the node's spire-agent keeps
serving from cache. Pre-flight the SVID TTL and **abort if < 30m**.

**Tier 1 (one node).** Scale `spire-server` to 0, wait 60s, then delete that node's
`spire-agent` pod **and** its `aether-agent` pod. Expect: Running with **0 restarts**,
the `waiting…` INFO lines, `readyz` `spire-svid` **ok inside the dwell** and failing
after it, and **no taint** inside the dwell. Scale spire-server back to 1 → ready within
~10s, taint cleared, `obtained this workload's SVID` logged.

**Tier 2 (fleet).** Same, but `rollout restart ds/spire-agent` + `ds/aether-agent`,
completed under 10 minutes, with **no workload pod creation** in the window. The prober
SLI must be flat throughout (Envoy serves on its last certs).

Abort criteria: any agent restart, any `failed to create SPIRE Workload API source`, any
`aether_agent_spire_source_restarts_total > 0`, any prober `http_error` attributable to
the window, or a node tainted inside the dwell. Note `ssl_fail_verify_san_total` needs
the `_total` suffix when querying.

Not deployed; a soak is being scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
