### PR TITLE
fix(agent): hold xDS, hold the taint, and mean it when identity is ready (#740)

### DIFF
--- a/agent/internal/cmd/BUILD.bazel
+++ b/agent/internal/cmd/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "config.go",
         "edge.go",
+        "readiness.go",
         "root.go",
         "supervisor.go",
     ],
@@ -36,6 +37,7 @@ go_library(
         "//common/apis/config/v1:config",
         "//common/config",
         "//common/constants/mesh",
+        "//common/log",
         "//common/manager",
         "//common/must",
         "//common/readymarker",
@@ -51,6 +53,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//:controller-runtime",
         "@io_k8s_sigs_controller_runtime//pkg/cache",
         "@io_k8s_sigs_controller_runtime//pkg/client",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
         "@io_k8s_sigs_controller_runtime//pkg/manager",
         "@io_k8s_sigs_gateway_api//apis/v1:apis",
         "@io_k8s_sigs_gateway_api//apis/v1beta1",
@@ -63,6 +66,7 @@ go_test(
     name = "cmd_test",
     srcs = [
         "config_test.go",
+        "readiness_test.go",
         "root_test.go",
         "spire_identity_test.go",
         "supervisor_test.go",
@@ -74,6 +78,7 @@ go_test(
         "//agent/internal/node",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@io_k8s_sigs_controller_runtime//pkg/healthz",
         "@io_k8s_sigs_controller_runtime//pkg/manager",
     ],
 )

--- a/agent/internal/cmd/readiness.go
+++ b/agent/internal/cmd/readiness.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+
+	commonlog "aethermesh.dev/common/log"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+// readyzAdder is the one thing agentReadiness needs from the manager, narrow so
+// the aggregate is testable without a live manager (and an apiserver).
+type readyzAdder interface {
+	AddReadyzCheck(name string, check healthz.Checker) error
+}
+
+// agentReadiness owns the agent's /readyz checks so that ONE verdict serves two
+// consumers that must never disagree: the kubelet, which polls the endpoint, and
+// the node taint remover, which asks in-process.
+//
+// The split is what issue #740's finding 2 was: the controller's node-taint
+// guard armed aether.io/agent-not-ready 30s after an identity-less agent went
+// NotReady, and this agent's own taint remover — gated on the CNI socket and
+// conflist chaining only (#667) — dropped it ~50ms later, every 30s for eight
+// cycles. The node was tainted for about 50ms per 30s, i.e. never, and the
+// escalation the readiness gate exists to trigger did not happen. Removing a
+// taint is a claim that this node can mesh a new pod; readiness is where that
+// claim is computed, so the remover has to read it rather than a subset of it.
+//
+// It also gives an operator the failure REASON. controller-runtime's
+// /readyz?verbose redacts checker errors as "reason withheld", so the useful
+// text ("no SPIRE SVID after 2m10s (socket …)") was unreachable from the
+// endpoint an operator would actually curl. Each check is wrapped so every
+// transition between passing and failing is logged exactly once.
+type agentReadiness struct {
+	log    *slog.Logger
+	checks []*namedCheck
+}
+
+// namedCheck is one registered readiness check plus the last verdict observed
+// for it, so transitions can be logged once instead of on every poll.
+type namedCheck struct {
+	name    string
+	check   healthz.Checker
+	failing atomic.Bool
+}
+
+// newAgentReadiness returns an empty aggregate.
+func newAgentReadiness(log *slog.Logger) *agentReadiness {
+	return &agentReadiness{log: commonlog.Named(log, "readiness")}
+}
+
+// add registers check under name with the manager and keeps it in the aggregate.
+// The registered checker is the wrapped one, so the transition logging fires on
+// the kubelet's polls as well as on the taint remover's in-process calls.
+func (a *agentReadiness) add(m readyzAdder, name string, check healthz.Checker) error {
+	nc := &namedCheck{name: name, check: check}
+	a.checks = append(a.checks, nc)
+	if err := m.AddReadyzCheck(name, a.wrap(nc)); err != nil {
+		return fmt.Errorf("failed to set up the %s ready check: %w", name, err)
+	}
+	return nil
+}
+
+// wrap returns nc's checker with once-per-transition logging attached.
+func (a *agentReadiness) wrap(nc *namedCheck) healthz.Checker {
+	return func(req *http.Request) error {
+		err := nc.check(req)
+		a.logTransition(nc, err)
+		return err
+	}
+}
+
+// logTransition logs a check's first failure and its first subsequent pass, and
+// nothing in between. The message carries the check name so an operator can grep
+// for the one they saw in /readyz?verbose ("spire-svid readiness failing").
+func (a *agentReadiness) logTransition(nc *namedCheck, err error) {
+	if nc.failing.Swap(err != nil) == (err != nil) {
+		return // no transition
+	}
+	if err != nil {
+		a.log.Warn(nc.name+" readiness failing", "check", nc.name, "reason", err.Error())
+		return
+	}
+	a.log.Info(nc.name + " readiness passing")
+}
+
+// Err returns the aggregate verdict — nil when every check passes, otherwise the
+// first failure, named. It is the same computation /readyz performs, minus the
+// HTTP.
+//
+// The checks registered here ignore the request (they read a Unix socket, an
+// in-memory conflist observation and an SVID holder), so a nil request is what
+// they get; the aggregate never accepts a check from outside this file.
+func (a *agentReadiness) Err() error {
+	var errs []error
+	for _, nc := range a.checks {
+		if err := a.wrap(nc)(nil); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", nc.name, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/agent/internal/cmd/readiness_test.go
+++ b/agent/internal/cmd/readiness_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+// fakeReadyzAdder records what would have been registered with the manager.
+type fakeReadyzAdder struct {
+	checks map[string]healthz.Checker
+	err    error
+}
+
+func newFakeReadyzAdder() *fakeReadyzAdder {
+	return &fakeReadyzAdder{checks: map[string]healthz.Checker{}}
+}
+
+func (f *fakeReadyzAdder) AddReadyzCheck(name string, check healthz.Checker) error {
+	if f.err != nil {
+		return f.err
+	}
+	f.checks[name] = check
+	return nil
+}
+
+// newTestReadiness returns an aggregate writing JSON logs into buf.
+func newTestReadiness() (*agentReadiness, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return newAgentReadiness(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))), buf
+}
+
+// logLines parses the JSON log records emitted so far.
+func logLines(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &rec))
+		out = append(out, rec)
+	}
+	return out
+}
+
+// TestAgentReadinessErr is the aggregate the node taint remover consults: the
+// SAME verdict the kubelet computes from /readyz, so the two cannot disagree
+// (issue #740, finding 2 — the remover used to see only a subset and cleared a
+// taint the controller had armed for a check it could not see).
+func TestAgentReadinessErr(t *testing.T) {
+	errChain := errors.New("aether is not chained in the node conflist")
+	errSVID := errors.New("no SPIRE SVID after 2m10s (socket /run/spire.sock)")
+
+	t.Run("all passing", func(t *testing.T) {
+		ready, _ := newTestReadiness()
+		m := newFakeReadyzAdder()
+		require.NoError(t, ready.add(m, "cni-chained", func(*http.Request) error { return nil }))
+		require.NoError(t, ready.add(m, "spire-svid", func(*http.Request) error { return nil }))
+
+		assert.NoError(t, ready.Err())
+		assert.Len(t, m.checks, 2, "every check must still be registered with the manager")
+	})
+
+	t.Run("one failing names itself", func(t *testing.T) {
+		ready, _ := newTestReadiness()
+		m := newFakeReadyzAdder()
+		require.NoError(t, ready.add(m, "cni-chained", func(*http.Request) error { return nil }))
+		require.NoError(t, ready.add(m, "spire-svid", func(*http.Request) error { return errSVID }))
+
+		err := ready.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spire-svid")
+		assert.Contains(t, err.Error(), "no SPIRE SVID")
+	})
+
+	t.Run("several failing are all reported", func(t *testing.T) {
+		ready, _ := newTestReadiness()
+		m := newFakeReadyzAdder()
+		require.NoError(t, ready.add(m, "cni-chained", func(*http.Request) error { return errChain }))
+		require.NoError(t, ready.add(m, "spire-svid", func(*http.Request) error { return errSVID }))
+
+		err := ready.Err()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cni-chained")
+		assert.Contains(t, err.Error(), "spire-svid")
+	})
+
+	t.Run("no checks is ready", func(t *testing.T) {
+		// SPIRE off and the re-assert loop off: nothing to gate on.
+		ready, _ := newTestReadiness()
+		assert.NoError(t, ready.Err())
+	})
+
+	t.Run("a registration failure is named", func(t *testing.T) {
+		ready, _ := newTestReadiness()
+		m := newFakeReadyzAdder()
+		m.err = errors.New("manager already started")
+
+		err := ready.add(m, "spire-svid", func(*http.Request) error { return nil })
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "spire-svid")
+	})
+}
+
+// TestAgentReadinessLogsTransitions covers the operator-visible half.
+// controller-runtime's /readyz?verbose redacts checker errors — the cluster
+// prints `spire-svid failed: reason withheld` — so the only place the actual
+// reason can reach an operator is the log, once per transition rather than on
+// every kubelet poll.
+func TestAgentReadinessLogsTransitions(t *testing.T) {
+	ready, buf := newTestReadiness()
+	m := newFakeReadyzAdder()
+
+	failing := errors.New("no SPIRE SVID after 2m10s (socket /run/spire.sock)")
+	var fail bool
+	require.NoError(t, ready.add(m, "spire-svid", func(*http.Request) error {
+		if fail {
+			return failing
+		}
+		return nil
+	}))
+
+	// Passing from the start logs nothing: the steady state must be silent.
+	for range 3 {
+		require.NoError(t, ready.Err())
+	}
+	assert.Empty(t, logLines(t, buf), "a check that never changed state must not log")
+
+	// First failure: one WARN carrying the reason the endpoint withholds.
+	fail = true
+	require.Error(t, ready.Err())
+	require.Error(t, ready.Err())
+	require.Error(t, ready.Err())
+
+	records := logLines(t, buf)
+	require.Len(t, records, 1, "the failure must be logged ONCE, not once per poll")
+	assert.Equal(t, "WARN", records[0]["level"])
+	assert.Equal(t, "spire-svid readiness failing", records[0]["msg"])
+	assert.Contains(t, records[0]["reason"], "no SPIRE SVID after 2m10s")
+
+	// Recovery: one INFO, so the log brackets the outage.
+	fail = false
+	require.NoError(t, ready.Err())
+	require.NoError(t, ready.Err())
+
+	records = logLines(t, buf)
+	require.Len(t, records, 2)
+	assert.Equal(t, "INFO", records[1]["level"])
+	assert.Equal(t, "spire-svid readiness passing", records[1]["msg"])
+}
+
+// TestAgentReadinessRegisteredCheckerLogsToo pins that the checker handed to the
+// manager is the WRAPPED one: the kubelet's polls are what usually observe a
+// transition first, and an operator reading the log should not have to wait for
+// the taint remover's next reconcile to see why.
+func TestAgentReadinessRegisteredCheckerLogsToo(t *testing.T) {
+	ready, buf := newTestReadiness()
+	m := newFakeReadyzAdder()
+	require.NoError(t, ready.add(m, "cni-chained", func(*http.Request) error {
+		return errors.New("aether is not chained in the node conflist")
+	}))
+
+	registered, ok := m.checks["cni-chained"]
+	require.True(t, ok)
+	require.Error(t, registered(nil))
+
+	records := logLines(t, buf)
+	require.Len(t, records, 1)
+	assert.Equal(t, "cni-chained readiness failing", records[0]["msg"])
+}

--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -256,6 +256,7 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 	defer func() { retErr = errors.Join(retErr, reg.Close()) }()
+	wakeRegistryOnIdentity(ctx, spireSource, reg)
 
 	snapshotCache, err := configureSnapshotCache(ctx, m)
 	if err != nil {
@@ -277,7 +278,7 @@ func runAgent(ctx context.Context) (retErr error) {
 		return err
 	}
 
-	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache, ackTracker, identityTrustDomain.Get()); err != nil {
+	if err = setXDSServer(ctx, m, reg, localStorage, snapshotCache, ackTracker, identityTrustDomain.Get(), identityGateOf(spireSource)); err != nil {
 		return err
 	}
 
@@ -371,6 +372,39 @@ func startSpireIdentity(ctx context.Context, m runnableAdder) (*commonspire.Wait
 	l.InfoContext(ctx, "acquiring this agent's SVID in the background; startup does not wait for SPIRE",
 		"socket", cfg.SpireWorkloadSocketPath, "warnAfter", cfg.SpireWaitWarnAfter)
 	return src, trustDomain, nil
+}
+
+// identityWaker is the registry-side half of the identity handshake: a client
+// that wants to be told the moment this workload can complete an mTLS handshake.
+type identityWaker interface {
+	NotifyIdentityReady()
+}
+
+// wakeRegistryOnIdentity kicks the registrar client the instant the SVID lands,
+// instead of leaving it to discover the fact on its own schedule.
+//
+// Without this, recovery is announced long before it happens. The watch loop's
+// own backoff is short, but the gRPC ClientConn underneath it has its own — and
+// after a multi-minute outage's worth of failed handshakes that one has reached
+// its ~120s cap, so new RPCs are answered from the cached failure rather than a
+// fresh dial. On 2026-09-07 readiness, svid_ready and the pod all said
+// "recovered" while the node's data path stayed down for another 2m11s (#740,
+// finding 3). A no-op when SPIRE is disabled or the registry does not implement
+// the wake.
+func wakeRegistryOnIdentity(ctx context.Context, src *commonspire.WaitingSource, reg registry.Registry) {
+	waker, ok := reg.(identityWaker)
+	if src == nil || !ok {
+		return
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-src.Ready():
+		}
+		l.InfoContext(ctx, "identity acquired; reconnecting the registrar client immediately rather than waiting out its backoff")
+		waker.NotifyIdentityReady()
+	}()
 }
 
 // reconcileSpireIdentity folds the trust domain SPIRE actually issued into the
@@ -535,26 +569,34 @@ func newCNIConflistReasserter() *cniconflist.Reasserter {
 //     the taint isn't present. Best-effort: NeedLeaderElection=false, never fails
 //     startup.
 //
-// The two compose: the guard arms the taint, and the remover then refuses to drop
-// it while the node is still unchained. A nil re-asserter
-// (--cni-conflist-reassert=false) reduces both to their pre-#667 behaviour.
+// The two compose, and they compose through ONE verdict: the guard arms the
+// taint, and the remover refuses to drop it while any readiness check is
+// failing. Letting the remover gate on a subset of readiness is what made the
+// escalation a no-op in #740's finding 2 — the guard armed the taint for the
+// SPIRE gate and the remover, which could not see it, cleared it 50ms later,
+// every 30s. A nil re-asserter (--cni-conflist-reassert=false) reduces the
+// chaining half of both to its pre-#667 behaviour.
 func setupNodeGating(m ctrl.Manager, reasserter *cniconflist.Reasserter, spireSource *commonspire.WaitingSource) error {
 	chain := chainStateOf(reasserter)
+	ready := newAgentReadiness(l)
 
-	if err := m.AddReadyzCheck("cni-chained", cniconflist.ReadyChecker(chain)); err != nil {
-		return fmt.Errorf("failed to set up the CNI chaining ready check: %w", err)
+	if err := ready.add(m, "cni-chained", cniconflist.ReadyChecker(chain)); err != nil {
+		return err
 	}
 
 	// The identity half of the same question, on the same terms (#740). A node
 	// with no SVID cannot give a new pod a working mesh identity, so past the
 	// dwell it should stop attracting pods — but only past the dwell: the taint
-	// guard re-arms on 30s of NotReady and spire-server does not tolerate that
-	// taint, so a hard-from-t=0 gate would let a brief SPIRE outage fence the
-	// cluster against spire-server's own rescheduling. See
-	// commonspire.NotReadyDwell. Nil (SPIRE disabled) registers no check at all.
+	// guard re-arms on 30s of NotReady, so a hard-from-t=0 gate would turn a
+	// brief SPIRE hiccup into a fleet-wide taint. That is survivable only
+	// because spire-server, spire-agent and the SPIFFE CSI driver now TOLERATE
+	// aether.io/agent-not-ready (k8s-talos-main #45, 2026-09-07); before they
+	// did, the outage could have fenced out its own cure, which is why SPIRE was
+	// kept out of the taint gate. It no longer is. See commonspire.NotReadyDwell.
+	// Nil (SPIRE disabled) registers no check at all.
 	if spireSource != nil {
-		if err := m.AddReadyzCheck("spire-svid", commonspire.ReadyChecker(spireSource)); err != nil {
-			return fmt.Errorf("failed to set up the SPIRE identity ready check: %w", err)
+		if err := ready.add(m, "spire-svid", commonspire.ReadyChecker(spireSource)); err != nil {
+			return err
 		}
 	}
 
@@ -564,6 +606,7 @@ func setupNodeGating(m ctrl.Manager, reasserter *cniconflist.Reasserter, spireSo
 		SocketPath: cfg.CNIServerConfig.SocketPath,
 		Log:        l,
 		Chain:      chain,
+		Ready:      ready.Err,
 	}
 	if err := tr.SetupWithManager(m); err != nil {
 		return fmt.Errorf("failed to set up startup-taint remover: %w", err)
@@ -586,6 +629,22 @@ func chainStateOf(r *cniconflist.Reasserter) cniconflist.ChainState {
 		return nil
 	}
 	return r
+}
+
+// identityGateOf adapts the SPIRE identity source to the interface the xDS
+// server takes, returning a TRULY nil interface when SPIRE is disabled.
+//
+// Same load-bearing guard as chainStateOf, and the same trap: assigning a nil
+// *WaitingSource straight into an interface-typed field yields a NON-nil
+// interface holding a nil pointer, so the server's `identity == nil` check would
+// be false and it would hold its first snapshot forever waiting on a source
+// nobody is ever going to start. Going through here is what keeps
+// --spire-enabled=false (#421) byte-identical.
+func identityGateOf(src *commonspire.WaitingSource) xdsServer.IdentityGate {
+	if src == nil {
+		return nil
+	}
+	return src
 }
 
 // wireCNIConflistReasserter registers the re-assert loop with the manager. A nil
@@ -771,12 +830,16 @@ func wireCaptureReconciler(m ctrl.Manager, snapshotCache *cache.SnapshotCache) e
 // setXDSServer creates and registers an Agent xDS server as a runnable with the Manager.
 // The server listens on a Unix domain socket and serves Envoy discovery service requests
 // (LDS, CDS, EDS, RDS, ADS) with resource snapshots generated from local pod storage and the registry.
-func setXDSServer(ctx context.Context, m ctrl.Manager, registry registry.Registry, localStorage storage.Storage[*cniv1.CNIPod], snapshotCache *cache.SnapshotCache, ackTracker *ack.Tracker, trustDomain string) error {
+func setXDSServer(ctx context.Context, m ctrl.Manager, registry registry.Registry, localStorage storage.Storage[*cniv1.CNIPod], snapshotCache *cache.SnapshotCache, ackTracker *ack.Tracker, trustDomain string, identity xdsServer.IdentityGate) error {
 	// Create xDS server
 	xdsSrv, err := xdsServer.NewAgentXdsServer(ctx, cfg.ClusterName, cfg.NodeName, trustDomain, registry, localStorage, snapshotCache, ackTracker.Callbacks(), l)
 	if err != nil {
 		return err
 	}
+	// Hold the first snapshot until this agent has an identity: without one the
+	// registrar handshake cannot succeed, so publishing anyway would replace
+	// Envoy's working config with a local-only one (#740, finding 1).
+	xdsSrv.SetIdentityGate(identity)
 	if err = m.Add(xdsSrv); err != nil {
 		return fmt.Errorf("failed to add xDS server: %w", err)
 	}

--- a/agent/internal/node/taint.go
+++ b/agent/internal/node/taint.go
@@ -54,10 +54,12 @@ func hasTaint(node *corev1.Node, key string) bool {
 // TaintRemover is a controller-runtime reconciler that removes the aether
 // startup taint (aetherlabels.TaintAgentNotReady) from this agent's OWN node
 // whenever the taint is present AND this node can actually mesh a NEW pod —
-// which takes two conditions, not one: the CNI server's Unix socket exists, so a
-// CNI ADD can be handled, and aether is chained in the node's active conflist,
-// so a CNI ADD is ever ISSUED to us at all (#667). Workload pods don't tolerate
-// the taint, so they wait until this runs.
+// which takes three conditions, not one: the CNI server's Unix socket exists, so
+// a CNI ADD can be handled; aether is chained in the node's active conflist, so
+// a CNI ADD is ever ISSUED to us at all (#667); and this agent's own readiness
+// passes, which is where every other such condition is already computed — today
+// the CNI chaining check and the SPIRE identity gate (#740). Workload pods don't
+// tolerate the taint, so they wait until this runs.
 //
 // Unlike the original one-shot remover, it reconciles: the controller's node-taint
 // guard can (re-)apply the taint to a running node after a reboot or an agent
@@ -76,6 +78,19 @@ type TaintRemover struct {
 	// gate, not a node that can never be untainted because nothing is left to
 	// observe the conflist.
 	Chain cniconflist.ChainState
+
+	// Ready reports this agent's own readiness — the SAME aggregate the kubelet
+	// reads from /readyz — returning nil when every check passes. Optional: a nil
+	// Ready keeps the socket+chained gate alone.
+	//
+	// It exists because removing this taint is a claim that the node can mesh a
+	// new pod, and readiness is where that claim is computed. Gating on a subset
+	// of it made the escalation a no-op: on 2026-09-07 the controller's guard
+	// armed the taint because this agent had no SVID, and this remover — which
+	// could only see the socket and the conflist — dropped it ~50ms later, eight
+	// times in a row (issue #740, finding 2). Two controllers fighting is not a
+	// gate. Reading the same verdict the guard reacted to makes them agree.
+	Ready func() error
 }
 
 // NeedLeaderElection runs on every agent (the taint is per-node), not just the
@@ -96,10 +111,11 @@ func (r *TaintRemover) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // Reconcile removes the startup taint from this agent's node when it is present
-// and the CNI socket is serving. When the taint is present but CNI isn't up yet,
-// it requeues (the reconciler can't watch a Unix socket) rather than blocking a
-// worker. Best-effort: a patch failure is retried by controller-runtime, never
-// surfaced as a startup failure.
+// and this node can mesh a pod: the CNI socket is serving, aether is chained,
+// and this agent's own readiness passes. When any of those is not yet true it
+// requeues (the reconciler can watch neither a Unix socket nor a readiness
+// checker) rather than blocking a worker. Best-effort: a patch failure is
+// retried by controller-runtime, never surfaced as a startup failure.
 func (r *TaintRemover) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	if req.Name != r.NodeName {
 		return reconcile.Result{}, nil
@@ -115,15 +131,17 @@ func (r *TaintRemover) Reconcile(ctx context.Context, req reconcile.Request) (re
 		return reconcile.Result{}, nil // nothing to do
 	}
 
-	if socket, chained := r.socketServing(), r.chained(); !socket || !chained {
+	socket, chained, notReady := r.socketServing(), r.chained(), r.notReady()
+	if !socket || !chained || notReady != nil {
 		// The taint is present but this node can't mesh a pod yet — don't remove it
-		// (that's the whole point of the gate). Requeue to re-check. Both conditions
-		// are logged because they fail for entirely different reasons and have
-		// entirely different recoveries: no socket is a slow start that fixes
+		// (that's the whole point of the gate). Requeue to re-check. Every
+		// condition is logged because they fail for entirely different reasons and
+		// have entirely different recoveries: no socket is a slow start that fixes
 		// itself, not chained is a stripped conflist that only a fresh cni-install
-		// run can fix.
+		// run can fix, and a failing readyz names its own reason (an absent SVID
+		// resolves when SPIRE does).
 		r.Log.DebugContext(ctx, "startup taint present but this node cannot mesh a pod; requeueing",
-			"node", r.NodeName, "socket", socket, "chained", chained)
+			"node", r.NodeName, "socket", socket, "chained", chained, "readyz", readyzReason(notReady))
 		return reconcile.Result{RequeueAfter: notReadyRequeue}, nil
 	}
 
@@ -145,6 +163,23 @@ func (r *TaintRemover) Reconcile(ctx context.Context, req reconcile.Request) (re
 func (r *TaintRemover) socketServing() bool {
 	_, err := os.Stat(r.SocketPath)
 	return err == nil
+}
+
+// notReady returns this agent's readiness failure, or nil when it is ready (or
+// when no readiness aggregate was wired).
+func (r *TaintRemover) notReady() error {
+	if r.Ready == nil {
+		return nil
+	}
+	return r.Ready()
+}
+
+// readyzReason renders a readiness verdict for the log: "ok" or the reason.
+func readyzReason(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	return err.Error()
 }
 
 // chained reports whether the re-assert loop has POSITIVELY observed aether in

--- a/agent/internal/node/taint_test.go
+++ b/agent/internal/node/taint_test.go
@@ -2,9 +2,11 @@ package node
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -227,6 +229,83 @@ func TestReconcileChainGate(t *testing.T) {
 		// Re-arming is the controller's guard, driven by the readiness check.
 		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, false))
 		r.Chain = observed(false)
+		res := reconcileNode(t, r)
+		assert.False(t, nodeTaintPresent(t, c))
+		assert.Zero(t, res.RequeueAfter)
+	})
+}
+
+// TestReconcileReadinessGate covers the third condition (#740, finding 2): the
+// remover must not clear a taint the controller's guard armed because this
+// agent is NotReady. Before this, the guard armed the taint for a failing
+// spire-svid check and the remover — which could see only the socket and the
+// conflist — dropped it ~50ms later, every 30s for eight cycles, so the node
+// was effectively never tainted and the designed escalation never happened.
+func TestReconcileReadinessGate(t *testing.T) {
+	errNoSVID := errors.New("spire-svid: no SPIRE SVID after 2m10s (socket /run/spire.sock)")
+
+	t.Run("readyz failing -> taint kept, requeued", func(t *testing.T) {
+		// Socket and chaining both good — exactly the state in which the old gate
+		// removed the taint — but the agent has no identity, so a pod scheduled
+		// here would come up without one.
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, true))
+		r.Chain = observed(true)
+		r.Ready = func() error { return errNoSVID }
+
+		res := reconcileNode(t, r)
+		assert.True(t, nodeTaintPresent(t, c), "taint must be HELD while a readiness check is failing")
+		assert.Positive(t, res.RequeueAfter)
+	})
+
+	t.Run("readyz recovers -> taint removed", func(t *testing.T) {
+		// The other half: holding must be a hold, not a deadlock. Once the gate
+		// passes (SPIRE issued the SVID) the very next reconcile releases the node.
+		var failing atomic.Bool
+		failing.Store(true)
+
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, true))
+		r.Chain = observed(true)
+		r.Ready = func() error {
+			if failing.Load() {
+				return errNoSVID
+			}
+			return nil
+		}
+
+		reconcileNode(t, r)
+		require.True(t, nodeTaintPresent(t, c))
+
+		failing.Store(false)
+		res := reconcileNode(t, r)
+		assert.False(t, nodeTaintPresent(t, c), "a passing readyz must release the node")
+		assert.Zero(t, res.RequeueAfter)
+	})
+
+	t.Run("nil Ready -> pre-#740 socket+chained gate", func(t *testing.T) {
+		// Nothing wired (the edge, or a test): the #667 semantics are unchanged.
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, true))
+		r.Chain = observed(true)
+		r.Ready = nil
+		reconcileNode(t, r)
+		assert.False(t, nodeTaintPresent(t, c))
+	})
+
+	t.Run("readyz passing but unchained -> still held", func(t *testing.T) {
+		// The conditions are conjunctive: readiness does not substitute for the
+		// #667 chaining evidence any more than chaining substitutes for the socket.
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, true))
+		r.Chain = observed(false)
+		r.Ready = func() error { return nil }
+		res := reconcileNode(t, r)
+		assert.True(t, nodeTaintPresent(t, c))
+		assert.Positive(t, res.RequeueAfter)
+	})
+
+	t.Run("no taint + readyz failing -> no-op, no requeue", func(t *testing.T) {
+		// Remove-only, as before: the agent never ADDS the taint (proposal 033).
+		r, c := newRemover(t, touchSocket(t), nodeWithTaint(testNode, false))
+		r.Chain = observed(true)
+		r.Ready = func() error { return errNoSVID }
 		res := reconcileNode(t, r)
 		assert.False(t, nodeTaintPresent(t, c))
 		assert.Zero(t, res.RequeueAfter)

--- a/agent/internal/xds/server/BUILD.bazel
+++ b/agent/internal/xds/server/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
 go_test(
     name = "server_test",
     srcs = [
+        "identity_hold_test.go",
         "odcds_test.go",
         "refresh_test.go",
         "server_integration_test.go",

--- a/agent/internal/xds/server/identity_hold_test.go
+++ b/agent/internal/xds/server/identity_hold_test.go
@@ -1,0 +1,139 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"aethermesh.dev/agent/internal/xds/cache"
+	"aethermesh.dev/agent/storage"
+	cniv1 "aethermesh.dev/api/aether/cni/v1"
+	registryv1 "aethermesh.dev/api/aether/registry/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeIdentity is an IdentityGate whose readiness the test controls.
+type fakeIdentity struct {
+	ready chan struct{}
+	has   atomic.Bool
+}
+
+func newFakeIdentity() *fakeIdentity {
+	return &fakeIdentity{ready: make(chan struct{})}
+}
+
+func (f *fakeIdentity) HasSVID() bool          { return f.has.Load() }
+func (f *fakeIdentity) Ready() <-chan struct{} { return f.ready }
+func (f *fakeIdentity) arrive()                { f.has.Store(true); close(f.ready) }
+
+// newHoldServer builds an xDS server whose registry always fails, so a PreListen
+// that runs to completion necessarily takes the local-only fallback — which is
+// precisely what must not happen while identity is pending.
+func newHoldServer(t *testing.T, gate IdentityGate) (*AgentXdsServer, *atomic.Int64) {
+	t.Helper()
+
+	var registryCalls atomic.Int64
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(_ context.Context, _ registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			registryCalls.Add(1)
+			return nil, errors.New("registry unavailable: no SPIRE SVID yet")
+		},
+	}
+	store := storage.NewMockStorageWithGetAll(func(_ context.Context) ([]*cniv1.CNIPod, error) {
+		return []*cniv1.CNIPod{}, nil
+	})
+	snapshotCache := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
+
+	srv, err := NewAgentXdsServer(t.Context(), "cluster-1", "node-1", "example.org", reg, store, snapshotCache, nil, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+	srv.SetIdentityGate(gate)
+	return srv, &registryCalls
+}
+
+// TestPreListen_HoldsUntilIdentity is issue #740's finding 1. With SPIRE down, a
+// restarted agent cannot handshake to the registrar, so the local-only fallback
+// fires and the snapshot it publishes has no cross-node endpoints — which
+// REPLACES the complete config Envoy was still happily serving. On
+// main-worker-03 on 2026-09-07 that failed ~95% of the node's mesh probes for a
+// whole 6m41s outage. The crash loop this replaced never did that, because a
+// dying agent published nothing.
+//
+// So: while identity is pending, PreListen must not reach the registry at all,
+// must not return, and must not open the socket.
+func TestPreListen_HoldsUntilIdentity(t *testing.T) {
+	gate := newFakeIdentity() // no SVID yet
+	srv, registryCalls := newHoldServer(t, gate)
+
+	done := make(chan error, 1)
+	go func() { done <- srv.PreListen(t.Context()) }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("PreListen returned while identity was pending (err=%v): Envoy would be served a local-only snapshot", err)
+	case <-time.After(250 * time.Millisecond):
+	}
+	assert.Zero(t, registryCalls.Load(), "the registry must not be consulted before identity exists")
+
+	// Identity lands: the hold releases and the normal path runs, including the
+	// local-only fallback it is allowed to take from here on.
+	gate.arrive()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err, "a registry that is still unavailable must not fail startup")
+	case <-time.After(30 * time.Second):
+		t.Fatal("PreListen did not proceed after identity arrived")
+	}
+	assert.Positive(t, registryCalls.Load(), "with identity in hand PreListen must build the snapshot as before")
+}
+
+// TestPreListen_IdentityAlreadyHeld is the steady-state control: an agent that
+// already has its SVID (every restart outside a SPIRE outage) must not pay so
+// much as a scheduling hop for the gate.
+func TestPreListen_IdentityAlreadyHeld(t *testing.T) {
+	gate := newFakeIdentity()
+	gate.arrive()
+	srv, registryCalls := newHoldServer(t, gate)
+
+	start := time.Now()
+	require.NoError(t, srv.PreListen(t.Context()))
+	assert.Less(t, time.Since(start), 5*time.Second)
+	assert.Positive(t, registryCalls.Load())
+}
+
+// TestPreListen_NoGateIsUnchanged pins the --spire-enabled=false path (#421) and
+// the edge, which builds this server without a gate: no gate means no hold, byte
+// for byte the pre-#740 behaviour including the local-only fallback.
+func TestPreListen_NoGateIsUnchanged(t *testing.T) {
+	srv, registryCalls := newHoldServer(t, nil)
+
+	require.NoError(t, srv.PreListen(t.Context()))
+	assert.Positive(t, registryCalls.Load())
+}
+
+// TestPreListen_HoldEndsOnShutdown proves the hold is not a way to wedge a
+// shutdown: cancelling the context ends it, and without an error — a SPIRE
+// outage must never be the reason a shutdown is reported as a failure.
+func TestPreListen_HoldEndsOnShutdown(t *testing.T) {
+	gate := newFakeIdentity()
+	srv, registryCalls := newHoldServer(t, gate)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- srv.PreListen(ctx) }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("the identity hold did not end when the context was cancelled")
+	}
+	assert.Zero(t, registryCalls.Load(), "a cancelled hold must not fall through to the snapshot build")
+}

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -37,7 +37,33 @@ type AgentXdsServer struct {
 	registry registry.Registry
 
 	cache *cache.SnapshotCache
+
+	// identity gates the first snapshot on this agent holding a mesh identity.
+	// Optional: nil means "no identity to wait for" (--spire-enabled=false, and
+	// the edge, whose source is still created synchronously).
+	identity IdentityGate
 }
+
+// IdentityGate is the mesh identity as the xDS server needs to see it: is it
+// here yet, and a channel to wait on until it is. commonspire.WaitingSource
+// implements it.
+type IdentityGate interface {
+	// HasSVID reports whether this workload's identity (SVID and trust bundle)
+	// is complete.
+	HasSVID() bool
+	// Ready returns a channel closed when that identity first arrives. It is
+	// closed, not sent on, so any number of waiters may select on it.
+	Ready() <-chan struct{}
+}
+
+// SetIdentityGate makes the initial snapshot wait for this agent's mesh
+// identity. A setter rather than another positional argument to
+// NewAgentXdsServer, for the same reason CNIServer.SetChainState is one: the
+// gate is an interlock on WHEN the server may first serve, not something it
+// needs in order to exist, and the edge builds the same server without one.
+//
+// Pass a nil gate (or never call this) to keep the pre-#740 behaviour.
+func (s *AgentXdsServer) SetIdentityGate(gate IdentityGate) { s.identity = gate }
 
 // NewAgentXdsServer creates a new AgentXdsServer.
 // It initializes an xDS server with a snapshot cache and registers itself as a callback
@@ -90,7 +116,20 @@ func (s *AgentXdsServer) NeedLeaderElection() bool { return false }
 // PreListen generates the initial Envoy snapshot from local pod storage and the service registry.
 // It creates listeners, clusters, endpoints, and routes, then sets the snapshot in the cache
 // before the server starts accepting xDS client connections.
+//
+// It first HOLDS until this agent has a mesh identity (see holdForIdentity):
+// the whole point of the local-only fallback below is to survive a registrar
+// blip, and without an SVID there is no such thing as a registrar blip — every
+// handshake fails, so the fallback would fire on every restart and publish a
+// snapshot with no cross-node endpoints at all.
 func (s *AgentXdsServer) PreListen(ctx context.Context) error {
+	if !s.holdForIdentity(ctx) {
+		// Shutting down before identity arrived. Return nil rather than an error:
+		// the manager is already stopping and a SPIRE outage must never be the
+		// reason a shutdown is reported as a failure.
+		return nil
+	}
+
 	s.log.DebugContext(ctx, "generating initial snapshot")
 
 	if err := s.cache.LoadListenersFromStorage(ctx, s.storage, s.trustDomain); err != nil {
@@ -130,6 +169,61 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// identityHoldLogInterval is how often the identity hold re-announces itself.
+// Frequent enough that an operator watching the log sees it is a hold and not a
+// hang, sparse enough that a long SPIRE outage does not fill the log — the
+// authoritative per-attempt ladder (including the escalation to WARN) belongs
+// to the identity source's own logger, not to this one.
+const identityHoldLogInterval = 15 * time.Second
+
+// holdForIdentity blocks until this agent holds a mesh identity, reporting
+// whether it got one (false = ctx ended first). With no gate wired, or with the
+// identity already in hand, it returns immediately.
+//
+// This is the difference between a restart during a SPIRE outage costing
+// nothing and costing the node its data path (issue #740, finding 1). Envoy
+// keeps serving the last configuration it was given whenever its management
+// server is unreachable, which is exactly why the crash loop this replaced was
+// survivable: a dying agent published nothing. A LIVING agent that opens the
+// xDS socket and pushes what it can does the one thing the crash loop never
+// did — it REPLACES a complete snapshot with a local-only one. On main-worker-03
+// on 2026-09-07 that evicted every cross-node endpoint and failed ~95% of the
+// node's mesh probes for the whole 6m41s outage (+5,083 errors), on a node whose
+// Envoy had been serving fine a second earlier.
+//
+// So while identity is pending the agent programs everything else and simply
+// does not open the socket. Envoy keeps its config, the node keeps working, and
+// the readiness gate plus the node taint (past their dwell) stop NEW pods from
+// landing on a node that cannot give them an identity — which is the honest
+// signal, since a new pod is precisely what this state cannot serve.
+//
+// Mid-life is already correct and is deliberately left alone: once a snapshot
+// has been published the cache keeps it, so a registrar that goes away later
+// costs nothing — the refresher retries in the background and Envoy holds the
+// last good config.
+func (s *AgentXdsServer) holdForIdentity(ctx context.Context) bool {
+	if s.identity == nil || s.identity.HasSVID() {
+		return true
+	}
+
+	started := time.Now()
+	s.log.InfoContext(ctx, "holding xDS until this agent has an SVID; Envoy keeps its current configuration", "elapsed", time.Duration(0).String())
+
+	ticker := time.NewTicker(identityHoldLogInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return false
+		case <-s.identity.Ready():
+			s.log.InfoContext(ctx, "identity acquired; generating the initial snapshot", "held", time.Since(started).Round(time.Millisecond).String())
+			return true
+		case <-ticker.C:
+			s.log.InfoContext(ctx, "holding xDS until this agent has an SVID; Envoy keeps its current configuration", "elapsed", time.Since(started).Round(time.Second).String())
+		}
+	}
 }
 
 // registryReadyTimeout bounds how long PreListen waits for the registry watch

--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.9"
+version: "0.92.10"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -98,11 +98,16 @@ spire:
   # startup no longer dies when the Workload API is not serving yet, it waits and
   # keeps /healthz and /readyz answering.
   #
-  # NOTE: spire-server AND spire-agent must tolerate aether.io/agent-not-ready
-  # (:NoSchedule). Past this dwell an identity-less node reports NotReady, and the
-  # controller's node-taint guard re-arms that taint 30s later — a SPIRE that
-  # cannot be rescheduled onto the very nodes it has to attest cannot recover the
-  # cluster on its own.
+  # REQUIRED: spire-server, spire-agent AND the SPIFFE CSI driver MUST tolerate
+  # aether.io/agent-not-ready (:NoSchedule). Past this dwell an identity-less node
+  # reports NotReady, the controller's node-taint guard re-arms that taint 30s
+  # later, and — since #740 — the agent's own taint remover HOLDS it until every
+  # readiness gate passes, which for an identity-less node means until SPIRE
+  # recovers. That is the point (nothing new should be scheduled onto a node that
+  # cannot give it an identity), but it also means a SPIRE that does not tolerate
+  # the taint cannot be rescheduled onto the very nodes it has to attest: the
+  # outage would fence out its own cure. On talos-main these tolerations were
+  # applied in k8s-talos-main #45 (2026-09-07).
   waitWarnAfter: 2m
 
 # Proxy MeshConfig — the controller seeds and projects the singleton MeshConfig CR

--- a/common/spire/BUILD.bazel
+++ b/common/spire/BUILD.bazel
@@ -24,13 +24,16 @@ go_library(
 go_test(
     name = "spire_test",
     srcs = [
+        "identity_test.go",
         "tls_test.go",
         "waiting_test.go",
     ],
     embed = [":spire"],
     deps = [
+        "@com_github_spiffe_go_spiffe_v2//bundle/x509bundle",
         "@com_github_spiffe_go_spiffe_v2//proto/spiffe/workload",
         "@com_github_spiffe_go_spiffe_v2//spiffeid",
+        "@com_github_spiffe_go_spiffe_v2//svid/x509svid",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel//:otel",

--- a/common/spire/identity_test.go
+++ b/common/spire/identity_test.go
@@ -1,0 +1,71 @@
+package spire
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// svidOnlySource serves an SVID but no bundle for its trust domain — the half
+// identity that readiness silently accepted before #740's finding 3.
+type svidOnlySource struct {
+	svid *x509svid.SVID
+}
+
+func (s *svidOnlySource) GetX509SVID() (*x509svid.SVID, error) { return s.svid, nil }
+
+func (s *svidOnlySource) GetX509BundleForTrustDomain(td spiffeid.TrustDomain) (*x509bundle.Bundle, error) {
+	return nil, fmt.Errorf("x509bundle: no X.509 bundle found for trust domain: %q", td.Name())
+}
+
+func (s *svidOnlySource) Updated() <-chan struct{} { return nil }
+
+var _ SVIDSource = (*svidOnlySource)(nil)
+
+// TestFirstIdentityRequiresBothHalves pins what "has identity" means: an mTLS
+// peer needs this workload's own SVID AND the bundle it verifies the other side
+// against, so a source that can produce only one of them is not ready — and
+// neither is the WaitingSource built on it, since firstIdentity is the sole gate
+// on publishing the acquired source.
+//
+// This is issue #740's finding 3. On 2026-09-07 readyz reported `spire-svid ok`
+// and svid_ready went to 1 three seconds after the SVID landed, while every mTLS
+// client kept failing `x509svid: could not get X509 bundle` for another 2m11s.
+// Readiness was answering a narrower question than the one its consumers ask.
+func TestFirstIdentityRequiresBothHalves(t *testing.T) {
+	t.Run("bundle missing is not an identity", func(t *testing.T) {
+		svid := &x509svid.SVID{
+			ID: spiffeid.RequireFromString("spiffe://" + testTrustDomain + "/ns/aether-system/sa/aether-agent"),
+		}
+
+		_, err := firstIdentity(&svidOnlySource{svid: svid})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "X.509 bundle")
+		assert.Contains(t, err.Error(), testTrustDomain, "the failure must name the trust domain it looked for")
+	})
+
+	t.Run("both halves present yields the trust domain", func(t *testing.T) {
+		// The real Workload API path: what a WaitingSource publishes answers both,
+		// and the trust domain it reports is the SVID's own.
+		fake, socket := startFakeWorkloadAPI(t)
+		fake.startServing()
+
+		w, _ := newTestWaitingSource(t, socket, time.Minute)
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		go func() { _ = w.Start(ctx) }()
+
+		require.Eventually(t, w.HasSVID, 30*time.Second, 10*time.Millisecond)
+
+		td, err := firstIdentity(w)
+		require.NoError(t, err)
+		assert.Equal(t, testTrustDomain, td)
+	})
+}

--- a/common/spire/waiting.go
+++ b/common/spire/waiting.go
@@ -176,12 +176,12 @@ func (w *WaitingSource) attempt(ctx context.Context, attempt int) bool {
 		return false
 	}
 
-	td, err := TrustDomainFromSource(src)
+	td, err := firstIdentity(src)
 	if err != nil {
-		// A source that was created but cannot serve an SVID is worse than none:
-		// drop it and build a fresh one. This is the only path that re-creates a
-		// source, which is why aether.agent.spire.source_restarts staying 0 is a
-		// meaningful signal.
+		// A source that was created but cannot serve a COMPLETE identity is worse
+		// than none: drop it and build a fresh one. This is the only path that
+		// re-creates a source, which is why aether.agent.spire.source_restarts
+		// staying 0 is a meaningful signal.
 		_ = src.Close()
 		w.metrics.sourceRestarted(ctx)
 		w.logWaiting(ctx, attempt, err)
@@ -199,6 +199,30 @@ func (w *WaitingSource) attempt(ctx context.Context, attempt int) bool {
 	w.log.InfoContext(ctx, "obtained this workload's SVID from the SPIRE Workload API",
 		"socket", w.socketPath, "attempts", attempt, "elapsed", waited.Round(time.Millisecond), "trustDomain", td)
 	return true
+}
+
+// firstIdentity reads BOTH halves of this workload's mesh identity out of a
+// freshly created source — its own SVID and the X.509 bundle for the trust
+// domain that SVID belongs to — and returns the trust-domain name.
+//
+// Both, not just the SVID, because an mTLS peer needs both and they are what
+// readiness has to mean. On 2026-09-07 the agent announced recovery on the SVID
+// alone (readyz spire-svid ok, svid_ready=1) while every mTLS client kept
+// failing `x509svid: could not get X509 bundle` — the bundle half of the
+// identity was what the peers were actually blocked on, and readiness said
+// nothing about it. go-spiffe fills both from the same Workload API update, so
+// in practice this costs one extra map lookup and closes the window where they
+// could ever disagree (issue #740, finding 3).
+func firstIdentity(src SVIDSource) (string, error) {
+	svid, err := src.GetX509SVID()
+	if err != nil {
+		return "", fmt.Errorf("fetching workload SVID: %w", err)
+	}
+	td := svid.ID.TrustDomain()
+	if _, err := src.GetX509BundleForTrustDomain(td); err != nil {
+		return "", fmt.Errorf("fetching the X.509 bundle for trust domain %q: %w", td.Name(), err)
+	}
+	return td.Name(), nil
 }
 
 // logWaiting emits the one line per attempt that makes the wait visible, at INFO
@@ -252,8 +276,11 @@ func (w *WaitingSource) Updated() <-chan struct{} { return w.updated }
 // number of goroutines may wait on it.
 func (w *WaitingSource) Ready() <-chan struct{} { return w.ready }
 
-// HasSVID reports whether the first SVID has arrived. It is what the readiness
-// gate and the registrar client's identity check read.
+// HasSVID reports whether this workload's identity is complete: the first SVID
+// has arrived AND the bundle for its trust domain is servable (see
+// firstIdentity — the source is only published once both are). It is what the
+// readiness gate, the xDS hold and the registrar client's identity check read,
+// so all three mean the same thing an mTLS handshake means.
 func (w *WaitingSource) HasSVID() bool {
 	if w == nil {
 		return false

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -463,13 +463,45 @@ kubectl -n aether exec ds/aether-agent -c agent -- wget -qO- localhost:8082/read
 ```
 
 `readyz?verbose` reads `spire-svid ok` for the first **2 minutes** of the wait
-(`--spire-wait-warn-after`, `spire.waitWarnAfter`) and then fails with
-`no SPIRE SVID after 2m10s (socket …)`. The dwell is deliberate: the controller's
-node-taint guard re-arms `aether.io/agent-not-ready:NoSchedule` after 30s of NotReady,
-and spire-server does not tolerate that taint — a gate that failed immediately would let
-a brief SPIRE outage fence the cluster against spire-server's own rescheduling. Past the
-dwell the NotReady is the point: stop scheduling pods onto a node that cannot give them
-an identity.
+(`--spire-wait-warn-after`, `spire.waitWarnAfter`) and then fails. It prints
+**`spire-svid failed: reason withheld`** — controller-runtime redacts checker errors, so
+the endpoint never shows the reason. The reason is in the **log**, once per transition:
+
+```bash
+kubectl -n aether logs ds/aether-agent | grep -E "readiness (failing|passing)"
+# spire-svid readiness failing   reason="no SPIRE SVID after 2m10s (socket /run/secrets/…)"
+# spire-svid readiness passing
+```
+
+The dwell is deliberate: the controller's node-taint guard re-arms
+`aether.io/agent-not-ready:NoSchedule` after 30s of NotReady, so a gate that failed
+immediately would turn a brief SPIRE hiccup into a fleet-wide taint. Past the dwell the
+NotReady is the point: stop scheduling pods onto a node that cannot give them an
+identity. Since #740 the agent's own taint remover **holds** that taint while any
+readiness gate is failing, instead of clearing it 50ms after the guard arms it — so
+**spire-server, spire-agent and the SPIFFE CSI driver must tolerate the taint**
+(`spire.waitWarnAfter`'s note in `values.yaml`; applied on talos-main in
+k8s-talos-main #45). Without those tolerations the outage fences out its own cure.
+
+**The node keeps serving.** While the agent has no SVID it does NOT open the xDS socket
+— it logs `holding xDS until this agent has an SVID; Envoy keeps its current
+configuration` every 15s with a rising `elapsed`, and Envoy goes on serving the last
+config it was given. This matters because the alternative is worse than the crash loop
+#740 replaced: a live agent that cannot reach the registrar publishes a **local-only**
+snapshot, which REPLACES a complete one and strips every cross-node endpoint. On
+2026-09-07 that failed ~95% of one node's mesh probes for a whole 6m41s outage. If you
+see `registry unavailable for initial snapshot; starting with local-only config` while
+SPIRE is down, that is the bug — the hold is missing.
+
+Recovery is announced only when **both** halves of the identity exist (the SVID and the
+bundle for its trust domain), and the registrar client is kicked out of its gRPC
+backoff the moment they do:
+
+```bash
+kubectl -n aether logs ds/aether-agent | grep -E "identity acquired"
+# identity acquired; generating the initial snapshot                      held=6m41.2s
+# identity acquired; reconnecting the registrar client immediately …
+```
 
 The upstream cause is almost always spire-server or the node's spire-agent, not aether:
 
@@ -493,9 +525,11 @@ sum(increase(aether_agent_spire_source_restarts_total[1h]))
 While the wait is on, the registrar watch stream logs
 `watch stream deferred until this agent has an SVID` at INFO and counts no
 `watch_errors` — the agent cannot handshake without a certificate, and that is not a
-registrar fault. Envoy keeps serving on the certificates it already holds; a **new** pod
-on that node gets its listener but no upstream mTLS until the SVID lands, which is the
-same absent-secret transient #715 covers.
+registrar fault. Envoy keeps serving on the certificates and the configuration it
+already holds. A **new** pod on that node is still registered and still gets its CNI
+redirect, but nothing is pushed to Envoy until the SVID lands (and it could not have
+meshed without an identity anyway) — which is why the node reports NotReady and stays
+tainted for the duration.
 
 ### Grepping the outbound identity bindings during a soak (issue #638)
 

--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "registrar_test.go",
         "watch_drain_test.go",
         "watch_identity_test.go",
+        "watch_identity_wake_test.go",
         "watch_startup_test.go",
     ],
     embed = [":registrar"],

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -101,6 +101,12 @@ type RegistrarRegistry struct {
 	// on every reconnect; swapped atomically at SNAPSHOT_COMPLETE.
 	services map[string]struct{}
 
+	// wake cuts short the retry sleep between watch-stream attempts. Buffered
+	// with capacity 1 and written non-blocking, so a signal raised while the
+	// loop is not sleeping is still consumed by the next sleep. See
+	// NotifyIdentityReady.
+	wake chan struct{}
+
 	// notify coalesces endpoint-change signals for consumers (e.g. the agent
 	// xDS cache). It is buffered with capacity 1 and written non-blocking, so a
 	// burst of watch events collapses into a single pending signal.
@@ -152,6 +158,7 @@ func NewRegistrarRegistry(log *slog.Logger, cfg Config) *RegistrarRegistry {
 		metrics:     metrics,
 		cache:       make(map[registryv1.Service_Protocol]map[string][]*registryv1.ServiceEndpoint),
 		services:    make(map[string]struct{}),
+		wake:        make(chan struct{}, 1),
 		notify:      make(chan struct{}, 1),
 		ready:       make(chan struct{}),
 		reconnected: make(chan struct{}, 1),
@@ -565,10 +572,8 @@ func (r *RegistrarRegistry) failStream(ctx context.Context, msg string, err erro
 	jitter := time.Duration(float64(*backoff) * jitterFraction * rand.Float64())
 	wait := *backoff + jitter
 	r.log.ErrorContext(ctx, msg, "error", err, "backoff", wait)
-	select {
-	case <-ctx.Done():
+	if !r.waitBeforeRetry(ctx, wait) {
 		return false
-	case <-time.After(wait):
 	}
 	*backoff = min(*backoff*2, maxBackoff)
 	return true
@@ -591,12 +596,52 @@ func (r *RegistrarRegistry) deferStream(ctx context.Context, err error, backoff 
 	jitter := time.Duration(float64(backoff) * jitterFraction * rand.Float64())
 	wait := backoff + jitter
 	r.log.InfoContext(ctx, "watch stream deferred until this agent has an SVID", "error", err, "backoff", wait)
+	return r.waitBeforeRetry(ctx, wait)
+}
+
+// waitBeforeRetry sleeps between watch attempts, returning false if the context
+// ended first (shutdown). A NotifyIdentityReady wake cuts the sleep short: the
+// reason the loop was waiting has just gone away, so paying out the rest of the
+// backoff is pure added downtime.
+func (r *RegistrarRegistry) waitBeforeRetry(ctx context.Context, wait time.Duration) bool {
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
 	select {
 	case <-ctx.Done():
 		return false
-	case <-time.After(wait):
+	case <-r.wake:
+		return true
+	case <-timer.C:
+		return true
 	}
-	return true
+}
+
+// NotifyIdentityReady tells this client that SPIRE has now issued the SVID its
+// mTLS handshake needs, so the next watch attempt should happen NOW.
+//
+// Two things stand between the SVID landing and the stream working, and this
+// clears both:
+//
+//   - The gRPC ClientConn's OWN reconnect backoff, which the app-level loop
+//     cannot see. Every attempt during the outage failed the handshake, so by
+//     the time identity arrived the ClientConn had backed off to its ~120s cap
+//     and was answering new RPCs with the cached failure instead of dialling.
+//     On 2026-09-07 that made the node's data path stay down for 2m11s AFTER
+//     readiness said it had recovered — `could not get X509 bundle` long after
+//     the bundle existed, because nothing had tried again (#740, finding 3).
+//     ResetConnectBackoff drops the ClientConn straight back to CONNECTING.
+//   - This loop's own sleep, cut short by the wake.
+//
+// Safe to call at any time and from any goroutine, including before Initialize
+// (the wake is buffered and the nil conn is skipped).
+func (r *RegistrarRegistry) NotifyIdentityReady() {
+	if r.conn != nil {
+		r.conn.ResetConnectBackoff()
+	}
+	select {
+	case r.wake <- struct{}{}:
+	default:
+	}
 }
 
 // isServerDrainGoaway reports whether err is an established stream ending

--- a/registry/internal/registrar/watch_identity_wake_test.go
+++ b/registry/internal/registrar/watch_identity_wake_test.go
@@ -1,0 +1,120 @@
+package registrar
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TestNotifyIdentityReadyCutsTheRetrySleep is issue #740's finding 3 at the
+// retry level: when the thing the loop was waiting for arrives, the rest of the
+// backoff is pure added downtime.
+//
+// Both retry paths are covered because both were live during the outage — the
+// deferral while the SVID was pending, and the ordinary failure path after it
+// landed but before the transport recovered.
+func TestNotifyIdentityReadyCutsTheRetrySleep(t *testing.T) {
+	t.Run("failStream", func(t *testing.T) {
+		r, _, _ := newIdentityGatedRegistry(t, func() bool { return true })
+
+		backoff := 30 * time.Second // the cap: where a long outage leaves it
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			r.NotifyIdentityReady()
+		}()
+
+		start := time.Now()
+		require.True(t, r.failStream(t.Context(), "watch stream disconnected, retrying", errors.New("boom"), &backoff))
+		assert.Less(t, time.Since(start), 2*time.Second, "the wake must cut the 30s backoff short")
+	})
+
+	t.Run("deferStream", func(t *testing.T) {
+		r, _, _ := newIdentityGatedRegistry(t, func() bool { return false })
+
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			r.NotifyIdentityReady()
+		}()
+
+		start := time.Now()
+		require.True(t, r.deferStream(t.Context(), errors.New("no SPIRE SVID yet"), 30*time.Second))
+		assert.Less(t, time.Since(start), 2*time.Second)
+	})
+
+	t.Run("shutdown still wins", func(t *testing.T) {
+		// The wake must not turn a shutdown into another attempt.
+		r, _, _ := newIdentityGatedRegistry(t, func() bool { return true })
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		backoff := 30 * time.Second
+		assert.False(t, r.failStream(ctx, "watch stream disconnected, retrying", errors.New("boom"), &backoff))
+	})
+
+	t.Run("safe before Initialize", func(t *testing.T) {
+		// The agent wires the wake from a goroutine that can fire at any moment,
+		// including before the client has a connection to reset.
+		r, _, _ := newIdentityGatedRegistry(t, func() bool { return false })
+		require.Nil(t, r.conn)
+		assert.NotPanics(t, r.NotifyIdentityReady)
+	})
+}
+
+// TestWatchLoop_ConnectsImmediatelyWhenIdentityArrives is the end-to-end shape
+// of the same finding, with the fake registrar standing in for the transport
+// that cannot handshake until this workload has an SVID.
+//
+// On 2026-09-07 the SVID landed at 19:23:11 and readiness flipped 3s later, but
+// the node's mTLS clients kept failing until 19:25:22 — 2m11s of "recovered"
+// that was not, because the gRPC ClientConn had backed off to its ~120s cap and
+// was answering from the cached handshake failure instead of dialling again.
+// Nothing polls a ClientConn out of that; something has to reset it. This pins
+// the observable consequence: once identity exists the very next attempt
+// connects, in about a second rather than in minutes.
+func TestWatchLoop_ConnectsImmediatelyWhenIdentityArrives(t *testing.T) {
+	// Nothing is listening and identity is pending: every attempt fails the way
+	// a handshake without a certificate does.
+	target := &swappableListener{}
+	var ready atomic.Bool
+
+	r, logs := newLoggingRegistry(t, []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(target.dial),
+	})
+	r.config.IdentityReady = ready.Load
+	metrics, _ := newTestClientMetrics(t)
+	r.metrics = metrics
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	require.NoError(t, r.Initialize(ctx))
+	defer func() { _ = r.Close() }()
+
+	require.Eventually(t, func() bool {
+		return findRecord(logRecords(t, logs), "watch stream deferred until this agent has an SVID") != nil
+	}, 30*time.Second, 10*time.Millisecond, "the client must be waiting on identity first; logs:\n%s", logs.String())
+
+	// SPIRE starts serving: identity exists, the peer is reachable, and the agent
+	// says so.
+	_, lis, _ := serveCatalog(t, "svc-a", "v1")
+	target.set(lis)
+	ready.Store(true)
+
+	start := time.Now()
+	r.NotifyIdentityReady()
+
+	select {
+	case <-r.Reconnects():
+	case <-time.After(10 * time.Second):
+		t.Fatalf("the watch stream did not connect after identity arrived; logs:\n%s", logs.String())
+	}
+	assert.Less(t, time.Since(start), 2*time.Second,
+		"recovery must follow identity within about a second, not a backoff interval")
+}


### PR DESCRIPTION
PR 3 of #740. Fixes the three findings from the on-cluster validation of #741
(talos-main rev209 / chart 0.92.9-1559e83, 2026-09-07 19:14–19:28Z, verdict
**PARTIAL**). #741's core claim held — the agent survived a 6m41s SPIRE blackout
with **0 restarts**, never fatal, waiting ladder and metrics exactly as designed —
but three assertions in its body did not survive contact with the cluster.

## F1 — a restarted agent loses the node's data path (regression vs. the crash loop)

**Observed.** `mesh_dns` non-success over the window: **+5,083**, *all of it* from
`prober-rw6z8` = **main-worker-03**; every other node exactly **0**.
`AetherProberHTTPErrorBurst` CRITICAL fired at 19:18:55Z. `liveness` stayed at
**0 of 298,495** and `aether_mesh_dns_records` was 14 on all five nodes — DNS was
never implicated.

**Mechanism.** With no SVID the fresh agent cannot handshake to the registrar, so
`PreListen`'s bounded registry-ready wait expires, the local-only fallback fires,
and the agent **pushes** that snapshot — replacing a complete one and evicting
every cross-node endpoint. `echo` has no replica on w03, so ~95% of that node's
probes failed for the whole outage. The crash loop this replaced never did that:
a dying agent publishes nothing, so Envoy kept its last config and the node kept
working. The exposure is not "SPIRE is down" but **"SPIRE is down AND that node's
agent restarts"** — exactly the power-failure scenario #740 is about.

**Fix.** `PreListen` holds while identity is pending instead of falling through:

```
holding xDS until this agent has an SVID; Envoy keeps its current configuration  elapsed=15s
…
identity acquired; generating the initial snapshot  held=6m41.2s
```

The socket is not opened, so Envoy keeps its configuration exactly as it did
under the crash loop. From the moment identity exists, the registry wait and its
local-only fallback apply unchanged. **Mid-life is already correct and is left
alone**: once a snapshot is published the cache keeps it, so a registrar that
goes away later costs nothing (confirmed in `retryInitialRegistryLoad` + the
refresher; no change).

## F2 — the taint escalation is a fight between two controllers

**Observed.** The controller's guard armed `aether.io/agent-not-ready` at
19:19:38.9Z (29.9s after NotReady — the 30s grace is right), and the agent's own
`agent-taint-remover` removed it **~50 ms later**, repeating every 30s for eight
cycles. The node was tainted ~50 ms per 30s: **effectively never**.

**Mechanism.** SPIRE was deliberately excluded from the #667 taint gate, so the
remover saw socket + chained satisfied and cleared a taint the controller had
armed for a check it could not see.

**Fix.** The remover now consults the **same readiness aggregate the kubelet
polls** (`agentReadiness.Err()`), so both controllers read one verdict. The
socket + chained conditions keep their #667 semantics and are still conjunctive.
This is only safe because spire-server, spire-agent and the SPIFFE CSI driver now
**tolerate** the taint (k8s-talos-main #45, applied 2026-09-07) — the deadlock
argument that kept SPIRE out of the gate no longer applies. `values.yaml` and the
runbook now say those tolerations are **required**, not advisory.

## F3 — recovery signalled 2m11s early

**Observed.** SVID at 19:23:11.0Z, `svid_ready`=1, pod Ready 19:23:14Z — but mTLS
clients kept failing `x509svid: could not get X509 bundle` until **19:25:22.0Z**,
and the prober error bleed stopped at that same instant.

**Mechanism, two parts.** (a) Readiness flipped on the SVID alone; an mTLS peer
needs the SVID *and* the bundle for its trust domain. (b) The gRPC ClientConn's
own reconnect backoff — invisible to the app-level loop, whose logged backoff
stayed ~1.0–1.2s — had reached its ~120s cap after an outage's worth of failed
handshakes and was answering new RPCs from the cached failure instead of dialling.
Nothing polls a ClientConn out of that.

**Fix.** Readiness = SVID **AND** bundle (`firstIdentity`; the `WaitingSource`
publishes its source only when both are servable, so `HasSVID`, `/readyz`, the
xDS hold and the registrar's `IdentityReady` all mean the same thing). And the
registrar client is woken on identity — `ResetConnectBackoff()` plus a wake that
cuts the retry sleep short:

```
identity acquired; reconnecting the registrar client immediately rather than waiting out its backoff
```

## Also: the withheld readiness reason

`/readyz?verbose` prints `spire-svid failed: reason withheld` — controller-runtime
redacts checker errors, so the useful text is unreachable from the endpoint an
operator would curl. Each check now logs its reason **once per transition**:

```
WARN  spire-svid readiness failing   reason="no SPIRE SVID after 2m10s (socket /run/secrets/…)"
INFO  spire-svid readiness passing
```

Runbook updated with all of the above.

## Negative controls

- `--spire-enabled=false` (#421): no gate, no check, no hold — `identityGateOf`
  returns a **truly nil** interface (the same typed-nil trap `chainStateOf`
  guards), pinned by `TestPreListen_NoGateIsUnchanged`.
- `nil Ready` on the taint remover reproduces the pre-#740 socket+chained gate
  (`TestReconcileReadinessGate/nil Ready`); readiness does **not** substitute for
  chaining (`readyz passing but unchained -> still held`); the remover is still
  remove-only and never adds a taint.
- The hold ends on context cancel and returns **nil**, so a SPIRE outage can never
  make a shutdown look like a failure (`TestPreListen_HoldEndsOnShutdown`).
- `NotifyIdentityReady` is safe before `Initialize` (nil conn) and a shutdown
  still beats a wake.
- Both new production gates were disabled locally and the new tests **fail**
  (`//agent/internal/node:node_test`, `//agent/internal/xds/server:server_test`),
  then pass with them restored.

## Tests

`TestPreListen_HoldsUntilIdentity` (registry not consulted, PreListen does not
return, then proceeds once identity lands) · `TestPreListen_IdentityAlreadyHeld` ·
`TestReconcileReadinessGate` (held past the dwell while the SPIRE gate fails,
released once it passes) · `TestAgentReadinessErr` / `…LogsTransitions` (one
verdict, one line per transition, silent steady state) ·
`TestFirstIdentityRequiresBothHalves` · `TestNotifyIdentityReadyCutsTheRetrySleep`
(30s backoff cut to <2s on both retry paths) ·
`TestWatchLoop_ConnectsImmediatelyWhenIdentityArrives` (first successful watch
attempt ~1s after the peer becomes reachable).

## Re-validation recipe

Tier 1 on **main-worker-03** again (the no-local-replica node — the blast radius
is why it was chosen the first time), per #740's plan: pre-flight the SVID TTL
(abort under 30m), scale `spire-server` to 0, wait 60s, delete that node's
`spire-agent` **and** `aether-agent` pods, then scale back to 1. Grade from
**attestation**, not from the scale command.

Expect:

1. **The node's `mesh_dns` errors stay at 0 through the outage** (they were
   +5,083 last time) — Envoy keeps its config because nothing is pushed. Log
   shows `holding xDS until this agent has an SVID` and **no**
   `registry unavailable for initial snapshot; starting with local-only config`.
2. **The taint STAYS armed** from ~2m30s after the agent goes NotReady until
   recovery — no `removed startup taint` lines during the outage, one at the end.
   Verify with the controller's guard log rather than a JSONPath loop (zsh mangles
   `[?(@.key=="…")]` silently).
3. **Readiness flips only when both SVID and bundle are present**, and the
   registrar reconnects within seconds of it — the gap between `identity
   acquired` and the last `could not get X509 bundle` should be seconds, not the
   2m11s measured last time.
4. Unchanged from #741: 0 restarts, `source_restarts` absent, one `wait_seconds`
   observation matching the log's elapsed, `liveness` non-success 0.
5. `spire-svid readiness failing`/`passing` bracket the outage in the log, with
   the reason text.

Tier 2 (fleet) is now reasonable to run once Tier 1 is clean, since assertion 1
removes the per-node data-path loss that made it a fleet-wide outage last time —
still with `echo` scaled to every node.

Chart bumped 0.92.9 → 0.92.10 (values.yaml comment change is CI-enforced).

Follows #741. PR 2 (controller/registrar/edge) is in flight separately and does
not overlap these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
