### PR TITLE
fix(agent): the initial snapshot waits for endpoints, not for a latch (#740)

### DIFF
--- a/agent/internal/cmd/root.go
+++ b/agent/internal/cmd/root.go
@@ -300,6 +300,10 @@ func runAgent(ctx context.Context) (retErr error) {
 	// endpoint changes, so services registered after startup become routable
 	// without restarting the agent. No-op if the registry can't notify.
 	refresher := xdsServer.NewRegistryRefresher(cfg.ClusterName, cfg.NodeName, snapshotCache, reg, l)
+	// Same gate the xDS server holds on: it lets a reload that fails the mTLS
+	// handshake say WHOSE identity was missing — ours, the connection's
+	// catch-up right after ours arrived, or the registrar's (#740 PR 5).
+	refresher.SetIdentityGate(identityGateOf(spireSource))
 	if err = m.Add(refresher); err != nil {
 		return fmt.Errorf("failed to add registry refresher: %w", err)
 	}

--- a/agent/internal/xds/server/BUILD.bazel
+++ b/agent/internal/xds/server/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
     name = "server_test",
     srcs = [
         "identity_hold_test.go",
+        "initial_snapshot_test.go",
         "odcds_test.go",
         "refresh_identity_test.go",
         "refresh_test.go",
@@ -46,6 +47,7 @@ go_test(
         "//agent/storage",
         "//api/aether/cni/v1:cni",
         "//api/aether/registry/v1:registry",
+        "//common/constants/mesh",
         "//common/log",
         "//common/xds",
         "//registry",
@@ -54,6 +56,7 @@ go_test(
         "@com_github_envoyproxy_go_control_plane//pkg/resource/v3:resource",
         "@com_github_envoyproxy_go_control_plane_envoy//config/cluster/v3:cluster",
         "@com_github_envoyproxy_go_control_plane_envoy//config/core/v3:core",
+        "@com_github_envoyproxy_go_control_plane_envoy//config/endpoint/v3:endpoint",
         "@com_github_envoyproxy_go_control_plane_envoy//config/route/v3:route",
         "@com_github_envoyproxy_go_control_plane_envoy//service/discovery/v3:discovery",
         "@com_github_stretchr_testify//assert",

--- a/agent/internal/xds/server/initial_snapshot_test.go
+++ b/agent/internal/xds/server/initial_snapshot_test.go
@@ -1,0 +1,291 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"aethermesh.dev/agent/internal/xds/cache"
+	"aethermesh.dev/agent/internal/xds/proxy"
+	"aethermesh.dev/agent/storage"
+	cniv1 "aethermesh.dev/api/aether/cni/v1"
+	registryv1 "aethermesh.dev/api/aether/registry/v1"
+	meshconst "aethermesh.dev/common/constants/mesh"
+	"aethermesh.dev/registry"
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// lateRegistry is a watch-backed registry (registry.ReadyWaiter, like the
+// registrar client) that models the gap the incident turned on: its readiness
+// latch is ALREADY satisfied — WaitReady returns at once, as a one-shot latch
+// closed earlier does — while reads keep failing until servingAt with the
+// handshake error a connection that has not caught up gives back. That is
+// exactly the state main-worker-02's agent was in for the ~1.1s between
+// acquiring its SVID and its watch stream connecting.
+type lateRegistry struct {
+	*mockRegistry
+
+	servingAt time.Time
+	service   string
+	endpoint  string
+
+	reads    atomic.Int64
+	failed   atomic.Int64
+	waitCall atomic.Int64
+}
+
+func newLateRegistry(serveIn time.Duration, service, endpoint string) *lateRegistry {
+	l := &lateRegistry{
+		mockRegistry: &mockRegistry{},
+		servingAt:    time.Now().Add(serveIn),
+		service:      service,
+		endpoint:     endpoint,
+	}
+	l.mockRegistry.listAllEndpointsFunc = l.listAll
+	return l
+}
+
+func (l *lateRegistry) serving() bool { return !time.Now().Before(l.servingAt) }
+
+func (l *lateRegistry) listAll(_ context.Context, protocol registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+	l.reads.Add(1)
+	if !l.serving() {
+		l.failed.Add(1)
+		return nil, status.Error(codes.Unavailable,
+			`connection error: desc = "transport: authentication handshake failed: x509svid: could not get X509 bundle"`)
+	}
+	if protocol != registryv1.Service_PROTOCOL_HTTP {
+		return map[string][]*registryv1.ServiceEndpoint{}, nil
+	}
+	return map[string][]*registryv1.ServiceEndpoint{
+		l.service: {{Ip: l.endpoint, Port: 8080, Weight: 100, ClusterName: "cluster-1"}},
+	}, nil
+}
+
+// WaitReady answers what the registrar client's latch answers — "a complete
+// snapshot arrived at some point" — and answers it immediately, which is the
+// whole point: satisfying it says nothing about whether the next read works.
+func (l *lateRegistry) WaitReady(context.Context) error {
+	l.waitCall.Add(1)
+	return nil
+}
+
+// deadRegistry is a watch-backed registry that never comes up: WaitReady blocks
+// until the caller's budget expires and every read fails.
+type deadRegistry struct {
+	*mockRegistry
+	reads atomic.Int64
+}
+
+func newDeadRegistry() *deadRegistry {
+	d := &deadRegistry{mockRegistry: &mockRegistry{}}
+	d.mockRegistry.listAllEndpointsFunc = func(context.Context, registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+		d.reads.Add(1)
+		return nil, errors.New("registry unavailable: connection refused")
+	}
+	return d
+}
+
+func (d *deadRegistry) WaitReady(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// newWaitServer builds an xDS server over the given registry with one local pod,
+// so the dependency set is non-empty and the registry-derived load has something
+// to build.
+func newWaitServer(t *testing.T, reg registry.Registry, budget time.Duration) (*AgentXdsServer, *cache.SnapshotCache) {
+	t.Helper()
+
+	store := storage.NewMockStorageWithGetAll(func(_ context.Context) ([]*cniv1.CNIPod, error) {
+		return []*cniv1.CNIPod{}, nil
+	})
+	snapshotCache := cache.NewSnapshotCache("node-1", slog.New(slog.DiscardHandler))
+
+	srv, err := NewAgentXdsServer(t.Context(), "cluster-1", "node-1", "example.org",
+		reg, store, snapshotCache, nil, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	// One declared upstream: LoadClustersFromRegistry scopes the snapshot to the
+	// node's dependency set, so without this there is nothing for the registry's
+	// endpoints to become.
+	snapshotCache.ObserveDependency(t.Context(), waitTestService)
+
+	gate := newFakeIdentity()
+	gate.arrive()
+	srv.SetIdentityGate(gate)
+	srv.readyTimeout = budget
+	return srv, snapshotCache
+}
+
+// The service the fake registry serves, and the endpoint behind it.
+const (
+	waitTestService  = "team-a/echo"
+	waitTestEndpoint = "10.244.2.7"
+)
+
+// waitTestCluster is the CDS name that service becomes (<svc>.<ns>.<meshDomain>).
+var waitTestCluster = proxy.ServiceClusterName(waitTestService, meshconst.DefaultMeshDomain)
+
+// clusterNames returns the CDS resource names in the node's published snapshot.
+func clusterNames(t *testing.T, c *cache.SnapshotCache) []string {
+	t.Helper()
+
+	snap, err := c.GetSnapshot("node-1")
+	require.NoError(t, err, "PreListen must have published a snapshot")
+
+	var names []string
+	for name, res := range snap.GetResources(resourcev3.ClusterType) {
+		if _, ok := res.(*clusterv3.Cluster); ok {
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// endpointAddresses returns every EDS address in the node's published snapshot.
+func endpointAddresses(t *testing.T, c *cache.SnapshotCache) []string {
+	t.Helper()
+
+	snap, err := c.GetSnapshot("node-1")
+	require.NoError(t, err)
+
+	var addrs []string
+	for _, res := range snap.GetResources(resourcev3.EndpointType) {
+		cla, ok := res.(*endpointv3.ClusterLoadAssignment)
+		if !ok {
+			continue
+		}
+		for _, locality := range cla.GetEndpoints() {
+			for _, lb := range locality.GetLbEndpoints() {
+				addrs = append(addrs, lb.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+			}
+		}
+	}
+	return addrs
+}
+
+// TestPreListen_WaitsForRegistryEndpoints is issue #740's PR 5. On the rev211
+// deploy roll (2026-09-07 20:47:28Z) main-worker-02's agent acquired its SVID
+// and published the initial snapshot 0.4s later, while its registrar client was
+// still recovering from the handshakes it had failed before identity existed.
+// The registry read failed, the snapshot went out with no cross-node endpoints,
+// and the node's prober logged 316 http_error over the ~30s until the next
+// refresh repaired it — on a node whose Envoy had been serving fine.
+//
+// The wait that was supposed to prevent this (registry.ReadyWaiter) means "a
+// complete snapshot arrived at some point", which is not the same question as
+// "will this read succeed". So: the initial snapshot must not go out until the
+// registry actually answers with endpoints.
+func TestPreListen_WaitsForRegistryEndpoints(t *testing.T) {
+	const serveIn = 400 * time.Millisecond
+	reg := newLateRegistry(serveIn, waitTestService, waitTestEndpoint)
+	srv, snapshotCache := newWaitServer(t, reg, 5*time.Second)
+
+	start := time.Now()
+	require.NoError(t, srv.PreListen(t.Context()))
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, serveIn,
+		"PreListen returned before the registry could serve endpoints; Envoy would get a snapshot without them")
+	assert.Positive(t, reg.failed.Load(), "the test did not exercise the racing window it exists for")
+
+	// The published snapshot carries the registry's endpoints — not local-only
+	// config that would have evicted every cross-node endpoint from Envoy.
+	assert.Contains(t, clusterNames(t, snapshotCache), waitTestCluster,
+		"the initial snapshot must contain the registry's service cluster")
+	assert.Contains(t, endpointAddresses(t, snapshotCache), waitTestEndpoint,
+		"the initial snapshot must contain the registry's endpoints")
+}
+
+// TestPreListen_PublishesOneInitialRegistrySnapshot pins the other half: the
+// wait must not turn into a stream of snapshots. The failed attempts leave the
+// snapshot alone (LoadClustersFromRegistry returns before touching it), so Envoy
+// is never shown an endpoint-less generation on its way to the good one.
+//
+// Graded against the control — the same startup with a registry that was
+// serving all along — because it is the DIFFERENCE that would be the extra
+// publications.
+func TestPreListen_PublishesOneInitialRegistrySnapshot(t *testing.T) {
+	control := newLateRegistry(0, waitTestService, waitTestEndpoint)
+	controlSrv, controlCache := newWaitServer(t, control, 5*time.Second)
+	require.NoError(t, controlSrv.PreListen(t.Context()))
+	controlSnap, err := controlCache.GetSnapshot("node-1")
+	require.NoError(t, err)
+	require.Zero(t, control.failed.Load(), "the control must not have raced")
+
+	raced := newLateRegistry(300*time.Millisecond, waitTestService, waitTestEndpoint)
+	racedSrv, racedCache := newWaitServer(t, raced, 5*time.Second)
+	require.NoError(t, racedSrv.PreListen(t.Context()))
+	racedSnap, err := racedCache.GetSnapshot("node-1")
+	require.NoError(t, err)
+	require.Positive(t, raced.failed.Load(), "the raced case must have failed at least once")
+
+	// Snapshot versions are "<millis>.<generation>.snapshot"; the generation is
+	// the publication count, which is what must not have grown.
+	assert.Equal(t, snapshotGeneration(t, controlSnap.GetVersion(resourcev3.ClusterType)),
+		snapshotGeneration(t, racedSnap.GetVersion(resourcev3.ClusterType)),
+		"every failed attempt must be silent; only the successful load publishes")
+}
+
+// snapshotGeneration pulls the publication counter out of a snapshot version.
+func snapshotGeneration(t *testing.T, version string) string {
+	t.Helper()
+
+	parts := strings.Split(version, ".")
+	require.Len(t, parts, 3, "unexpected snapshot version shape: %q", version)
+	return parts[1]
+}
+
+// TestPreListen_UnreachableRegistryFallsBackLocalOnly is the bound on all of the
+// above: waiting is not stalling. A registry that never comes up costs the
+// budget and then the pre-existing local-only fallback, because a stalled agent
+// takes down the node's CNI ADD/DEL and xDS entirely (talos-main, 2026-06-10).
+func TestPreListen_UnreachableRegistryFallsBackLocalOnly(t *testing.T) {
+	const budget = 300 * time.Millisecond
+	reg := newDeadRegistry()
+	srv, snapshotCache := newWaitServer(t, reg, budget)
+
+	start := time.Now()
+	require.NoError(t, srv.PreListen(t.Context()), "an unreachable registry must not fail startup")
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, budget, "the bounded wait must actually be waited out")
+	assert.Less(t, elapsed, 10*time.Second, "and it must be BOUNDED")
+	assert.Positive(t, reg.reads.Load(), "the local-only fallback is taken only after trying")
+
+	// Local-only config: the snapshot exists (Envoy is served), it just has no
+	// registry-derived clusters.
+	assert.NotContains(t, clusterNames(t, snapshotCache), waitTestCluster)
+}
+
+// TestPreListen_SynchronousRegistryIsUnchanged is the negative control for the
+// scoping: a registry with no watch (the synchronous backends) has no readiness
+// to wait on, so it keeps the single-attempt behaviour exactly — no retry loop,
+// no added startup latency.
+func TestPreListen_SynchronousRegistryIsUnchanged(t *testing.T) {
+	var reads atomic.Int64
+	reg := &mockRegistry{
+		listAllEndpointsFunc: func(context.Context, registryv1.Service_Protocol) (map[string][]*registryv1.ServiceEndpoint, error) {
+			reads.Add(1)
+			return nil, errors.New("registry unavailable")
+		},
+	}
+	srv, _ := newWaitServer(t, reg, 10*time.Second)
+
+	start := time.Now()
+	require.NoError(t, srv.PreListen(t.Context()))
+
+	assert.Less(t, time.Since(start), time.Second, "a registry with no watch must not be waited on")
+	assert.Equal(t, int64(1), reads.Load(), "exactly one attempt, as before")
+}

--- a/agent/internal/xds/server/refresh.go
+++ b/agent/internal/xds/server/refresh.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"aethermesh.dev/agent/internal/xds/cache"
@@ -47,7 +48,23 @@ type RegistryRefresher struct {
 	// retried). Either may be nil (instrumentation disabled).
 	coalesced     metric.Int64Counter
 	refreshErrors metric.Int64Counter
+
+	// identity is this agent's own mesh identity, and identityAt the instant
+	// it arrived (unix nanos; 0 = not yet). Together they are what makes a
+	// failed reload classifiable — see reportReloadFailure. Optional: a nil
+	// gate means "no identity to wait for" (--spire-enabled=false).
+	identity   IdentityGate
+	identityAt atomic.Int64
 }
+
+// SetIdentityGate gives the refresher this agent's own identity, so a reload
+// that fails the mTLS handshake can be attributed to the right party. A setter
+// for the same reason AgentXdsServer.SetIdentityGate is one: the gate is
+// diagnostic context, not something the refresher needs in order to exist.
+//
+// Pass a nil gate (or never call this) and every failure is classified from the
+// error alone, as it was before issue #740's PR 5.
+func (r *RegistryRefresher) SetIdentityGate(gate IdentityGate) { r.identity = gate }
 
 // AssertWatchFilter pushes the cache's current dependency set to the registry
 // as the watch service filter (registry.WatchScoper capability), so the
@@ -108,6 +125,8 @@ func NewRegistryRefresher(clusterName, nodeName string, snapshotCache *cache.Sna
 // upstreams) both funnel into the same debounced reload. It implements
 // controller-runtime's manager.Runnable.
 func (r *RegistryRefresher) Start(ctx context.Context) error {
+	r.watchIdentity(ctx)
+
 	depChanges := r.cache.DependencyChanges()
 
 	notifier, ok := r.registry.(registry.ChangeNotifier)
@@ -197,25 +216,82 @@ func (l *refreshLoop) reload(ctx context.Context) {
 	l.r.log.DebugContext(ctx, "refreshed clusters from registry")
 }
 
-// reportReloadFailure logs a failed reload and counts it — except when the
-// failure is the registrar's own startup, which is neither (issue #740, PR 4).
-//
-// A registrar replica that is in its Service's endpoints before SPIRE has issued
-// its SVID rejects the mTLS handshake with `x509svid: could not get X509 bundle`.
-// That surfaced here on the rev210 roll (2026-09-07 20:03:45Z) as
-// `failed to refresh clusters from registry` at ERROR, alongside the watch
-// stream's ERROR for the same handshake — two alarms for one transient that
-// self-heals in seconds and leaves the previous snapshot in place, which is
-// exactly what a WARN is for. Every other reload failure keeps ERROR and the
-// counter: those leave the cluster snapshot stale until the next change signal
-// (reloads are not retried), which is the condition refresh_errors exists to
-// surface, and burying it under a boot's worth of handshake noise is the thing
-// this avoids.
-func (r *RegistryRefresher) reportReloadFailure(ctx context.Context, err error) {
-	if spire.IsPeerIdentityUnavailable(err) {
-		r.log.WarnContext(ctx, "cluster refresh deferred: the registrar has no identity yet, keeping the current snapshot", "error", err)
+// watchIdentity stamps the instant this agent's own identity arrives, which is
+// half of what reportReloadFailure needs to attribute a failed handshake. A
+// gate that is already satisfied stamps now: a reload failing in the first
+// seconds of the process is the connection coming up either way.
+func (r *RegistryRefresher) watchIdentity(ctx context.Context) {
+	if r.identity == nil {
 		return
 	}
+	if r.identity.HasSVID() {
+		r.identityAt.Store(time.Now().UnixNano())
+		return
+	}
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-r.identity.Ready():
+			r.identityAt.Store(time.Now().UnixNano())
+		}
+	}()
+}
+
+// identityReady reports whether this agent can complete an mTLS handshake at
+// all. No gate means nothing to wait for (SPIRE disabled).
+func (r *RegistryRefresher) identityReady() bool {
+	return r.identity == nil || r.identity.HasSVID()
+}
+
+// sinceIdentity is how long ago this agent's identity arrived, or a negative
+// duration when that is unknown (no gate, or identity not yet acquired).
+func (r *RegistryRefresher) sinceIdentity() time.Duration {
+	at := r.identityAt.Load()
+	if at == 0 {
+		return -1
+	}
+	return time.Since(time.Unix(0, at))
+}
+
+// reportReloadFailure logs a failed reload and counts it — except when the
+// failure is one of the three startup transients that are neither
+// (issues #740 PR 4 and PR 5).
+//
+// The classification order is spire.ClassifyHandshake's, and it matters: the
+// same `x509svid: could not get X509 bundle` text is produced whichever party
+// was short of an identity, and after a pre-identity attempt it is not even
+// current. So this asks in the order the answers are trustworthy — our own
+// identity, then the connection catching up right after it, then the peer's:
+//
+//   - Our own SVID is pending: a workload with no certificate fails every
+//     handshake, and nothing about the registrar follows from that. Logged as
+//     itself; the rev211 roll (2026-09-07 20:47:27.338Z, main-worker-02) logged
+//     it as the registrar's problem.
+//   - Identity arrived moments ago: the ClientConn is still carrying the
+//     failures it collected before, so this is the reconnect, not a fault.
+//     Same roll, 20:47:27.912Z — 85ms after the SVID landed and 1.1s before the
+//     watch stream connected, again blamed on the registrar.
+//   - The registrar has no SVID yet (PR 4): its own startup, self-healing in
+//     seconds, leaving the previous snapshot in place — a WARN.
+//
+// Every other reload failure keeps ERROR and the counter: those leave the
+// cluster snapshot stale until the next change signal (reloads are not
+// retried), which is the condition refresh_errors exists to surface, and
+// burying it under a boot's worth of handshake noise is the thing this avoids.
+func (r *RegistryRefresher) reportReloadFailure(ctx context.Context, err error) {
+	switch spire.ClassifyHandshake(err, r.identityReady(), r.sinceIdentity()) {
+	case spire.HandshakeOwnIdentityPending:
+		r.log.InfoContext(ctx, "cluster refresh deferred until this agent has an SVID, keeping the current snapshot", "error", err)
+		return
+	case spire.HandshakeReconnecting:
+		r.log.InfoContext(ctx, "registrar connection not yet re-established after identity; retrying", "error", err)
+		return
+	case spire.HandshakePeerIdentityPending:
+		r.log.WarnContext(ctx, "cluster refresh deferred: the registrar has no identity yet, keeping the current snapshot", "error", err)
+		return
+	case spire.HandshakeFailure:
+	}
+
 	r.log.ErrorContext(ctx, "failed to refresh clusters from registry", "error", err)
 	if r.refreshErrors != nil {
 		r.refreshErrors.Add(ctx, 1)

--- a/agent/internal/xds/server/refresh_identity_test.go
+++ b/agent/internal/xds/server/refresh_identity_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -119,4 +120,72 @@ func TestReportReloadFailure_NilCounter(t *testing.T) {
 	r.reportReloadFailure(context.Background(), errors.New("boom"))
 
 	assert.Equal(t, "ERROR", lastRecord(t, logs)["level"])
+}
+
+// TestReportReloadFailure_ClassifiesInOrder is PR 5 of #740: the same error text
+// arrives for three different conditions, and only local state tells them apart.
+// On the rev211 deploy roll (2026-09-07) main-worker-02 logged the registrar as
+// the culprit twice within 600ms — once while the AGENT had no SVID, once while
+// its own connection was still re-establishing itself after acquiring one. The
+// registrar had had its identity for a minute.
+func TestReportReloadFailure_ClassifiesInOrder(t *testing.T) {
+	t.Run("our own identity pending outranks the peer", func(t *testing.T) {
+		r, logs, reader := newCountingRefresher(t)
+		r.SetIdentityGate(newFakeIdentity()) // no SVID
+
+		r.reportReloadFailure(context.Background(), errRegistrarNoIdentity)
+
+		rec := lastRecord(t, logs)
+		assert.Equal(t, "INFO", rec["level"])
+		assert.Equal(t, "cluster refresh deferred until this agent has an SVID, keeping the current snapshot", rec["msg"])
+
+		_, found := refreshErrorCount(t, reader)
+		assert.False(t, found, "our own missing identity is not a refresh error")
+	})
+
+	t.Run("the reconnect window outranks the peer", func(t *testing.T) {
+		r, logs, reader := newCountingRefresher(t)
+		gate := newFakeIdentity()
+		gate.arrive()
+		r.SetIdentityGate(gate)
+		r.watchIdentity(t.Context()) // identity is in hand as of now
+
+		r.reportReloadFailure(context.Background(), errRegistrarNoIdentity)
+
+		rec := lastRecord(t, logs)
+		assert.Equal(t, "INFO", rec["level"])
+		assert.Equal(t, "registrar connection not yet re-established after identity; retrying", rec["msg"])
+
+		_, found := refreshErrorCount(t, reader)
+		assert.False(t, found, "our own reconnect is not a refresh error")
+	})
+
+	t.Run("past the window it is the peer again", func(t *testing.T) {
+		r, logs, _ := newCountingRefresher(t)
+		gate := newFakeIdentity()
+		gate.arrive()
+		r.SetIdentityGate(gate)
+		r.identityAt.Store(time.Now().Add(-time.Hour).UnixNano())
+
+		r.reportReloadFailure(context.Background(), errRegistrarNoIdentity)
+
+		rec := lastRecord(t, logs)
+		assert.Equal(t, "WARN", rec["level"])
+		assert.Equal(t, "cluster refresh deferred: the registrar has no identity yet, keeping the current snapshot", rec["msg"])
+	})
+
+	t.Run("a settled identity keeps real failures loud", func(t *testing.T) {
+		r, logs, reader := newCountingRefresher(t)
+		gate := newFakeIdentity()
+		gate.arrive()
+		r.SetIdentityGate(gate)
+		r.identityAt.Store(time.Now().Add(-time.Hour).UnixNano())
+
+		r.reportReloadFailure(context.Background(), errors.New("registry: malformed response"))
+
+		assert.Equal(t, "ERROR", lastRecord(t, logs)["level"])
+		got, found := refreshErrorCount(t, reader)
+		require.True(t, found)
+		assert.Equal(t, int64(1), got)
+	})
 }

--- a/agent/internal/xds/server/server.go
+++ b/agent/internal/xds/server/server.go
@@ -42,6 +42,12 @@ type AgentXdsServer struct {
 	// Optional: nil means "no identity to wait for" (--spire-enabled=false, and
 	// the edge, whose source is still created synchronously).
 	identity IdentityGate
+
+	// readyTimeout bounds the initial snapshot's wait for a registry that can
+	// serve endpoints. A field rather than the bare constant so tests can hold
+	// the unreachable-registrar path to a fraction of a second; production
+	// never changes it from registryReadyTimeout.
+	readyTimeout time.Duration
 }
 
 // IdentityGate is the mesh identity as the xDS server needs to see it: is it
@@ -89,14 +95,15 @@ func NewAgentXdsServer(ctx context.Context, clusterName string, nodeName string,
 	snapshotCache.SetRegistry(registry)
 
 	aXdsServer := &AgentXdsServer{
-		XdsServer:   xds.NewXdsServer(ctx, cfg, snapshotCache, combined, log),
-		log:         commonlog.Named(log, "agent-xds"),
-		clusterName: clusterName,
-		nodeName:    nodeName,
-		trustDomain: trustDomain,
-		registry:    registry,
-		storage:     storage,
-		cache:       snapshotCache,
+		XdsServer:    xds.NewXdsServer(ctx, cfg, snapshotCache, combined, log),
+		log:          commonlog.Named(log, "agent-xds"),
+		clusterName:  clusterName,
+		nodeName:     nodeName,
+		trustDomain:  trustDomain,
+		registry:     registry,
+		storage:      storage,
+		cache:        snapshotCache,
+		readyTimeout: registryReadyTimeout,
 	}
 
 	aXdsServer.AddCallback(aXdsServer)
@@ -142,33 +149,103 @@ func (s *AgentXdsServer) PreListen(ctx context.Context) error {
 	// registrar streams is the filtered one (demand-scoped distribution).
 	AssertWatchFilter(s.cache, s.registry)
 
-	// Wait (bounded) for the registry watch cache to hold a complete snapshot
-	// before deriving the initial config from it: a fresh agent that builds its
-	// snapshot from an empty/partial cache opens the xDS socket serving a
-	// route config with missing vhosts, and the reconnecting Envoy 404s live
-	// traffic until the next refresh (rev-66 agent roll, 2026-06-11). On
-	// timeout we proceed — the fallback below still serves local-only config
-	// rather than crash-looping the node.
-	if rw, ok := s.registry.(registry.ReadyWaiter); ok {
-		waitCtx, cancel := context.WithTimeout(ctx, registryReadyTimeout)
-		if err := rw.WaitReady(waitCtx); err != nil {
-			s.log.InfoContext(ctx, "registry watch cache not complete in time; proceeding (RPC fallback / background retry will fill in)", "timeout", registryReadyTimeout.String(), "error", err.Error())
-		}
-		cancel()
-	}
-
-	// Registry unavailability must not prevent the agent from starting: a
-	// crash-looping agent takes down the node's CNI ADD/DEL and xDS entirely,
-	// turning a registrar blip into a node-wide outage (observed cascading
-	// failure on talos-main, 2026-06-10). Serve the local-only snapshot now and
-	// fill in registry-derived clusters/endpoints as soon as the registry
-	// answers; the registry refresher keeps it current afterwards.
-	if err := s.cache.LoadClustersFromRegistry(ctx, s.clusterName, s.nodeName, s.registry); err != nil {
-		s.log.ErrorContext(ctx, "registry unavailable for initial snapshot; starting with local-only config and retrying in background", "error", err)
-		go s.retryInitialRegistryLoad(ctx)
-	}
+	s.loadInitialRegistryConfig(ctx)
 
 	return nil
+}
+
+// loadInitialRegistryConfig derives the registry half of the initial snapshot,
+// waiting (bounded) until the registry can actually answer with endpoints
+// before it does — and falling back to local-only config when it genuinely
+// cannot.
+//
+// "Can answer with endpoints" is the load-bearing part, and it is what changed
+// in issue #740's PR 5. The wait this replaced was
+// registry.ReadyWaiter.WaitReady alone, which is satisfied by the one-shot latch
+// the registrar client closes at its first SNAPSHOT_COMPLETE
+// (registry/internal/registrar: readyOnce) — "a complete snapshot arrived at
+// some point", not "the registry will serve this read now". The read that
+// follows takes a different path (the RPC fallback when the cache is not
+// serving), and on the rev211 deploy roll (2026-09-07 20:47:28Z on
+// main-worker-02) it failed while the registrar client's ClientConn was still
+// recovering from the handshakes it had failed before this agent acquired its
+// SVID a fraction of a second earlier. The registrar was healthy and both
+// replicas had been Ready for 43 seconds. The snapshot published from that
+// failure had no cross-node endpoints, and the node's prober logged 316
+// http_error over the ~30s until the next refresh repaired it.
+//
+// So the wait now ends on a SUCCESSFUL load, not on a latch: retry inside the
+// same bounded budget the ready-wait already had. A registrar that is genuinely
+// unreachable still costs exactly what it cost before — the budget, then the
+// local-only fallback and the background retry — because a crash-looping or
+// stalled agent takes down the node's CNI ADD/DEL and xDS entirely, turning a
+// registrar blip into a node-wide outage (talos-main, 2026-06-10).
+//
+// Registries with no watch (the synchronous backends) have nothing to wait for
+// and keep the single-attempt behaviour exactly.
+func (s *AgentXdsServer) loadInitialRegistryConfig(ctx context.Context) {
+	started := time.Now()
+
+	rw, watchBacked := s.registry.(registry.ReadyWaiter)
+	if !watchBacked {
+		if err := s.cache.LoadClustersFromRegistry(ctx, s.clusterName, s.nodeName, s.registry); err != nil {
+			s.startLocalOnly(ctx, err)
+		}
+		return
+	}
+
+	deadline := started.Add(s.readyTimeout)
+
+	// First the watch cache: a fresh agent that builds its snapshot from an
+	// empty/partial cache opens the xDS socket serving a route config with
+	// missing vhosts, and the reconnecting Envoy 404s live traffic until the
+	// next refresh (rev-66 agent roll, 2026-06-11).
+	waitCtx, cancel := context.WithDeadline(ctx, deadline)
+	err := rw.WaitReady(waitCtx)
+	cancel()
+	if err != nil {
+		s.log.InfoContext(ctx, "registry watch cache not complete in time; proceeding (RPC fallback / background retry will fill in)", "timeout", s.readyTimeout.String(), "error", err.Error())
+	}
+
+	if loadErr := s.loadClustersUntil(ctx, deadline); loadErr != nil {
+		s.startLocalOnly(ctx, loadErr)
+		return
+	}
+
+	s.log.InfoContext(ctx, "registry connected; generating the initial snapshot",
+		"waited", time.Since(started).Round(time.Millisecond).String())
+}
+
+// loadClustersUntil builds the registry-derived config, retrying until it
+// succeeds or the deadline passes. It always makes at least one attempt, so an
+// already-expired budget behaves exactly as the single attempt it replaces.
+func (s *AgentXdsServer) loadClustersUntil(ctx context.Context, deadline time.Time) error {
+	backoff := initialRegistryLoadBackoff
+	for {
+		err := s.cache.LoadClustersFromRegistry(ctx, s.clusterName, s.nodeName, s.registry)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil || !time.Now().Add(backoff).Before(deadline) {
+			return err
+		}
+		s.log.DebugContext(ctx, "registry not serving endpoints yet; holding the initial snapshot",
+			"backoff", backoff.String(), "error", err)
+		select {
+		case <-ctx.Done():
+			return err
+		case <-time.After(backoff):
+		}
+		backoff = min(backoff*2, maxInitialRegistryLoadBackoff)
+	}
+}
+
+// startLocalOnly publishes what the node knows on its own and keeps trying for
+// the rest of the process's life. Deliberately loud: a node running on
+// local-only config has no cross-node endpoints at all.
+func (s *AgentXdsServer) startLocalOnly(ctx context.Context, err error) {
+	s.log.ErrorContext(ctx, "registry unavailable for initial snapshot; starting with local-only config and retrying in background", "error", err)
+	go s.retryInitialRegistryLoad(ctx)
 }
 
 // identityHoldLogInterval is how often the identity hold re-announces itself.
@@ -226,11 +303,22 @@ func (s *AgentXdsServer) holdForIdentity(ctx context.Context) bool {
 	}
 }
 
-// registryReadyTimeout bounds how long PreListen waits for the registry watch
-// cache to hold a complete snapshot. Generous enough to cover a registrar
-// restart finishing its first external-registry sync (~3-5s observed), small
-// enough that a genuinely unavailable registrar cannot stall agent startup.
+// registryReadyTimeout bounds how long PreListen waits for the registry to be
+// able to serve this node's endpoints — the watch cache holding a complete
+// snapshot AND a load succeeding against it. Generous enough to cover a
+// registrar restart finishing its first external-registry sync (~3-5s observed)
+// and a client connection re-establishing itself after identity (~1.1s on the
+// rev211 roll), small enough that a genuinely unavailable registrar cannot stall
+// agent startup.
 const registryReadyTimeout = 15 * time.Second
+
+// The retry cadence inside that budget. Short at first — the condition it exists
+// for clears in about a second — then backing off so a longer outage spends the
+// budget on a handful of attempts rather than a busy loop.
+const (
+	initialRegistryLoadBackoff    = 250 * time.Millisecond
+	maxInitialRegistryLoadBackoff = 2 * time.Second
+)
 
 // retryInitialRegistryLoad retries the registry-derived snapshot load with
 // capped exponential backoff until it succeeds or ctx ends.

--- a/common/spire/BUILD.bazel
+++ b/common/spire/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "spire",
     srcs = [
+        "handshake.go",
         "metrics.go",
         "peer.go",
         "tls.go",
@@ -19,12 +20,15 @@ go_library(
         "@com_github_spiffe_go_spiffe_v2//workloadapi",
         "@io_opentelemetry_go_otel//:otel",
         "@io_opentelemetry_go_otel_metric//:metric",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
     ],
 )
 
 go_test(
     name = "spire_test",
     srcs = [
+        "handshake_test.go",
         "identity_test.go",
         "peer_test.go",
         "tls_test.go",

--- a/common/spire/handshake.go
+++ b/common/spire/handshake.go
@@ -1,0 +1,100 @@
+package spire
+
+import (
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// ReconnectWindow is how long after this workload's own identity arrives a
+// failed mTLS attempt is still attributed to the connection catching up rather
+// than to either party's identity.
+//
+// It exists because the error text cannot answer the question. Every attempt
+// made before the SVID landed failed the handshake, so the gRPC ClientConn has
+// a cached transport failure and a backoff of its own; the next RPC is answered
+// from that cache — with the PRE-identity error string — for as long as it takes
+// the connection to redial. #740's wake (NotifyIdentityReady →
+// ResetConnectBackoff) makes that a redial rather than a wait, but not an
+// instant one: on the rev211 deploy roll (2026-09-07 20:47Z) the reset landed at
+// 20:47:27.911 and the watch stream connected at 20:47:29.017, and every failure
+// in between carried an error written before identity existed.
+//
+// A few seconds, therefore: long enough to cover a redial plus a handshake,
+// short enough that a registrar which is genuinely down is misreported for one
+// log line and then escalates normally.
+const ReconnectWindow = 5 * time.Second
+
+// HandshakeClass says why an mTLS attempt against a mesh peer failed, in the
+// only order that is sound (see ClassifyHandshake).
+type HandshakeClass int
+
+const (
+	// HandshakeFailure is a real failure: log it, count it, escalate it. The
+	// zero value, so an unclassifiable error keeps the alarm it had before.
+	HandshakeFailure HandshakeClass = iota
+	// HandshakeOwnIdentityPending: this workload has no SVID yet, so it cannot
+	// present a certificate or verify the peer's. Nothing about the peer is
+	// known from such an attempt.
+	HandshakeOwnIdentityPending
+	// HandshakeReconnecting: identity arrived moments ago and the connection
+	// has not finished re-establishing itself on top of it.
+	HandshakeReconnecting
+	// HandshakePeerIdentityPending: our identity is in hand and settled, and
+	// the handshake still fails the way a peer without an SVID makes it fail.
+	HandshakePeerIdentityPending
+)
+
+// ClassifyHandshake classifies a failed mTLS attempt from what the caller knows
+// LOCALLY — whether its own identity is ready, and how long it has been ready —
+// before falling back to the error text.
+//
+// The order is the whole point, and it is the order in which the answers are
+// trustworthy:
+//
+//  1. Our own identity. A workload without an SVID fails every handshake for a
+//     reason that has nothing to do with the far side.
+//  2. The reconnect window. Right after identity arrives the transport is still
+//     carrying the failure it collected before, so an Unavailable here is the
+//     connection catching up (see ReconnectWindow).
+//  3. The peer. Only once our identity is in hand AND settled does a handshake
+//     failure say anything about the other side.
+//
+// Why local state and not the error text: the marker
+// `x509svid: could not get X509 bundle` that IsPeerIdentityUnavailable matches
+// is raised by go-spiffe's own verifier —
+// svid/x509svid/verify.go, `bundleSource.GetX509BundleForTrustDomain` — against
+// the LOCAL bundle source, so the identical string is produced whether it was
+// our source or the peer's process that was short. (A peer that cannot present
+// a certificate at all reaches us as a `remote error: tls: …` alert instead.)
+// The text names no party, and after a failed pre-identity attempt it is not
+// even current. That leaves local state as the only sound discriminator, which
+// is what this function keys on.
+//
+// sinceIdentity is how long ago this workload's identity became usable; pass a
+// negative duration when that is unknown (SPIRE disabled, or a client never told
+// about identity) to disable the reconnect window. A nil err is not a failure
+// and classifies as HandshakeFailure — callers only call this on an error.
+func ClassifyHandshake(err error, identityReady bool, sinceIdentity time.Duration) HandshakeClass {
+	if err == nil {
+		return HandshakeFailure
+	}
+	if !identityReady {
+		return HandshakeOwnIdentityPending
+	}
+	if sinceIdentity >= 0 && sinceIdentity <= ReconnectWindow && isTransportUnavailable(err) {
+		return HandshakeReconnecting
+	}
+	if IsPeerIdentityUnavailable(err) {
+		return HandshakePeerIdentityPending
+	}
+	return HandshakeFailure
+}
+
+// isTransportUnavailable reports whether err is the shape a connection that is
+// not up (yet) fails RPCs with: a gRPC Unavailable status, or a handshake error
+// that never got as far as a status.
+func isTransportUnavailable(err error) bool {
+	return status.Code(err) == codes.Unavailable || IsPeerIdentityUnavailable(err)
+}

--- a/common/spire/handshake_test.go
+++ b/common/spire/handshake_test.go
@@ -1,0 +1,124 @@
+package spire
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// errBundle is the string every mTLS failure in this area arrives as, whichever
+// party was short of an identity: go-spiffe's verifier raises it against the
+// LOCAL bundle source (svid/x509svid/verify.go), so it names nobody.
+var errBundle = status.Error(codes.Unavailable,
+	`connection error: desc = "transport: authentication handshake failed: x509svid: could not get X509 bundle"`)
+
+// TestClassifyHandshake is issue #740, PR 5: the rev211 deploy roll
+// (2026-09-07 20:47Z) produced this exact error twice on main-worker-02 within
+// 600ms, and both times it was attributed to the registrar — once while the
+// AGENT had no SVID, once while the agent's own connection was still
+// re-establishing itself after acquiring one. The registrar had had its identity
+// for a minute by then. Order of interrogation, not error text, is what tells
+// the three apart.
+func TestClassifyHandshake(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		identityReady bool
+		sinceIdentity time.Duration
+		want          HandshakeClass
+	}{
+		{
+			// 20:47:27.338 on the rev211 roll: logged as "the registrar has no
+			// identity yet" while it was this agent's own SVID that was pending.
+			name:          "our own identity is pending",
+			err:           errBundle,
+			identityReady: false,
+			sinceIdentity: -1,
+			want:          HandshakeOwnIdentityPending,
+		},
+		{
+			// Our own pending identity outranks everything, including an error
+			// that says nothing about identity at all: without a certificate
+			// this client learns nothing about the far side.
+			name:          "our own identity is pending, whatever the error says",
+			err:           errors.New("connection refused"),
+			identityReady: false,
+			sinceIdentity: -1,
+			want:          HandshakeOwnIdentityPending,
+		},
+		{
+			// 20:47:27.912: 85ms after the SVID landed, ResetConnectBackoff
+			// already called, the watch stream 1.1s from connecting.
+			name:          "identity just arrived and the connection is catching up",
+			err:           errBundle,
+			identityReady: true,
+			sinceIdentity: 85 * time.Millisecond,
+			want:          HandshakeReconnecting,
+		},
+		{
+			name:          "a plain Unavailable inside the reconnect window is the reconnect",
+			err:           status.Error(codes.Unavailable, "connection error: desc = \"transport: Error while dialing: dial tcp: connect: connection refused\""),
+			identityReady: true,
+			sinceIdentity: time.Second,
+			want:          HandshakeReconnecting,
+		},
+		{
+			name:          "the window is bounded",
+			err:           errBundle,
+			identityReady: true,
+			sinceIdentity: ReconnectWindow + time.Millisecond,
+			want:          HandshakePeerIdentityPending,
+		},
+		{
+			// PR 4's case, now reached only when it is the only one left: our
+			// identity is in hand and has been for a while.
+			name:          "the peer has no identity yet",
+			err:           errBundle,
+			identityReady: true,
+			sinceIdentity: time.Minute,
+			want:          HandshakePeerIdentityPending,
+		},
+		{
+			// SPIRE disabled, or a client never told when identity arrived: no
+			// window, and the pre-#740 classification stands.
+			name:          "an unknown identity age disables the window",
+			err:           errBundle,
+			identityReady: true,
+			sinceIdentity: -1,
+			want:          HandshakePeerIdentityPending,
+		},
+		{
+			// The condition the ERROR path exists for (#700) must survive all
+			// three deferrals once identity is settled.
+			name:          "a registrar that will not serve is still a failure",
+			err:           status.Error(codes.Unavailable, "connection error: desc = \"transport: Error while dialing: dial tcp: connect: connection refused\""),
+			identityReady: true,
+			sinceIdentity: time.Minute,
+			want:          HandshakeFailure,
+		},
+		{
+			name:          "a non-transport failure is still a failure",
+			err:           errors.New("registry: malformed response"),
+			identityReady: true,
+			sinceIdentity: time.Millisecond,
+			want:          HandshakeFailure,
+		},
+		{
+			name:          "nil is not a failure to classify",
+			err:           nil,
+			identityReady: false,
+			sinceIdentity: -1,
+			want:          HandshakeFailure,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ClassifyHandshake(tc.err, tc.identityReady, tc.sinceIdentity))
+		})
+	}
+}

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -531,6 +531,32 @@ kubectl -n aether logs ds/aether-agent | grep -E "identity acquired"
 # identity acquired; reconnecting the registrar client immediately …
 ```
 
+**Acquiring the SVID is not the same as being able to use it.** Every handshake made
+before the SVID landed failed, so the registrar client's gRPC connection is still
+carrying that failure for the second or so it takes to redial — and a snapshot built in
+that window has no cross-node endpoints, which is the same local-only outage as above by
+another route. Since #740 PR 5 the initial snapshot therefore waits for a registry that
+actually **answers**, not merely for its readiness latch, and says so:
+
+```bash
+kubectl -n aether logs ds/aether-agent | grep -E "registry connected|not yet re-established|local-only"
+# registry connected; generating the initial snapshot                     waited=1.106s
+# registrar connection not yet re-established after identity; retrying    reconnecting=true …
+```
+
+`registry connected` is the healthy end of every agent start; `waited` is normally a few
+milliseconds and rises to about a second when the start raced identity. The
+`not yet re-established` INFO is that race being named correctly — it is **our own**
+connection catching up, not the registrar, so do not go reading registrar logs for it.
+Reserve that for `registrar has no identity yet; retrying`, which is only ever logged
+once this agent's identity has been settled for more than a few seconds. On the rev211
+deploy roll (2026-09-07 20:47Z) both lines read `registrar has no identity yet`, and
+`main-worker-02` published an endpoint-less snapshot and logged **316** prober
+`http_error` in ~30s while both registrar replicas had been Ready for 43 seconds. The
+wait is bounded by the same 15s budget as before, so a registrar that is genuinely
+unreachable still ends at `registry unavailable for initial snapshot; starting with
+local-only config` rather than stalling the node.
+
 The upstream cause is almost always spire-server or the node's spire-agent, not aether:
 
 ```bash

--- a/registry/internal/registrar/BUILD.bazel
+++ b/registry/internal/registrar/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "watch_identity_test.go",
         "watch_identity_wake_test.go",
         "watch_peer_identity_test.go",
+        "watch_reconnect_test.go",
         "watch_startup_test.go",
     ],
     embed = [":registrar"],

--- a/registry/internal/registrar/registrar.go
+++ b/registry/internal/registrar/registrar.go
@@ -12,6 +12,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	registrarv1 "aethermesh.dev/api/aether/registrar/v1"
@@ -107,6 +108,12 @@ type RegistrarRegistry struct {
 	// loop is not sleeping is still consumed by the next sleep. See
 	// NotifyIdentityReady.
 	wake chan struct{}
+
+	// identityReadyAt is when this client was first told SPIRE had issued its
+	// SVID (unix nanos; 0 = never). It bounds the window in which a failed
+	// handshake is this connection catching up rather than the peer's fault —
+	// see sinceIdentity and failStream.
+	identityReadyAt atomic.Int64
 
 	// notify coalesces endpoint-change signals for consumers (e.g. the agent
 	// xDS cache). It is buffered with capacity 1 and written non-blocking, so a
@@ -565,13 +572,26 @@ func (r *RegistrarRegistry) recoverStreamOpen(ctx context.Context, err error, ca
 // the failure, log it at ERROR, then sleep the current backoff with jitter and
 // double it for the next attempt. It reports whether the loop should keep
 // watching (false = the context ended while waiting, i.e. shutdown).
+//
+// Three startup transients are classified out of that path first, in
+// spire.ClassifyHandshake's order — our own pending identity, the connection
+// re-establishing itself in the seconds right after identity, then the peer's
+// pending identity. The error text cannot order them: `x509svid: could not get
+// X509 bundle` is raised by the local verifier whichever party was short, and
+// the ClientConn hands back the failure it cached before identity for as long
+// as it takes to redial. #718's drain classification never reaches here (an
+// established stream ending on a GOAWAY returns no failure at all).
 func (r *RegistrarRegistry) failStream(ctx context.Context, msg string, err error, backoff *time.Duration) bool {
-	if r.identityPending() {
+	switch spire.ClassifyHandshake(err, !r.identityPending(), r.sinceIdentity()) {
+	case spire.HandshakeOwnIdentityPending:
 		return r.deferStream(ctx, err, *backoff)
-	}
-	if spire.IsPeerIdentityUnavailable(err) {
+	case spire.HandshakeReconnecting:
+		return r.deferReconnect(ctx, err, backoff)
+	case spire.HandshakePeerIdentityPending:
 		return r.deferPeerStream(ctx, err, backoff)
+	case spire.HandshakeFailure:
 	}
+
 	r.metrics.streamFailed(ctx)
 	jitter := time.Duration(float64(*backoff) * jitterFraction * rand.Float64())
 	wait := *backoff + jitter
@@ -590,6 +610,19 @@ func (r *RegistrarRegistry) identityPending() bool {
 	return r.config.IdentityReady != nil && !r.config.IdentityReady()
 }
 
+// sinceIdentity is how long ago this client was told its identity had arrived
+// (NotifyIdentityReady), or a negative duration when it never was — SPIRE
+// disabled, or a caller with no such notion. A negative value disables the
+// reconnect window, which is what keeps those callers on their pre-#740
+// classification exactly.
+func (r *RegistrarRegistry) sinceIdentity() time.Duration {
+	at := r.identityReadyAt.Load()
+	if at == 0 {
+		return -1
+	}
+	return time.Since(time.Unix(0, at))
+}
+
 // deferStream is the failure path's counterpart for a stream that could not be
 // established because this workload has no identity yet (issue #740): announce
 // it at INFO, wait out the CURRENT backoff with the usual jitter, and leave the
@@ -604,29 +637,56 @@ func (r *RegistrarRegistry) deferStream(ctx context.Context, err error, backoff 
 }
 
 // deferPeerStream is the other half of the same idea (issue #740, PR 4): OUR
-// identity is ready, but the REGISTRAR's is not, so the mTLS handshake fails
-// with `x509svid: could not get X509 bundle` raised by the server side of the
-// connection. That is the server's startup — not a client fault, and not the
-// "registrar will not serve this stream" condition #700 made these ERRORs for —
-// so it is classified the way #718 classified a drain GOAWAY: INFO, no
-// watch_errors, bounded retry.
+// identity is ready and has been for a while, and the mTLS handshake still fails
+// the way it fails when the REGISTRAR has no SVID. That is the server's startup
+// — not a client fault, and not the "registrar will not serve this stream"
+// condition #700 made these ERRORs for — so it is classified the way #718
+// classified a drain GOAWAY: INFO, no watch_errors, bounded retry.
 //
-// Unlike deferStream the backoff DOES escalate (capped at maxBackoff), because
-// nothing wakes this loop when the FAR side acquires its SVID: there is no local
-// signal to fire, so the loop has to keep polling, and the doubling is what stops
-// a genuinely dead registrar from being polled every second forever. The cap
-// bounds the added reconnect latency at maxBackoff.
+// "and has been for a while" is PR 5's correction: for the first seconds after
+// identity the identical error is our own reconnect, not the peer — see
+// deferReconnect and spire.ClassifyHandshake.
 //
 // Observed on the rev210 upgrade roll (2026-09-07 20:03:45Z): a registrar pod was
-// in its Service's endpoints before it had an SVID (the readiness dwell this PR
-// also removes), and the agent on main-worker-01 logged this as
+// in its Service's endpoints before it had an SVID (the readiness dwell #744
+// removed), and the agent on main-worker-01 logged this as
 // `failed to start watch stream, retrying` at ERROR for a replica that was
 // serving seconds later.
 func (r *RegistrarRegistry) deferPeerStream(ctx context.Context, err error, backoff *time.Duration) bool {
+	return r.deferRetry(ctx, "registrar has no identity yet; retrying", err, backoff, "peer_identity_pending")
+}
+
+// deferReconnect is the third shape (issue #740, PR 5), and the one that used
+// to be misread as the second: OUR identity has just arrived and the connection
+// underneath the watch loop has not caught up with it. Every attempt made before
+// the SVID landed failed the handshake, so the ClientConn holds a cached
+// transport failure — with the pre-identity error text — until it redials.
+//
+// On the rev211 deploy roll (2026-09-07, main-worker-02) the wake fired
+// ResetConnectBackoff at 20:47:27.911Z, this loop logged
+// `registrar has no identity yet; retrying` 1ms later, and the stream connected
+// at 20:47:29.017Z. The registrar had had its identity for a minute. Blaming the
+// far side for our own reconnect sends an operator to the wrong pod's logs.
+//
+// Same handling as deferPeerStream — INFO, no watch_errors, escalating backoff
+// capped at maxBackoff — only the attribution differs.
+func (r *RegistrarRegistry) deferReconnect(ctx context.Context, err error, backoff *time.Duration) bool {
+	return r.deferRetry(ctx, "registrar connection not yet re-established after identity; retrying", err, backoff, "reconnecting")
+}
+
+// deferRetry is the shared body of the two peer-side deferrals: announce at
+// INFO, wait out the current backoff with the usual jitter, then double it
+// (capped). No ERROR and no watch_errors — nothing here is a failure of either
+// party.
+//
+// Unlike deferStream the backoff DOES escalate, because nothing wakes this loop
+// for either condition: there is no local signal to fire, so the loop has to
+// keep polling, and the doubling is what stops a genuinely dead registrar from
+// being polled every second forever. The cap bounds the added reconnect latency.
+func (r *RegistrarRegistry) deferRetry(ctx context.Context, msg string, err error, backoff *time.Duration, reason string) bool {
 	jitter := time.Duration(float64(*backoff) * jitterFraction * rand.Float64())
 	wait := *backoff + jitter
-	r.log.InfoContext(ctx, "registrar has no identity yet; retrying",
-		"peer_identity_pending", true, "error", err, "backoff", wait)
+	r.log.InfoContext(ctx, msg, reason, true, "error", err, "backoff", wait)
 	if !r.waitBeforeRetry(ctx, wait) {
 		return false
 	}
@@ -670,6 +730,10 @@ func (r *RegistrarRegistry) waitBeforeRetry(ctx context.Context, wait time.Durat
 // Safe to call at any time and from any goroutine, including before Initialize
 // (the wake is buffered and the nil conn is skipped).
 func (r *RegistrarRegistry) NotifyIdentityReady() {
+	// Stamp the FIRST notification only: what the reconnect window measures is
+	// the age of this connection's identity, and a later re-announcement must
+	// not reopen a window that closed seconds after boot.
+	r.identityReadyAt.CompareAndSwap(0, time.Now().UnixNano())
 	if r.conn != nil {
 		r.conn.ResetConnectBackoff()
 	}

--- a/registry/internal/registrar/watch_reconnect_test.go
+++ b/registry/internal/registrar/watch_reconnect_test.go
@@ -1,0 +1,137 @@
+package registrar
+
+import (
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// errHandshakeBundle is how a failed mesh handshake reaches this loop. It is the
+// SAME text whichever side was short of an identity — go-spiffe raises
+// `could not get X509 bundle` in its own verifier, against the LOCAL bundle
+// source (svid/x509svid/verify.go) — and after a pre-identity attempt the gRPC
+// ClientConn hands it back from cache, so it is not even current. Local state is
+// the only sound discriminator.
+var errHandshakeBundle = status.Error(codes.Unavailable,
+	`connection error: desc = "transport: authentication handshake failed: x509svid: could not get X509 bundle"`)
+
+// newClassifyingRegistry builds a client with no connection at all: failStream
+// is exercised directly, so the classification is tested without racing a dial.
+func newClassifyingRegistry(t *testing.T, identityReady func() bool) (*RegistrarRegistry, *lockedBuffer) {
+	t.Helper()
+
+	logs := &lockedBuffer{}
+	r := NewRegistrarRegistry(slog.New(slog.NewJSONHandler(logs, &slog.HandlerOptions{Level: slog.LevelDebug})), Config{
+		Address:       "passthrough:///registrar-test",
+		ClusterName:   "test-cluster",
+		NodeName:      "test-node",
+		IdentityReady: identityReady,
+	})
+	metrics, _ := newTestClientMetrics(t)
+	r.metrics = metrics
+	return r, logs
+}
+
+// TestFailStream_ClassificationOrder is PR 5 of #740. The rev211 deploy roll
+// (2026-09-07 20:47Z, main-worker-02) logged `registrar has no identity yet` for
+// two conditions that were not that: at 20:47:27.338 the AGENT had no SVID, and
+// at 20:47:27.912 the agent had one (85ms old) while its ClientConn was still
+// recovering from the handshakes it had failed before. Both registrar replicas
+// had been Ready with identities since 20:46:45.
+//
+// The three must be told apart in this order — ours, the reconnect, then the
+// peer's — because that is the order in which the answers are trustworthy.
+func TestFailStream_ClassificationOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		identityReady bool
+		identityAge   time.Duration // 0 = never notified
+		wantLevel     string
+		wantMsg       string
+	}{
+		{
+			name:          "our own identity is pending",
+			identityReady: false,
+			wantLevel:     "INFO",
+			wantMsg:       "watch stream deferred until this agent has an SVID",
+		},
+		{
+			name:          "identity just arrived and the connection is catching up",
+			identityReady: true,
+			identityAge:   85 * time.Millisecond,
+			wantLevel:     "INFO",
+			wantMsg:       "registrar connection not yet re-established after identity; retrying",
+		},
+		{
+			name:          "a settled identity leaves only the peer",
+			identityReady: true,
+			identityAge:   time.Hour,
+			wantLevel:     "INFO",
+			wantMsg:       "registrar has no identity yet; retrying",
+		},
+		{
+			name:          "never notified: no window, pre-PR-5 classification",
+			identityReady: true,
+			wantLevel:     "INFO",
+			wantMsg:       "registrar has no identity yet; retrying",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ready := tc.identityReady
+			r, logs := newClassifyingRegistry(t, func() bool { return ready })
+			if tc.identityAge != 0 {
+				r.identityReadyAt.Store(time.Now().Add(-tc.identityAge).UnixNano())
+			}
+
+			backoff := time.Millisecond
+			require.True(t, r.failStream(t.Context(), "failed to start watch stream, retrying", errHandshakeBundle, &backoff))
+
+			rec := findRecord(logRecords(t, logs), tc.wantMsg)
+			require.NotNil(t, rec, "expected %q; logs:\n%s", tc.wantMsg, logs.String())
+			assert.Equal(t, tc.wantLevel, rec["level"])
+
+			for _, r := range logRecords(t, logs) {
+				assert.NotEqual(t, "ERROR", r["level"], "none of the three is a failure; logs:\n%s", logs.String())
+			}
+		})
+	}
+}
+
+// TestFailStream_RealFailuresSurviveTheWindow is the negative control the ERROR
+// path exists for (#700): a registrar that will not serve must still be an ERROR
+// once identity is settled, and a dial failure that is not a handshake must not
+// be swallowed by the reconnect window's transport check either.
+func TestFailStream_RealFailuresSurviveTheWindow(t *testing.T) {
+	r, logs := newClassifyingRegistry(t, func() bool { return true })
+	r.identityReadyAt.Store(time.Now().Add(-time.Hour).UnixNano())
+
+	backoff := time.Millisecond
+	err := status.Error(codes.Internal, "registrar: watcher evicted")
+	require.True(t, r.failStream(t.Context(), "failed to start watch stream, retrying", err, &backoff))
+
+	rec := findRecord(logRecords(t, logs), "failed to start watch stream, retrying")
+	require.NotNil(t, rec, "logs:\n%s", logs.String())
+	assert.Equal(t, "ERROR", rec["level"])
+}
+
+// TestNotifyIdentityReady_StampsOnce pins the window's anchor: it measures the
+// age of THIS connection's identity, so a later re-announcement must not reopen
+// a window that closed seconds after boot.
+func TestNotifyIdentityReady_StampsOnce(t *testing.T) {
+	r, _ := newClassifyingRegistry(t, func() bool { return true })
+
+	r.NotifyIdentityReady()
+	first := r.identityReadyAt.Load()
+	require.NotZero(t, first)
+
+	time.Sleep(2 * time.Millisecond)
+	r.NotifyIdentityReady()
+	assert.Equal(t, first, r.identityReadyAt.Load(), "only the first identity is the anchor")
+}


### PR DESCRIPTION
PR 5 of #740. A race found on the rev211 deploy roll: with SPIRE healthy and both registrar replicas Ready since 20:46:45Z, `main-worker-02`'s agent produced a **316-request `http_error` burst** on that node's prober (~30s at 10 rq/s).

## The timeline (all 2026-09-07, within 3 seconds)

```
20:47:26.342 INFO  registrar client using SPIRE mTLS / initialized registrar registry
20:47:26.413 INFO  restored 9 observed upstreams from local storage
20:47:27.124..27.423 DEBUG setting snapshot (×~12)            ← before identity
20:47:27.338 WARN  cluster refresh deferred: the registrar has no identity yet …   ← MISCLASSIFIED: it was the AGENT's own identity that was pending
20:47:27.339 INFO  watch stream deferred until this agent has an SVID              ← correct
20:47:27.827 INFO  identity acquired; generating the initial snapshot
20:47:27.828 DEBUG generating initial snapshot / found pods in local storage
20:47:27.911 INFO  identity acquired; reconnecting the registrar client immediately …
20:47:27.912 INFO  registrar has no identity yet; retrying                         ← MISCLASSIFIED again (the registrar had identity; our conn was still in its handshake-failed state)
20:47:28.212 DEBUG setting snapshot                                                ← the initial snapshot: local pods, NO registry endpoints
20:47:28.311 DEBUG generating clusters and endpoints from registry
20:47:28.312 WARN  cluster refresh deferred … (failed to list endpoints)
20:47:29.017 DEBUG watch stream connected / re-asserting this node's registrations
```

Once identity is acquired, `PreListen` generated and published the initial snapshot immediately, but the registrar client's connection was still recovering from its pre-identity handshake failures (`ResetConnectBackoff` at 27.911; the watch connected at 29.017). The registry list failed, the first snapshot Envoy received had no cross-node endpoints, and the next refresh (~30s) repaired it.

## What `registryReady` meant

`PreListen` type-asserted `registry.ReadyWaiter` (`registry/registry.go:52-59`) and called `WaitReady` (`registry/internal/registrar/registrar.go:207-214`), which blocks on a **one-shot latch** closed by `readyOnce` at `registrar.go:799` on the first `SNAPSHOT_COMPLETE`.

So it meant *"a complete snapshot arrived at some point"* — not *"the registry will serve this read now"*:

- it is a **latch, not a live state**: once closed it never re-opens, so mid-life it is a no-op — including immediately after `AssertWatchFilter` (`server.go:150`) has purged cache entries leaving the filter and forced a re-filtered resnapshot;
- the read that follows takes a **different path** — `ListAllEndpoints` falls through to the RPC fallback (`registrar.go:377-397`) whenever the cache is not serving — and that path fails on a ClientConn still in its handshake-failed state;
- on expiry the branch only logs at **INFO** and proceeds, and nothing downstream checks that the resulting snapshot actually contains registry endpoints. The failure was handled by the local-only fallback, not by more waiting.

## The fix

1. **The initial snapshot waits for endpoints, not for a latch.** `loadInitialRegistryConfig` keeps `WaitReady` and then retries `LoadClustersFromRegistry` inside the **same 15s budget** the ready-wait already had, ending only on a successful load. New INFO `registry connected; generating the initial snapshot` with `waited=`. A genuinely unreachable registrar costs exactly what it cost before — the budget, then the unchanged `registry unavailable for initial snapshot; starting with local-only config` and the background retry. Failed attempts publish nothing (`LoadClustersFromRegistry` returns before touching the snapshot), so Envoy never sees an endpoint-less generation on the way to the good one. Registries with no watch (synchronous backends) keep the single attempt exactly. **Nothing else in `PreListen` moves** — #700/#712's `AssertWatchFilter` ordering stands.

2. **Classification order.** The two `x509svid: could not get X509 bundle` cases are **textually identical**, and the reason is structural: that string is raised by go-spiffe's own verifier against the **local** bundle source (`svid/x509svid/verify.go:59-61`), so it is produced whichever party was short — and after a pre-identity attempt the gRPC ClientConn hands it back **from cache**, so it is not even current. (A peer that cannot present a certificate at all arrives as a `remote error: tls: …` alert instead.) Text therefore cannot name the party; local state can. New `spire.ClassifyHandshake(err, identityReady, sinceIdentity)` asks in the order the answers are trustworthy:
   1. our own `IdentityReady()` false → `deferred until this agent has an SVID`;
   2. a transport-level `Unavailable` within `ReconnectWindow` (5s) of identity arriving → INFO `registrar connection not yet re-established after identity; retrying`;
   3. only then → `registrar has no identity yet`.

   Used by both the cluster-refresh path (`reportReloadFailure`, #744) and the watch loop (`failStream`). The window's anchor is `NotifyIdentityReady`, stamped once; a client never told about identity (SPIRE off) gets no window and keeps its pre-PR-5 classification byte for byte. **#718's drain classification is untouched** — an established stream ending on a `NO_ERROR` GOAWAY returns no failure and never reaches `failStream`.

3. **Tests** (hermetic, no cluster, no sleep-based flake): a watch-backed fake whose readiness latch is *already* satisfied while reads keep failing for 400ms — `PreListen` must not return before the registry can serve, and the published snapshot must carry the fake registry's cluster **and** its endpoint IP; a control run proving the failed attempts publish nothing (same snapshot generation as a registry that was serving all along); the never-comes-up registry still falling back local-only inside its bound (existing behaviour, kept); the synchronous-backend negative control; and the three-way classification pinned in `common/spire`, in the refresher, and in the registrar client — with the #700 ERROR path as the negative control in each.

4. **Runbook**: a paragraph in *The agent is stuck waiting for SPIRE* on `registry connected; generating the initial snapshot` and on reading the reconnect INFO as ours rather than the registrar's.

No chart change.

## Validation

`bazel test --test_arg=-test.short //agent/... //common/... //registry/...` — 56/56 pass. `make gazelle`, `bazel build --config=lint` on the touched packages, `make format-check` all clean.

On talos: a plain `kubectl -n aether rollout restart ds/aether-agent` must produce **0 mesh_dns `http_error` on every node** — the rev211 roll produced 316 on `main-worker-02`. Grade per node against a pre-roll baseline of the prober counters, and expect `registry connected; generating the initial snapshot` once per agent with `waited` in the tens-of-ms to ~1s range, `registrar has no identity yet` only when a registrar replica really is starting, and zero `registry unavailable for initial snapshot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
