### PR TITLE
chore(deps): Go 1.26.8 → 1.27.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ make format-check  # CI-friendly check (fails on drift)
 ## Toolchain
 
 - **Bazel:** 9.2.0 (via Bazelisk). Use `bazel` commands directly or via `Makefile`.
-- **Go:** 1.26.8
+- **Go:** 1.27.1
 - **Container images:** Built with `rules_img`, pushed to distroless (`gcr.io/distroless/static-debian13:nonroot`).
 - **Protobuf:** Uses `buf/validate` for validation, `protoc-gen-dynamo` for DynamoDB marshaling.
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -40,7 +40,7 @@ bazel_dep(name = "rules_helm", version = "0.32.0")
 bazel_dep(name = "toolchains_buildbuddy", version = "0.0.4")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.download(version = "1.26.8")
+go_sdk.download(version = "1.27.1")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -2340,162 +2340,162 @@
           "138aa10a6808b4cff8657478be14772a05335bc8d7e51955e7a6d9ac335af3e4"
         ]
       },
-      "1.26.8": {
+      "1.27.1": {
         "aix_ppc64": [
-          "go1.26.8.aix-ppc64.tar.gz",
-          "cca7850af0cb7eae901b957b226eaf1306be3cd9b122f362e390ad66178b14e3"
+          "go1.27.1.aix-ppc64.tar.gz",
+          "43b4827f082b94b7b6de28a49dd80df268e06935fd82a1b57aab3a772343bf6c"
         ],
         "darwin_amd64": [
-          "go1.26.8.darwin-amd64.tar.gz",
-          "186be014105aa6542b767d2c6ed5cca10a0214bdff809ef1724022a8c7894150"
+          "go1.27.1.darwin-amd64.tar.gz",
+          "8f8f52c6649542cf027bbc9b9c68d1ec042f9f34808a40413f0b8b3f66f3caa4"
         ],
         "darwin_arm64": [
-          "go1.26.8.darwin-arm64.tar.gz",
-          "a012b25b571bd0138a03dcd25375ceba866fe5ca822f426d2c66a4de56fd3f4b"
+          "go1.27.1.darwin-arm64.tar.gz",
+          "ee215d57e0ec269c60cc9ceca68e6bda321ba9ee5afe24f4b0988703c2d87d12"
         ],
         "dragonfly_amd64": [
-          "go1.26.8.dragonfly-amd64.tar.gz",
-          "0cd8ee4589fd4a5a661826ac46fdf5214e3897e4b36585822425e77e9cee06a9"
+          "go1.27.1.dragonfly-amd64.tar.gz",
+          "bda1f327b9a792be80da856a3ea8f92cbfd138a3991e0a97049ee4d4904196a2"
         ],
         "freebsd_386": [
-          "go1.26.8.freebsd-386.tar.gz",
-          "2a082608129d754d06ad2cb110f3a9d347ba2bf8cac91f587a2a4f21da340729"
+          "go1.27.1.freebsd-386.tar.gz",
+          "a01f190a079150ada777fcd1a7fb27ab1a98caf9f09b2411b2ffb7e9486e0030"
         ],
         "freebsd_amd64": [
-          "go1.26.8.freebsd-amd64.tar.gz",
-          "458adea37c17ce9a8754a0455fa43e84f27d7e7de3fee81041a13de40c766434"
+          "go1.27.1.freebsd-amd64.tar.gz",
+          "9761194512938a640948ae5ba273df73a441f4229ea21a1503937e55c69bf107"
         ],
         "freebsd_arm": [
-          "go1.26.8.freebsd-arm.tar.gz",
-          "60476d7f48f6d79b186f2bcaf2a76fb08a0445b6edad7463f50de8b606cf97cf"
+          "go1.27.1.freebsd-arm.tar.gz",
+          "e5b55c9f6646373c221f8384cee60321128e7f48b42da3b7da7bce3fae44a88c"
         ],
         "freebsd_arm64": [
-          "go1.26.8.freebsd-arm64.tar.gz",
-          "041d822e331b6c45b393bb3314ad890e4f622c4ffb6eba6cd7e934afed4158a9"
+          "go1.27.1.freebsd-arm64.tar.gz",
+          "8b155a723a584fb29125c6b36fc9cb0d5489a3f7fb76670508a2c51af718074d"
         ],
         "illumos_amd64": [
-          "go1.26.8.illumos-amd64.tar.gz",
-          "a3ed45dc338a6db5edb554e03a37c06a2063022bb7599de4d2e46bbd5d9d2c72"
+          "go1.27.1.illumos-amd64.tar.gz",
+          "ed04719b94b176745e08847f48d8a9e92b49330f2ff4ca2cf34e1b66cb5fd682"
         ],
         "linux_386": [
-          "go1.26.8.linux-386.tar.gz",
-          "55115677dfcd953fa9d2fe376039125a60ff14fe0e619a2339a364860dda64ef"
+          "go1.27.1.linux-386.tar.gz",
+          "3b72028095439d2bc0ce84e271cc70328a878d879020c5721eaa46df5f72fbc0"
         ],
         "linux_amd64": [
-          "go1.26.8.linux-amd64.tar.gz",
-          "d0f743b33e8d8945e6b1f432edd15785c70507121d6e2a723b21285eddf8b57b"
+          "go1.27.1.linux-amd64.tar.gz",
+          "63d339f0da5ab53635a56f2490a7984dfe12dfcff22ad749f63edaf590168445"
         ],
         "linux_arm64": [
-          "go1.26.8.linux-arm64.tar.gz",
-          "211ffced9dcb9633a55eac6364816ec0ddd951389a740e88fa8b3337971bdda0"
+          "go1.27.1.linux-arm64.tar.gz",
+          "3450b45a3f9ee8568792736a5c5e70a1f2e9b36c35a8f74958c03e51d7d92bec"
         ],
         "linux_armv6l": [
-          "go1.26.8.linux-armv6l.tar.gz",
-          "eab440beabf395870752021fa74cedf04f97b61e43ebbe005ecbb98b94e55697"
+          "go1.27.1.linux-armv6l.tar.gz",
+          "44893f200fb034791d4188df9fc9b9e73eadbb5fceafd5166703f0b9bab73fc2"
         ],
         "linux_loong64": [
-          "go1.26.8.linux-loong64.tar.gz",
-          "64fb507c00d6f830f71a342feb80b05641b4da5d5ca1d5e06896d5572f8a458c"
+          "go1.27.1.linux-loong64.tar.gz",
+          "a3df3db12e0b16d932bbfd3f6025473faf8bfeb13ea2177de5e8fac1d4124b7f"
         ],
         "linux_mips": [
-          "go1.26.8.linux-mips.tar.gz",
-          "134d7d4c83fb16dc25ef7ad283c28d13a018da06531f6894868ade510bd33e62"
+          "go1.27.1.linux-mips.tar.gz",
+          "a6e637864e6801408d2d8d7f5d429b90bf8854ac320eb70778f4ac36e9b8e889"
         ],
         "linux_mips64": [
-          "go1.26.8.linux-mips64.tar.gz",
-          "dada97e3b32b2d6cb5df319d2223dcd28a7dfe1fcf29ca78d364c937acb09246"
+          "go1.27.1.linux-mips64.tar.gz",
+          "ba3d2d4969d901cdf15d930f0cbcaa761da9d4c98386a6a26d4a82cdf596aa9f"
         ],
         "linux_mips64le": [
-          "go1.26.8.linux-mips64le.tar.gz",
-          "4d67357ce7909cbf28489562d58150162036dfe696b207a9d49f96d7ea99f814"
+          "go1.27.1.linux-mips64le.tar.gz",
+          "23f9b4ce864764849ca792d8cf6bd8e00880ef3c6070a2717509f8d3f6059ba5"
         ],
         "linux_mipsle": [
-          "go1.26.8.linux-mipsle.tar.gz",
-          "8cf4a4e029cee32f54539625f002820ed134ac3030b43483432d8be124d22e14"
+          "go1.27.1.linux-mipsle.tar.gz",
+          "06cfb6c5528a54d53580c6390efea9ad0362322518bc32129ea6c0145f1e6a23"
         ],
         "linux_ppc64": [
-          "go1.26.8.linux-ppc64.tar.gz",
-          "e4cc0ff1eba37e9b228c49fda1e5eca3a0a29edd3ec7631fbcbc73fae79c7155"
+          "go1.27.1.linux-ppc64.tar.gz",
+          "e91dee51bdfa08e034d9ed4016929a2008f179caa004922d637a97d5cda05778"
         ],
         "linux_ppc64le": [
-          "go1.26.8.linux-ppc64le.tar.gz",
-          "0ddf3ecab842013e6bd618602823a0b8158a18d3e9362f2540463ea5aa184975"
+          "go1.27.1.linux-ppc64le.tar.gz",
+          "ad1ff83c24f783c2d4a025852b928a05c199e8742a14a5482d88de0293d2bd0d"
         ],
         "linux_riscv64": [
-          "go1.26.8.linux-riscv64.tar.gz",
-          "75d368eef1dc44ff9de0c8cac4b37c519e541e6d46c4291c1ff959644a71af32"
+          "go1.27.1.linux-riscv64.tar.gz",
+          "62287667ee5e5f540f30fb9b7529a27fe582f22c6bfd726ece9b045f4c54ee61"
         ],
         "linux_s390x": [
-          "go1.26.8.linux-s390x.tar.gz",
-          "339d1a09716815f737cb5ddd355e04e339312b449c268cc417118f4b8137ddd1"
+          "go1.27.1.linux-s390x.tar.gz",
+          "c9e1ad7bddea40e2eb10b4d3267ae06d462667839bf0ba94c2e2d160b06f9b9e"
         ],
         "netbsd_386": [
-          "go1.26.8.netbsd-386.tar.gz",
-          "039a7ea1da0c1b8771cde7edef70fedebadb6fa9bdeae69be15afa47e0ac98c5"
+          "go1.27.1.netbsd-386.tar.gz",
+          "6bde412641300348cc571cfcf3384071934c5005c8057325e29763963107b932"
         ],
         "netbsd_amd64": [
-          "go1.26.8.netbsd-amd64.tar.gz",
-          "8f30a489d4985cd61a56d1d47326de1682e6668c99a6a904decc974513a8c43c"
+          "go1.27.1.netbsd-amd64.tar.gz",
+          "4ace14c14e7c6eb1d06890433afe81f8c2dc746d1d5f4df3ae6d2d7dd0481ba2"
         ],
         "netbsd_arm": [
-          "go1.26.8.netbsd-arm.tar.gz",
-          "382b36fecb6c4684db8eec888fa079ba6991f27501bcfb5cf3207ca5baccd79a"
+          "go1.27.1.netbsd-arm.tar.gz",
+          "da7db485266e309cca263bcad95197d2c21e747e14698bc1d95704e9939fd07a"
         ],
         "netbsd_arm64": [
-          "go1.26.8.netbsd-arm64.tar.gz",
-          "5548fac5866d75d2cdaf39ed5fb832d8864e0b3a045c0c1476d8d2c30f484c9a"
+          "go1.27.1.netbsd-arm64.tar.gz",
+          "c0ac5527cdde89e31d40e536a1cec4a8d8b2903f79e2356645c862dfab6f3181"
         ],
         "openbsd_386": [
-          "go1.26.8.openbsd-386.tar.gz",
-          "c71eff4b5a3a037ddbe3b52ed67c774c60be59b1dce7ba6c5fbdfc33a7e7f257"
+          "go1.27.1.openbsd-386.tar.gz",
+          "3434ae1ef067666d4df50f883e985a49e7589d6004a412329e7684ff80f40852"
         ],
         "openbsd_amd64": [
-          "go1.26.8.openbsd-amd64.tar.gz",
-          "338be23e51b38df2fba23b6b523b879dc90aa0408080b36cb68afc21169fd0a9"
+          "go1.27.1.openbsd-amd64.tar.gz",
+          "db0566b3b3ddf6eda09cb3434a9401eb2583ffa539475e45592812813f11c792"
         ],
         "openbsd_arm": [
-          "go1.26.8.openbsd-arm.tar.gz",
-          "e5031bec4507c289a6809bd6d1256a95077c9e980a650fc85e3403d3117df8f4"
+          "go1.27.1.openbsd-arm.tar.gz",
+          "5423e99d338cf9ccebbfce0e373095e63b62fbedd7a1b99436bb7e0f3184069c"
         ],
         "openbsd_arm64": [
-          "go1.26.8.openbsd-arm64.tar.gz",
-          "2bb1cc5bf6f988dba69facc51e8d5debcc8d019415a90289976d8fbe53653229"
+          "go1.27.1.openbsd-arm64.tar.gz",
+          "953142ae3734098e65118ddca29ed2f469a85f039a78a1572da98ba271042e65"
         ],
         "openbsd_ppc64": [
-          "go1.26.8.openbsd-ppc64.tar.gz",
-          "01f9060b3d479692c3b9b0f11b655ea701568ddb62af521328683eee79d967e4"
+          "go1.27.1.openbsd-ppc64.tar.gz",
+          "93e32d7c0ba24e56f5f75aed454e9301c7204605c11508d65ecb39356c221106"
         ],
         "openbsd_riscv64": [
-          "go1.26.8.openbsd-riscv64.tar.gz",
-          "018bae3b35a0402b0e7b2b1c050212e47231c0b00aa8f03727bac79905c49ff7"
+          "go1.27.1.openbsd-riscv64.tar.gz",
+          "1683c8e86157739bfee080d38919750366aeed8fe77576b0798460a2f06d6b98"
         ],
         "plan9_386": [
-          "go1.26.8.plan9-386.tar.gz",
-          "93a6f4924dea52749f00d454048fc9e15e16d2eb054f5079756317c14cce8524"
+          "go1.27.1.plan9-386.tar.gz",
+          "7dbc261ab5c1100581427aa009964c142abb46520af6a31f6ff761b0f0a61f33"
         ],
         "plan9_amd64": [
-          "go1.26.8.plan9-amd64.tar.gz",
-          "f7fa9732a1b763cc5d6f9bf39f75d6b1dc38e6e2e2b9adede7618bca181125e6"
+          "go1.27.1.plan9-amd64.tar.gz",
+          "fc546629513ba62403657d2355b3982b7ff59934fec5ca0cde32e18d9f2b65b9"
         ],
         "plan9_arm": [
-          "go1.26.8.plan9-arm.tar.gz",
-          "8afe9bc4a38ee4f94bc282933aa8853a8b473ee9b0423e4a69a7e0187fc9dc14"
+          "go1.27.1.plan9-arm.tar.gz",
+          "5e420ef8837a708246a7959bf56b1b6c6ca765c4f16dd953b4e09290d9cd4b53"
         ],
         "solaris_amd64": [
-          "go1.26.8.solaris-amd64.tar.gz",
-          "519b707164dc01b46f5aad6ecc7eeeb8531fbcab5082fe0e62a8baf09920e2ff"
+          "go1.27.1.solaris-amd64.tar.gz",
+          "7efd1b6d470ea724db178f17d3bd1b66931e2aa79c4389fe75228f2aef6014a4"
         ],
         "windows_386": [
-          "go1.26.8.windows-386.zip",
-          "5e7d3334bdcec2541cf33c4ef5135726c6c278068a7fd6d3aaef5b9e308d8e2d"
+          "go1.27.1.windows-386.zip",
+          "1670510496778ee976de09c91b7960f76cb7dbf90968cfea98bb51fa80c9de91"
         ],
         "windows_amd64": [
-          "go1.26.8.windows-amd64.zip",
-          "b92c3b2adae85a11ba71fe7216daf0d84e82af4c8ab6c5625807f28622043a59"
+          "go1.27.1.windows-amd64.zip",
+          "a3911b5e0e1b1053f25ed0675f4c1c6aad1e2bfcf253df2b9be4caabd2edd95d"
         ],
         "windows_arm64": [
-          "go1.26.8.windows-arm64.zip",
-          "4bc560ed3ccb64eec0be6180b8c29185c07f5215276820adb4303d7bf3365435"
+          "go1.27.1.windows-arm64.zip",
+          "13b69b87bb0e83f96bc68560a8cace7f0343b1e03469f1110ea18d17e3234069"
         ]
       }
     },

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ graph TD
 ### Prerequisites
 
 - [Bazelisk](https://github.com/bazelbuild/bazelisk) (Bazel 9.2.0)
-- Go 1.26.8
+- Go 1.27.1
 - Docker (or Colima) for container images and integration tests
 
 ### Setup (macOS with Colima)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -15,7 +15,7 @@ chart values and CLI/annotation reference, see
 | Tool | Why | Notes |
 |---|---|---|
 | **Bazel** via [Bazelisk](https://github.com/bazelbuild/bazelisk) | build system | The pinned version (`9.2.0`) is read from `.bazelversion`; just run `bazel …` and Bazelisk fetches it. |
-| **Go** 1.26.8 | language toolchain | Managed by `rules_go`; you rarely invoke `go` directly (use `bazel run @rules_go//go …`). |
+| **Go** 1.27.1 | language toolchain | Managed by `rules_go`; you rarely invoke `go` directly (use `bazel run @rules_go//go …`). |
 | **Docker** (or **Colima** on macOS) | container images + integration tests | Integration tests spin up real etcd / DynamoDB Local via testcontainers-go. |
 | **kubectl**, **Helm 3** (OCI) | deploy / e2e | |
 | **kind** | local multi-cluster e2e | Only needed for `e2e/multicluster_config.sh`. |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module aethermesh.dev
 
-go 1.26.8
+go 1.27.1
 
 require go.uber.org/zap v1.28.0
 


### PR DESCRIPTION
Part 11/11 of the 2026-09-12 dependency-upgrade stack (top). Base: `upgrade/website-deps`. Audit of everything that was checked, including what is already current, is in the bottom PR #747.

Minor Go toolchain bump on top of the 1.26.8 patch bump earlier in this
stack: rules_go `go_sdk.download`, the `go` directive in go.mod, and the
three docs that quote the version (AGENTS.md, README.md, docs/runbook.md).
MODULE.bazel.lock carries the 1.27.1 SDK hashes.

Why it is safe with rules_go 0.63.0: the two Go 1.27 fixes in rules_go are
the cgo ldflags response-file escaping (bazel-contrib/rules_go#4641, merged
2026-07-02, in 0.63.0) and the nogo x/tools bump (#4701, merged 2026-08-31,
after 0.63.0). This repo has no cgo and does not enable nogo, so neither
path is exercised.

Go 1.27 behaviour changes reviewed against this codebase: no removed GODEBUG
setting (asynctimerchan, tlsrsakex, tls3des, tls10server, tlsunsafeekm,
x509keypairleaf, gotypesalias) is set anywhere; encoding/json is now backed
by the v2 implementation with the v1 API kept compatible; HTTP/1
Response.Body now auto-drains on Close (the prober already drains
explicitly); size-specialised small allocations are on by default.

Verified (all with --repo_env=GOPROXY=https://proxy.golang.org,direct):
- bazel mod tidy                        lock updated for the 1.27.1 SDK only
- bazel build //...                     OK (4999 actions)
- bazel test //... --test_output=errors OK (99/99 pass, incl. testcontainers
  integration tests)
- bazel run //:format.check             OK
- bazel build --config=lint --@aspect_rules_lint//lint:fail_on_violation //... OK
- bazel run //:gazelle                  no BUILD.bazel churn
- `go version bazel-bin/agent/cmd/agent/agent_/agent` → go1.27.1



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NArCRTfMPZkw4Y97U9Gdsr
