### PR TITLE
fix(controller,registrar,edge): wait for the SPIRE Workload API instead of dying on it (#740)

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/cache",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
         "@io_k8s_sigs_controller_runtime//pkg/manager",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
@@ -63,6 +64,7 @@ go_test(
     name = "cmd_test",
     srcs = [
         "config_test.go",
+        "edge_identity_test.go",
         "root_test.go",
         "spire_identity_test.go",
         "supervisor_test.go",
@@ -72,8 +74,11 @@ go_test(
         "//agent/internal/cni/server",
         "//agent/internal/cniconflist",
         "//agent/internal/node",
+        "//common/spire",
+        "//common/spire/spiretest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
         "@io_k8s_sigs_controller_runtime//pkg/manager",
     ],
 )

--- a/agent/internal/cmd/edge.go
+++ b/agent/internal/cmd/edge.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
@@ -135,7 +136,7 @@ func runEdge(ctx context.Context) (retErr error) {
 	defer deferTelemetryShutdown(ctx, result.Shutdown)
 	m := result.Manager
 
-	spireSource, identityTrustDomain, edgeSpiffeID, err := resolveEdgeIdentity(ctx)
+	spireSource, identityTrustDomain, edgeSpiffeID, err := resolveEdgeIdentity(ctx, m)
 	if err != nil {
 		return err
 	}
@@ -150,6 +151,9 @@ func runEdge(ctx context.Context) (retErr error) {
 	defer func() { retErr = errors.Join(retErr, reg.Close()) }()
 
 	snapshotCache := configureEdgeSnapshotCache(edgeSpiffeID, identityTrustDomain)
+
+	// Replace the seeds with the identity SPIRE issues, whenever it does (#740).
+	wireEdgeIdentity(ctx, spireSource, snapshotCache)
 
 	ackTracker := ack.NewTracker(l)
 
@@ -212,34 +216,105 @@ func buildEdgeScheme() (*runtime.Scheme, error) {
 	return scheme, nil
 }
 
-// resolveEdgeIdentity opens the SPIRE Workload API source and derives the edge's
-// trust domain and SPIFFE ID. When SPIRE is disabled, it returns nil source and
-// the mesh domain as trust domain. The caller is responsible for closing the source.
-func resolveEdgeIdentity(ctx context.Context) (*commonspire.Source, string, string, error) {
+// edgeSpireComponent namespaces the edge's SPIRE identity-wait metrics
+// (aether.edge.spire.wait_seconds and friends). The edge shares the agent binary
+// but is a separate workload with its own SPIRE registration entry and its own
+// failure mode, so it gets its own series rather than being collapsed into the
+// node agent's (#210: a fleet-collapsed counter makes rate() lie).
+const edgeSpireComponent = "edge"
+
+// edgeIdentityManager is the slice of the controller-runtime manager the edge's
+// identity wiring needs. A narrow interface rather than ctrl.Manager is what lets
+// the "returns immediately" test run without an apiserver.
+type edgeIdentityManager interface {
+	runnableAdder
+	AddReadyzCheck(name string, check healthz.Checker) error
+}
+
+// resolveEdgeIdentity starts acquiring the edge's SPIRE identity and RETURNS
+// IMMEDIATELY with the SEED values everything downstream is wired from: the mesh
+// domain as trust domain and an empty SPIFFE ID. When SPIRE is disabled it
+// registers nothing and returns those same seeds, byte for byte what it did
+// before (#421). The caller owns the returned source and must Close it.
+//
+// This slot used to be a blocking, FATAL 25s wait for the first SVID (issue #740).
+// The edge needs MORE from SPIRE than the other three — the trust domain AND its
+// own SPIFFE ID name the SDS resources and the upstream mTLS its Envoy presents —
+// which is exactly why the wait was here, and exactly why dying on it was wrong: a
+// north-south gateway that exits during a SPIRE cold boot takes ingress with it,
+// while an edge that starts without an identity simply cannot inject upstream mTLS
+// yet. SetEdgeIdentity recomputes the mTLS clusters and pushes a new snapshot, so
+// the identity folds in late without a restart (wireEdgeIdentity).
+//
+// The empty SPIFFE ID is not a placeholder that leaks: recomputeMTLSClusters skips
+// mTLS injection entirely while nodeSpiffeID is "", so the edge serves plain
+// clusters until the SVID lands rather than clusters naming an identity it does
+// not hold.
+func resolveEdgeIdentity(ctx context.Context, m edgeIdentityManager) (*commonspire.WaitingSource, string, string, error) {
 	if !cfg.SpireEnabled {
 		return nil, cfg.MeshDomain, "", nil
 	}
-	// Open the SPIRE Workload API source for registrar mTLS and to resolve the
-	// edge's own identity (trust domain + SVID name). The Envoy fetches its SVID
-	// from SPIRE directly over the spire_agent SDS cluster, so the agent runs no
-	// SPIRE bridge — it only needs the names to program into the clusters.
-	spireSource, err := commonspire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
-	if err != nil {
-		return nil, "", "", err
+	// The Envoy fetches its own SVID from SPIRE directly over the spire_agent SDS
+	// cluster, so the edge control plane runs no SPIRE bridge — it only needs the
+	// names to program into the clusters, and it can learn them late.
+	src := commonspire.NewWaitingSource(cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l, commonspire.WithComponent(edgeSpireComponent))
+	if err := m.Add(src); err != nil {
+		return nil, "", "", fmt.Errorf("failed to add the SPIRE identity source: %w", err)
 	}
-	identityTrustDomain, err := commonspire.TrustDomainFromSource(spireSource)
-	if err != nil {
-		_ = spireSource.Close()
-		return nil, "", "", fmt.Errorf("failed to resolve SPIRE trust domain: %w", err)
+	// Load-bearing: the edge is behind a LoadBalancer Service, so past the dwell
+	// NotReady takes this replica out of the ingress endpoints rather than letting
+	// it advertise an edge whose upstreams have no identity.
+	if err := m.AddReadyzCheck(commonspire.ReadyCheckName, commonspire.ReadyChecker(src)); err != nil {
+		return nil, "", "", fmt.Errorf("failed to set up the SPIRE identity ready check: %w", err)
 	}
-	svid, err := spireSource.GetX509SVID()
-	if err != nil {
-		_ = spireSource.Close()
-		return nil, "", "", fmt.Errorf("failed to read edge SVID: %w", err)
+	l.InfoContext(ctx, "acquiring the edge's SVID in the background; startup does not wait for SPIRE",
+		"socket", cfg.SpireWorkloadSocketPath, "warnAfter", cfg.SpireWaitWarnAfter)
+	return src, cfg.MeshDomain, "", nil
+}
+
+// edgeIdentitySink is the slice of the snapshot cache wireEdgeIdentity writes to.
+type edgeIdentitySink interface {
+	UpdateEdgeIdentity(ctx context.Context, spiffeID, trustDomain string) error
+}
+
+// wireEdgeIdentity folds the edge's real identity into the snapshot cache once
+// SPIRE issues its first SVID, replacing the seeds resolveEdgeIdentity handed out.
+// It is a no-op when SPIRE is disabled and returns immediately otherwise: the work
+// happens in a goroutine that ends with ctx.
+//
+// UpdateEdgeIdentity recomputes the cached mTLS clusters and pushes a snapshot, so
+// the edge Envoy picks the identity up on the next CDS update rather than on a
+// restart — which is what makes acquiring it late acceptable in the first place.
+func wireEdgeIdentity(ctx context.Context, src *commonspire.WaitingSource, sink edgeIdentitySink) {
+	if src == nil {
+		return
 	}
-	edgeSpiffeID := svid.ID.String()
-	l.InfoContext(ctx, "resolved edge identity from SPIRE", "trustDomain", identityTrustDomain, "spiffeID", edgeSpiffeID)
-	return spireSource, identityTrustDomain, edgeSpiffeID, nil
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-src.Ready():
+		}
+
+		svid, err := src.GetX509SVID()
+		if err != nil {
+			l.WarnContext(ctx, "failed to read the edge SVID after SPIRE issued it", "error", err)
+			return
+		}
+		spiffeID, trustDomain := svid.ID.String(), svid.ID.TrustDomain().Name()
+		l.InfoContext(ctx, "resolved edge identity from SPIRE", "trustDomain", trustDomain, "spiffeID", spiffeID)
+		if trustDomain != cfg.MeshDomain {
+			// The seed everything else was wired from (xDS server, cluster SDS names)
+			// is the mesh domain; SPIRE issuing into a different one is a topology
+			// aether does not support (addressing and identity are one domain by
+			// design). Say so loudly rather than serving a half-updated edge.
+			l.WarnContext(ctx, "SPIRE issues into a different trust domain than the mesh domain",
+				"meshDomain", cfg.MeshDomain, "trustDomain", trustDomain)
+		}
+		if err := sink.UpdateEdgeIdentity(ctx, spiffeID, trustDomain); err != nil {
+			l.ErrorContext(ctx, "failed to apply the edge identity to the xDS snapshot", "error", err, "spiffeID", spiffeID)
+		}
+	}()
 }
 
 // configureEdgeSnapshotCache creates and configures the xDS snapshot cache for edge

--- a/agent/internal/cmd/edge_identity_test.go
+++ b/agent/internal/cmd/edge_identity_test.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	commonspire "aethermesh.dev/common/spire"
+	"aethermesh.dev/common/spire/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+// gatingAdder is startingAdder plus the readiness registry, which is what the
+// edge's identity wiring needs from the manager.
+type gatingAdder struct {
+	*startingAdder
+
+	mu     sync.Mutex
+	checks map[string]healthz.Checker
+}
+
+func newGatingAdder(ctx context.Context) *gatingAdder {
+	return &gatingAdder{startingAdder: &startingAdder{ctx: ctx}, checks: map[string]healthz.Checker{}}
+}
+
+func (g *gatingAdder) AddReadyzCheck(name string, check healthz.Checker) error {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.checks[name] = check
+	return nil
+}
+
+func (g *gatingAdder) check(name string) (healthz.Checker, bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	c, ok := g.checks[name]
+	return c, ok
+}
+
+// gatingAdder must satisfy exactly what the production wiring asks for.
+var _ edgeIdentityManager = (*gatingAdder)(nil)
+
+// recordingSink records the identity the edge folds into its snapshot cache,
+// standing in for the real SnapshotCache (whose UpdateEdgeIdentity recomputes the
+// mTLS clusters and pushes a snapshot).
+type recordingSink struct {
+	mu       sync.Mutex
+	calls    int
+	spiffeID string
+	td       string
+}
+
+func (s *recordingSink) UpdateEdgeIdentity(_ context.Context, spiffeID, trustDomain string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.spiffeID, s.td = spiffeID, trustDomain
+	return nil
+}
+
+func (s *recordingSink) get() (int, string, string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls, s.spiffeID, s.td
+}
+
+// TestResolveEdgeIdentityReturnsImmediately is the regression test for #740 at
+// the edge's call site. It used to block for up to 25s against an unreachable
+// Workload API and then EXIT THE PROCESS — on a north-south gateway, which means
+// ingress stayed down for the whole crash loop.
+//
+// The negative control is the code this replaces: commonspire.NewSource on the
+// same unreachable socket returns only after commonspire.SourceTimeout (25s).
+func TestResolveEdgeIdentityReturnsImmediately(t *testing.T) {
+	withSpireConfig(t, true, spiretest.UnservedSocket(t), slog.New(slog.DiscardHandler))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	m := newGatingAdder(ctx)
+
+	start := time.Now()
+	src, trustDomain, spiffeID, err := resolveEdgeIdentity(ctx, m)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "an unreachable Workload API must not fail startup")
+	require.NotNil(t, src)
+	t.Cleanup(func() { _ = src.Close() })
+	assert.Less(t, elapsed, 100*time.Millisecond, "startup must not wait for SPIRE")
+	assert.Equal(t, "aether.internal", trustDomain, "the trust domain is seeded with the mesh domain")
+	assert.Empty(t, spiffeID, "no identity is claimed before SPIRE issues one")
+	assert.Equal(t, 1, m.count(), "the identity source must be registered as a runnable")
+
+	// The readiness gate is registered and inside its dwell (warnAfter is a minute
+	// here), so a booting edge is Ready while it waits.
+	req, err := http.NewRequest(http.MethodGet, "/readyz", nil)
+	require.NoError(t, err)
+	check, ok := m.check(commonspire.ReadyCheckName)
+	require.True(t, ok, "the gate must be registered as %q", commonspire.ReadyCheckName)
+	assert.NoError(t, check(req), "a wait inside the dwell is a normal startup, not NotReady")
+
+	cancel()
+	select {
+	case runErr := <-m.done:
+		require.NoError(t, runErr, "the identity runnable must never fail the manager")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the identity runnable did not return after cancellation")
+	}
+}
+
+// TestResolveEdgeIdentityPastTheDwellIsNotReady is the other half of the gate: an
+// edge that never gets an identity stops advertising itself.
+func TestResolveEdgeIdentityPastTheDwellIsNotReady(t *testing.T) {
+	withSpireConfig(t, true, spiretest.UnservedSocket(t), slog.New(slog.DiscardHandler))
+	cfg.SpireWaitWarnAfter = time.Nanosecond // already elapsed when the check runs
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	m := newGatingAdder(ctx)
+
+	src, _, _, err := resolveEdgeIdentity(ctx, m)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	req, err := http.NewRequest(http.MethodGet, "/readyz", nil)
+	require.NoError(t, err)
+	check, ok := m.check(commonspire.ReadyCheckName)
+	require.True(t, ok)
+	checkErr := check(req)
+	require.Error(t, checkErr, "past the dwell the edge must leave the ingress Service's endpoints")
+	assert.Contains(t, checkErr.Error(), "no SPIRE SVID after")
+}
+
+// TestResolveEdgeIdentitySpireDisabled pins the #421 cleartext path: nothing is
+// registered, nothing is logged, and the seeds are exactly what they always were.
+func TestResolveEdgeIdentitySpireDisabled(t *testing.T) {
+	logs := &bytes.Buffer{}
+	withSpireConfig(t, false, "/nonexistent/workload.sock",
+		slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	m := newGatingAdder(t.Context())
+	src, trustDomain, spiffeID, err := resolveEdgeIdentity(t.Context(), m)
+
+	require.NoError(t, err)
+	assert.Nil(t, src, "SPIRE off must create no source at all")
+	assert.Equal(t, "aether.internal", trustDomain)
+	assert.Empty(t, spiffeID)
+	assert.Equal(t, 0, m.count(), "SPIRE off must register no runnable")
+	_, gated := m.check(commonspire.ReadyCheckName)
+	assert.False(t, gated, "with no identity to wait for the check must disappear entirely")
+	assert.Empty(t, logs.String(), "SPIRE off must log nothing")
+
+	// And the post-arrival half is a no-op with no source: a nil sink would panic.
+	wireEdgeIdentity(t.Context(), nil, nil)
+}
+
+// TestWireEdgeIdentityFoldsInTheSVID is the payoff: the edge starts with seeds,
+// and the moment the Workload API issues its SVID the real SPIFFE ID and trust
+// domain reach the snapshot cache — which recomputes the mTLS clusters and pushes
+// a snapshot, so no restart is needed.
+func TestWireEdgeIdentityFoldsInTheSVID(t *testing.T) {
+	const edgeID = "spiffe://" + spiretest.TrustDomain + "/ns/aether-ingress/sa/aether-edge"
+
+	wlapi, sock := spiretest.Start(t, edgeID)
+	withSpireConfig(t, true, sock, slog.New(slog.DiscardHandler))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	m := newGatingAdder(ctx)
+
+	src, _, _, err := resolveEdgeIdentity(ctx, m)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	sink := &recordingSink{}
+	wireEdgeIdentity(ctx, src, sink)
+
+	// Still refusing to attest: the cache keeps the seeds, so the edge serves
+	// clusters with no mTLS injection rather than clusters naming an identity it
+	// does not hold.
+	require.Eventually(t, func() bool { return wlapi.Fetches() >= 1 }, 30*time.Second, 10*time.Millisecond,
+		"the source must be attempting")
+	calls, _, _ := sink.get()
+	require.Equal(t, 0, calls, "no identity can be applied before SPIRE issues one")
+
+	wlapi.StartServing()
+
+	require.Eventually(t, func() bool {
+		calls, _, _ := sink.get()
+		return calls >= 1
+	}, 30*time.Second, 20*time.Millisecond, "the edge identity must be applied once the SVID lands")
+
+	calls, gotID, gotTD := sink.get()
+	assert.Equal(t, 1, calls, "the identity is applied once, not polled")
+	assert.Equal(t, edgeID, gotID)
+	assert.Equal(t, spiretest.TrustDomain, gotTD)
+	assert.Equal(t, int64(0), wlapi.BadHeaders(), "every call must carry the workload.spiffe.io header")
+}

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -553,7 +553,7 @@ func setupNodeGating(m ctrl.Manager, reasserter *cniconflist.Reasserter, spireSo
 	// cluster against spire-server's own rescheduling. See
 	// commonspire.NotReadyDwell. Nil (SPIRE disabled) registers no check at all.
 	if spireSource != nil {
-		if err := m.AddReadyzCheck("spire-svid", commonspire.ReadyChecker(spireSource)); err != nil {
+		if err := m.AddReadyzCheck(commonspire.ReadyCheckName, commonspire.ReadyChecker(spireSource)); err != nil {
 			return fmt.Errorf("failed to set up the SPIRE identity ready check: %w", err)
 		}
 	}
@@ -855,9 +855,10 @@ func setupRegistrarClient(ctx context.Context, src commonspire.SVIDSource) (regi
 		}
 		regCfg.DialOptions = []grpc.DialOption{grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg))}
 		// The SVID may not exist yet (#740): the watch loop defers instead of
-		// reporting stream failures it cannot do anything about. Sources that
-		// always hold one (the edge's, which is still created synchronously
-		// until PR 2) advertise no readiness and keep today's behaviour.
+		// reporting stream failures it cannot do anything about. Both callers —
+		// the node agent and the edge — now pass a WaitingSource, so both defer;
+		// a source that always holds an SVID advertises no readiness and keeps
+		// the pre-#740 behaviour.
 		if waiting, ok := src.(interface{ HasSVID() bool }); ok {
 			regCfg.IdentityReady = waiting.HasSVID
 		}

--- a/agent/internal/xds/cache/cache.go
+++ b/agent/internal/xds/cache/cache.go
@@ -17,6 +17,7 @@
 package cache
 
 import (
+	"context"
 	"log/slog"
 	"sync"
 	"time"
@@ -661,8 +662,8 @@ func (c *SnapshotCache) SetEdgeHTTPRedirect(enabled bool) {
 // SetEdgeIdentity records the edge proxy's single SVID name and trust domain so
 // the edge service clusters' upstream mTLS presents that identity and validates
 // the trust-domain bundle (served by SPIRE over the spire_agent SDS cluster).
-// The node proxy sets these via the SPIRE bridge instead. Must be called before
-// the manager starts.
+// The node proxy sets these via the SPIRE bridge instead. It is the pre-start
+// seed; UpdateEdgeIdentity is the after-start form.
 func (c *SnapshotCache) SetEdgeIdentity(spiffeID, trustDomain string) {
 	c.localMu.Lock()
 	c.nodeSpiffeID = spiffeID
@@ -672,6 +673,32 @@ func (c *SnapshotCache) SetEdgeIdentity(spiffeID, trustDomain string) {
 	// Rebuild the cached mTLS-injected clusters (usually a no-op here: the
 	// identity is set before the manager starts, ahead of any registry load).
 	c.recomputeMTLSClusters()
+}
+
+// UpdateEdgeIdentity is SetEdgeIdentity for an identity that arrives AFTER the
+// manager has started, which is the normal case once the edge stops blocking
+// startup on SPIRE (issue #740): it records the identity, rebuilds the cached
+// mTLS-injected clusters, and pushes a new snapshot so the edge Envoy picks the
+// change up on the next CDS update instead of on a restart. Unchanged input is a
+// no-op, so it is safe to call on every SVID rotation.
+//
+// It is the edge's counterpart to SetNodeIdentity, which does the same for the
+// node proxy when the SPIRE bridge delivers the node SVID.
+func (c *SnapshotCache) UpdateEdgeIdentity(ctx context.Context, spiffeID, trustDomain string) error {
+	c.localMu.Lock()
+	unchanged := c.nodeSpiffeID == spiffeID && c.trustDomain == trustDomain
+	if !unchanged {
+		c.nodeSpiffeID = spiffeID
+		c.trustDomain = trustDomain
+	}
+	c.localMu.Unlock()
+	if unchanged {
+		return nil
+	}
+
+	c.recomputeMTLSClusters()
+
+	return c.generateSnapshot(ctx)
 }
 
 // SetRegistry stores the service registry for use in HasRegistryService.

--- a/agent/internal/xds/cache/mtls_cache_test.go
+++ b/agent/internal/xds/cache/mtls_cache_test.go
@@ -215,6 +215,37 @@ func TestCachedMTLSClusterInvalidatedOnNodeIdentity(t *testing.T) {
 	assert.NotNil(t, echo.GetTransportSocket(), "SetNodeIdentity after the load must rebuild the cached cluster")
 }
 
+// TestUpdateEdgeIdentityAfterStart is the edge's counterpart, and the cache half
+// of issue #740: the edge no longer blocks startup on SPIRE, so its clusters are
+// loaded BEFORE it has an identity and are emitted bare. UpdateEdgeIdentity, called
+// when the SVID finally lands, must rebuild them and push a snapshot, so the edge
+// Envoy picks the identity up on the next CDS update instead of on a restart.
+func TestUpdateEdgeIdentityAfterStart(t *testing.T) {
+	c := newTestCache("edge-1")
+	ctx := context.Background()
+	ns := "default"
+
+	c.SetEdgeMode(8080)
+	// The seeds resolveEdgeIdentity hands out while SPIRE is still coming up.
+	c.SetEdgeIdentity("", "aether.internal")
+	c.SetStaticDependencies([]string{"aether-test/echo"})
+	require.NoError(t, c.LoadClustersFromRegistry(ctx, "cluster-1", "edge-1", echoRegistry(&ns)))
+
+	echo := snapshotEchoCluster(t, c, "edge-1")
+	assert.Nil(t, echo.GetTransportSocket(), "no upstream mTLS before the edge SVID exists")
+
+	require.NoError(t, c.UpdateEdgeIdentity(ctx, nodeIdentity, "aether.internal"))
+
+	echo = snapshotEchoCluster(t, c, "edge-1")
+	require.NotNil(t, echo.GetTransportSocket(), "a late edge identity must rebuild the cached cluster")
+
+	// Idempotent: an unchanged identity (every SVID rotation that keeps the same
+	// SPIFFE ID) is a no-op rather than another snapshot push.
+	before := c.version.Load()
+	require.NoError(t, c.UpdateEdgeIdentity(ctx, nodeIdentity, "aether.internal"))
+	assert.Equal(t, before, c.version.Load(), "an unchanged identity must not bump the snapshot version")
+}
+
 // TestCachedMTLSClusterInvalidatedOnSANNamespaceChange verifies the
 // sanNamespaces invalidation path: a registry reload whose endpoints moved to
 // a different namespace must re-render the pinned server identities on the

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.9"
+version: "0.92.10"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -93,10 +93,12 @@ spire:
     mountPath: /run/spire/admin-sockets
     socketName: admin.sock
   # How long a component may wait for SPIRE to issue its first SVID before the
-  # waiting log line escalates from INFO to WARN. On the agent this is ALSO the
-  # dwell before the spire-svid readiness check reports NotReady (issue #740):
-  # startup no longer dies when the Workload API is not serving yet, it waits and
-  # keeps /healthz and /readyz answering.
+  # waiting log line escalates from INFO to WARN. It is ALSO the dwell before the
+  # spire-svid readiness check reports NotReady, on all four components (issue
+  # #740): startup no longer dies when the Workload API is not serving yet, it
+  # waits and keeps /healthz and /readyz answering. Past the dwell an identity-less
+  # controller, registrar or edge replica leaves its Service's endpoints (the
+  # webhooks are failurePolicy: Ignore, so admission fails open meanwhile).
   #
   # NOTE: spire-server AND spire-agent must tolerate aether.io/agent-not-ready
   # (:NoSchedule). Past this dwell an identity-less node reports NotReady, and the

--- a/common/spire/BUILD.bazel
+++ b/common/spire/BUILD.bazel
@@ -29,16 +29,12 @@ go_test(
     ],
     embed = [":spire"],
     deps = [
-        "@com_github_spiffe_go_spiffe_v2//proto/spiffe/workload",
+        "//common/spire/spiretest",
         "@com_github_spiffe_go_spiffe_v2//spiffeid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_sdk_metric//:metric",
         "@io_opentelemetry_go_otel_sdk_metric//metricdata",
-        "@org_golang_google_grpc//:grpc",
-        "@org_golang_google_grpc//codes",
-        "@org_golang_google_grpc//metadata",
-        "@org_golang_google_grpc//status",
     ],
 )

--- a/common/spire/metrics.go
+++ b/common/spire/metrics.go
@@ -12,11 +12,16 @@ import (
 const waitMeterName = "aether/spire-identity"
 
 // waitSecondsBuckets are the explicit boundaries, in SECONDS, for
-// aether.agent.spire.wait_seconds. The OTel defaults are millisecond-oriented
+// aether.<component>.spire.wait_seconds. The OTel defaults are millisecond-oriented
 // (0, 5, 10, … 10000), which would put every wait short of 5s — the healthy
 // case — into one bucket and every outage into the next (#732). The interesting
 // range is one retry (1s) to well past the warn threshold (2m).
 var waitSecondsBuckets = []float64{0.5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600}
+
+// metricName builds this component's name for one of the wait instruments.
+func metricName(component, instrument string) string {
+	return fmt.Sprintf("aether.%s.spire.%s", component, instrument)
+}
 
 // waitMetrics instruments the wait for the first SVID. All methods are
 // nil-receiver-safe so the wait runs unchanged when instrument registration
@@ -28,22 +33,31 @@ type waitMetrics struct {
 	meter    metric.Meter
 }
 
-// newWaitMetrics registers the identity-wait instruments on the given meter.
-func newWaitMetrics(meter metric.Meter) (*waitMetrics, error) {
+// newWaitMetrics registers the identity-wait instruments on the given meter,
+// namespaced by the component that is waiting (aether.agent.spire.*,
+// aether.controller.spire.*, aether.registrar.spire.*, aether.edge.spire.*).
+//
+// The instruments are defined ONCE, here, and only their namespace varies: four
+// binaries wait for the same thing for the same reason, and an operator reading
+// one dashboard panel per component should be reading the same three series. The
+// namespace is per-component rather than a component ATTRIBUTE because these are
+// separate workloads with separate resource attributes, and #210's lesson is that
+// a fleet-collapsed counter makes rate() lie.
+func newWaitMetrics(meter metric.Meter, component string) (*waitMetrics, error) {
 	m := &waitMetrics{meter: meter}
 	var err error
 
-	if m.wait, err = meter.Float64Histogram("aether.agent.spire.wait_seconds",
+	if m.wait, err = meter.Float64Histogram(metricName(component, "wait_seconds"),
 		metric.WithDescription("Seconds from process start to the SPIRE Workload API issuing this workload's first SVID (recorded once, when it arrives)"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(waitSecondsBuckets...)); err != nil {
 		return nil, fmt.Errorf("spire wait seconds: %w", err)
 	}
-	if m.restarts, err = meter.Int64Counter("aether.agent.spire.source_restarts",
+	if m.restarts, err = meter.Int64Counter(metricName(component, "source_restarts"),
 		metric.WithDescription("Workload API sources that connected but could not serve an SVID and were re-created; expected to stay 0")); err != nil {
 		return nil, fmt.Errorf("spire source restarts: %w", err)
 	}
-	if m.ready, err = meter.Int64ObservableGauge("aether.agent.spire.svid_ready",
+	if m.ready, err = meter.Int64ObservableGauge(metricName(component, "svid_ready"),
 		metric.WithDescription("1 when this workload holds a SPIRE SVID, 0 while it is still waiting for its first one")); err != nil {
 		return nil, fmt.Errorf("spire svid ready: %w", err)
 	}

--- a/common/spire/spiretest/BUILD.bazel
+++ b/common/spire/spiretest/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "spiretest",
+    # keep: a fake Workload API server must never link into a production binary.
+    testonly = True,
+    srcs = ["fake.go"],
+    importpath = "aethermesh.dev/common/spire/spiretest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_spiffe_go_spiffe_v2//proto/spiffe/workload",
+        "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//metadata",
+        "@org_golang_google_grpc//status",
+    ],
+)

--- a/common/spire/spiretest/fake.go
+++ b/common/spire/spiretest/fake.go
@@ -1,0 +1,173 @@
+// Package spiretest provides a fake SPIRE Workload API server for tests.
+//
+// It exists so every binary that waits for an SVID (issue #740) can prove the
+// same two things hermetically, without a container or a real SPIRE agent: that
+// startup returns immediately while the Workload API is refusing to attest, and
+// that identity is folded in the moment it starts serving. The refusal is a
+// switch (StartServing) rather than a delay, because the window being reproduced
+// is exactly "the agent socket is there, but no identity has been issued yet".
+package spiretest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// TrustDomain is the trust domain of every SVID this package mints.
+const TrustDomain = "example.org"
+
+// FakeWorkloadAPI is a SPIRE Workload API server whose FetchX509SVID refuses to
+// serve — exactly as a SPIRE agent that is up but cannot attest the workload yet
+// — until StartServing is called.
+type FakeWorkloadAPI struct {
+	workload.UnimplementedSpiffeWorkloadAPIServer
+
+	spiffeID string
+	svid     *workload.X509SVID
+
+	serving   atomic.Bool
+	fetches   atomic.Int64
+	badHeader atomic.Int64
+}
+
+// StartServing makes the fake issue its SVID to every subsequent fetch.
+func (f *FakeWorkloadAPI) StartServing() { f.serving.Store(true) }
+
+// SpiffeID is the SPIFFE ID of the SVID this fake serves.
+func (f *FakeWorkloadAPI) SpiffeID() string { return f.spiffeID }
+
+// Fetches counts the FetchX509SVID calls received so far.
+func (f *FakeWorkloadAPI) Fetches() int64 { return f.fetches.Load() }
+
+// BadHeaders counts calls that arrived without the Workload API security header.
+// A real SPIRE agent rejects those, so a non-zero count means the client is
+// misconfigured.
+func (f *FakeWorkloadAPI) BadHeaders() int64 { return f.badHeader.Load() }
+
+// FetchX509SVID implements the Workload API.
+func (f *FakeWorkloadAPI) FetchX509SVID(_ *workload.X509SVIDRequest, stream grpc.ServerStreamingServer[workload.X509SVIDResponse]) error {
+	f.fetches.Add(1)
+
+	// The Workload API's security header. go-spiffe sets it on every call; a
+	// real SPIRE agent rejects calls without it, so the fake asserts it too.
+	md, _ := metadata.FromIncomingContext(stream.Context())
+	if values := md.Get("workload.spiffe.io"); len(values) != 1 || values[0] != "true" {
+		f.badHeader.Add(1)
+		return status.Error(codes.InvalidArgument, "missing workload.spiffe.io header")
+	}
+
+	if !f.serving.Load() {
+		return status.Error(codes.Unavailable, "no identity issued for this workload yet")
+	}
+	if err := stream.Send(&workload.X509SVIDResponse{Svids: []*workload.X509SVID{f.svid}}); err != nil {
+		return err
+	}
+	<-stream.Context().Done()
+	return nil
+}
+
+// Start serves a FakeWorkloadAPI carrying spiffeID on a temporary UDS and returns
+// it with the socket path. It is not serving yet: call StartServing to release
+// the SVID.
+//
+// os.MkdirTemp("") keeps the path inside the ~108-byte AF_UNIX budget, which a
+// Bazel sandbox path would blow (same reason as agent/internal/spire's fake SPIRE
+// agent).
+func Start(t *testing.T, spiffeID string) (*FakeWorkloadAPI, string) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "wlapi")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sock := filepath.Join(dir, "workload.sock")
+
+	lis, err := net.Listen("unix", sock)
+	require.NoError(t, err)
+
+	fake := &FakeWorkloadAPI{spiffeID: spiffeID, svid: NewWorkloadSVID(t, spiffeID)}
+	srv := grpc.NewServer()
+	workload.RegisterSpiffeWorkloadAPIServer(srv, fake)
+	go func() { _ = srv.Serve(lis) }()
+	t.Cleanup(srv.Stop)
+
+	return fake, sock
+}
+
+// UnservedSocket returns a path inside a temporary directory that nothing is
+// listening on: the "SPIRE is not there at all" half of the #740 matrix.
+func UnservedSocket(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "wlapi")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "absent.sock")
+}
+
+// NewWorkloadSVID mints a CA plus a leaf carrying the SPIFFE ID as its URI SAN
+// and marshals them the way the Workload API returns them (DER chain, PKCS#8
+// key, DER bundle), so go-spiffe's own parser accepts them.
+func NewWorkloadSVID(t *testing.T, id string) *workload.X509SVID {
+	t.Helper()
+
+	sid := spiffeid.RequireFromString(id)
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{Organization: []string{"SPIRE test CA"}},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	caCert, err := x509.ParseCertificate(caDER)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(2),
+		Subject:               pkix.Name{Organization: []string{"SPIRE test leaf"}},
+		URIs:                  []*url.URL{sid.URL()},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
+	require.NoError(t, err)
+
+	return &workload.X509SVID{
+		SpiffeId:    id,
+		X509Svid:    leafDER,
+		X509SvidKey: keyDER,
+		Bundle:      caDER,
+	}
+}

--- a/common/spire/tls.go
+++ b/common/spire/tls.go
@@ -7,6 +7,7 @@ package spire
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"time"
@@ -114,6 +115,33 @@ func ServerTLSConfig(src SVIDSource, trustDomain string) (*tls.Config, error) {
 		return nil, err
 	}
 	return tlsconfig.MTLSServerConfig(src, src, auth), nil
+}
+
+// ServerTLSConfigForOwnTrustDomain returns a mutual-TLS server config that
+// presents the workload SVID from src and authorizes peers belonging to src's
+// OWN trust domain — resolved at HANDSHAKE time, not at construction.
+//
+// It is the deferred form of ServerTLSConfig, for a src that may not hold an SVID
+// yet (a WaitingSource, issue #740). Nothing is lost by deferring: the peer
+// authorizer is only ever consulted after the server has presented a certificate,
+// and a server with no SVID cannot present one — GetCertificate returns
+// ErrNoSVIDYet and the handshake fails there. So until the SVID lands this config
+// authorizes NOTHING, and once it lands the trust domain it authorizes against is
+// the one SPIRE actually issued into, re-read on every handshake and therefore
+// still correct after a rotation. That is strictly more accurate than resolving
+// the trust domain once at startup, which is what forced the process to own an
+// SVID before it could serve at all.
+func ServerTLSConfigForOwnTrustDomain(src SVIDSource) *tls.Config {
+	auth := func(peer spiffeid.ID, verifiedChains [][]*x509.Certificate) error {
+		svid, err := src.GetX509SVID()
+		if err != nil {
+			// Unreachable through a completed handshake (see above); returning the
+			// error rather than authorizing keeps the failure closed if it ever is.
+			return fmt.Errorf("cannot authorize peer %s without this workload's own SVID: %w", peer, err)
+		}
+		return tlsconfig.AuthorizeMemberOf(svid.ID.TrustDomain())(peer, verifiedChains)
+	}
+	return tlsconfig.MTLSServerConfig(src, src, auth)
 }
 
 // WebhookServerCert returns a tls.Config mutator (suitable for

--- a/common/spire/waiting.go
+++ b/common/spire/waiting.go
@@ -93,17 +93,48 @@ type WaitingSource struct {
 	src *Source
 }
 
+// DefaultComponent is the component name a WaitingSource is namespaced under
+// when the caller passes no WithComponent: the node agent, which is where the
+// wait shipped first (#741) and whose metric names are already on dashboards.
+const DefaultComponent = "agent"
+
+// WaitOption customises a WaitingSource. It exists so the four binaries that
+// wait for an SVID share one implementation and one set of log lines while
+// still reporting under their own names.
+type WaitOption func(*waitOptions)
+
+type waitOptions struct {
+	component string
+}
+
+// WithComponent names the binary doing the waiting ("agent", "controller",
+// "registrar", "edge"). It selects the metric namespace —
+// aether.<component>.spire.wait_seconds and friends — so a wait can be attributed
+// to the workload that is stuck without the instruments being redefined per
+// binary. An empty name keeps DefaultComponent.
+func WithComponent(component string) WaitOption {
+	return func(o *waitOptions) {
+		if component != "" {
+			o.component = component
+		}
+	}
+}
+
 // NewWaitingSource returns a WaitingSource for the Workload API at socketPath.
 // warnAfter is how long the wait stays at INFO before escalating to WARN (and
 // the readiness dwell); a non-positive value means DefaultWaitWarnAfter.
 // Nothing is dialled until Start runs.
-func NewWaitingSource(socketPath string, warnAfter time.Duration, log *slog.Logger) *WaitingSource {
+func NewWaitingSource(socketPath string, warnAfter time.Duration, log *slog.Logger, opts ...WaitOption) *WaitingSource {
 	if warnAfter <= 0 {
 		warnAfter = DefaultWaitWarnAfter
 	}
+	o := &waitOptions{component: DefaultComponent}
+	for _, opt := range opts {
+		opt(o)
+	}
 	// Instruments ride the global MeterProvider (no-op unless --otel-enabled); a
 	// registration failure only disables instrumentation, never the wait.
-	metrics, err := newWaitMetrics(otel.Meter(waitMeterName))
+	metrics, err := newWaitMetrics(otel.Meter(waitMeterName), o.component)
 	if err != nil {
 		log.Error("failed to create SPIRE wait metrics; continuing without instrumentation", "error", err)
 	}
@@ -324,6 +355,11 @@ func (w *WaitingSource) source() (*Source, error) {
 // genuine outage still escalates to NotReady, which is what an operator wants:
 // no new pods scheduled onto a node that cannot give them an identity.
 const NotReadyDwell = DefaultWaitWarnAfter
+
+// ReadyCheckName is the /readyz check name every binary registers its identity
+// gate under, so `readyz?verbose` reads the same on an agent, the controller, the
+// registrar and the edge — and one runbook line covers all four.
+const ReadyCheckName = "spire-svid"
 
 // ReadyChecker returns a readiness check (assignable to controller-runtime's
 // healthz.Checker) that fails once this workload has been waiting for its first

--- a/common/spire/waiting_test.go
+++ b/common/spire/waiting_test.go
@@ -3,149 +3,28 @@ package spire
 import (
 	"bytes"
 	"context"
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/json"
 	"log/slog"
-	"math/big"
-	"net"
 	"net/http"
-	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/spiffe/go-spiffe/v2/proto/spiffe/workload"
+	"aethermesh.dev/common/spire/spiretest"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
-const testTrustDomain = "example.org"
+// testTrustDomain is the trust domain spiretest mints SVIDs in.
+const testTrustDomain = spiretest.TrustDomain
 
-// fakeWorkloadAPI is a SPIRE Workload API server whose FetchX509SVID refuses to
-// serve — exactly as a SPIRE agent that is up but cannot attest the workload yet
-// — until startServing is called. That switch is the whole point: it reproduces
-// the boot-time window in issue #740 without a container.
-type fakeWorkloadAPI struct {
-	workload.UnimplementedSpiffeWorkloadAPIServer
-
-	svid *workload.X509SVID
-
-	serving   atomic.Bool
-	fetches   atomic.Int64
-	badHeader atomic.Int64
-}
-
-func (f *fakeWorkloadAPI) startServing() { f.serving.Store(true) }
-
-func (f *fakeWorkloadAPI) FetchX509SVID(_ *workload.X509SVIDRequest, stream grpc.ServerStreamingServer[workload.X509SVIDResponse]) error {
-	f.fetches.Add(1)
-
-	// The Workload API's security header. go-spiffe sets it on every call; a
-	// real SPIRE agent rejects calls without it, so the fake asserts it too.
-	md, _ := metadata.FromIncomingContext(stream.Context())
-	if values := md.Get("workload.spiffe.io"); len(values) != 1 || values[0] != "true" {
-		f.badHeader.Add(1)
-		return status.Error(codes.InvalidArgument, "missing workload.spiffe.io header")
-	}
-
-	if !f.serving.Load() {
-		return status.Error(codes.Unavailable, "no identity issued for this workload yet")
-	}
-	if err := stream.Send(&workload.X509SVIDResponse{Svids: []*workload.X509SVID{f.svid}}); err != nil {
-		return err
-	}
-	<-stream.Context().Done()
-	return nil
-}
-
-// startFakeWorkloadAPI serves a fakeWorkloadAPI on a temporary UDS and returns
-// it with the socket path. os.MkdirTemp("") keeps the path inside the ~108-byte
-// AF_UNIX budget, which a Bazel sandbox path would blow (same reason as
-// agent/internal/spire's fake SPIRE agent).
-func startFakeWorkloadAPI(t *testing.T) (*fakeWorkloadAPI, string) {
-	t.Helper()
-
-	dir, err := os.MkdirTemp("", "wlapi")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-	sock := filepath.Join(dir, "workload.sock")
-
-	lis, err := net.Listen("unix", sock)
-	require.NoError(t, err)
-
-	fake := &fakeWorkloadAPI{svid: newWorkloadSVID(t, "spiffe://"+testTrustDomain+"/ns/aether-system/sa/aether-agent")}
-	srv := grpc.NewServer()
-	workload.RegisterSpiffeWorkloadAPIServer(srv, fake)
-	go func() { _ = srv.Serve(lis) }()
-	t.Cleanup(srv.Stop)
-
-	return fake, sock
-}
-
-// newWorkloadSVID mints a CA plus a leaf carrying the SPIFFE ID as its URI SAN
-// and marshals them the way the Workload API returns them (DER chain, PKCS#8
-// key, DER bundle), so go-spiffe's own parser accepts them.
-func newWorkloadSVID(t *testing.T, id string) *workload.X509SVID {
-	t.Helper()
-
-	sid := spiffeid.RequireFromString(id)
-
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	caTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{Organization: []string{"SPIRE test CA"}},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
-		IsCA:                  true,
-		BasicConstraintsValid: true,
-	}
-	caDER, err := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
-	require.NoError(t, err)
-	caCert, err := x509.ParseCertificate(caDER)
-	require.NoError(t, err)
-
-	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	leafTmpl := &x509.Certificate{
-		SerialNumber:          big.NewInt(2),
-		Subject:               pkix.Name{Organization: []string{"SPIRE test leaf"}},
-		URIs:                  []*url.URL{sid.URL()},
-		NotBefore:             time.Now().Add(-time.Hour),
-		NotAfter:              time.Now().Add(time.Hour),
-		KeyUsage:              x509.KeyUsageDigitalSignature,
-		BasicConstraintsValid: true,
-	}
-	leafDER, err := x509.CreateCertificate(rand.Reader, leafTmpl, caCert, &leafKey.PublicKey, caKey)
-	require.NoError(t, err)
-
-	keyDER, err := x509.MarshalPKCS8PrivateKey(leafKey)
-	require.NoError(t, err)
-
-	return &workload.X509SVID{
-		SpiffeId:    id,
-		X509Svid:    leafDER,
-		X509SvidKey: keyDER,
-		Bundle:      caDER,
-	}
-}
+// testSpiffeID is the workload identity the fake Workload API issues.
+const testSpiffeID = "spiffe://" + testTrustDomain + "/ns/aether-system/sa/aether-agent"
 
 // newTestWaitingSource builds a WaitingSource with the retry policy compressed
 // so a test can watch several attempts go by, plus a recorder for its logs.
@@ -214,11 +93,7 @@ func (b *lockedBuffer) waitingLines(t *testing.T) []map[string]any {
 // the process.
 func TestWaitingSourceIsNeverFatal(t *testing.T) {
 	// A path nobody is serving: attempts fail, forever.
-	dir, err := os.MkdirTemp("", "wlapi")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
-	w, logs := newTestWaitingSource(t, filepath.Join(dir, "absent.sock"), time.Hour)
+	w, logs := newTestWaitingSource(t, spiretest.UnservedSocket(t), time.Hour)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	done := make(chan error, 1)
@@ -262,12 +137,8 @@ func TestWaitingSourceIsNeverFatal(t *testing.T) {
 // --spire-wait-warn-after the same line is logged at WARN, so a wait that has
 // stopped being a normal boot is loud without ever being fatal.
 func TestWaitingSourceEscalatesToWarn(t *testing.T) {
-	dir, err := os.MkdirTemp("", "wlapi")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
-
 	// Warn immediately: every line must be WARN.
-	w, logs := newTestWaitingSource(t, filepath.Join(dir, "absent.sock"), time.Nanosecond)
+	w, logs := newTestWaitingSource(t, spiretest.UnservedSocket(t), time.Nanosecond)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
@@ -289,7 +160,7 @@ func TestWaitingSourceEscalatesToWarn(t *testing.T) {
 func TestWaitingSourceBecomesReadyWhenSPIREArrives(t *testing.T) {
 	reader := installTestMeterProvider(t)
 
-	fake, sock := startFakeWorkloadAPI(t)
+	fake, sock := spiretest.Start(t, testSpiffeID)
 	w, logs := newTestWaitingSource(t, sock, time.Hour)
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -298,16 +169,16 @@ func TestWaitingSourceBecomesReadyWhenSPIREArrives(t *testing.T) {
 
 	// Still refusing to attest: the source waits and serves ErrNoSVIDYet.
 	require.Eventually(t, func() bool {
-		return fake.fetches.Load() >= 1
+		return fake.Fetches() >= 1
 	}, 30*time.Second, 10*time.Millisecond, "the source must be attempting; logs:\n%s", logs.String())
 	require.False(t, w.HasSVID())
 	_, err := w.GetX509SVID()
 	require.ErrorIs(t, err, ErrNoSVIDYet)
-	require.Equal(t, int64(0), fake.badHeader.Load(), "every call must carry the workload.spiffe.io header")
+	require.Equal(t, int64(0), fake.BadHeaders(), "every call must carry the workload.spiffe.io header")
 	require.Equal(t, int64(0), metricSum(t, reader, "aether.agent.spire.source_restarts"))
 	require.Equal(t, int64(0), gaugeValue(t, reader, "aether.agent.spire.svid_ready"))
 
-	fake.startServing()
+	fake.StartServing()
 
 	select {
 	case <-w.Ready():
@@ -345,6 +216,44 @@ func TestWaitingSourceBecomesReadyWhenSPIREArrives(t *testing.T) {
 	ready := findRecord(logs.records(t), "obtained this workload's SVID from the SPIRE Workload API")
 	require.NotNil(t, ready, "the arrival must be announced; logs:\n%s", logs.String())
 	assert.Equal(t, testTrustDomain, ready["trustDomain"])
+}
+
+// TestWaitingSourceComponentNamespacesItsMetrics pins the one thing that differs
+// between the four binaries that wait for an SVID (issue #740): the metric
+// namespace. The instruments themselves are defined once, so a per-component
+// dashboard panel reads the same three series everywhere, and a wait can still be
+// attributed to the workload that is stuck rather than collapsed across the fleet.
+func TestWaitingSourceComponentNamespacesItsMetrics(t *testing.T) {
+	reader := installTestMeterProvider(t)
+
+	fake, sock := spiretest.Start(t, testSpiffeID)
+	w := NewWaitingSource(sock, time.Hour, slog.New(slog.DiscardHandler), WithComponent("registrar"))
+	w.attemptTimeout = 500 * time.Millisecond
+	w.backoffInitial = 10 * time.Millisecond
+	w.backoffMax = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = w.Start(ctx) }()
+
+	fake.StartServing()
+	select {
+	case <-w.Ready():
+	case <-time.After(30 * time.Second):
+		t.Fatal("the source never became ready")
+	}
+
+	require.Equal(t, uint64(1), histogramCount(t, reader, "aether.registrar.spire.wait_seconds"))
+	require.Equal(t, int64(1), gaugeValue(t, reader, "aether.registrar.spire.svid_ready"))
+	assert.Nil(t, collect(t, reader, "aether.agent.spire.wait_seconds"),
+		"a registrar's wait must not land in the agent's series")
+
+	// An empty component keeps the default, so the agent's existing series — the
+	// ones already on dashboards — cannot be renamed by accident.
+	assert.Equal(t, "aether.agent.spire.wait_seconds", metricName(DefaultComponent, "wait_seconds"))
+	o := &waitOptions{component: DefaultComponent}
+	WithComponent("")(o)
+	assert.Equal(t, DefaultComponent, o.component)
 }
 
 // TestWaitingSourceErrNoSVIDYet pins the pre-identity contract every consumer

--- a/controller/internal/cmd/BUILD.bazel
+++ b/controller/internal/cmd/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
         "@io_k8s_sigs_controller_runtime//pkg/webhook",
         "@io_k8s_sigs_controller_runtime//pkg/webhook/admission",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
@@ -33,7 +34,17 @@ go_library(
 
 go_test(
     name = "cmd_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "spire_identity_test.go",
+    ],
     embed = [":cmd"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "//common/spire",
+        "//common/spire/spiretest",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
+    ],
 )

--- a/controller/internal/cmd/root.go
+++ b/controller/internal/cmd/root.go
@@ -38,12 +38,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const name = "aether-controller"
+
+// spireComponent namespaces this binary's SPIRE identity-wait metrics
+// (aether.controller.spire.wait_seconds and friends).
+const spireComponent = "controller"
+
+// readyzAdder is the one thing wireSpireReadiness needs from the manager. A
+// narrow interface rather than ctrl.Manager keeps the readiness table testable
+// without an apiserver.
+type readyzAdder interface {
+	AddReadyzCheck(name string, check healthz.Checker) error
+}
 
 // Version is set at build time via -ldflags (Bazel x_defs).
 var Version = "dev"
@@ -119,6 +131,10 @@ func runController(ctx context.Context) (retErr error) {
 
 	m := result.Manager
 
+	if err = wireSpireReadiness(m, spireSource); err != nil {
+		return err
+	}
+
 	// The controller's own namespace holds the canonical (fallback) MeshConfig that
 	// other namespaces inherit from unless they set their own.
 	fallbackNamespace := currentNamespace()
@@ -168,10 +184,26 @@ func runController(ctx context.Context) (retErr error) {
 }
 
 // buildControllerBootstrapOpts builds the manager scheme and SPIRE webhook options.
-// When SPIRE is enabled, it opens the Workload API source and configures the webhook
-// to serve with an X.509 SVID; otherwise the default Helm-provisioned cert is used.
-// The caller is responsible for closing the returned spireSource.
-func buildControllerBootstrapOpts(ctx context.Context) (*spire.Source, []func(*ctrl.Options), error) {
+// When SPIRE is enabled it starts acquiring the Workload API source in the
+// background and configures the webhook to serve with the X.509 SVID; otherwise
+// the default Helm-provisioned cert is used. The caller is responsible for closing
+// the returned spireSource.
+//
+// This is the EARLIEST SPIRE call site of the four (issue #740): it runs before
+// manager.Bootstrap, because the webhook server is built from the options it
+// returns. It used to be a blocking, fatal 25s wait for the first SVID, which made
+// a cold boot — SPIRE server and controller starting together — exit the process
+// with "failed to open SPIRE Workload API source: context deadline exceeded" and
+// crash-loop until SPIRE won the race.
+//
+// Nothing here needs the SVID at construction time: WebhookServerCert installs
+// tls.Config.GetCertificate, which is consulted per HANDSHAKE, so a source that is
+// still waiting fails individual TLS handshakes instead of the process. Both
+// webhook configurations are failurePolicy: Ignore, so the apiserver fails OPEN
+// for the duration — admission proceeds unvalidated and un-mutated, which is what
+// it already did while the container was crash-looping, only now the controller is
+// alive to start serving the moment the SVID lands.
+func buildControllerBootstrapOpts(ctx context.Context) (*spire.WaitingSource, []func(*ctrl.Options), error) {
 	// Manager scheme = client-go built-ins + the typed MeshConfig CRD, so the
 	// reconciler and webhook work against the typed object (no unstructured).
 	scheme := runtime.NewScheme()
@@ -196,17 +228,38 @@ func buildControllerBootstrapOpts(ctx context.Context) (*spire.Source, []func(*c
 	if !cfg.SpireEnabled {
 		return nil, bootstrapOpts, nil
 	}
-	src, srcErr := spire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
-	if srcErr != nil {
-		return nil, nil, fmt.Errorf("failed to open SPIRE Workload API source: %w", srcErr)
-	}
+	src := spire.NewWaitingSource(cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l, spire.WithComponent(spireComponent))
+	// There is no manager to register the runnable with yet — the manager is built
+	// FROM these options — so the acquisition runs on the command context, which
+	// SIGTERM cancels exactly as it does the manager's.
+	go func() { _ = src.Start(ctx) }()
 	bootstrapOpts = append(bootstrapOpts, func(o *ctrl.Options) {
 		o.WebhookServer = webhook.NewServer(webhook.Options{
 			TLSOpts: []func(*tls.Config){spire.WebhookServerCert(src)},
 		})
 	})
-	l.InfoContext(ctx, "webhook serving with SPIRE SVID", "socket", cfg.SpireWorkloadSocketPath)
+	l.InfoContext(ctx, "webhook will serve with the SPIRE SVID; startup does not wait for SPIRE",
+		"socket", cfg.SpireWorkloadSocketPath, "warnAfter", cfg.SpireWaitWarnAfter)
 	return src, bootstrapOpts, nil
+}
+
+// wireSpireReadiness registers the identity half of the controller's readiness
+// (issue #740). It is load-bearing here in a way it is not for a DaemonSet: the
+// controller is behind a Service, so NotReady removes this replica from the
+// webhook Service's endpoints — the apiserver stops routing admission to a replica
+// that cannot complete a TLS handshake and (failurePolicy: Ignore) fails open
+// immediately instead of waiting out its 10s webhook timeout on every request.
+//
+// The dwell is commonspire.NotReadyDwell, the same 2m the agent uses, for the same
+// reason: a routine cold boot must not produce NotReady churn.
+func wireSpireReadiness(m readyzAdder, src *spire.WaitingSource) error {
+	if src == nil {
+		return nil // --spire-enabled=false: no identity to wait for, no check
+	}
+	if err := m.AddReadyzCheck(spire.ReadyCheckName, spire.ReadyChecker(src)); err != nil {
+		return fmt.Errorf("failed to set up the SPIRE identity ready check: %w", err)
+	}
+	return nil
 }
 
 // wireNodeTaintGuard registers the leader-elected node-taint guard, which
@@ -231,8 +284,12 @@ func wireNodeTaintGuard(m ctrl.Manager, agentNamespace string) error {
 // In SPIRE mode the webhook presents an SVID, so the apiserver must trust the
 // SPIRE CA: keep the ValidatingWebhookConfiguration caBundle in sync with the
 // rotating trust bundle.
-func wireCABundleInjector(m ctrl.Manager, spireSource *spire.Source) error {
-	if !cfg.SpireEnabled {
+//
+// The source may not hold an SVID yet (issue #740). The injector handles that by
+// deferring: it logs the first attempt at INFO and injects on the Updated() wake
+// that WaitingSource fires the moment the SVID lands.
+func wireCABundleInjector(m ctrl.Manager, spireSource *spire.WaitingSource) error {
+	if !cfg.SpireEnabled || spireSource == nil {
 		return nil
 	}
 	injector := &meshconfig.CABundleInjector{

--- a/controller/internal/cmd/spire_identity_test.go
+++ b/controller/internal/cmd/spire_identity_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"aethermesh.dev/common/spire"
+	"aethermesh.dev/common/spire/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+// recordingReadyz stands in for the controller-runtime manager's readiness
+// registry, so the readiness table can be exercised without an apiserver.
+type recordingReadyz struct {
+	checks map[string]healthz.Checker
+}
+
+func newRecordingReadyz() *recordingReadyz {
+	return &recordingReadyz{checks: map[string]healthz.Checker{}}
+}
+
+func (r *recordingReadyz) AddReadyzCheck(name string, check healthz.Checker) error {
+	r.checks[name] = check
+	return nil
+}
+
+// withSpireConfig sets the SPIRE-related globals for one test and restores them.
+func withSpireConfig(t *testing.T, enabled bool, socket string, warnAfter time.Duration, logger *slog.Logger) {
+	t.Helper()
+
+	prevEnabled, prevSocket, prevWarn, prevLog := cfg.SpireEnabled, cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l
+	t.Cleanup(func() {
+		cfg.SpireEnabled, cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l = prevEnabled, prevSocket, prevWarn, prevLog
+	})
+
+	cfg.SpireEnabled = enabled
+	cfg.SpireWorkloadSocketPath = socket
+	cfg.SpireWaitWarnAfter = warnAfter
+	l = logger
+}
+
+// TestBuildControllerBootstrapOptsReturnsImmediately is the regression test for
+// #740 at the controller's call site — the earliest SPIRE call of the four,
+// because it runs BEFORE manager.Bootstrap to build the webhook server. It used
+// to block for up to 25s against an unreachable Workload API and then exit the
+// process, so the controller was crash-looping through exactly the boot window in
+// which the apiserver needed it.
+//
+// The negative control is the code this replaces: spire.NewSource on the same
+// unreachable socket returns only after spire.SourceTimeout (25s) and with an
+// error that the caller turned into a process exit.
+func TestBuildControllerBootstrapOptsReturnsImmediately(t *testing.T) {
+	withSpireConfig(t, true, spiretest.UnservedSocket(t), time.Minute, slog.New(slog.DiscardHandler))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	start := time.Now()
+	src, opts, err := buildControllerBootstrapOpts(ctx)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "an unreachable Workload API must not fail startup")
+	require.NotNil(t, src)
+	t.Cleanup(func() { _ = src.Close() })
+	assert.Less(t, elapsed, 100*time.Millisecond, "startup must not wait for SPIRE")
+	assert.False(t, src.HasSVID(), "no SVID can exist against a socket nobody serves")
+
+	// The webhook server option is still installed: the certificate is resolved per
+	// handshake (GetCertificate), so a source that is still waiting fails individual
+	// handshakes — and the apiserver fails open, failurePolicy: Ignore — instead of
+	// failing the process.
+	require.Len(t, opts, 2, "scheme + webhook server options")
+	o := &ctrl.Options{}
+	opts[1](o)
+	assert.NotNil(t, o.WebhookServer, "the webhook must be wired to serve with the SPIRE SVID")
+}
+
+// TestBuildControllerBootstrapOptsSpireDisabled pins the #421 path: with
+// --spire-enabled=false there is no source, no log line and no webhook override —
+// controller-runtime serves from the Helm-provisioned cert exactly as before.
+func TestBuildControllerBootstrapOptsSpireDisabled(t *testing.T) {
+	logs := &bytes.Buffer{}
+	withSpireConfig(t, false, "/nonexistent/workload.sock", time.Minute,
+		slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	src, opts, err := buildControllerBootstrapOpts(t.Context())
+
+	require.NoError(t, err)
+	assert.Nil(t, src, "SPIRE off must create no source at all")
+	assert.Len(t, opts, 1, "SPIRE off must add no webhook server option")
+	assert.Empty(t, logs.String(), "SPIRE off must log nothing")
+}
+
+// TestWireSpireReadiness is the controller's readiness table. The gate is
+// load-bearing here in a way it is not on a DaemonSet: NotReady removes this
+// replica from the webhook Service's endpoints.
+func TestWireSpireReadiness(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "/readyz", nil)
+	require.NoError(t, err)
+
+	t.Run("SPIRE disabled registers no check", func(t *testing.T) {
+		readyz := newRecordingReadyz()
+		require.NoError(t, wireSpireReadiness(readyz, nil))
+		assert.Empty(t, readyz.checks, "with no identity to wait for the check must disappear entirely")
+	})
+
+	t.Run("inside the dwell the gate passes", func(t *testing.T) {
+		readyz := newRecordingReadyz()
+		src := spire.NewWaitingSource(spiretest.UnservedSocket(t), time.Hour, slog.New(slog.DiscardHandler))
+		require.NoError(t, wireSpireReadiness(readyz, src))
+
+		check, ok := readyz.checks[spire.ReadyCheckName]
+		require.True(t, ok, "the gate must be registered as %q", spire.ReadyCheckName)
+		assert.NoError(t, check(req), "a wait inside the dwell is a normal startup, not NotReady")
+	})
+
+	t.Run("past the dwell the gate fails", func(t *testing.T) {
+		readyz := newRecordingReadyz()
+		// A dwell of one nanosecond has already elapsed by the time the check runs.
+		src := spire.NewWaitingSource(spiretest.UnservedSocket(t), time.Nanosecond, slog.New(slog.DiscardHandler))
+		require.NoError(t, wireSpireReadiness(readyz, src))
+
+		err := readyz.checks[spire.ReadyCheckName](req)
+		require.Error(t, err, "past the dwell the replica must leave the webhook Service's endpoints")
+		assert.Contains(t, err.Error(), "no SPIRE SVID after")
+	})
+}

--- a/controller/internal/meshconfig/BUILD.bazel
+++ b/controller/internal/meshconfig/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
 go_test(
     name = "meshconfig_test",
     srcs = [
+        "cabundle_test.go",
         "meshconfig_test.go",
         "reconciler_test.go",
     ],
@@ -42,10 +43,15 @@ go_test(
         "//api/aether/config/v1:config",
         "//common/apis/config/v1:config",
         "//common/config",
+        "//common/spire",
+        "//common/spire/spiretest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_api//admissionregistration/v1:admissionregistration",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
         "@io_k8s_apimachinery//pkg/runtime",
+        "@io_k8s_apimachinery//pkg/types",
+        "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_sigs_controller_runtime//pkg/client",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake",
         "@org_golang_google_protobuf//proto",

--- a/controller/internal/meshconfig/cabundle.go
+++ b/controller/internal/meshconfig/cabundle.go
@@ -3,6 +3,7 @@ package meshconfig
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -18,8 +19,13 @@ import (
 // bundle into the ValidatingWebhookConfiguration on startup and on every SVID
 // rotation. It runs on the leader only (a cluster-wide single writer).
 type CABundleInjector struct {
-	Client            client.Client
-	Source            *spire.Source
+	Client client.Client
+	// Source is this workload's SVID source. It is the narrow SVIDSource interface
+	// rather than a *spire.Source because the controller's source may still be
+	// waiting for its first SVID when this runnable starts (issue #740): the
+	// initial injection is then deferred (INFO, not ERROR) and performed on the
+	// Updated() wake that WaitingSource fires when the SVID lands.
+	Source            spire.SVIDSource
 	WebhookConfigName string
 	// MutatingWebhookConfigName is the pod-ndots MutatingWebhookConfiguration to
 	// keep in sync too; empty skips it.
@@ -34,9 +40,20 @@ func (i *CABundleInjector) NeedLeaderElection() bool { return true }
 // reports a rotation, until the context is cancelled.
 func (i *CABundleInjector) Start(ctx context.Context) error {
 	if err := i.inject(ctx); err != nil {
-		// Don't fail startup: failurePolicy=Ignore means an un-injected webhook
-		// fails open, and the next rotation tick retries.
-		i.Log.ErrorContext(ctx, "initial webhook caBundle injection failed", "error", err)
+		if errors.Is(err, spire.ErrNoSVIDYet) {
+			// Not a failure, and not something an operator can act on: SPIRE has not
+			// issued this workload's first SVID yet, so there is no trust bundle to
+			// inject (issue #740). The wait itself is announced, once per attempt, by
+			// the identity source. WaitingSource fires Updated() when the first SVID
+			// LANDS as well as on every rotation after it, so the loop below performs
+			// the initial injection — no polling, no retry logic here.
+			i.Log.InfoContext(ctx, "webhook caBundle injection deferred until this workload has an SVID",
+				"webhookConfig", i.WebhookConfigName)
+		} else {
+			// Don't fail startup: failurePolicy=Ignore means an un-injected webhook
+			// fails open, and the next rotation tick retries.
+			i.Log.ErrorContext(ctx, "initial webhook caBundle injection failed", "error", err)
+		}
 	}
 	for {
 		select {

--- a/controller/internal/meshconfig/cabundle_test.go
+++ b/controller/internal/meshconfig/cabundle_test.go
@@ -1,0 +1,159 @@
+package meshconfig
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"aethermesh.dev/common/spire"
+	"aethermesh.dev/common/spire/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	testWebhookConfigName = "aether-validating-webhook"
+	testSpiffeID          = "spiffe://" + spiretest.TrustDomain + "/ns/aether-system/sa/aether-controller"
+)
+
+// lockedBuffer is a concurrency-safe log sink: the injector logs from its own
+// goroutine while the test reads.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// records returns the JSON log records emitted so far.
+func (b *lockedBuffer) records(t *testing.T) []map[string]any {
+	t.Helper()
+
+	var out []map[string]any
+	for line := range strings.SplitSeq(strings.TrimSpace(b.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &rec), "log line is not JSON: %s", line)
+		out = append(out, rec)
+	}
+	return out
+}
+
+// level returns the level a message was logged at, or "" if it was not logged.
+func (b *lockedBuffer) level(t *testing.T, msg string) string {
+	t.Helper()
+
+	for _, rec := range b.records(t) {
+		if rec["msg"] == msg {
+			level, _ := rec["level"].(string)
+			return level
+		}
+	}
+	return ""
+}
+
+// newWebhookClient returns a fake client holding an un-injected
+// ValidatingWebhookConfiguration.
+func newWebhookClient(t *testing.T) client.Client {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(&admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: testWebhookConfigName},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:                    "meshconfig.aether.io",
+			SideEffects:             ptr(admissionregistrationv1.SideEffectClassNone),
+			AdmissionReviewVersions: []string{"v1"},
+		}},
+	}).Build()
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// caBundle reads the caBundle currently on the webhook configuration.
+func caBundle(t *testing.T, c client.Client) []byte {
+	t.Helper()
+
+	var vwc admissionregistrationv1.ValidatingWebhookConfiguration
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: testWebhookConfigName}, &vwc))
+	return vwc.Webhooks[0].ClientConfig.CABundle
+}
+
+// TestCABundleInjectorDefersUntilTheSVIDArrives is the controller half of #740:
+// the injector starts before SPIRE has issued this workload's first SVID, must
+// say so at INFO rather than ERROR (there is nothing an operator can do, and the
+// webhook fails open meanwhile), and must inject the bundle on the Updated() wake
+// that WaitingSource fires when the SVID lands — without any retry logic of its
+// own.
+func TestCABundleInjectorDefersUntilTheSVIDArrives(t *testing.T) {
+	wlapi, sock := spiretest.Start(t, testSpiffeID)
+	logs := &lockedBuffer{}
+	log := slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	src := spire.NewWaitingSource(sock, time.Hour, log)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = src.Start(ctx) }()
+	t.Cleanup(func() { _ = src.Close() })
+
+	c := newWebhookClient(t)
+	injector := &CABundleInjector{
+		Client:            c,
+		Source:            src,
+		WebhookConfigName: testWebhookConfigName,
+		Log:               log,
+	}
+	done := make(chan error, 1)
+	go func() { done <- injector.Start(ctx) }()
+
+	// Before the SVID: the deferral is announced at INFO, nothing is injected, and
+	// the ERROR the pre-#740 code would have logged is absent.
+	require.Eventually(t, func() bool {
+		return logs.level(t, "webhook caBundle injection deferred until this workload has an SVID") == "INFO"
+	}, 30*time.Second, 10*time.Millisecond, "logs:\n%s", logs.String())
+	assert.Empty(t, logs.level(t, "initial webhook caBundle injection failed"),
+		"a missing SVID is a wait, not an error to report")
+	assert.Empty(t, caBundle(t, c), "nothing can be injected before the trust bundle exists")
+
+	// The SVID lands: WaitingSource fires Updated(), and the injector — already
+	// parked on that channel — writes the bundle.
+	wlapi.StartServing()
+
+	require.Eventually(t, func() bool {
+		return len(caBundle(t, c)) > 0
+	}, 30*time.Second, 20*time.Millisecond, "the caBundle must be injected once the SVID lands; logs:\n%s", logs.String())
+	assert.Contains(t, string(caBundle(t, c)), "BEGIN CERTIFICATE", "the caBundle must be PEM")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a SPIRE outage must never fail the injector")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the injector did not return after cancellation")
+	}
+}

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -497,6 +497,50 @@ registrar fault. Envoy keeps serving on the certificates it already holds; a **n
 on that node gets its listener but no upstream mTLS until the SVID lands, which is the
 same absent-secret transient #715 covers.
 
+#### The controller, registrar or edge is stuck waiting for SPIRE
+
+All four binaries wait the same way, log the same two lines, and register the same
+`spire-svid` readiness gate with the same 2m dwell, so the commands above work
+verbatim against `deploy/aether-controller`, `deploy/aether-registrar` and
+`deploy/aether-edge`. Only the metric namespace differs:
+`aether_controller_spire_*`, `aether_registrar_spire_*`, `aether_edge_spire_*`
+(**not** `aether_agent_spire_*` -- a false zero if you query the wrong one).
+
+What each component does while it waits:
+
+- **Controller** -- the admission webhooks cannot complete a TLS handshake, so the
+  apiserver **fails open**: both webhook configurations are `failurePolicy: Ignore`,
+  so `MeshConfig`/`HTTPFilter`/`EdgeConfig`/`EndpointPolicy`/`HTTPRoute` creations are
+  admitted **unvalidated** and pods are **not** mutated (no mesh-domain `ndots`
+  injection) for the duration. The caBundle injector logs
+  `webhook caBundle injection deferred until this workload has an SVID` at INFO and
+  injects on the first SVID. Symptom of the wait having ended: one
+  `injected SPIRE trust bundle into webhook caBundle`. Past the dwell the replica goes
+  NotReady and leaves the webhook Service's endpoints, which is what makes the
+  fail-open immediate instead of a 10s webhook timeout per request.
+- **Registrar** -- agents cannot handshake, so their watch streams retry (they log
+  `watch stream deferred until this agent has an SVID`, not errors). While the SVID is
+  pending the registrar authorizes **nothing**; the trust domain it authorizes against
+  is read from its own SVID at handshake time and announced once, as
+  `resolved workload trust domain from SPIRE`. Past the dwell the replica leaves the
+  registrar Service's endpoints so agents dial one that can serve.
+- **Edge** -- ingress keeps serving on the certificates its Envoy already holds. The
+  control plane starts with seeds (mesh domain, empty SPIFFE ID), so newly loaded
+  clusters carry **no upstream mTLS** until the SVID lands; the arrival logs
+  `resolved edge identity from SPIRE` and pushes a new snapshot, so no restart is
+  needed. Past the dwell the replica leaves the LoadBalancer's endpoints.
+
+```bash
+for d in aether-controller aether-registrar aether-edge; do
+  echo "== $d"
+  kubectl -n aether logs deploy/$d | grep -E "waiting for the SPIRE Workload API|obtained this workload's SVID"
+done
+```
+
+Before #740 each of these exited with `failed to create SPIRE Workload API source`
+(the controller: `failed to open SPIRE Workload API source`) and crash-looped. Seeing
+that error at all now means an OLD image.
+
 ### Grepping the outbound identity bindings during a soak (issue #638)
 
 `ssl_fail_verify_san` bursts a few tens of seconds into a fresh proxy generation point at

--- a/registrar/internal/cmd/BUILD.bazel
+++ b/registrar/internal/cmd/BUILD.bazel
@@ -25,6 +25,8 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_client_go//kubernetes/scheme",
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
+        "@io_k8s_sigs_controller_runtime//pkg/manager",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
         "@io_k8s_sigs_mcs_api//pkg/apis/v1alpha1",
@@ -36,10 +38,17 @@ go_library(
 
 go_test(
     name = "cmd_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "spire_identity_test.go",
+    ],
     embed = [":cmd"],
     deps = [
+        "//common/spire",
+        "//common/spire/spiretest",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
+        "@io_k8s_sigs_controller_runtime//pkg/manager",
     ],
 )

--- a/registrar/internal/cmd/root.go
+++ b/registrar/internal/cmd/root.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	mcsv1alpha1 "sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
@@ -32,7 +34,20 @@ import (
 
 const (
 	name = "aether-registrar"
+
+	// spireComponent namespaces this binary's SPIRE identity-wait metrics
+	// (aether.registrar.spire.wait_seconds and friends).
+	spireComponent = "registrar"
 )
+
+// readyzAdder is the slice of the controller-runtime manager buildSpireGRPCCreds
+// needs: register the identity runnable and its readiness gate. A narrow interface
+// rather than ctrl.Manager is what lets the "returns immediately" test run without
+// an apiserver.
+type readyzAdder interface {
+	Add(ctrlmanager.Runnable) error
+	AddReadyzCheck(name string, check healthz.Checker) error
+}
 
 // Version is set at build time via -ldflags (Bazel x_defs).
 var Version = "dev"
@@ -147,12 +162,12 @@ func runRegistrar(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	grpcOpts, spireCloser, err := buildSpireGRPCCreds(ctx)
+	grpcOpts, spireSource, err := buildSpireGRPCCreds(ctx, m)
 	if err != nil {
 		return err
 	}
-	if spireCloser != nil {
-		defer func() { retErr = errors.Join(retErr, spireCloser()) }()
+	if spireSource != nil {
+		defer func() { retErr = errors.Join(retErr, spireSource.Close()) }()
 	}
 
 	return wireGRPCServer(ctx, m, reg, snapshot, broadcaster, syncer, serverMetrics, grpcOpts)
@@ -336,33 +351,70 @@ func wireReplication(ctx context.Context, m ctrl.Manager, reg registry.Registry)
 	return nil
 }
 
-// buildSpireGRPCCreds opens the SPIRE Workload API source, resolves the trust domain,
-// and builds mTLS credentials for the gRPC server. When SPIRE is disabled, it returns
-// nil opts and nil closer. The caller must call the returned closer when done.
-func buildSpireGRPCCreds(ctx context.Context) ([]grpc.ServerOption, func() error, error) {
+// buildSpireGRPCCreds starts acquiring the SPIRE Workload API source and builds
+// mTLS credentials for the gRPC server from it. It RETURNS IMMEDIATELY, before the
+// first SVID exists. When SPIRE is disabled it returns nil opts and a nil source.
+// The caller owns the returned source and must Close it.
+//
+// This slot used to be a blocking, FATAL 25s wait (issue #740): a registrar that
+// started while SPIRE was still coming up — the normal state of a cold boot — died
+// with "failed to create SPIRE Workload API source: context deadline exceeded" and
+// crash-looped, taking every agent's endpoint watch with it for the duration.
+//
+// Nothing about the credentials needs the SVID now. grpc.Creds accepts a lazy
+// source: everything in the tls.Config resolves per HANDSHAKE — the certificate
+// through GetCertificate, and the peer authorizer through the source's own trust
+// domain (ServerTLSConfigForOwnTrustDomain). So while the SVID is pending the
+// registrar authorizes NOTHING — an agent's handshake fails before authorization is
+// ever consulted — and the moment it lands, handshakes succeed against the trust
+// domain SPIRE actually issued into. That is the same peer policy as before (the
+// mesh is a single trust domain by design; the old --spire-trust-domain flag could
+// silently disagree with it), only resolved late instead of at startup.
+//
+// The readiness gate is what keeps a stuck registrar from silently absorbing dials:
+// past the dwell this replica leaves the registrar Service's endpoints and agents
+// dial one that can actually handshake.
+func buildSpireGRPCCreds(ctx context.Context, m readyzAdder) ([]grpc.ServerOption, *spire.WaitingSource, error) {
 	if !cfg.SpireEnabled {
 		l.InfoContext(ctx, "SPIRE disabled, gRPC server will use insecure transport")
 		return nil, nil, nil
 	}
-	src, srcErr := spire.NewSource(ctx, cfg.SpireWorkloadSocketPath)
-	if srcErr != nil {
-		return nil, nil, srcErr
+
+	src := spire.NewWaitingSource(cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l, spire.WithComponent(spireComponent))
+	if err := m.Add(src); err != nil {
+		return nil, nil, fmt.Errorf("failed to add the SPIRE identity source: %w", err)
 	}
-	// Authorize peers in the registrar's own trust domain, resolved from its
-	// SVID (the mesh is a single trust domain by design; the old
-	// --spire-trust-domain flag could silently disagree with it).
-	trustDomain, tdErr := spire.TrustDomainFromSource(src)
-	if tdErr != nil {
-		_ = src.Close()
-		return nil, nil, fmt.Errorf("failed to resolve SPIRE trust domain: %w", tdErr)
+	// Load-bearing here: the registrar is behind a Service, so NotReady takes this
+	// replica out of the endpoints agents dial. Dwell = commonspire.NotReadyDwell.
+	if err := m.AddReadyzCheck(spire.ReadyCheckName, spire.ReadyChecker(src)); err != nil {
+		return nil, nil, fmt.Errorf("failed to set up the SPIRE identity ready check: %w", err)
 	}
-	tlsCfg, tlsErr := spire.ServerTLSConfig(src, trustDomain)
-	if tlsErr != nil {
-		_ = src.Close()
-		return nil, nil, tlsErr
+
+	// One line when the identity actually arrives, naming the trust domain peers
+	// are authorized against. It replaces the startup resolution: there is nothing
+	// to configure from it, only to report.
+	go logRegistrarTrustDomain(ctx, src)
+
+	tlsCfg := spire.ServerTLSConfigForOwnTrustDomain(src)
+	l.InfoContext(ctx, "SPIRE mTLS enabled for gRPC server; startup does not wait for SPIRE",
+		"socket", cfg.SpireWorkloadSocketPath, "warnAfter", cfg.SpireWaitWarnAfter)
+	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}, src, nil
+}
+
+// logRegistrarTrustDomain reports the trust domain the registrar authorizes peers
+// against, once its first SVID has been issued. It ends with ctx.
+func logRegistrarTrustDomain(ctx context.Context, src *spire.WaitingSource) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-src.Ready():
 	}
-	l.InfoContext(ctx, "SPIRE mTLS enabled for gRPC server", "socket", cfg.SpireWorkloadSocketPath, "trustDomain", trustDomain)
-	return []grpc.ServerOption{grpc.Creds(credentials.NewTLS(tlsCfg))}, src.Close, nil
+	trustDomain, err := spire.TrustDomainFromSource(src)
+	if err != nil {
+		l.WarnContext(ctx, "failed to read the workload trust domain from the SPIRE SVID", "error", err)
+		return
+	}
+	l.InfoContext(ctx, "resolved workload trust domain from SPIRE", "trustDomain", trustDomain)
 }
 
 // wireGRPCServer assembles the gRPC registrar server, wires write-behind, gates on

--- a/registrar/internal/cmd/spire_identity_test.go
+++ b/registrar/internal/cmd/spire_identity_test.go
@@ -1,0 +1,232 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"aethermesh.dev/common/spire"
+	"aethermesh.dev/common/spire/spiretest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	ctrlmanager "sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// startingManager stands in for the controller-runtime manager: it records what
+// was registered, starts the runnables as m.Start would, and keeps the readiness
+// checks so the test can run them. Starting the runnable is what makes the timing
+// assertion meaningful — the retry loop is genuinely running while the caller
+// carries on building the gRPC server.
+type startingManager struct {
+	ctx context.Context
+
+	mu     sync.Mutex
+	added  []ctrlmanager.Runnable
+	checks map[string]healthz.Checker
+	done   chan error
+}
+
+func newStartingManager(ctx context.Context) *startingManager {
+	return &startingManager{ctx: ctx, checks: map[string]healthz.Checker{}, done: make(chan error, 1)}
+}
+
+func (m *startingManager) Add(r ctrlmanager.Runnable) error {
+	m.mu.Lock()
+	m.added = append(m.added, r)
+	m.mu.Unlock()
+
+	go func() { m.done <- r.Start(m.ctx) }()
+	return nil
+}
+
+func (m *startingManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.checks[name] = check
+	return nil
+}
+
+func (m *startingManager) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.added)
+}
+
+func (m *startingManager) check(name string) (healthz.Checker, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.checks[name]
+	return c, ok
+}
+
+// withSpireConfig sets the SPIRE-related globals for one test and restores them.
+func withSpireConfig(t *testing.T, enabled bool, socket string, warnAfter time.Duration, logger *slog.Logger) {
+	t.Helper()
+
+	prevEnabled, prevSocket, prevWarn, prevLog := cfg.SpireEnabled, cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l
+	t.Cleanup(func() {
+		cfg.SpireEnabled, cfg.SpireWorkloadSocketPath, cfg.SpireWaitWarnAfter, l = prevEnabled, prevSocket, prevWarn, prevLog
+	})
+
+	cfg.SpireEnabled = enabled
+	cfg.SpireWorkloadSocketPath = socket
+	cfg.SpireWaitWarnAfter = warnAfter
+	l = logger
+}
+
+// TestBuildSpireGRPCCredsReturnsImmediately is the regression test for #740 at
+// the registrar's call site. It used to block for up to 25s against an
+// unreachable Workload API and then EXIT THE PROCESS, which took every agent's
+// endpoint watch down with it for the length of the crash loop.
+//
+// The negative control is the code this replaces: spire.NewSource on the same
+// unreachable socket returns only after spire.SourceTimeout (25s), with an error
+// the caller propagated straight out of runRegistrar.
+func TestBuildSpireGRPCCredsReturnsImmediately(t *testing.T) {
+	withSpireConfig(t, true, spiretest.UnservedSocket(t), time.Minute, slog.New(slog.DiscardHandler))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	m := newStartingManager(ctx)
+
+	start := time.Now()
+	opts, src, err := buildSpireGRPCCreds(ctx, m)
+	elapsed := time.Since(start)
+
+	require.NoError(t, err, "an unreachable Workload API must not fail startup")
+	require.NotNil(t, src)
+	t.Cleanup(func() { _ = src.Close() })
+	assert.Less(t, elapsed, 100*time.Millisecond, "startup must not wait for SPIRE")
+	assert.Len(t, opts, 1, "the gRPC server must still be given mTLS credentials")
+	assert.Equal(t, 1, m.count(), "the identity source must be registered as a runnable")
+	assert.False(t, src.HasSVID(), "no SVID can exist against a socket nobody serves")
+
+	// And the runnable it registered keeps waiting rather than failing.
+	cancel()
+	select {
+	case runErr := <-m.done:
+		require.NoError(t, runErr, "the identity runnable must never fail the manager")
+	case <-time.After(30 * time.Second):
+		t.Fatal("the identity runnable did not return after cancellation")
+	}
+}
+
+// TestBuildSpireGRPCCredsSpireDisabled pins the #421 path: with
+// --spire-enabled=false the gRPC server is insecure, nothing is registered, and
+// no readiness gate appears.
+func TestBuildSpireGRPCCredsSpireDisabled(t *testing.T) {
+	logs := &bytes.Buffer{}
+	withSpireConfig(t, false, "/nonexistent/workload.sock", time.Minute,
+		slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	m := newStartingManager(t.Context())
+	opts, src, err := buildSpireGRPCCreds(t.Context(), m)
+
+	require.NoError(t, err)
+	assert.Nil(t, opts, "SPIRE off means insecure transport, unchanged")
+	assert.Nil(t, src, "SPIRE off must create no source at all")
+	assert.Equal(t, 0, m.count(), "SPIRE off must register no runnable")
+	_, gated := m.check(spire.ReadyCheckName)
+	assert.False(t, gated, "with no identity to wait for the check must disappear entirely")
+	assert.Contains(t, logs.String(), "SPIRE disabled, gRPC server will use insecure transport")
+}
+
+// TestBuildSpireGRPCCredsReadiness is the registrar's readiness table. The gate is
+// load-bearing here: NotReady removes this replica from the registrar Service's
+// endpoints, so agents dial one that can actually complete a handshake instead of
+// retrying against a registrar with no certificate to present.
+func TestBuildSpireGRPCCredsReadiness(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "/readyz", nil)
+	require.NoError(t, err)
+
+	t.Run("inside the dwell the gate passes", func(t *testing.T) {
+		withSpireConfig(t, true, spiretest.UnservedSocket(t), time.Hour, slog.New(slog.DiscardHandler))
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		m := newStartingManager(ctx)
+
+		_, src, err := buildSpireGRPCCreds(ctx, m)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = src.Close() })
+
+		check, ok := m.check(spire.ReadyCheckName)
+		require.True(t, ok, "the gate must be registered as %q", spire.ReadyCheckName)
+		assert.NoError(t, check(req), "a wait inside the dwell is a normal startup, not NotReady")
+	})
+
+	t.Run("past the dwell the gate fails", func(t *testing.T) {
+		// A dwell of one nanosecond has already elapsed by the time the check runs.
+		withSpireConfig(t, true, spiretest.UnservedSocket(t), time.Nanosecond, slog.New(slog.DiscardHandler))
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		m := newStartingManager(ctx)
+
+		_, src, err := buildSpireGRPCCreds(ctx, m)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = src.Close() })
+
+		check, ok := m.check(spire.ReadyCheckName)
+		require.True(t, ok)
+		checkErr := check(req)
+		require.Error(t, checkErr, "past the dwell the replica must leave the registrar Service's endpoints")
+		assert.Contains(t, checkErr.Error(), "no SPIRE SVID after")
+	})
+}
+
+// TestRegistrarTrustDomainIsLoggedOnArrival pins the post-arrival callback that
+// replaced the startup trust-domain resolution: nothing is resolved (and nothing
+// is authorized — the handshake fails first) until SPIRE issues the SVID, and when
+// it does, the trust domain peers are authorized against is announced.
+func TestRegistrarTrustDomainIsLoggedOnArrival(t *testing.T) {
+	wlapi, sock := spiretest.Start(t, "spiffe://"+spiretest.TrustDomain+"/ns/aether-system/sa/aether-registrar")
+
+	logs := &lockedBuffer{}
+	log := slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	withSpireConfig(t, true, sock, time.Hour, log)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	m := newStartingManager(ctx)
+
+	_, src, err := buildSpireGRPCCreds(ctx, m)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = src.Close() })
+
+	// While the Workload API refuses to attest, the source holds no SVID, so the
+	// server can present no certificate and authorizes nothing.
+	require.False(t, src.HasSVID())
+	_, svidErr := src.GetX509SVID()
+	require.ErrorIs(t, svidErr, spire.ErrNoSVIDYet)
+	assert.NotContains(t, logs.String(), "resolved workload trust domain from SPIRE")
+
+	wlapi.StartServing()
+
+	require.Eventually(t, func() bool {
+		return strings.Contains(logs.String(), "resolved workload trust domain from SPIRE")
+	}, 30*time.Second, 20*time.Millisecond, "logs:\n%s", logs.String())
+	assert.Contains(t, logs.String(), spiretest.TrustDomain)
+}
+
+// lockedBuffer is a concurrency-safe log sink.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}


### PR DESCRIPTION
Closes the remaining #740 call sites. PR 1 (#741) moved the node agent off the one-shot, fatal `commonspire.NewSource`; the controller, registrar and edge still exited the process on a 25 s Workload API wait, so a cold boot in which SPIRE was still coming up crash-looped all three.

## Per-binary mechanism

| Binary | Call site | What replaces the fatal wait | Why nothing needs the SVID at construction |
|---|---|---|---|
| **Controller** | `buildControllerBootstrapOpts` (the earliest of the four — runs *before* `manager.Bootstrap`, because the webhook server is built from its options) | `WaitingSource` whose `Run` is started on the command context (goroutine — there is no manager yet), handed to `spire.WebhookServerCert` | `WebhookServerCert` installs `tls.Config.GetCertificate`, consulted **per handshake**. A still-waiting source fails individual TLS handshakes, not the process. |
| **Registrar** | `buildSpireGRPCCreds` (before `m.Start`) | `WaitingSource` registered with the manager; `grpc.Creds(credentials.NewTLS(...))` over a new `spire.ServerTLSConfigForOwnTrustDomain` | The whole `tls.Config` resolves at handshake time. The trust-domain resolution moved out of startup into the authorizer (which re-reads the registrar's own SVID, so it is also correct across a rotation) plus a post-arrival callback that logs it. |
| **Edge** | `resolveEdgeIdentity` | Returns the **seeds** (mesh domain, empty SPIFFE ID) immediately; `wireEdgeIdentity` calls the new `SnapshotCache.UpdateEdgeIdentity` on the first SVID | `UpdateEdgeIdentity` rebuilds the cached mTLS clusters **and pushes a snapshot**, so the edge Envoy picks the identity up on the next CDS update rather than on a restart. The empty ID does not leak: `recomputeMTLSClusters` skips injection entirely while `nodeSpiffeID == ""`. |

## Fail-open / endpoint semantics

- **Controller — the apiserver fails open.** Both webhook configurations are `failurePolicy: Ignore`, so while the SVID is pending, admission proceeds **unvalidated** and pods are **not** ndots-mutated. That is exactly what happened while the container was crash-looping; the difference is that the controller is now alive and starts serving the moment the SVID lands. `CABundleInjector.Source` widens to `SVIDSource`, its initial-inject **ERROR becomes INFO** on `errors.Is(err, spire.ErrNoSVIDYet)`, and the injection is performed by the `Updated()` wake — verified: `WaitingSource` fires `Updated()` on **first land** as well as on every rotation, so no retry logic was added.
- **Registrar — authorizes nothing until the SVID lands.** An agent's handshake fails before the peer authorizer is ever consulted, so the deferred trust-domain read cannot widen authorization.
- **Edge — ingress keeps serving on the certs its Envoy already holds**; only newly loaded clusters carry no upstream mTLS until the SVID arrives.
- **Readiness is load-bearing on all three** (unlike on the DaemonSet): these are Deployments behind Services, so past the dwell the replica leaves the endpoints — the apiserver stops routing admission to a controller that cannot handshake, agents stop dialing a registrar that cannot, and the edge stops advertising an ingress whose upstreams have no identity. A workload that already holds an SVID keeps it, so the gate can only fail one that never got its first.

## Names

- **readyz check**: `spire-svid` on all four, now from one constant (`spire.ReadyCheckName`), dwell `commonspire.NotReadyDwell` = 2 m.
- **log lines** (PR 1's, shared via the same helper, so one LogsQL phrase covers all four binaries):
  - `waiting for the SPIRE Workload API to issue this workload's SVID` (INFO, escalating to WARN past `--spire-wait-warn-after`)
  - `obtained this workload's SVID from the SPIRE Workload API`
  - plus per-component arrivals: `webhook caBundle injection deferred until this workload has an SVID` (INFO), `resolved workload trust domain from SPIRE`, `resolved edge identity from SPIRE`.
- **metrics** — a minimal `WithComponent` option on `NewWaitingSource` namespaces the instruments PR 1 defined instead of duplicating them: `aether.controller.spire.{wait_seconds,source_restarts,svid_ready}`, `aether.registrar.spire.*`, `aether.edge.spire.*`. The agent's `aether.agent.spire.*` names are unchanged (`DefaultComponent`).

## Negative controls

| Control | Result |
|---|---|
| **The code this replaces** — `spire.NewSource` on an unserved socket (the pre-fix shape at all three call sites) | returned after **25.02 s** with `failed to create SPIRE Workload API source (socket …): context deadline exceeded` — the error the callers turned into a process exit. Run once as a throwaway test, not committed. |
| `buildControllerBootstrapOpts` against an unserved socket | returned in **3.94 ms** (asserted < 100 ms) |
| `buildSpireGRPCCreds` against an unserved socket | returned in **32.6 µs** (asserted < 100 ms) |
| `resolveEdgeIdentity` against an unserved socket | returned in **46.6 µs** (asserted < 100 ms) |
| `spire-svid` inside the dwell / past it | passes / fails with `no SPIRE SVID after …`, per binary |
| `--spire-enabled=false` (#421) | no source, no runnable, no readiness check, **no log line** — asserted per binary |
| `CABundleInjector` before the SVID | logs the deferral at **INFO**, `initial webhook caBundle injection failed` is **absent**, caBundle empty; injects PEM on `Updated()` once the fake Workload API serves |
| Edge identity | `UpdateEdgeIdentity` called **exactly once**, with the fake's SPIFFE ID and trust domain, only after it starts serving; unchanged identity does not bump the snapshot version |

All tests are hermetic: PR 1's fake `SpiffeWorkloadAPIServer` moved to a shared `common/spire/spiretest` (`testonly`) helper so all four binaries exercise the same fake.

## Chart / docs

- `charts/aether/values.yaml`: the `spire.waitWarnAfter` note said the dwell applied "on the agent"; it now applies to all four. Chart.yaml PATCH bumped `0.92.9 → 0.92.10` (comment-only changes are CI-enforced too). No new values — PR 1 already threaded `--spire-wait-warn-after` to all four components.
- `docs/runbook.md`: "The agent is stuck waiting for SPIRE" gains a per-component section (webhook fail-open, registrar out of endpoints, edge seeds) and the correct metric namespaces (querying `aether_agent_spire_*` for the controller is a false zero).

## Verification

- `bazel test --test_arg=-test.short //agent/... //common/... //registrar/... //controller/...` — 66 tests pass
- `bazel build --config=lint //controller/... //registrar/... //agent/internal/cmd/... //common/spire/...` — clean
- `make gazelle`, `make format-check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
