### PR TITLE
chore(deps): bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - main
+      # Stacked PRs: a PR whose base is another `upgrade/**` branch must still
+      # get the `ci` gate, otherwise the required check never reports on it.
+      - "upgrade/**"
 
 permissions:
   contents: read
@@ -26,7 +29,7 @@ jobs:
     outputs:
       control_plane: ${{ steps.filter.outputs.control_plane }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -52,13 +55,13 @@ jobs:
       has_e2e: ${{ steps.impacted.outputs.has_e2e }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           # Full history so the base commit is reachable for the diff.
           fetch-depth: 0
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "21"
@@ -97,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Full history so the PR base commit is reachable for the diff.
           fetch-depth: 0
@@ -112,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Require the xDS bindings to match the proxy's Envoy
         run: scripts/check-envoy-api-parity.sh
 
@@ -136,9 +139,9 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
       - name: Assert the aether-proxy pin agrees with the registry and the chart
         run: |
           values=charts/aether/values.yaml
@@ -267,13 +270,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: impacted-targets
           path: ${{ runner.temp }}/impacted
@@ -308,13 +311,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: impacted-targets
           path: ${{ runner.temp }}/impacted
@@ -330,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -104,10 +104,10 @@ jobs:
       KIND_CLUSTER: aether-conformance
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download images artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: aether-images
           path: /tmp
@@ -189,7 +189,7 @@ jobs:
             echo "agent DaemonSet not Ready (not required for GATEWAY-HTTP); continuing"
 
       - name: Check out gateway-api @ suite version
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: kubernetes-sigs/gateway-api
           ref: ${{ env.GATEWAY_API_VERSION }}
@@ -268,10 +268,10 @@ jobs:
       KIND_CLUSTER: aether-conformance-mesh
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download images artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: aether-images
           path: /tmp
@@ -334,7 +334,7 @@ jobs:
             echo "controller not Ready; continuing (namespace injection may be degraded)"
 
       - name: Check out gateway-api @ suite version
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: kubernetes-sigs/gateway-api
           ref: ${{ env.GATEWAY_API_VERSION }}
@@ -407,10 +407,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download images artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: aether-images
           path: /tmp
@@ -466,10 +466,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download images artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: aether-images
           path: /tmp
@@ -529,10 +529,10 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download images artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: aether-images
           path: /tmp

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -58,7 +58,7 @@ jobs:
       has_unit: ${{ steps.impacted.outputs.has_unit }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
           # Full history so the first parent is reachable for the diff.
@@ -76,7 +76,7 @@ jobs:
             echo "sha=" >>"$GITHUB_OUTPUT"
           fi
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: "21"
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.sha }}
       - name: Setup Bazel
@@ -126,7 +126,7 @@ jobs:
         with:
           bazelisk-cache: true
       - name: Download impacted target lists
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: impacted-targets-main
           path: ${{ runner.temp }}/impacted

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:

--- a/.github/workflows/proxy-release.yml
+++ b/.github/workflows/proxy-release.yml
@@ -63,7 +63,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -72,7 +72,7 @@ jobs:
           repository-cache: true
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -146,14 +146,14 @@ jobs:
       index_digest: ${{ steps.manifest.outputs.index_digest }}
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download digests
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: digests
 
@@ -299,7 +299,7 @@ jobs:
           echo "release token mode: ${mode}${reason:+ (${reason})}"
 
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
 

--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -10,7 +10,9 @@ name: proxy
 # happens on merge (proxy-release.yml).
 on:
   pull_request:
-    branches: [main]
+    # `upgrade/**`: stacked PRs based on another upgrade branch must still get
+    # the `proxy` gate, otherwise the required check never reports on them.
+    branches: [main, "upgrade/**"]
 
 permissions:
   contents: read
@@ -30,7 +32,7 @@ jobs:
     outputs:
       proxy: ${{ steps.filter.outputs.proxy }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -63,7 +65,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,7 @@ jobs:
       name: main
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
         with:


### PR DESCRIPTION
Part 1/11 of the 2026-09-12 dependency-upgrade stack (merge bottom → top: gh-actions go-toolchain go-deps-core go-deps-otel go-deps-k8s go-deps-aws bazel-rules bazel-protobuf-36 base-images website-deps go-1.27). Base: `main`. Audit of everything that was checked, including what is already current, is in the bottom PR.

Every `uses:` reference in .github/workflows, moved to the latest major tag.
The repo pins floating majors (no SHAs), so this keeps that style.

  actions/checkout           v6 -> v7   (22 steps: ci, e2e, main, pages,
                                         proxy, proxy-release, publish)
  actions/download-artifact  v7 -> v8   (9 steps: ci x2, e2e x5, main,
                                         proxy-release)
  dorny/paths-filter         v3 -> v4   (ci `changes`, proxy `changes`)
  docker/login-action        v3 -> v4   (proxy-release x2; publish was
                                         already v4, so all three unify)
  actions/setup-java         v4 -> v6   (ci `diff`, main `diff`)
  azure/setup-helm           v4 -> v5   (ci `proxy-pin`)

Left alone, already current: bazel-contrib/setup-bazel@0.19.0,
actions/upload-artifact@v7 (v7.0.1 is the latest; there is no v8),
actions/upload-pages-artifact@v5, actions/deploy-pages@v5,
helm/kind-action@v1.

Release-note review of the majors crossed:

- checkout v7: ESM + node24. v7.0.0 blocks checking out a fork PR head for
  `pull_request_target` and `workflow_run`; no workflow here uses either
  event, and every input we pass (`ref`, `fetch-depth`, `repository`,
  `path`) still exists in v7.0.1's action.yml.
- download-artifact v8: ESM; digest mismatch now fails by default
  (`digest-mismatch: error`) and non-zipped downloads are no longer
  unzipped. v8 is the pair of upload-artifact v7 (both released
  2026-02-26, same @actions/artifact v4 API generation, and v8's
  release notes describe it as the download side of upload-artifact's
  direct uploads), so keeping upload at v7 is correct. The v5 breaking
  change was scoped to single downloads by `artifact-ids`; every step
  here downloads by `name` or downloads the whole run, so nothing moves.
- paths-filter v4: runtime bump to node24 only; `filters` is the sole
  input we pass and the per-filter boolean outputs are unchanged. v4.0.3
  also carries GHSA-7hc6-8hq5-9q2m (list-files escaping), which we do not
  use but is free.
- setup-java v6: ESM, node24, Azul metadata API, legacy `adopt`
  distributions dropped, `jdkFile` renamed to `jdk-file` (alias kept). We
  pass `distribution: temurin` and `java-version: "21"`; both still exist.
- setup-helm v5: ESM + node24. We pass no inputs at all.
- login-action v4: ESM + node24. `registry`/`username`/`password`
  unchanged.

Also: run PR checks for stacked PRs whose base is an upgrade/** branch.
ci.yaml and proxy.yml trigger on `pull_request` restricted to
`branches: [main]`, so a PR stacked on another `upgrade/*` branch would
get neither the required `ci` nor the required `proxy` check. Both now
also match `upgrade/**`. No other trigger changed.

Verified: `python3 -c 'yaml.safe_load(...)'` over all seven workflow
files parses and the two `pull_request.branches` lists read
`['main', 'upgrade/**']`; `bazel run //:format.check` clean. actionlint
is not installed on this host. Workflow files cannot be exercised
locally — CI on the PR is the test.



## Upgrade audit 2026-09-12 — checked and already current (no PR)

- Bazel 9.2.0 (latest 9.x; 8.8.0 is the LTS line). proxy/.bazelversion 8.7.0 == Envoy main's .bazelversion (tracks Envoy, not bumpable independently).
- Envoy pin 1.40.0-dev.20260904.13144fb.envoy is the ONLY version in envoyproxy/bazel-registry (registry head f0dced2 2026-09-11 only touched libevent); Envoy 1.40.0 not released (latest 1.39.1).
- BCR current: bazel_skylib 1.9.2, platforms 1.1.0, rules_foreign_cc 0.15.1, rules_android 0.7.3, container_structure_test 1.22.1, protovalidate 1.2.2, rules_buf 0.5.4, toolchains_buildbuddy 0.0.4; proxy rules_cc 0.2.22, rules_shell 0.8.0.
- Actions current: setup-bazel 0.19.0, upload-artifact v7, upload-pages-artifact v5, deploy-pages v5, kind-action v1.
- Go deps current: go-control-plane v0.14.0 / envoy v1.39.0 (parity-gated to the proxy), cncf/xds, cobra 1.10.2, fsnotify 1.10.1, logr 1.4.4, renameio 2.0.2, nftables 0.3.0, blang/semver, spdystream, go-flowrate, protoc-gen-doc 1.5.1, protokit 0.3.0, gocognit 1.2.1, gexe 0.5.0, zeebo/errs, etcd 3.7.1, otlp proto 1.11.0, zap 1.28.0, atomic 1.11.0, lumberjack 2.2.1, sigs yaml 1.6.0, e2e-framework 0.7.0, mcs-api 0.5.2.
- mkdocs 1.6.1 current.

Deferred on purpose (Go 1.27.1 is now the top PR of the stack: the only post-0.63.0 rules_go fix is for nogo, which this repo does not enable):
- mermaid 12.0.0: mkdocs-material 9.7.7 still loads `mermaid@11`, so the self-hosted copy stays on the 11 line (11.17.2).
- distroless cc-debian13 for the proxy: kept on the cc-debian12 track this round (digest of cc-debian13:nonroot recorded in the base-images commit).
- Envoy 1.40.0: not released; the proxy pin is already the only snapshot in envoyproxy/bazel-registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
