### PR TITLE
chore(proxy): pin aether chart to aether-proxy:733802bafb723dae61df2b986e274c1b2ffcede0

### DIFF
--- a/charts/aether/Chart.yaml
+++ b/charts/aether/Chart.yaml
@@ -10,7 +10,7 @@ description: |
   `crds` chart, which must be installed first. See docs/proposals/015_mesh-config.md.
 type: application
 # Stamped at package time when built with `--stamp` (see other charts).
-version: "0.92.17"
+version: "0.92.18"
 appVersion: "{STABLE_GIT_VERSION}"
 keywords:
   - aether

--- a/charts/aether/values.yaml
+++ b/charts/aether/values.yaml
@@ -330,10 +330,10 @@ proxy:
   # commit SHA. Mirror by overriding `repository`.
   image:
     repository: ghcr.io/bpalermo/aether/aether-proxy
-    tag: 96ddda078354f2a181983631ddfd224fdede1b80
+    tag: 733802bafb723dae61df2b986e274c1b2ffcede0
     # Digest-pinned (option A): content-addressed, tamper-proof. The aether.image
-    # helper prefers digest over tag. Multi-arch index for 96ddda078354f2a181983631ddfd224fdede1b80.
-    digest: "sha256:07c28f9a884360a07e7697e9fc69abd0f6e995efe9a5ba4556161709fdb3fcda"
+    # helper prefers digest over tag. Multi-arch index for 733802bafb723dae61df2b986e274c1b2ffcede0.
+    digest: "sha256:9613fa9f05711183dbd31a2d91b64004552173f090eebd863ac60fa6e4cd2b02"
     pullPolicy: Always
   logLevel: info
   # Emit Envoy's own application logs as one JSON object per line (bootstrap


### PR DESCRIPTION
Auto-generated by the `proxy-release` run for `733802bafb723dae61df2b986e274c1b2ffcede0` (https://github.com/bpalermo/aether/actions/runs/34720270295).

Pins the aether chart's proxy image to the multi-arch index published for
that commit, and bumps the chart patch version.

| | |
|---|---|
| image | `ghcr.io/bpalermo/aether/aether-proxy:733802bafb723dae61df2b986e274c1b2ffcede0` |
| index digest | `sha256:9613fa9f05711183dbd31a2d91b64004552173f090eebd863ac60fa6e4cd2b02` |
| chart version | `0.92.15` -> `0.92.16` |

`aether.image` (`charts/aether/templates/_helpers.tpl`) prefers `digest:`
over `tag:`, so both lines move — a tag-only bump would leave the
previously pinned image deployed (#703, #705). The `proxy-pin` CI job
re-checks that `tag:`, `digest:` and the registry agree.

Opened by the `proxy-release` workflow with the `RELEASE_PAT` fine-grained
token (#727). A PR opened by a *user* token fires `pull_request` normally,
so `ci` + `proxy` run and report — unlike one opened by `GITHUB_TOKEN`,
which GitHub's recursion guard leaves without checks and therefore
permanently unmergeable under the `main` ruleset (#703). Auto-merge
(squash) is armed: GitHub merges this the moment the required checks pass,
and the ruleset — which has no bypass actors — is still the only gate.

Any older `chore/proxy-image-bump-*` PR is superseded and was closed by
the same run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
